### PR TITLE
Fix debug notebook code with refactored package structure (#250)

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -45,7 +45,7 @@ import logging
 from pathlib import Path
 from databricks.labs.ucx.__about__ import __version__
 from databricks.labs.ucx.config import MigrationConfig
-from databricks.labs.ucx import logger
+from databricks.labs.ucx.framework import logger
 from databricks.sdk import WorkspaceClient
 
 logger._install()


### PR DESCRIPTION
Fixes #250 

Since the packages were refactored, the debug notebook yields this: 

```
cannot import name 'logger' from 'databricks.labs.ucx' (/local_disk0/.ephemeral_nfs/envs/pythonEnv-ce5bf3ef-5751-49fc-a077-d25850790a9b/lib/python3.10/site-packages/databricks/labs/ucx/__init__.py)
```