### PR TITLE
Always install the latest `pip` version in `./install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,13 @@ $py -m venv "$tmp_dir"
 # Use the Python from Virtualenv
 py="$tmp_dir/bin/python"
 
+echo "[+] making sure we have the latest pip version"
+# Always upgrade pip, so that the hatchling build backend works. Hinted by errors like
+# > File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
+#
+# See https://github.com/databrickslabs/ucx/issues/198
+$py -m pip install --quiet --upgrade pip
+
 echo "[+] installing dependencies within ephemeral Virtualenv: $tmp_dir"
 # Install all project dependencies, so that installer can proceed
 $py -m pip install --quiet -e .


### PR DESCRIPTION
This is an attempt to fix #198 by using the latest pip:

```
[+] installing dependencies within ephemeral Virtualenv: /var/folders/qd/8k4t20c9593_c05dv4mbrpx40000gp/T/tmp.dQz0ZxQ5
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: /Users/$USER/Documents/ucx
(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)


WARNING: You are using pip version 21.2.4; however, version 23.2.1 is available.
You should consider upgrading via the '/private/var/folders/qd/8k4t20c9593_c05dv4mbrpx40000gp/T/tmp.dQz0ZxQ5/bin/python -m pip install --upgrade pip' command.
```