### PR TITLE
Added functions to do list of group size and members

### DIFF
--- a/GroupMigration/WSGroupMigration.py
+++ b/GroupMigration/WSGroupMigration.py
@@ -1651,10 +1651,10 @@ class GroupMigration:
 
       print(f'Performing inventory of workspace object permissions. Filtering results by group list for mode: {mode}.')
       try:
-        if self.groupMembers == {} :
-          self.setGroupListForMode(mode)
-          print(f'Skipping inventory for mode = {mode} since already performed.')
-          return
+        # if self.groupMembers == {} :
+        #   self.setGroupListForMode(mode)
+        #   print(f'Skipping inventory for mode = {mode} since already performed.')
+        #   return
         for obj in objList :
           self.performInventoryOnObject(obj)
 
@@ -1892,10 +1892,10 @@ class GroupMigration:
 
     def deleteWorkspaceLocalGroups(self):
       try:
-        # self.setGroupListForMode("Workspace")
-        # if self.validateTempWSGroup() == 0:
-        #     print("temp group validation failed, aborting deletion")
-        #     return;
+        self.setGroupListForMode("Workspace")
+        if self.validateTempWSGroup() == 0:
+            print("temp group validation failed, aborting deletion")
+            return;
         self.bulkTryDelete(self.groupL)
       except Exception as e:
         print(f"Error deleting groups : {e}")

--- a/GroupMigration/Workspace_Group_Migration_Notebook.py
+++ b/GroupMigration/Workspace_Group_Migration_Notebook.py
@@ -143,6 +143,11 @@ df.filter(df.ws_group_size > df.account_group_size).display()
 
 # COMMAND ----------
 
+gm.setGroupListForMode("Workspace")
+gm.groupIdDict.values()
+
+# COMMAND ----------
+
 # Comment out line of object to omit from inventory listing
 objListTemp = [
 'Password',
@@ -188,7 +193,7 @@ gm.migrationLoadPerGroup().filter(~gm.migrationLoadPerGroupDF.GroupName.isin(mig
 
 # DBTITLE 1,Set Groups or SubGroups to be Migrated (Optional)
 # subGroupL = set(gm.groupL).difference(set(migratedGroupL)).difference(set(['ACL:Databricks:GEN2:Data', 'ACL:Databricks:GEN2:DataPlatform', 'dashboard', 'tableau']))
-subGroupL = ['ACL:Databricks:GEN2:Data', 'ACL:Databricks:GEN2:DataPlatform', 'dashboard', 'tableau']
+subGroupL = gm.groupL
 gm.migrationLoadPerGroupDF.filter(gm.migrationLoadPerGroupDF.GroupName.isin(subGroupL)).sort("GroupName").display()
 gm.groupL = subGroupL
 


### PR DESCRIPTION
This is useful to create a list of existing members in the workspace group and comparing it to the members in the account group so we can prevent outages for individual members within the workspace group

Added a cache mechanism so we don't have to repeatedly query Group Listing API