### PR TITLE
Added `make_*_permissions` fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -580,7 +580,7 @@ def workspace_objects(ws: WorkspaceClient, env: EnvironmentInfo) -> WorkspaceObj
 
         ws.permissions.set(
             request_object_type=RequestObjectType.DIRECTORIES,
-            request_object_id=object_info.object_id,
+            request_object_id=object_info._object_id,
             access_control_list=[
                 AccessControlRequest(group_name=ws_group.display_name, permission_level=PermissionLevel.CAN_MANAGE)
             ],
@@ -599,7 +599,7 @@ def workspace_objects(ws: WorkspaceClient, env: EnvironmentInfo) -> WorkspaceObj
         notebooks.append(_nb_obj)
         ws.permissions.set(
             request_object_type=RequestObjectType.NOTEBOOKS,
-            request_object_id=_nb_obj.object_id,
+            request_object_id=_nb_obj._object_id,
             access_control_list=[
                 AccessControlRequest(group_name=random_group.display_name, permission_level=PermissionLevel.CAN_EDIT)
             ],
@@ -609,7 +609,7 @@ def workspace_objects(ws: WorkspaceClient, env: EnvironmentInfo) -> WorkspaceObj
         root_dir=ObjectInfo(
             path=f"/{env.test_uid}",
             object_type=ObjectType.DIRECTORY,
-            object_id=ws.workspace.get_status(f"/{env.test_uid}").object_id,
+            object_id=ws.workspace.get_status(f"/{env.test_uid}")._object_id,
         ),
         directories=base_dirs,
         notebooks=notebooks,

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -31,6 +31,15 @@ def test_notebook(make_notebook):
     logger.info(f"created {make_notebook()}")
 
 
+def test_notebook_permissions(make_notebook, make_notebook_permissions, make_group):
+    group = make_group()
+    notebook = make_notebook()
+    acl = make_notebook_permissions(
+        object_id=notebook, permission_level=iam.PermissionLevel.CAN_RUN, group_name=group.display_name  # noqa: F405
+    )
+    logger.info(f"created {acl}")
+
+
 def test_directory(make_notebook, make_directory):
     logger.info(f'created {make_notebook(path=f"{make_directory()}/foo.py")}')
 


### PR DESCRIPTION
This PR introduces new permissions fixtures. Example usage:

```python
def test_notebook_permissions(make_notebook, make_notebook_permissions, make_group):
    group = make_group()
    notebook = make_notebook()
    make_notebook_permissions(object_id=notebook,
                              permission_level=PermissionLevel.CAN_RUN,
                              group_name=group.display_name)
```