### PR TITLE
Create `$inventory.tables` from Scala notebook

### DIFF
--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -18,9 +18,10 @@ class Task:
     fn: Callable[[MigrationConfig], None]
     depends_on: list[str] = None
     job_cluster: str = "main"
+    notebook: str = None
 
 
-def task(workflow, *, depends_on=None, job_cluster="main"):
+def task(workflow, *, depends_on=None, job_cluster="main", notebook: str | None = None):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -52,7 +53,13 @@ def task(workflow, *, depends_on=None, job_cluster="main"):
             raise SyntaxError(msg)
 
         _TASKS[func.__name__] = Task(
-            workflow=workflow, name=func.__name__, doc=func.__doc__, fn=func, depends_on=deps, job_cluster=job_cluster
+            workflow=workflow,
+            name=func.__name__,
+            doc=func.__doc__,
+            fn=func,
+            depends_on=deps,
+            job_cluster=job_cluster,
+            notebook=notebook,
         )
 
         return wrapper

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -1,50 +1,42 @@
-import spark.implicits._
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.DataFrame
 
-val PERSIST_SCHEMA = "ucx"
-val DEBUG = true
-
+// must follow the same structure as databricks.labs.ucx.hive_metastore.tables.Table
 case class TableDetails(catalog: String, database: String, name: String, object_type: String,
                         table_format: String, location: String, view_text: String)
 
-// Get metadata for a given table and map it to a TableDetails case class object
-def getTableDetails(db: String, t: String): Option[TableDetails] = {
-  try {
-    val table: CatalogTable = spark.sharedState.externalCatalog.getTable(db = db, table = t)
+def metadataForAllTables(databases: Seq[String]): DataFrame = {
+  import spark.implicits._
 
-    if (table == null) {
-      println(s"getTable('${db}.${t}') returned null")
-      None
+  val externalCatalog = spark.sharedState.externalCatalog
+  databases.par.flatMap(databaseName => {
+    val tables = externalCatalog.listTables(databaseName)
+    if (tables == null) {
+      println(s"[WARN][${databaseName}] listTables returned null")
+      Seq()
     } else {
-      Some(TableDetails("hive_metastore", db, t, table.tableType.name, table.provider.getOrElse("Unknown"),
-        table.storage.locationUri.getOrElse("None").toString, table.viewText.getOrElse("None"), "", // TBD: Set WS ID
-        table.createTime, table.lastAccessTime))
+      tables.par.map(tableName => try {
+        val table = externalCatalog.getTable(databaseName, tableName)
+        if (table == null) {
+          println(s"[WARN][${databaseName}.${tableName}] result is null")
+          None
+        } else {
+          Some(TableDetails("hive_metastore", databaseName, tableName, table.tableType.name, table.provider.orNull,
+            table.storage.locationUri.map(_.toString).orNull, table.viewText.orNull))
+        }
+      } catch {
+        case err: Throwable =>
+          println(s"[ERROR][${databaseName}.${tableName}] ignoring table because of ${err}")
+          None
+      }).toList.collect {
+        case Some(x) => x
+      }
     }
-  } catch {
-    case err: Throwable =>
-      println(s"Got some other kind of Throwable exception, ignoring for ${db}.${t}")
-      println(s"Error: ${err}")
-      None
-  }
+  }).toList.toDF
 }
 
-// Retrieve metadata for a database and map it to a list of TableDetails case class objects
-def getDbTables(db: String): Seq[TableDetails] = {
-  val tables = spark.sharedState.externalCatalog.listTables(db)
-  if (tables == null) {
-    println(s"listTable('${db}') returned null")
-    Seq()
-  } else {
-    tables.par.map(getTableDetails(db, _)).toList.collect { case Some(x) => x }
-  }
-}
+dbutils.widgets.text("inventory_database", "ucx")
+val inventoryDatabase = dbutils.widgets.get("inventory_database")
 
-val dbs = spark.sharedState.externalCatalog.listDatabases()
-
-// create schema if not available
-spark.sql(s"CREATE SCHEMA IF NOT EXISTS ${PERSIST_SCHEMA}")
-
-val df = dbs.par.flatMap(getDbTables).toList.toDF
-
-// write rows to table
-df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(s"${PERSIST_SCHEMA}.tables")
+val df = metadataForAllTables(spark.sharedState.externalCatalog.listDatabases())
+df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(s"$inventoryDatabase.tables")

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -1,0 +1,50 @@
+import spark.implicits._
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+
+val PERSIST_SCHEMA = "ucx"
+val DEBUG = true
+
+case class TableDetails(catalog: String, database: String, name: String, object_type: String,
+                        table_format: String, location: String, view_text: String)
+
+// Get metadata for a given table and map it to a TableDetails case class object
+def getTableDetails(db: String, t: String): Option[TableDetails] = {
+  try {
+    val table: CatalogTable = spark.sharedState.externalCatalog.getTable(db = db, table = t)
+
+    if (table == null) {
+      println(s"getTable('${db}.${t}') returned null")
+      None
+    } else {
+      Some(TableDetails("hive_metastore", db, t, table.tableType.name, table.provider.getOrElse("Unknown"),
+        table.storage.locationUri.getOrElse("None").toString, table.viewText.getOrElse("None"), "", // TBD: Set WS ID
+        table.createTime, table.lastAccessTime))
+    }
+  } catch {
+    case err: Throwable =>
+      println(s"Got some other kind of Throwable exception, ignoring for ${db}.${t}")
+      println(s"Error: ${err}")
+      None
+  }
+}
+
+// Retrieve metadata for a database and map it to a list of TableDetails case class objects
+def getDbTables(db: String): Seq[TableDetails] = {
+  val tables = spark.sharedState.externalCatalog.listTables(db)
+  if (tables == null) {
+    println(s"listTable('${db}') returned null")
+    Seq()
+  } else {
+    tables.par.map(getTableDetails(db, _)).toList.collect { case Some(x) => x }
+  }
+}
+
+val dbs = spark.sharedState.externalCatalog.listDatabases()
+
+// create schema if not available
+spark.sql(s"CREATE SCHEMA IF NOT EXISTS ${PERSIST_SCHEMA}")
+
+val df = dbs.par.flatMap(getDbTables).toList.toDF
+
+// write rows to table
+df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(s"${PERSIST_SCHEMA}.tables")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -246,7 +246,7 @@ class Installer:
             "tasks": [self._job_task(task, dbfs_path) for task in tasks],
         }
 
-    def _job_task(self, task: Task, dbfs_path: str):
+    def _job_task(self, task: Task, dbfs_path: str) -> jobs.Task:
         jobs_task = jobs.Task(
             task_key=task.name,
             job_cluster_key=task.job_cluster,

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -20,8 +20,8 @@ def setup_schema(cfg: MigrationConfig):
     backend.execute(f"CREATE SCHEMA IF NOT EXISTS hive_metastore.{cfg.inventory_database}")
 
 
-@task("assessment", depends_on=[setup_schema])
-def crawl_tables(cfg: MigrationConfig):
+@task("assessment", depends_on=[setup_schema], notebook="hive_metastore/tables.scala")
+def crawl_tables(_: MigrationConfig):
     """During this operation, a systematic scan is conducted, encompassing every table within the Hive Metastore.
     This scan extracts essential details associated with each table, including its unique identifier or name, table
     format, storage location details.
@@ -29,11 +29,6 @@ def crawl_tables(cfg: MigrationConfig):
     The extracted metadata is subsequently organized and cataloged within a dedicated storage entity known as
     the `$inventory.tables` table. This table functions as a comprehensive inventory, providing a structured and
     easily accessible reference point for users, data engineers, and administrators."""
-    ws = WorkspaceClient(config=cfg.to_databricks_config())
-    tacls = TaclToolkit(
-        ws, inventory_catalog="hive_metastore", inventory_schema=cfg.inventory_database, databases=cfg.tacl.databases
-    )
-    tacls.database_snapshot()
 
 
 @task("assessment", depends_on=[crawl_tables], job_cluster="tacl")


### PR DESCRIPTION
This PR allows fetching table metadata without the need to access storage, allowing for a more straightforward configuration that no longer requires Azure storage credentials to be present in the cluster config. This notebook allows for a faster scanning performance.

Fixes #205

Co-authored by: Lars George <lars.george@databricks.com>