### PR TITLE
Added `sqlglot` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ dev/cleanup.py
 
 .python-version
 .databricks-login.json
+/src/databricks/labs/ucx/framework/lakeview/.gitattributes

--- a/NOTICE
+++ b/NOTICE
@@ -14,3 +14,7 @@ PyYAML - https://github.com/yaml/pyyaml
 Copyright (c) 2017-2021 Ingy döt Net
 Copyright (c) 2006-2016 Kirill Simonov
 License - https://github.com/yaml/pyyaml/blob/main/LICENSE
+
+SQLGlot - https://sqlglot.com
+Copyright (c) 2023 Toby Mao
+License - https://github.com/tobymao/sqlglot/blob/main/LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 dependencies = ["databricks-sdk~=0.17.0",
                 "databricks-labs-blueprint",
-                "PyYAML>=6.0.0,<7.0.0"]
+                "PyYAML>=6.0.0,<7.0.0",
+                "sqlglot~=18.8.0"]
 
 [project.entry-points.databricks]
 runtime = "databricks.labs.ucx.runtime:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,8 @@ ban-relative-imports = "all"
     "ARG001" # tests may not use the provided fixtures
 ]
 
+"src/databricks/labs/ucx/framework/lakeview/model.py" = ["C416", "ARG003"]
+
 "src/databricks/labs/ucx/mixins/redash.py" = ["A002", "A003", "N815"]
 
 [tool.coverage.run]

--- a/src/databricks/labs/ucx/framework/dashboards.py
+++ b/src/databricks/labs/ucx/framework/dashboards.py
@@ -142,11 +142,9 @@ class DashboardFromFiles:
             logger.debug(f"Reading step folder {step_folder}...")
             dashboard_folders = [f for f in step_folder.glob("*") if f.is_dir()]
 
-            datasets: list[lakeview.Dataset] = []
-            pages: list[lakeview.Page] = []
-
             # Create separate dashboards per step, represented as second-level folders
             for dashboard_folder in dashboard_folders:
+
                 logger.debug(f"Reading dashboard folder {dashboard_folder}...")
                 main_name = step_folder.stem.title()
                 sub_name = dashboard_folder.stem.title()
@@ -157,24 +155,21 @@ class DashboardFromFiles:
                 # parent_folder_id = self._installed_query_state()
                 # data_source_id = self._dashboard_data_source()
 
+                datasets: list[lakeview.Dataset] = []
+                pages: list[lakeview.Page] = []
                 layout: list[lakeview.Layout] = []
                 for query in desired_queries:
-                    datasets.append(lakeview.Dataset(query.name, query.query))
+                    datasets.append(lakeview.Dataset(query.name, query.query, display_name=query.name))
                     fields = []
                     widget = lakeview.Widget(query.viz['name'], [
                         lakeview.NamedQuery(query.name, lakeview.Query(query.name, fields, disaggregated=True))
                     ], query.widget_spec())
-                    layout.append(lakeview.Layout(widget, query.position()))
+                    # layout.append(lakeview.Layout(widget, query.position()))
                 pages.append(lakeview.Page(dashboard_ref, layout, dashboard_name))
-            dash = lakeview.Dashboard(datasets, pages)
-            lvdash_json = json.dumps(dash.as_dict(), indent=2)
-            # self._ws.workspace.upload(f'{self._state.install_folder()}/{step_folder.name}.lvdash.json', lvdash_json, format=ImportFormat.AUTO, overwrite=True)
-            b64 = base64.b64encode(lvdash_json.encode('utf8'))
-            self._ws.workspace.import_(f'{self._state.install_folder()}/{step_folder.name}.lvdash.json',
-                                       content=b64.decode('utf8'),
-                                       format=ImportFormat.AUTO,
-                                       overwrite=True)
-            print(1)
+                dash = lakeview.Dashboard(datasets, pages)
+                lvdash_json = json.dumps(dash.as_dict(), indent=2)
+                self._ws.workspace.upload(f'{self._state.install_folder()}/{dashboard_ref}.lvdash.json', lvdash_json, format=ImportFormat.AUTO, overwrite=True)
+                print(1)
 
     def validate(self):
         step_folders = [f for f in self._local_folder.glob("*") if f.is_dir()]

--- a/src/databricks/labs/ucx/framework/lakeview/.codegen.json
+++ b/src/databricks/labs/ucx/framework/lakeview/.codegen.json
@@ -1,0 +1,6 @@
+{
+  "formatter": "../../../../../../.venv/bin/black .",
+  "batch": {
+    "model.py.tmpl": "model.py"
+  }
+}

--- a/src/databricks/labs/ucx/framework/lakeview/.codegen.json
+++ b/src/databricks/labs/ucx/framework/lakeview/.codegen.json
@@ -1,5 +1,5 @@
 {
-  "formatter": "../../../../../../.venv/bin/black .",
+  "formatter": "../../../../../../.venv/bin/black . && ../../../../../../.venv/bin/ruff . --fix",
   "batch": {
     "model.py.tmpl": "model.py"
   }

--- a/src/databricks/labs/ucx/framework/lakeview/__init__.py
+++ b/src/databricks/labs/ucx/framework/lakeview/__init__.py
@@ -1,0 +1,1 @@
+from .model import *

--- a/src/databricks/labs/ucx/framework/lakeview/model.py
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py
@@ -1256,7 +1256,6 @@ class RenderFieldEncoding:
         return cls(display_name=d.get('displayName', None), field_name=d.get('fieldName', None))
 
 
-@dataclass
 class Scale:
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> CategoricalScale | QuantitativeScale | TemporalScale:
@@ -1859,7 +1858,6 @@ class WidgetFrameSpec:
         )
 
 
-@dataclass
 class WidgetSpec:
     @classmethod
     def from_dict(

--- a/src/databricks/labs/ucx/framework/lakeview/model.py
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py
@@ -1,20 +1,24 @@
 # Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 
 from __future__ import annotations
+
 from dataclasses import dataclass
-from datetime import timedelta
 from enum import Enum
-from typing import Dict, List, Any, Iterator, Type, Callable, Optional, BinaryIO
-import time
-import random
-import logging
-from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
+from typing import Any
+
+from databricks.sdk.service._internal import (
+    _enum,
+    _from_dict,
+    _repeated_dict,
+)
+
+Json = dict[str, Any]
 
 
 class Alignment(Enum):
-    CENTER = 'center'
-    LEFT = 'left'
-    RIGHT = 'right'
+    CENTER = "center"
+    LEFT = "left"
+    RIGHT = "right"
 
 
 @dataclass
@@ -22,17 +26,17 @@ class AngleAxisSpec:
     hide_title: bool | None = None
     title: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.hide_title is not None:
-            body['hideTitle'] = self.hide_title
+            body["hideTitle"] = self.hide_title
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> AngleAxisSpec:
-        return cls(hide_title=d.get('hideTitle', None), title=d.get('title', None))
+    def from_dict(cls, d: Json) -> AngleAxisSpec:
+        return cls(hide_title=d.get("hideTitle", None), title=d.get("title", None))
 
 
 @dataclass
@@ -42,25 +46,25 @@ class AngleFieldEncoding:
     axis: AngleAxisSpec | None = None
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.axis:
-            body['axis'] = self.axis.as_dict()
+            body["axis"] = self.axis.as_dict()
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.scale:
-            body['scale'] = self.scale.as_dict()
+            body["scale"] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> AngleFieldEncoding:
+    def from_dict(cls, d: Json) -> AngleFieldEncoding:
         return cls(
-            axis=_from_dict(d, 'axis', AngleAxisSpec),
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            scale=_from_dict(d, 'scale', QuantitativeScale),
+            axis=_from_dict(d, "axis", AngleAxisSpec),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            scale=_from_dict(d, "scale", QuantitativeScale),
         )
 
 
@@ -73,28 +77,28 @@ class AreaSpec:
     frame: WidgetFrameSpec | None = None
     mark: MarkSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'area',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "area",
         }
         if self.encodings:
-            body['encodings'] = self.encodings
+            body["encodings"] = self.encodings
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.mark:
-            body['mark'] = self.mark.as_dict()
+            body["mark"] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> AreaSpec:
+    def from_dict(cls, d: Json) -> AreaSpec:
         return cls(
-            encodings=d.get('encodings', None),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            mark=_from_dict(d, 'mark', MarkSpec),
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
         )
 
 
@@ -104,20 +108,20 @@ class AxisSpec:
     hide_title: bool | None = None
     title: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.hide_labels is not None:
-            body['hideLabels'] = self.hide_labels
+            body["hideLabels"] = self.hide_labels
         if self.hide_title is not None:
-            body['hideTitle'] = self.hide_title
+            body["hideTitle"] = self.hide_title
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> AxisSpec:
+    def from_dict(cls, d: Json) -> AxisSpec:
         return cls(
-            hide_labels=d.get('hideLabels', None), hide_title=d.get('hideTitle', None), title=d.get('title', None)
+            hide_labels=d.get("hideLabels", None), hide_title=d.get("hideTitle", None), title=d.get("title", None)
         )
 
 
@@ -130,28 +134,28 @@ class BarSpec:
     frame: WidgetFrameSpec | None = None
     mark: MarkSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'bar',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "bar",
         }
         if self.encodings:
-            body['encodings'] = self.encodings
+            body["encodings"] = self.encodings
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.mark:
-            body['mark'] = self.mark.as_dict()
+            body["mark"] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> BarSpec:
+    def from_dict(cls, d: Json) -> BarSpec:
         return cls(
-            encodings=d.get('encodings', None),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            mark=_from_dict(d, 'mark', MarkSpec),
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
         )
 
 
@@ -160,38 +164,38 @@ class CategoricalColorScaleMappingEntry:
     value: DataDomainValue
     color: str
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.color is not None:
-            body['color'] = self.color
+            body["color"] = self.color
         if self.value is not None:
-            body['value'] = self.value.value
+            body["value"] = self.value.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CategoricalColorScaleMappingEntry:
-        return cls(color=d.get('color', None), value=_enum(d, 'value', DataDomainValue))
+    def from_dict(cls, d: Json) -> CategoricalColorScaleMappingEntry:
+        return cls(color=d.get("color", None), value=_enum(d, "value", DataDomainValue))
 
 
 @dataclass
 class CategoricalScale:
-    mappings: List[CategoricalColorScaleMappingEntry] | None = None
+    mappings: list[CategoricalColorScaleMappingEntry] | None = None
     sort: Sort | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'type': 'categorical',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "type": "categorical",
         }
         if self.mappings:
-            body['mappings'] = [v.as_dict() for v in self.mappings]
+            body["mappings"] = [v.as_dict() for v in self.mappings]
         if self.sort:
-            body['sort'] = self.sort.as_dict()
+            body["sort"] = self.sort.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CategoricalScale:
+    def from_dict(cls, d: Json) -> CategoricalScale:
         return cls(
-            mappings=_repeated_dict(d, 'mappings', CategoricalColorScaleMappingEntry), sort=_from_dict(d, 'sort', Sort)
+            mappings=_repeated_dict(d, "mappings", CategoricalColorScaleMappingEntry), sort=_from_dict(d, "sort", Sort)
         )
 
 
@@ -202,25 +206,25 @@ class ChartEncodingMapWithMultiX:
     label: LabelEncoding | None = None
     y: SingleFieldAxisEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.color:
-            body['color'] = self.color.as_dict()
+            body["color"] = self.color.as_dict()
         if self.label:
-            body['label'] = self.label.as_dict()
+            body["label"] = self.label.as_dict()
         if self.x:
-            body['x'] = self.x.as_dict()
+            body["x"] = self.x.as_dict()
         if self.y:
-            body['y'] = self.y.as_dict()
+            body["y"] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithMultiX:
+    def from_dict(cls, d: Json) -> ChartEncodingMapWithMultiX:
         return cls(
-            color=_from_dict(d, 'color', ColorEncodingForMultiSeries),
-            label=_from_dict(d, 'label', LabelEncoding),
-            x=_from_dict(d, 'x', MultiFieldAxisEncoding),
-            y=_from_dict(d, 'y', SingleFieldAxisEncoding),
+            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", MultiFieldAxisEncoding),
+            y=_from_dict(d, "y", SingleFieldAxisEncoding),
         )
 
 
@@ -231,54 +235,54 @@ class ChartEncodingMapWithMultiY:
     label: LabelEncoding | None = None
     x: SingleFieldAxisEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.color:
-            body['color'] = self.color.as_dict()
+            body["color"] = self.color.as_dict()
         if self.label:
-            body['label'] = self.label.as_dict()
+            body["label"] = self.label.as_dict()
         if self.x:
-            body['x'] = self.x.as_dict()
+            body["x"] = self.x.as_dict()
         if self.y:
-            body['y'] = self.y.as_dict()
+            body["y"] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithMultiY:
+    def from_dict(cls, d: Json) -> ChartEncodingMapWithMultiY:
         return cls(
-            color=_from_dict(d, 'color', ColorEncodingForMultiSeries),
-            label=_from_dict(d, 'label', LabelEncoding),
-            x=_from_dict(d, 'x', SingleFieldAxisEncoding),
-            y=_from_dict(d, 'y', MultiFieldAxisEncoding),
+            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", SingleFieldAxisEncoding),
+            y=_from_dict(d, "y", MultiFieldAxisEncoding),
         )
 
 
 @dataclass
 class ChartEncodingMapWithSingleXy:
+    x: SingleFieldAxisEncoding
     color: ColorFieldEncoding | None = None
     label: LabelEncoding | None = None
-    x: SingleFieldAxisEncoding | None = None
     y: SingleFieldAxisEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.color:
-            body['color'] = self.color.as_dict()
+            body["color"] = self.color.as_dict()
         if self.label:
-            body['label'] = self.label.as_dict()
+            body["label"] = self.label.as_dict()
         if self.x:
-            body['x'] = self.x.as_dict()
+            body["x"] = self.x.as_dict()
         if self.y:
-            body['y'] = self.y.as_dict()
+            body["y"] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithSingleXy:
+    def from_dict(cls, d: Json) -> ChartEncodingMapWithSingleXy:
         return cls(
-            color=_from_dict(d, 'color', ColorFieldEncoding),
-            label=_from_dict(d, 'label', LabelEncoding),
-            x=_from_dict(d, 'x', SingleFieldAxisEncoding),
-            y=_from_dict(d, 'y', SingleFieldAxisEncoding),
+            color=_from_dict(d, "color", ColorFieldEncoding),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", SingleFieldAxisEncoding),
+            y=_from_dict(d, "y", SingleFieldAxisEncoding),
         )
 
 
@@ -286,15 +290,15 @@ class ChartEncodingMapWithSingleXy:
 class ColorEncodingForMultiSeries:
     legend: LegendSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.legend:
-            body['legend'] = self.legend.as_dict()
+            body["legend"] = self.legend.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ColorEncodingForMultiSeries:
-        return cls(legend=_from_dict(d, 'legend', LegendSpec))
+    def from_dict(cls, d: Json) -> ColorEncodingForMultiSeries:
+        return cls(legend=_from_dict(d, "legend", LegendSpec))
 
 
 @dataclass
@@ -304,52 +308,52 @@ class ColorFieldEncoding:
     display_name: str | None = None
     legend: LegendSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.legend:
-            body['legend'] = self.legend.as_dict()
+            body["legend"] = self.legend.as_dict()
         if self.scale:
-            body['scale'] = self.scale.as_dict()
+            body["scale"] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ColorFieldEncoding:
+    def from_dict(cls, d: Json) -> ColorFieldEncoding:
         return cls(
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            legend=_from_dict(d, 'legend', LegendSpec),
-            scale=_from_dict(d, 'scale', Scale),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            legend=_from_dict(d, "legend", LegendSpec),
+            scale=_from_dict(d, "scale", Scale),
         )
 
 
 class ColumnType(Enum):
-    BOOLEAN = 'boolean'
-    COMPLEX = 'complex'
-    DATE = 'date'
-    DATETIME = 'datetime'
-    DECIMAL = 'decimal'
-    FLOAT = 'float'
-    INTEGER = 'integer'
-    STRING = 'string'
+    BOOLEAN = "boolean"
+    COMPLEX = "complex"
+    DATE = "date"
+    DATETIME = "datetime"
+    DECIMAL = "decimal"
+    FLOAT = "float"
+    INTEGER = "integer"
+    STRING = "string"
 
 
 @dataclass
 class ControlEncodingMap:
     fields: Any | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.fields:
-            body['fields'] = self.fields
+            body["fields"] = self.fields
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ControlEncodingMap:
-        return cls(fields=d.get('fields', None))
+    def from_dict(cls, d: Json) -> ControlEncodingMap:
+        return cls(fields=d.get("fields", None))
 
 
 @dataclass
@@ -357,18 +361,18 @@ class CounterEncodingMap:
     target: CounterFieldEncoding | None = None
     value: CounterFieldEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.target:
-            body['target'] = self.target.as_dict()
+            body["target"] = self.target.as_dict()
         if self.value:
-            body['value'] = self.value.as_dict()
+            body["value"] = self.value.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CounterEncodingMap:
+    def from_dict(cls, d: Json) -> CounterEncodingMap:
         return cls(
-            target=_from_dict(d, 'target', CounterFieldEncoding), value=_from_dict(d, 'value', CounterFieldEncoding)
+            target=_from_dict(d, "target", CounterFieldEncoding), value=_from_dict(d, "value", CounterFieldEncoding)
         )
 
 
@@ -378,22 +382,22 @@ class CounterFieldEncoding:
     display_name: str | None = None
     row_number: int | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.row_number is not None:
-            body['rowNumber'] = self.row_number
+            body["rowNumber"] = self.row_number
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CounterFieldEncoding:
+    def from_dict(cls, d: Json) -> CounterFieldEncoding:
         return cls(
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            row_number=d.get('rowNumber', None),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            row_number=d.get("rowNumber", None),
         )
 
 
@@ -403,51 +407,51 @@ class CounterSpec:
     format: FormatConfig | None = None
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'counter',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "counter",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CounterSpec:
+    def from_dict(cls, d: Json) -> CounterSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', CounterEncodingMap),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            encodings=_from_dict(d, "encodings", CounterEncodingMap),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
         )
 
 
 @dataclass
 class Dashboard:
-    datasets: List[Dataset]
-    pages: List[Page]
+    datasets: list[Dataset]
+    pages: list[Page]
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.datasets:
-            body['datasets'] = [v.as_dict() for v in self.datasets]
+            body["datasets"] = [v.as_dict() for v in self.datasets]
         if self.pages:
-            body['pages'] = [v.as_dict() for v in self.pages]
+            body["pages"] = [v.as_dict() for v in self.pages]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Dashboard:
-        return cls(datasets=_repeated_dict(d, 'datasets', Dataset), pages=_repeated_dict(d, 'pages', Page))
+    def from_dict(cls, d: Json) -> Dashboard:
+        return cls(datasets=_repeated_dict(d, "datasets", Dataset), pages=_repeated_dict(d, "pages", Page))
 
 
 class DataDomainValue(Enum):
-    BOOLEAN = 'boolean'
-    NULL = 'null'
-    NUMBER = 'number'
-    STRING = 'string'
+    BOOLEAN = "boolean"
+    NULL = "null"
+    NUMBER = "number"
+    STRING = "string"
 
 
 @dataclass
@@ -456,19 +460,19 @@ class Dataset:
     query: str
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         if self.query is not None:
-            body['query'] = self.query
+            body["query"] = self.query
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Dataset:
-        return cls(display_name=d.get('displayName', None), name=d.get('name', None), query=d.get('query', None))
+    def from_dict(cls, d: Json) -> Dataset:
+        return cls(display_name=d.get("displayName", None), name=d.get("name", None), query=d.get("query", None))
 
 
 @dataclass
@@ -477,25 +481,25 @@ class DatePickerSpec:
     exclude: bool | None = None
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'filter-date-picker',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "filter-date-picker",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.exclude is not None:
-            body['exclude'] = self.exclude
+            body["exclude"] = self.exclude
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DatePickerSpec:
+    def from_dict(cls, d: Json) -> DatePickerSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
-            exclude=d.get('exclude', None),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
         )
 
 
@@ -505,25 +509,25 @@ class DateRangePickerSpec:
     exclude: bool | None = None
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'filter-date-range-picker',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "filter-date-range-picker",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.exclude is not None:
-            body['exclude'] = self.exclude
+            body["exclude"] = self.exclude
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DateRangePickerSpec:
+    def from_dict(cls, d: Json) -> DateRangePickerSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
-            exclude=d.get('exclude', None),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
         )
 
 
@@ -534,41 +538,41 @@ class DetailsV1ColumnEncoding:
     title: str | None = None
     type: ColumnType | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         if self.type is not None:
-            body['type'] = self.type.value
+            body["type"] = self.type.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1ColumnEncoding:
+    def from_dict(cls, d: Json) -> DetailsV1ColumnEncoding:
         return cls(
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            title=d.get('title', None),
-            type=_enum(d, 'type', ColumnType),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
         )
 
 
 @dataclass
 class DetailsV1EncodingMap:
-    columns: List[DetailsV1ColumnEncoding] | None = None
+    columns: list[DetailsV1ColumnEncoding] | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.columns:
-            body['columns'] = [v.as_dict() for v in self.columns]
+            body["columns"] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1EncodingMap:
-        return cls(columns=_repeated_dict(d, 'columns', DetailsV1ColumnEncoding))
+    def from_dict(cls, d: Json) -> DetailsV1EncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", DetailsV1ColumnEncoding))
 
 
 @dataclass
@@ -576,38 +580,38 @@ class DetailsV1Spec:
     encodings: DetailsV1EncodingMap
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 1,
-            'widgetType': 'details',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 1,
+            "widgetType": "details",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1Spec:
+    def from_dict(cls, d: Json) -> DetailsV1Spec:
         return cls(
-            encodings=_from_dict(d, 'encodings', DetailsV1EncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
+            encodings=_from_dict(d, "encodings", DetailsV1EncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
         )
 
 
 class Direction(Enum):
-    ASC = 'ASC'
-    DESC = 'DESC'
-    DIRECTION_UNSPECIFIED = 'DIRECTION_UNSPECIFIED'
+    ASC = "ASC"
+    DESC = "DESC"
+    DIRECTION_UNSPECIFIED = "DIRECTION_UNSPECIFIED"
 
 
 class DisplayType(Enum):
-    BOOLEAN = 'boolean'
-    DATETIME = 'datetime'
-    IMAGE = 'image'
-    JSON = 'json'
-    LINK = 'link'
-    NUMBER = 'number'
-    STRING = 'string'
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+    IMAGE = "image"
+    JSON = "json"
+    LINK = "link"
+    NUMBER = "number"
+    STRING = "string"
 
 
 @dataclass
@@ -616,25 +620,25 @@ class DropdownSpec:
     exclude: bool | None = None
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'filter-single-select',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "filter-single-select",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.exclude is not None:
-            body['exclude'] = self.exclude
+            body["exclude"] = self.exclude
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> DropdownSpec:
+    def from_dict(cls, d: Json) -> DropdownSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
-            exclude=d.get('exclude', None),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
         )
 
 
@@ -643,17 +647,17 @@ class Field:
     name: str
     expression: str
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.expression is not None:
-            body['expression'] = self.expression
+            body["expression"] = self.expression
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Field:
-        return cls(expression=d.get('expression', None), name=d.get('name', None))
+    def from_dict(cls, d: Json) -> Field:
+        return cls(expression=d.get("expression", None), name=d.get("name", None))
 
 
 @dataclass
@@ -662,22 +666,22 @@ class FieldEncodingWithDataFor:
     query_name: str
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.query_name is not None:
-            body['queryName'] = self.query_name
+            body["queryName"] = self.query_name
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> FieldEncodingWithDataFor:
+    def from_dict(cls, d: Json) -> FieldEncodingWithDataFor:
         return cls(
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            query_name=d.get('queryName', None),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            query_name=d.get("queryName", None),
         )
 
 
@@ -685,15 +689,15 @@ class FieldEncodingWithDataFor:
 class Format:
     foreground_color: str
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.foreground_color is not None:
-            body['foregroundColor'] = self.foreground_color
+            body["foregroundColor"] = self.foreground_color
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Format:
-        return cls(foreground_color=d.get('foregroundColor', None))
+    def from_dict(cls, d: Json) -> Format:
+        return cls(foreground_color=d.get("foregroundColor", None))
 
 
 @dataclass
@@ -702,22 +706,22 @@ class FormatConfig:
     percent_format: NumeralNumberFormat | None = None
     time_format: MomentTimeFormat | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.number_format:
-            body['numberFormat'] = self.number_format.as_dict()
+            body["numberFormat"] = self.number_format.as_dict()
         if self.percent_format:
-            body['percentFormat'] = self.percent_format.as_dict()
+            body["percentFormat"] = self.percent_format.as_dict()
         if self.time_format:
-            body['timeFormat'] = self.time_format.as_dict()
+            body["timeFormat"] = self.time_format.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> FormatConfig:
+    def from_dict(cls, d: Json) -> FormatConfig:
         return cls(
-            number_format=_from_dict(d, 'numberFormat', NumeralNumberFormat),
-            percent_format=_from_dict(d, 'percentFormat', NumeralNumberFormat),
-            time_format=_from_dict(d, 'timeFormat', MomentTimeFormat),
+            number_format=_from_dict(d, "numberFormat", NumeralNumberFormat),
+            percent_format=_from_dict(d, "percentFormat", NumeralNumberFormat),
+            time_format=_from_dict(d, "timeFormat", MomentTimeFormat),
         )
 
 
@@ -725,15 +729,15 @@ class FormatConfig:
 class LabelEncoding:
     show: bool
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.show is not None:
-            body['show'] = self.show
+            body["show"] = self.show
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> LabelEncoding:
-        return cls(show=d.get('show', None))
+    def from_dict(cls, d: Json) -> LabelEncoding:
+        return cls(show=d.get("show", None))
 
 
 @dataclass
@@ -741,17 +745,17 @@ class Layout:
     widget: Widget
     position: Position
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.position:
-            body['position'] = self.position.as_dict()
+            body["position"] = self.position.as_dict()
         if self.widget:
-            body['widget'] = self.widget.as_dict()
+            body["widget"] = self.widget.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Layout:
-        return cls(position=_from_dict(d, 'position', Position), widget=_from_dict(d, 'widget', Widget))
+    def from_dict(cls, d: Json) -> Layout:
+        return cls(position=_from_dict(d, "position", Position), widget=_from_dict(d, "widget", Widget))
 
 
 @dataclass
@@ -760,28 +764,28 @@ class LegendSpec:
     position: LegendSpecPosition | None = None
     title: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.hide_title is not None:
-            body['hideTitle'] = self.hide_title
+            body["hideTitle"] = self.hide_title
         if self.position is not None:
-            body['position'] = self.position.value
+            body["position"] = self.position.value
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> LegendSpec:
+    def from_dict(cls, d: Json) -> LegendSpec:
         return cls(
-            hide_title=d.get('hideTitle', None),
-            position=_enum(d, 'position', LegendSpecPosition),
-            title=d.get('title', None),
+            hide_title=d.get("hideTitle", None),
+            position=_enum(d, "position", LegendSpecPosition),
+            title=d.get("title", None),
         )
 
 
 class LegendSpecPosition(Enum):
-    BOTTOM = 'bottom'
-    RIGHT = 'right'
+    BOTTOM = "bottom"
+    RIGHT = "right"
 
 
 @dataclass
@@ -793,94 +797,94 @@ class LineSpec:
     frame: WidgetFrameSpec | None = None
     mark: MarkSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'line',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "line",
         }
         if self.encodings:
-            body['encodings'] = self.encodings
+            body["encodings"] = self.encodings
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.mark:
-            body['mark'] = self.mark.as_dict()
+            body["mark"] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> LineSpec:
+    def from_dict(cls, d: Json) -> LineSpec:
         return cls(
-            encodings=d.get('encodings', None),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            mark=_from_dict(d, 'mark', MarkSpec),
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
         )
 
 
 class MarkLayout(Enum):
-    GROUP = 'group'
-    LAYER = 'layer'
-    STACK = 'stack'
+    GROUP = "group"
+    LAYER = "layer"
+    STACK = "stack"
 
 
 @dataclass
 class MarkSpec:
-    colors: List[str] | None = None
+    colors: list[str] | None = None
     layout: MarkLayout | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.colors:
-            body['colors'] = [v for v in self.colors]
+            body["colors"] = [v for v in self.colors]
         if self.layout is not None:
-            body['layout'] = self.layout.value
+            body["layout"] = self.layout.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> MarkSpec:
-        return cls(colors=d.get('colors', None), layout=_enum(d, 'layout', MarkLayout))
+    def from_dict(cls, d: Json) -> MarkSpec:
+        return cls(colors=d.get("colors", None), layout=_enum(d, "layout", MarkLayout))
 
 
 @dataclass
 class MomentTimeFormat:
     format: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'formatType': 'moment',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "formatType": "moment",
         }
         if self.format is not None:
-            body['format'] = self.format
+            body["format"] = self.format
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> MomentTimeFormat:
-        return cls(format=d.get('format', None))
+    def from_dict(cls, d: Json) -> MomentTimeFormat:
+        return cls(format=d.get("format", None))
 
 
 @dataclass
 class MultiFieldAxisEncoding:
-    fields: List[RenderFieldEncoding]
+    fields: list[RenderFieldEncoding]
     scale: QuantitativeScale
     axis: AxisSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.axis:
-            body['axis'] = self.axis.as_dict()
+            body["axis"] = self.axis.as_dict()
         if self.fields:
-            body['fields'] = [v.as_dict() for v in self.fields]
+            body["fields"] = [v.as_dict() for v in self.fields]
         if self.scale:
-            body['scale'] = self.scale.as_dict()
+            body["scale"] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> MultiFieldAxisEncoding:
+    def from_dict(cls, d: Json) -> MultiFieldAxisEncoding:
         return cls(
-            axis=_from_dict(d, 'axis', AxisSpec),
-            fields=_repeated_dict(d, 'fields', RenderFieldEncoding),
-            scale=_from_dict(d, 'scale', QuantitativeScale),
+            axis=_from_dict(d, "axis", AxisSpec),
+            fields=_repeated_dict(d, "fields", RenderFieldEncoding),
+            scale=_from_dict(d, "scale", QuantitativeScale),
         )
 
 
@@ -890,25 +894,25 @@ class MultiSelectSpec:
     exclude: bool | None = None
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'filter-multi-select',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "filter-multi-select",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.exclude is not None:
-            body['exclude'] = self.exclude
+            body["exclude"] = self.exclude
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> MultiSelectSpec:
+    def from_dict(cls, d: Json) -> MultiSelectSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
-            exclude=d.get('exclude', None),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
         )
 
 
@@ -917,34 +921,34 @@ class NamedQuery:
     name: str
     query: Order
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         if self.query:
-            body['query'] = self.query.as_dict()
+            body["query"] = self.query.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> NamedQuery:
-        return cls(name=d.get('name', None), query=_from_dict(d, 'query', Order))
+    def from_dict(cls, d: Json) -> NamedQuery:
+        return cls(name=d.get("name", None), query=_from_dict(d, "query", Order))
 
 
 @dataclass
 class NumeralNumberFormat:
     format: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'formatType': 'numeral',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "formatType": "numeral",
         }
         if self.format is not None:
-            body['format'] = self.format
+            body["format"] = self.format
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> NumeralNumberFormat:
-        return cls(format=d.get('format', None))
+    def from_dict(cls, d: Json) -> NumeralNumberFormat:
+        return cls(format=d.get("format", None))
 
 
 @dataclass
@@ -952,47 +956,47 @@ class Order:
     direction: Direction | None = None
     expression: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.direction is not None:
-            body['direction'] = self.direction.value
+            body["direction"] = self.direction.value
         if self.expression is not None:
-            body['expression'] = self.expression
+            body["expression"] = self.expression
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Order:
-        return cls(direction=_enum(d, 'direction', Direction), expression=d.get('expression', None))
+    def from_dict(cls, d: Json) -> Order:
+        return cls(direction=_enum(d, "direction", Direction), expression=d.get("expression", None))
 
 
 @dataclass
 class Page:
     name: str
-    layout: List[Layout]
+    layout: list[Layout]
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.layout:
-            body['layout'] = [v.as_dict() for v in self.layout]
+            body["layout"] = [v.as_dict() for v in self.layout]
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Page:
+    def from_dict(cls, d: Json) -> Page:
         return cls(
-            display_name=d.get('displayName', None),
-            layout=_repeated_dict(d, 'layout', Layout),
-            name=d.get('name', None),
+            display_name=d.get("displayName", None),
+            layout=_repeated_dict(d, "layout", Layout),
+            name=d.get("name", None),
         )
 
 
 class PaginationSize(Enum):
-    DEFAULT = 'default'
-    SMALL = 'small'
+    DEFAULT = "default"
+    SMALL = "small"
 
 
 @dataclass
@@ -1000,17 +1004,17 @@ class ParameterEncoding:
     dataset_name: str
     parameter_keyword: str
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.dataset_name is not None:
-            body['datasetName'] = self.dataset_name
+            body["datasetName"] = self.dataset_name
         if self.parameter_keyword is not None:
-            body['parameterKeyword'] = self.parameter_keyword
+            body["parameterKeyword"] = self.parameter_keyword
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ParameterEncoding:
-        return cls(dataset_name=d.get('datasetName', None), parameter_keyword=d.get('parameterKeyword', None))
+    def from_dict(cls, d: Json) -> ParameterEncoding:
+        return cls(dataset_name=d.get("datasetName", None), parameter_keyword=d.get("parameterKeyword", None))
 
 
 @dataclass
@@ -1019,22 +1023,22 @@ class PieEncodingMap:
     color: ColorFieldEncoding | None = None
     label: LabelEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.angle:
-            body['angle'] = self.angle.as_dict()
+            body["angle"] = self.angle.as_dict()
         if self.color:
-            body['color'] = self.color.as_dict()
+            body["color"] = self.color.as_dict()
         if self.label:
-            body['label'] = self.label.as_dict()
+            body["label"] = self.label.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> PieEncodingMap:
+    def from_dict(cls, d: Json) -> PieEncodingMap:
         return cls(
-            angle=_from_dict(d, 'angle', AngleFieldEncoding),
-            color=_from_dict(d, 'color', ColorFieldEncoding),
-            label=_from_dict(d, 'label', LabelEncoding),
+            angle=_from_dict(d, "angle", AngleFieldEncoding),
+            color=_from_dict(d, "color", ColorFieldEncoding),
+            label=_from_dict(d, "label", LabelEncoding),
         )
 
 
@@ -1045,28 +1049,28 @@ class PieSpec:
     frame: WidgetFrameSpec | None = None
     mark: MarkSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'pie',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "pie",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.mark:
-            body['mark'] = self.mark.as_dict()
+            body["mark"] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> PieSpec:
+    def from_dict(cls, d: Json) -> PieSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', PieEncodingMap),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            mark=_from_dict(d, 'mark', MarkSpec),
+            encodings=_from_dict(d, "encodings", PieEncodingMap),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
         )
 
 
@@ -1075,43 +1079,43 @@ class PivotCellEncoding:
     field_name: str
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'cellType': 'text',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "cellType": "text",
         }
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> PivotCellEncoding:
-        return cls(display_name=d.get('displayName', None), field_name=d.get('fieldName', None))
+    def from_dict(cls, d: Json) -> PivotCellEncoding:
+        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
 
 
 @dataclass
 class PivotEncodingMap:
     cell: PivotCellEncoding | None = None
-    columns: List[RenderFieldEncoding] | None = None
-    rows: List[RenderFieldEncoding] | None = None
+    columns: list[RenderFieldEncoding] | None = None
+    rows: list[RenderFieldEncoding] | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.cell:
-            body['cell'] = self.cell.as_dict()
+            body["cell"] = self.cell.as_dict()
         if self.columns:
-            body['columns'] = [v.as_dict() for v in self.columns]
+            body["columns"] = [v.as_dict() for v in self.columns]
         if self.rows:
-            body['rows'] = [v.as_dict() for v in self.rows]
+            body["rows"] = [v.as_dict() for v in self.rows]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> PivotEncodingMap:
+    def from_dict(cls, d: Json) -> PivotEncodingMap:
         return cls(
-            cell=_from_dict(d, 'cell', PivotCellEncoding),
-            columns=_repeated_dict(d, 'columns', RenderFieldEncoding),
-            rows=_repeated_dict(d, 'rows', RenderFieldEncoding),
+            cell=_from_dict(d, "cell", PivotCellEncoding),
+            columns=_repeated_dict(d, "columns", RenderFieldEncoding),
+            rows=_repeated_dict(d, "rows", RenderFieldEncoding),
         )
 
 
@@ -1120,21 +1124,21 @@ class PivotSpec:
     encodings: PivotEncodingMap
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'pivot',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "pivot",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> PivotSpec:
+    def from_dict(cls, d: Json) -> PivotSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', PivotEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
+            encodings=_from_dict(d, "encodings", PivotEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
         )
 
 
@@ -1145,21 +1149,21 @@ class Position:
     width: int
     height: int
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.height is not None:
-            body['height'] = self.height
+            body["height"] = self.height
         if self.width is not None:
-            body['width'] = self.width
+            body["width"] = self.width
         if self.x is not None:
-            body['x'] = self.x
+            body["x"] = self.x
         if self.y is not None:
-            body['y'] = self.y
+            body["y"] = self.y
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Position:
-        return cls(height=d.get('height', None), width=d.get('width', None), x=d.get('x', None), y=d.get('y', None))
+    def from_dict(cls, d: Json) -> Position:
+        return cls(height=d.get("height", None), width=d.get("width", None), x=d.get("x", None), y=d.get("y", None))
 
 
 @dataclass
@@ -1167,17 +1171,17 @@ class QuantitativeDomain:
     max: int | None = None
     min: int | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.max is not None:
-            body['max'] = self.max
+            body["max"] = self.max
         if self.min is not None:
-            body['min'] = self.min
+            body["min"] = self.min
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> QuantitativeDomain:
-        return cls(max=d.get('max', None), min=d.get('min', None))
+    def from_dict(cls, d: Json) -> QuantitativeDomain:
+        return cls(max=d.get("max", None), min=d.get("min", None))
 
 
 @dataclass
@@ -1192,47 +1196,47 @@ class QuantitativeScale:
     mapped to x=0 and domainMax is mapped to x=width. If reverse = true, domainMin is mapped to
     x=width and domainMax is mapped to x=0."""
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'type': 'quantitative',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "type": "quantitative",
         }
         if self.domain:
-            body['domain'] = self.domain.as_dict()
+            body["domain"] = self.domain.as_dict()
         if self.reverse is not None:
-            body['reverse'] = self.reverse
+            body["reverse"] = self.reverse
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> QuantitativeScale:
-        return cls(domain=_from_dict(d, 'domain', QuantitativeDomain), reverse=d.get('reverse', None))
+    def from_dict(cls, d: Json) -> QuantitativeScale:
+        return cls(domain=_from_dict(d, "domain", QuantitativeDomain), reverse=d.get("reverse", None))
 
 
 @dataclass
 class Query:
     dataset_name: str
-    fields: List[Field]
+    fields: list[Field]
     disaggregated: bool | None = None
-    orders: List[Order] | None = None
+    orders: list[Order] | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.dataset_name is not None:
-            body['datasetName'] = self.dataset_name
+            body["datasetName"] = self.dataset_name
         if self.disaggregated is not None:
-            body['disaggregated'] = self.disaggregated
+            body["disaggregated"] = self.disaggregated
         if self.fields:
-            body['fields'] = [v.as_dict() for v in self.fields]
+            body["fields"] = [v.as_dict() for v in self.fields]
         if self.orders:
-            body['orders'] = [v.as_dict() for v in self.orders]
+            body["orders"] = [v.as_dict() for v in self.orders]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Query:
+    def from_dict(cls, d: Json) -> Query:
         return cls(
-            dataset_name=d.get('datasetName', None),
-            disaggregated=d.get('disaggregated', None),
-            fields=_repeated_dict(d, 'fields', Field),
-            orders=_repeated_dict(d, 'orders', Order),
+            dataset_name=d.get("datasetName", None),
+            disaggregated=d.get("disaggregated", None),
+            fields=_repeated_dict(d, "fields", Field),
+            orders=_repeated_dict(d, "orders", Order),
         )
 
 
@@ -1243,27 +1247,27 @@ class RenderFieldEncoding:
     field_name: str
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> RenderFieldEncoding:
-        return cls(display_name=d.get('displayName', None), field_name=d.get('fieldName', None))
+    def from_dict(cls, d: Json) -> RenderFieldEncoding:
+        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
 
 
 class Scale:
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> CategoricalScale | QuantitativeScale | TemporalScale:
-        if 'type' == 'categorical':
+    def from_dict(cls, d: Json) -> CategoricalScale | QuantitativeScale | TemporalScale:
+        if d["type"] == "categorical":
             return CategoricalScale.from_dict(d)
-        elif 'type' == 'quantitative':
+        elif d["type"] == "quantitative":
             return QuantitativeScale.from_dict(d)
-        elif 'type' == 'temporal':
+        elif d["type"] == "temporal":
             return TemporalScale.from_dict(d)
         else:
             raise KeyError(...)
@@ -1278,28 +1282,28 @@ class ScatterSpec:
     frame: WidgetFrameSpec | None = None
     mark: MarkSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 3,
-            'widgetType': 'scatter',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 3,
+            "widgetType": "scatter",
         }
         if self.encodings:
-            body['encodings'] = self.encodings
+            body["encodings"] = self.encodings
         if self.format:
-            body['format'] = self.format.as_dict()
+            body["format"] = self.format.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.mark:
-            body['mark'] = self.mark.as_dict()
+            body["mark"] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> ScatterSpec:
+    def from_dict(cls, d: Json) -> ScatterSpec:
         return cls(
-            encodings=d.get('encodings', None),
-            format=_from_dict(d, 'format', FormatConfig),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            mark=_from_dict(d, 'mark', MarkSpec),
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
         )
 
 
@@ -1310,25 +1314,25 @@ class SingleFieldAxisEncoding:
     axis: AxisSpec | None = None
     display_name: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.axis:
-            body['axis'] = self.axis.as_dict()
+            body["axis"] = self.axis.as_dict()
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.scale:
-            body['scale'] = self.scale.as_dict()
+            body["scale"] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> SingleFieldAxisEncoding:
+    def from_dict(cls, d: Json) -> SingleFieldAxisEncoding:
         return cls(
-            axis=_from_dict(d, 'axis', AxisSpec),
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            scale=_from_dict(d, 'scale', Scale),
+            axis=_from_dict(d, "axis", AxisSpec),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            scale=_from_dict(d, "scale", Scale),
         )
 
 
@@ -1336,24 +1340,24 @@ class SingleFieldAxisEncoding:
 class Sort:
     by: SortBy
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.by is not None:
-            body['by'] = self.by.value
+            body["by"] = self.by.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Sort:
-        return cls(by=_enum(d, 'by', SortBy))
+    def from_dict(cls, d: Json) -> Sort:
+        return cls(by=_enum(d, "by", SortBy))
 
 
 class SortBy(Enum):
-    NATURAL_ORDER = 'natural-order'
-    NATURAL_ORDER_REVERSED = 'natural-order-reversed'
-    X = 'x'
-    X_REVERSED = 'x-reversed'
-    Y = 'y'
-    Y_REVERSED = 'y-reversed'
+    NATURAL_ORDER = "natural-order"
+    NATURAL_ORDER_REVERSED = "natural-order-reversed"
+    X = "x"
+    X_REVERSED = "x-reversed"
+    Y = "y"
+    Y_REVERSED = "y-reversed"
 
 
 @dataclass
@@ -1361,19 +1365,19 @@ class SymbolMapEncodingMap:
     latitude: RenderFieldEncoding | None = None
     longitude: RenderFieldEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.latitude:
-            body['latitude'] = self.latitude.as_dict()
+            body["latitude"] = self.latitude.as_dict()
         if self.longitude:
-            body['longitude'] = self.longitude.as_dict()
+            body["longitude"] = self.longitude.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> SymbolMapEncodingMap:
+    def from_dict(cls, d: Json) -> SymbolMapEncodingMap:
         return cls(
-            latitude=_from_dict(d, 'latitude', RenderFieldEncoding),
-            longitude=_from_dict(d, 'longitude', RenderFieldEncoding),
+            latitude=_from_dict(d, "latitude", RenderFieldEncoding),
+            longitude=_from_dict(d, "longitude", RenderFieldEncoding),
         )
 
 
@@ -1382,37 +1386,37 @@ class SymbolMapSpec:
     encodings: SymbolMapEncodingMap
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'symbol-map',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "symbol-map",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> SymbolMapSpec:
+    def from_dict(cls, d: Json) -> SymbolMapSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', SymbolMapEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
+            encodings=_from_dict(d, "encodings", SymbolMapEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
         )
 
 
 @dataclass
 class TableEncodingMap:
-    columns: List[RenderFieldEncoding] | None = None
+    columns: list[RenderFieldEncoding] | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.columns:
-            body['columns'] = [v.as_dict() for v in self.columns]
+            body["columns"] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableEncodingMap:
-        return cls(columns=_repeated_dict(d, 'columns', RenderFieldEncoding))
+    def from_dict(cls, d: Json) -> TableEncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", RenderFieldEncoding))
 
 
 @dataclass
@@ -1420,7 +1424,7 @@ class TableV1ColumnEncoding:
     """FieldEncoding for TableV1. Note that `visible?` is true by default, which is `false` in the
     legacy v1 table."""
 
-    boolean_values: List[str]
+    boolean_values: list[str]
     display_as: DisplayType
     field_name: str
     title: str
@@ -1448,111 +1452,111 @@ class TableV1ColumnEncoding:
     use_monospace_font: bool | None = None
     visible: bool | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.align_content is not None:
-            body['alignContent'] = self.align_content.value
+            body["alignContent"] = self.align_content.value
         if self.allow_html is not None:
-            body['allowHTML'] = self.allow_html
+            body["allowHTML"] = self.allow_html
         if self.allow_search is not None:
-            body['allowSearch'] = self.allow_search
+            body["allowSearch"] = self.allow_search
         if self.boolean_values:
-            body['booleanValues'] = [v for v in self.boolean_values]
+            body["booleanValues"] = [v for v in self.boolean_values]
         if self.date_time_format is not None:
-            body['dateTimeFormat'] = self.date_time_format
+            body["dateTimeFormat"] = self.date_time_format
         if self.decimal_format is not None:
-            body['decimalFormat'] = self.decimal_format
+            body["decimalFormat"] = self.decimal_format
         if self.default_column_width is not None:
-            body['defaultColumnWidth'] = self.default_column_width
+            body["defaultColumnWidth"] = self.default_column_width
         if self.description is not None:
-            body['description'] = self.description
+            body["description"] = self.description
         if self.display_as is not None:
-            body['displayAs'] = self.display_as.value
+            body["displayAs"] = self.display_as.value
         if self.display_name is not None:
-            body['displayName'] = self.display_name
+            body["displayName"] = self.display_name
         if self.field_name is not None:
-            body['fieldName'] = self.field_name
+            body["fieldName"] = self.field_name
         if self.highlight_links is not None:
-            body['highlightLinks'] = self.highlight_links
+            body["highlightLinks"] = self.highlight_links
         if self.image_height is not None:
-            body['imageHeight'] = self.image_height
+            body["imageHeight"] = self.image_height
         if self.image_title_template is not None:
-            body['imageTitleTemplate'] = self.image_title_template
+            body["imageTitleTemplate"] = self.image_title_template
         if self.image_url_template is not None:
-            body['imageUrlTemplate'] = self.image_url_template
+            body["imageUrlTemplate"] = self.image_url_template
         if self.image_width is not None:
-            body['imageWidth'] = self.image_width
+            body["imageWidth"] = self.image_width
         if self.link_open_in_new_tab is not None:
-            body['linkOpenInNewTab'] = self.link_open_in_new_tab
+            body["linkOpenInNewTab"] = self.link_open_in_new_tab
         if self.link_text_template is not None:
-            body['linkTextTemplate'] = self.link_text_template
+            body["linkTextTemplate"] = self.link_text_template
         if self.link_title_template is not None:
-            body['linkTitleTemplate'] = self.link_title_template
+            body["linkTitleTemplate"] = self.link_title_template
         if self.link_url_template is not None:
-            body['linkUrlTemplate'] = self.link_url_template
+            body["linkUrlTemplate"] = self.link_url_template
         if self.number_format is not None:
-            body['numberFormat'] = self.number_format
+            body["numberFormat"] = self.number_format
         if self.order is not None:
-            body['order'] = self.order
+            body["order"] = self.order
         if self.preserve_whitespace is not None:
-            body['preserveWhitespace'] = self.preserve_whitespace
+            body["preserveWhitespace"] = self.preserve_whitespace
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         if self.type is not None:
-            body['type'] = self.type.value
+            body["type"] = self.type.value
         if self.use_monospace_font is not None:
-            body['useMonospaceFont'] = self.use_monospace_font
+            body["useMonospaceFont"] = self.use_monospace_font
         if self.visible is not None:
-            body['visible'] = self.visible
+            body["visible"] = self.visible
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableV1ColumnEncoding:
+    def from_dict(cls, d: Json) -> TableV1ColumnEncoding:
         return cls(
-            align_content=_enum(d, 'alignContent', Alignment),
-            allow_html=d.get('allowHTML', None),
-            allow_search=d.get('allowSearch', None),
-            boolean_values=d.get('booleanValues', None),
-            date_time_format=d.get('dateTimeFormat', None),
-            decimal_format=d.get('decimalFormat', None),
-            default_column_width=d.get('defaultColumnWidth', None),
-            description=d.get('description', None),
-            display_as=_enum(d, 'displayAs', DisplayType),
-            display_name=d.get('displayName', None),
-            field_name=d.get('fieldName', None),
-            highlight_links=d.get('highlightLinks', None),
-            image_height=d.get('imageHeight', None),
-            image_title_template=d.get('imageTitleTemplate', None),
-            image_url_template=d.get('imageUrlTemplate', None),
-            image_width=d.get('imageWidth', None),
-            link_open_in_new_tab=d.get('linkOpenInNewTab', None),
-            link_text_template=d.get('linkTextTemplate', None),
-            link_title_template=d.get('linkTitleTemplate', None),
-            link_url_template=d.get('linkUrlTemplate', None),
-            number_format=d.get('numberFormat', None),
-            order=d.get('order', None),
-            preserve_whitespace=d.get('preserveWhitespace', None),
-            title=d.get('title', None),
-            type=_enum(d, 'type', ColumnType),
-            use_monospace_font=d.get('useMonospaceFont', None),
-            visible=d.get('visible', None),
+            align_content=_enum(d, "alignContent", Alignment),
+            allow_html=d.get("allowHTML", None),
+            allow_search=d.get("allowSearch", None),
+            boolean_values=d.get("booleanValues", None),
+            date_time_format=d.get("dateTimeFormat", None),
+            decimal_format=d.get("decimalFormat", None),
+            default_column_width=d.get("defaultColumnWidth", None),
+            description=d.get("description", None),
+            display_as=_enum(d, "displayAs", DisplayType),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            highlight_links=d.get("highlightLinks", None),
+            image_height=d.get("imageHeight", None),
+            image_title_template=d.get("imageTitleTemplate", None),
+            image_url_template=d.get("imageUrlTemplate", None),
+            image_width=d.get("imageWidth", None),
+            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
+            link_text_template=d.get("linkTextTemplate", None),
+            link_title_template=d.get("linkTitleTemplate", None),
+            link_url_template=d.get("linkUrlTemplate", None),
+            number_format=d.get("numberFormat", None),
+            order=d.get("order", None),
+            preserve_whitespace=d.get("preserveWhitespace", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
+            use_monospace_font=d.get("useMonospaceFont", None),
+            visible=d.get("visible", None),
         )
 
 
 @dataclass
 class TableV1EncodingMap:
-    columns: List[TableV1ColumnEncoding] | None = None
+    columns: list[TableV1ColumnEncoding] | None = None
     """Used columns. These columns are visible or used for search."""
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.columns:
-            body['columns'] = [v.as_dict() for v in self.columns]
+            body["columns"] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableV1EncodingMap:
-        return cls(columns=_repeated_dict(d, 'columns', TableV1ColumnEncoding))
+    def from_dict(cls, d: Json) -> TableV1EncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", TableV1ColumnEncoding))
 
 
 @dataclass
@@ -1561,7 +1565,7 @@ class TableV1Spec:
     """V1 uses `version` to determine if the v1 editor should set `allowHTML` by default."""
     condensed: bool
     encodings: TableV1EncodingMap
-    invisible_columns: List[TableV1SpecInvisibleColumnsItem]
+    invisible_columns: list[TableV1SpecInvisibleColumnsItem]
     """Unused columns. These columns are invisible and not referred, and thus should not be include in
     the queries (be outside of `encodings`). Even when the base query changes not to include these
     columns, the table still can work without throwing errors."""
@@ -1570,40 +1574,40 @@ class TableV1Spec:
     pagination_size: PaginationSize | None = None
     with_row_number: bool | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 1,
-            'widgetType': 'table',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 1,
+            "widgetType": "table",
         }
         if self.allow_html_by_default is not None:
-            body['allowHTMLByDefault'] = self.allow_html_by_default
+            body["allowHTMLByDefault"] = self.allow_html_by_default
         if self.condensed is not None:
-            body['condensed'] = self.condensed
+            body["condensed"] = self.condensed
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.invisible_columns:
-            body['invisibleColumns'] = [v.as_dict() for v in self.invisible_columns]
+            body["invisibleColumns"] = [v.as_dict() for v in self.invisible_columns]
         if self.items_per_page is not None:
-            body['itemsPerPage'] = self.items_per_page
+            body["itemsPerPage"] = self.items_per_page
         if self.pagination_size is not None:
-            body['paginationSize'] = self.pagination_size.value
+            body["paginationSize"] = self.pagination_size.value
         if self.with_row_number is not None:
-            body['withRowNumber'] = self.with_row_number
+            body["withRowNumber"] = self.with_row_number
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableV1Spec:
+    def from_dict(cls, d: Json) -> TableV1Spec:
         return cls(
-            allow_html_by_default=d.get('allowHTMLByDefault', None),
-            condensed=d.get('condensed', None),
-            encodings=_from_dict(d, 'encodings', TableV1EncodingMap),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            invisible_columns=_repeated_dict(d, 'invisibleColumns', TableV1SpecInvisibleColumnsItem),
-            items_per_page=d.get('itemsPerPage', None),
-            pagination_size=_enum(d, 'paginationSize', PaginationSize),
-            with_row_number=d.get('withRowNumber', None),
+            allow_html_by_default=d.get("allowHTMLByDefault", None),
+            condensed=d.get("condensed", None),
+            encodings=_from_dict(d, "encodings", TableV1EncodingMap),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            invisible_columns=_repeated_dict(d, "invisibleColumns", TableV1SpecInvisibleColumnsItem),
+            items_per_page=d.get("itemsPerPage", None),
+            pagination_size=_enum(d, "paginationSize", PaginationSize),
+            with_row_number=d.get("withRowNumber", None),
         )
 
 
@@ -1613,7 +1617,7 @@ class TableV1SpecInvisibleColumnsItem:
     display_as: DisplayType
     type: ColumnType
     title: str
-    boolean_values: List[str]
+    boolean_values: list[str]
     align_content: Alignment | None = None
     allow_html: bool | None = None
     allow_search: bool | None = None
@@ -1635,88 +1639,88 @@ class TableV1SpecInvisibleColumnsItem:
     preserve_whitespace: bool | None = None
     use_monospace_font: bool | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.align_content is not None:
-            body['alignContent'] = self.align_content.value
+            body["alignContent"] = self.align_content.value
         if self.allow_html is not None:
-            body['allowHTML'] = self.allow_html
+            body["allowHTML"] = self.allow_html
         if self.allow_search is not None:
-            body['allowSearch'] = self.allow_search
+            body["allowSearch"] = self.allow_search
         if self.boolean_values:
-            body['booleanValues'] = [v for v in self.boolean_values]
+            body["booleanValues"] = [v for v in self.boolean_values]
         if self.date_time_format is not None:
-            body['dateTimeFormat'] = self.date_time_format
+            body["dateTimeFormat"] = self.date_time_format
         if self.decimal_format is not None:
-            body['decimalFormat'] = self.decimal_format
+            body["decimalFormat"] = self.decimal_format
         if self.default_column_width is not None:
-            body['defaultColumnWidth'] = self.default_column_width
+            body["defaultColumnWidth"] = self.default_column_width
         if self.description is not None:
-            body['description'] = self.description
+            body["description"] = self.description
         if self.display_as is not None:
-            body['displayAs'] = self.display_as.value
+            body["displayAs"] = self.display_as.value
         if self.highlight_links is not None:
-            body['highlightLinks'] = self.highlight_links
+            body["highlightLinks"] = self.highlight_links
         if self.image_height is not None:
-            body['imageHeight'] = self.image_height
+            body["imageHeight"] = self.image_height
         if self.image_title_template is not None:
-            body['imageTitleTemplate'] = self.image_title_template
+            body["imageTitleTemplate"] = self.image_title_template
         if self.image_url_template is not None:
-            body['imageUrlTemplate'] = self.image_url_template
+            body["imageUrlTemplate"] = self.image_url_template
         if self.image_width is not None:
-            body['imageWidth'] = self.image_width
+            body["imageWidth"] = self.image_width
         if self.link_open_in_new_tab is not None:
-            body['linkOpenInNewTab'] = self.link_open_in_new_tab
+            body["linkOpenInNewTab"] = self.link_open_in_new_tab
         if self.link_text_template is not None:
-            body['linkTextTemplate'] = self.link_text_template
+            body["linkTextTemplate"] = self.link_text_template
         if self.link_title_template is not None:
-            body['linkTitleTemplate'] = self.link_title_template
+            body["linkTitleTemplate"] = self.link_title_template
         if self.link_url_template is not None:
-            body['linkUrlTemplate'] = self.link_url_template
+            body["linkUrlTemplate"] = self.link_url_template
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         if self.number_format is not None:
-            body['numberFormat'] = self.number_format
+            body["numberFormat"] = self.number_format
         if self.order is not None:
-            body['order'] = self.order
+            body["order"] = self.order
         if self.preserve_whitespace is not None:
-            body['preserveWhitespace'] = self.preserve_whitespace
+            body["preserveWhitespace"] = self.preserve_whitespace
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         if self.type is not None:
-            body['type'] = self.type.value
+            body["type"] = self.type.value
         if self.use_monospace_font is not None:
-            body['useMonospaceFont'] = self.use_monospace_font
+            body["useMonospaceFont"] = self.use_monospace_font
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableV1SpecInvisibleColumnsItem:
+    def from_dict(cls, d: Json) -> TableV1SpecInvisibleColumnsItem:
         return cls(
-            align_content=_enum(d, 'alignContent', Alignment),
-            allow_html=d.get('allowHTML', None),
-            allow_search=d.get('allowSearch', None),
-            boolean_values=d.get('booleanValues', None),
-            date_time_format=d.get('dateTimeFormat', None),
-            decimal_format=d.get('decimalFormat', None),
-            default_column_width=d.get('defaultColumnWidth', None),
-            description=d.get('description', None),
-            display_as=_enum(d, 'displayAs', DisplayType),
-            highlight_links=d.get('highlightLinks', None),
-            image_height=d.get('imageHeight', None),
-            image_title_template=d.get('imageTitleTemplate', None),
-            image_url_template=d.get('imageUrlTemplate', None),
-            image_width=d.get('imageWidth', None),
-            link_open_in_new_tab=d.get('linkOpenInNewTab', None),
-            link_text_template=d.get('linkTextTemplate', None),
-            link_title_template=d.get('linkTitleTemplate', None),
-            link_url_template=d.get('linkUrlTemplate', None),
-            name=d.get('name', None),
-            number_format=d.get('numberFormat', None),
-            order=d.get('order', None),
-            preserve_whitespace=d.get('preserveWhitespace', None),
-            title=d.get('title', None),
-            type=_enum(d, 'type', ColumnType),
-            use_monospace_font=d.get('useMonospaceFont', None),
+            align_content=_enum(d, "alignContent", Alignment),
+            allow_html=d.get("allowHTML", None),
+            allow_search=d.get("allowSearch", None),
+            boolean_values=d.get("booleanValues", None),
+            date_time_format=d.get("dateTimeFormat", None),
+            decimal_format=d.get("decimalFormat", None),
+            default_column_width=d.get("defaultColumnWidth", None),
+            description=d.get("description", None),
+            display_as=_enum(d, "displayAs", DisplayType),
+            highlight_links=d.get("highlightLinks", None),
+            image_height=d.get("imageHeight", None),
+            image_title_template=d.get("imageTitleTemplate", None),
+            image_url_template=d.get("imageUrlTemplate", None),
+            image_width=d.get("imageWidth", None),
+            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
+            link_text_template=d.get("linkTextTemplate", None),
+            link_title_template=d.get("linkTitleTemplate", None),
+            link_url_template=d.get("linkUrlTemplate", None),
+            name=d.get("name", None),
+            number_format=d.get("numberFormat", None),
+            order=d.get("order", None),
+            preserve_whitespace=d.get("preserveWhitespace", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
+            use_monospace_font=d.get("useMonospaceFont", None),
         )
 
 
@@ -1725,34 +1729,34 @@ class TableV2Spec:
     encodings: TableEncodingMap
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'table',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "table",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TableV2Spec:
+    def from_dict(cls, d: Json) -> TableV2Spec:
         return cls(
-            encodings=_from_dict(d, 'encodings', TableEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
+            encodings=_from_dict(d, "encodings", TableEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
         )
 
 
 @dataclass
 class TemporalScale:
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'type': 'temporal',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "type": "temporal",
         }
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TemporalScale:
+    def from_dict(cls, d: Json) -> TemporalScale:
         return cls()
 
 
@@ -1764,68 +1768,68 @@ class TextEntrySpec:
     is_case_sensitive: bool | None = None
     match_mode: TextEntrySpecMatchMode | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'filter-text-entry',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "filter-text-entry",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.exclude is not None:
-            body['exclude'] = self.exclude
+            body["exclude"] = self.exclude
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         if self.is_case_sensitive is not None:
-            body['isCaseSensitive'] = self.is_case_sensitive
+            body["isCaseSensitive"] = self.is_case_sensitive
         if self.match_mode is not None:
-            body['matchMode'] = self.match_mode.value
+            body["matchMode"] = self.match_mode.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> TextEntrySpec:
+    def from_dict(cls, d: Json) -> TextEntrySpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
-            exclude=d.get('exclude', None),
-            frame=_from_dict(d, 'frame', WidgetFrameSpec),
-            is_case_sensitive=d.get('isCaseSensitive', None),
-            match_mode=_enum(d, 'matchMode', TextEntrySpecMatchMode),
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            is_case_sensitive=d.get("isCaseSensitive", None),
+            match_mode=_enum(d, "matchMode", TextEntrySpecMatchMode),
         )
 
 
 class TextEntrySpecMatchMode(Enum):
-    CONTAINS = 'contains'
-    EXACT_MATCH = 'exact-match'
-    STARTS_WITH = 'starts-with'
+    CONTAINS = "contains"
+    EXACT_MATCH = "exact-match"
+    STARTS_WITH = "starts-with"
 
 
 @dataclass
 class Widget:
     name: str
-    queries: List[NamedQuery] | None = None
+    queries: list[NamedQuery] | None = None
     spec: DetailsV1Spec | TableV1Spec | CounterSpec | DatePickerSpec | DateRangePickerSpec | MultiSelectSpec | DropdownSpec | TextEntrySpec | SymbolMapSpec | TableV2Spec | WordCloudSpec | AreaSpec | BarSpec | LineSpec | PieSpec | PivotSpec | ScatterSpec | None = (
         None
     )
     textbox_spec: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.name is not None:
-            body['name'] = self.name
+            body["name"] = self.name
         if self.queries:
-            body['queries'] = [v.as_dict() for v in self.queries]
+            body["queries"] = [v.as_dict() for v in self.queries]
         if self.spec:
-            body['spec'] = self.spec.as_dict()
+            body["spec"] = self.spec.as_dict()
         if self.textbox_spec is not None:
-            body['textbox_spec'] = self.textbox_spec
+            body["textbox_spec"] = self.textbox_spec
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> Widget:
+    def from_dict(cls, d: Json) -> Widget:
         return cls(
-            name=d.get('name', None),
-            queries=_repeated_dict(d, 'queries', NamedQuery),
-            spec=_from_dict(d, 'spec', WidgetSpec),
-            textbox_spec=d.get('textbox_spec', None),
+            name=d.get("name", None),
+            queries=_repeated_dict(d, "queries", NamedQuery),
+            spec=_from_dict(d, "spec", WidgetSpec),
+            textbox_spec=d.get("textbox_spec", None),
         )
 
 
@@ -1836,32 +1840,32 @@ class WidgetFrameSpec:
     show_title: bool | None = None
     title: str | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.description is not None:
-            body['description'] = self.description
+            body["description"] = self.description
         if self.show_description is not None:
-            body['showDescription'] = self.show_description
+            body["showDescription"] = self.show_description
         if self.show_title is not None:
-            body['showTitle'] = self.show_title
+            body["showTitle"] = self.show_title
         if self.title is not None:
-            body['title'] = self.title
+            body["title"] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> WidgetFrameSpec:
+    def from_dict(cls, d: Json) -> WidgetFrameSpec:
         return cls(
-            description=d.get('description', None),
-            show_description=d.get('showDescription', None),
-            show_title=d.get('showTitle', None),
-            title=d.get('title', None),
+            description=d.get("description", None),
+            show_description=d.get("showDescription", None),
+            show_title=d.get("showTitle", None),
+            title=d.get("title", None),
         )
 
 
 class WidgetSpec:
     @classmethod
     def from_dict(
-        cls, d: Dict[str, Any]
+        cls, d: Json
     ) -> (
         DetailsV1Spec
         | TableV1Spec
@@ -1881,39 +1885,39 @@ class WidgetSpec:
         | PivotSpec
         | ScatterSpec
     ):
-        if 'version' == 1 and 'widgetType' == 'details':
+        if d["version"] == 1 and d["widgetType"] == "details":
             return DetailsV1Spec.from_dict(d)
-        elif 'version' == 1 and 'widgetType' == 'table':
+        elif d["version"] == 1 and d["widgetType"] == "table":
             return TableV1Spec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'counter':
+        elif d["version"] == 2 and d["widgetType"] == "counter":
             return CounterSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'filter-date-picker':
+        elif d["version"] == 2 and d["widgetType"] == "filter-date-picker":
             return DatePickerSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'filter-date-range-picker':
+        elif d["version"] == 2 and d["widgetType"] == "filter-date-range-picker":
             return DateRangePickerSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'filter-multi-select':
+        elif d["version"] == 2 and d["widgetType"] == "filter-multi-select":
             return MultiSelectSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'filter-single-select':
+        elif d["version"] == 2 and d["widgetType"] == "filter-single-select":
             return DropdownSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'filter-text-entry':
+        elif d["version"] == 2 and d["widgetType"] == "filter-text-entry":
             return TextEntrySpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'symbol-map':
+        elif d["version"] == 2 and d["widgetType"] == "symbol-map":
             return SymbolMapSpec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'table':
+        elif d["version"] == 2 and d["widgetType"] == "table":
             return TableV2Spec.from_dict(d)
-        elif 'version' == 2 and 'widgetType' == 'word-cloud':
+        elif d["version"] == 2 and d["widgetType"] == "word-cloud":
             return WordCloudSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'area':
+        elif d["version"] == 3 and d["widgetType"] == "area":
             return AreaSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'bar':
+        elif d["version"] == 3 and d["widgetType"] == "bar":
             return BarSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'line':
+        elif d["version"] == 3 and d["widgetType"] == "line":
             return LineSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'pie':
+        elif d["version"] == 3 and d["widgetType"] == "pie":
             return PieSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'pivot':
+        elif d["version"] == 3 and d["widgetType"] == "pivot":
             return PivotSpec.from_dict(d)
-        elif 'version' == 3 and 'widgetType' == 'scatter':
+        elif d["version"] == 3 and d["widgetType"] == "scatter":
             return ScatterSpec.from_dict(d)
         else:
             raise KeyError(...)
@@ -1924,17 +1928,17 @@ class WordCloudEncodingMap:
     size: RenderFieldEncoding | None = None
     text: RenderFieldEncoding | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
+    def as_dict(self) -> Json:
+        body: Json = {}
         if self.size:
-            body['size'] = self.size.as_dict()
+            body["size"] = self.size.as_dict()
         if self.text:
-            body['text'] = self.text.as_dict()
+            body["text"] = self.text.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> WordCloudEncodingMap:
-        return cls(size=_from_dict(d, 'size', RenderFieldEncoding), text=_from_dict(d, 'text', RenderFieldEncoding))
+    def from_dict(cls, d: Json) -> WordCloudEncodingMap:
+        return cls(size=_from_dict(d, "size", RenderFieldEncoding), text=_from_dict(d, "text", RenderFieldEncoding))
 
 
 @dataclass
@@ -1942,19 +1946,19 @@ class WordCloudSpec:
     encodings: WordCloudEncodingMap
     frame: WidgetFrameSpec | None = None
 
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            'version': 2,
-            'widgetType': 'word-cloud',
+    def as_dict(self) -> Json:
+        body: Json = {
+            "version": 2,
+            "widgetType": "word-cloud",
         }
         if self.encodings:
-            body['encodings'] = self.encodings.as_dict()
+            body["encodings"] = self.encodings.as_dict()
         if self.frame:
-            body['frame'] = self.frame.as_dict()
+            body["frame"] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> WordCloudSpec:
+    def from_dict(cls, d: Json) -> WordCloudSpec:
         return cls(
-            encodings=_from_dict(d, 'encodings', WordCloudEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
+            encodings=_from_dict(d, "encodings", WordCloudEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
         )

--- a/src/databricks/labs/ucx/framework/lakeview/model.py
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py
@@ -1,0 +1,1882 @@
+# Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from databricks.sdk.service._internal import (
+    _enum,
+    _from_dict,
+    _repeated_dict,
+)
+
+
+class Alignment(Enum):
+    CENTER = "center"
+    LEFT = "left"
+    RIGHT = "right"
+
+
+@dataclass
+class AngleAxisSpec:
+    hide_title: bool | None = None
+    title: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.hide_title is not None:
+            body["hideTitle"] = self.hide_title
+        if self.title is not None:
+            body["title"] = self.title
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AngleAxisSpec:
+        return cls(hide_title=d.get("hideTitle", None), title=d.get("title", None))
+
+
+@dataclass
+class AngleFieldEncoding:
+    field_name: str
+    scale: QuantitativeScale
+    axis: AngleAxisSpec | None = None
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.axis:
+            body["axis"] = self.axis.as_dict()
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.scale:
+            body["scale"] = self.scale.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AngleFieldEncoding:
+        return cls(
+            axis=_from_dict(d, "axis", AngleAxisSpec),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            scale=_from_dict(d, "scale", QuantitativeScale),
+        )
+
+
+@dataclass
+class AreaSpec:
+    encodings: Any
+    """Encoding map for the most common form of charts, which can have either a multi-X or multi-Y
+    encoding."""
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+    mark: MarkSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "area",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.mark:
+            body["mark"] = self.mark.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AreaSpec:
+        return cls(
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
+        )
+
+
+@dataclass
+class AxisSpec:
+    hide_labels: bool | None = None
+    hide_title: bool | None = None
+    title: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.hide_labels is not None:
+            body["hideLabels"] = self.hide_labels
+        if self.hide_title is not None:
+            body["hideTitle"] = self.hide_title
+        if self.title is not None:
+            body["title"] = self.title
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AxisSpec:
+        return cls(
+            hide_labels=d.get("hideLabels", None), hide_title=d.get("hideTitle", None), title=d.get("title", None)
+        )
+
+
+@dataclass
+class BarSpec:
+    encodings: Any
+    """Encoding map for the most common form of charts, which can have either a multi-X or multi-Y
+    encoding."""
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+    mark: MarkSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "bar",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.mark:
+            body["mark"] = self.mark.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BarSpec:
+        return cls(
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
+        )
+
+
+@dataclass
+class CategoricalColorScaleMappingEntry:
+    value: DataDomainValue
+    color: str
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.color is not None:
+            body["color"] = self.color
+        if self.value is not None:
+            body["value"] = self.value.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CategoricalColorScaleMappingEntry:
+        return cls(color=d.get("color", None), value=_enum(d, "value", DataDomainValue))
+
+
+@dataclass
+class CategoricalScale:
+    mappings: list[CategoricalColorScaleMappingEntry] | None = None
+    sort: Any | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "type": "categorical",
+        }
+        if self.mappings:
+            body["mappings"] = [v.as_dict() for v in self.mappings]
+        if self.sort:
+            body["sort"] = self.sort
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CategoricalScale:
+        return cls(mappings=_repeated_dict(d, "mappings", CategoricalColorScaleMappingEntry), sort=d.get("sort", None))
+
+
+@dataclass
+class ChartEncodingMapWithMultiX:
+    x: MultiFieldAxisEncoding
+    color: ColorEncodingForMultiSeries | None = None
+    label: LabelEncoding | None = None
+    y: SingleFieldAxisEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.color:
+            body["color"] = self.color.as_dict()
+        if self.label:
+            body["label"] = self.label.as_dict()
+        if self.x:
+            body["x"] = self.x.as_dict()
+        if self.y:
+            body["y"] = self.y.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithMultiX:
+        return cls(
+            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", MultiFieldAxisEncoding),
+            y=_from_dict(d, "y", SingleFieldAxisEncoding),
+        )
+
+
+@dataclass
+class ChartEncodingMapWithMultiY:
+    y: MultiFieldAxisEncoding
+    color: ColorEncodingForMultiSeries | None = None
+    label: LabelEncoding | None = None
+    x: SingleFieldAxisEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.color:
+            body["color"] = self.color.as_dict()
+        if self.label:
+            body["label"] = self.label.as_dict()
+        if self.x:
+            body["x"] = self.x.as_dict()
+        if self.y:
+            body["y"] = self.y.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithMultiY:
+        return cls(
+            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", SingleFieldAxisEncoding),
+            y=_from_dict(d, "y", MultiFieldAxisEncoding),
+        )
+
+
+@dataclass
+class ChartEncodingMapWithSingleXy:
+    color: ColorFieldEncoding | None = None
+    label: LabelEncoding | None = None
+    x: SingleFieldAxisEncoding | None = None
+    y: SingleFieldAxisEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.color:
+            body["color"] = self.color.as_dict()
+        if self.label:
+            body["label"] = self.label.as_dict()
+        if self.x:
+            body["x"] = self.x.as_dict()
+        if self.y:
+            body["y"] = self.y.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithSingleXy:
+        return cls(
+            color=_from_dict(d, "color", ColorFieldEncoding),
+            label=_from_dict(d, "label", LabelEncoding),
+            x=_from_dict(d, "x", SingleFieldAxisEncoding),
+            y=_from_dict(d, "y", SingleFieldAxisEncoding),
+        )
+
+
+@dataclass
+class ColorEncodingForMultiSeries:
+    legend: LegendSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.legend:
+            body["legend"] = self.legend.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ColorEncodingForMultiSeries:
+        return cls(legend=_from_dict(d, "legend", LegendSpec))
+
+
+@dataclass
+class ColorFieldEncoding:
+    field_name: str
+    scale: Any
+    display_name: str | None = None
+    legend: LegendSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.legend:
+            body["legend"] = self.legend.as_dict()
+        if self.scale:
+            body["scale"] = self.scale
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ColorFieldEncoding:
+        return cls(
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            legend=_from_dict(d, "legend", LegendSpec),
+            scale=d.get("scale", None),
+        )
+
+
+class ColumnType(Enum):
+    BOOLEAN = "boolean"
+    COMPLEX = "complex"
+    DATE = "date"
+    DATETIME = "datetime"
+    DECIMAL = "decimal"
+    FLOAT = "float"
+    INTEGER = "integer"
+    STRING = "string"
+
+
+@dataclass
+class ControlEncodingMap:
+    fields: Any | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.fields:
+            body["fields"] = self.fields
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ControlEncodingMap:
+        return cls(fields=d.get("fields", None))
+
+
+@dataclass
+class CounterEncodingMap:
+    target: CounterFieldEncoding | None = None
+    value: CounterFieldEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.target:
+            body["target"] = self.target.as_dict()
+        if self.value:
+            body["value"] = self.value.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CounterEncodingMap:
+        return cls(
+            target=_from_dict(d, "target", CounterFieldEncoding), value=_from_dict(d, "value", CounterFieldEncoding)
+        )
+
+
+@dataclass
+class CounterFieldEncoding:
+    field_name: str
+    display_name: str | None = None
+    row_number: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.row_number is not None:
+            body["rowNumber"] = self.row_number
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CounterFieldEncoding:
+        return cls(
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            row_number=d.get("rowNumber", None),
+        )
+
+
+@dataclass
+class CounterSpec:
+    encodings: CounterEncodingMap
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "counter",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CounterSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", CounterEncodingMap),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+        )
+
+
+@dataclass
+class Dashboard:
+    datasets: list[Dataset]
+    pages: list[Page]
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.datasets:
+            body["datasets"] = [v.as_dict() for v in self.datasets]
+        if self.pages:
+            body["pages"] = [v.as_dict() for v in self.pages]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Dashboard:
+        return cls(datasets=_repeated_dict(d, "datasets", Dataset), pages=_repeated_dict(d, "pages", Page))
+
+
+class DataDomainValue(Enum):
+    BOOLEAN = "boolean"
+    NULL = "null"
+    NUMBER = "number"
+    STRING = "string"
+
+
+@dataclass
+class Dataset:
+    name: str
+    query: str
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.name is not None:
+            body["name"] = self.name
+        if self.query is not None:
+            body["query"] = self.query
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Dataset:
+        return cls(display_name=d.get("displayName", None), name=d.get("name", None), query=d.get("query", None))
+
+
+@dataclass
+class DatePickerSpec:
+    encodings: ControlEncodingMap
+    exclude: bool | None = None
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "filter-date-picker",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.exclude is not None:
+            body["exclude"] = self.exclude
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DatePickerSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+        )
+
+
+@dataclass
+class DateRangePickerSpec:
+    encodings: ControlEncodingMap
+    exclude: bool | None = None
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "filter-date-range-picker",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.exclude is not None:
+            body["exclude"] = self.exclude
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DateRangePickerSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+        )
+
+
+@dataclass
+class DetailsV1ColumnEncoding:
+    field_name: str
+    display_name: str | None = None
+    title: str | None = None
+    type: ColumnType | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.title is not None:
+            body["title"] = self.title
+        if self.type is not None:
+            body["type"] = self.type.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DetailsV1ColumnEncoding:
+        return cls(
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
+        )
+
+
+@dataclass
+class DetailsV1EncodingMap:
+    columns: list[DetailsV1ColumnEncoding] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.columns:
+            body["columns"] = [v.as_dict() for v in self.columns]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DetailsV1EncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", DetailsV1ColumnEncoding))
+
+
+@dataclass
+class DetailsV1Spec:
+    encodings: DetailsV1EncodingMap
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 1,
+            "widgetType": "details",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DetailsV1Spec:
+        return cls(
+            encodings=_from_dict(d, "encodings", DetailsV1EncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+        )
+
+
+class Direction(Enum):
+    ASC = "ASC"
+    DESC = "DESC"
+    DIRECTION_UNSPECIFIED = "DIRECTION_UNSPECIFIED"
+
+
+class DisplayType(Enum):
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+    IMAGE = "image"
+    JSON = "json"
+    LINK = "link"
+    NUMBER = "number"
+    STRING = "string"
+
+
+@dataclass
+class DropdownSpec:
+    encodings: ControlEncodingMap
+    widget_type: DropdownSpecWidgetType
+    exclude: bool | None = None
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.exclude is not None:
+            body["exclude"] = self.exclude
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.widget_type is not None:
+            body["widgetType"] = self.widget_type.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DropdownSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            widget_type=_enum(d, "widgetType", DropdownSpecWidgetType),
+        )
+
+
+class DropdownSpecWidgetType(Enum):
+    FILTER_MULTI_SELECT = "filter-multi-select"
+    FILTER_SINGLE_SELECT = "filter-single-select"
+
+
+@dataclass
+class Field:
+    name: str
+    expression: str
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.expression is not None:
+            body["expression"] = self.expression
+        if self.name is not None:
+            body["name"] = self.name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Field:
+        return cls(expression=d.get("expression", None), name=d.get("name", None))
+
+
+@dataclass
+class FieldEncodingWithDataFor:
+    field_name: str
+    query_name: str
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.query_name is not None:
+            body["queryName"] = self.query_name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FieldEncodingWithDataFor:
+        return cls(
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            query_name=d.get("queryName", None),
+        )
+
+
+@dataclass
+class Format:
+    foreground_color: str
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.foreground_color is not None:
+            body["foregroundColor"] = self.foreground_color
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Format:
+        return cls(foreground_color=d.get("foregroundColor", None))
+
+
+@dataclass
+class FormatConfig:
+    number_format: NumeralNumberFormat | None = None
+    percent_format: NumeralNumberFormat | None = None
+    time_format: MomentTimeFormat | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.number_format:
+            body["numberFormat"] = self.number_format.as_dict()
+        if self.percent_format:
+            body["percentFormat"] = self.percent_format.as_dict()
+        if self.time_format:
+            body["timeFormat"] = self.time_format.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FormatConfig:
+        return cls(
+            number_format=_from_dict(d, "numberFormat", NumeralNumberFormat),
+            percent_format=_from_dict(d, "percentFormat", NumeralNumberFormat),
+            time_format=_from_dict(d, "timeFormat", MomentTimeFormat),
+        )
+
+
+@dataclass
+class LabelEncoding:
+    show: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.show is not None:
+            body["show"] = self.show
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LabelEncoding:
+        return cls(show=d.get("show", None))
+
+
+@dataclass
+class Layout:
+    widget: Widget
+    position: Position
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.position:
+            body["position"] = self.position.as_dict()
+        if self.widget:
+            body["widget"] = self.widget.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Layout:
+        return cls(position=_from_dict(d, "position", Position), widget=_from_dict(d, "widget", Widget))
+
+
+@dataclass
+class LegendSpec:
+    hide_title: bool | None = None
+    position: LegendSpecPosition | None = None
+    title: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.hide_title is not None:
+            body["hideTitle"] = self.hide_title
+        if self.position is not None:
+            body["position"] = self.position.value
+        if self.title is not None:
+            body["title"] = self.title
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LegendSpec:
+        return cls(
+            hide_title=d.get("hideTitle", None),
+            position=_enum(d, "position", LegendSpecPosition),
+            title=d.get("title", None),
+        )
+
+
+class LegendSpecPosition(Enum):
+    BOTTOM = "bottom"
+    RIGHT = "right"
+
+
+@dataclass
+class LineSpec:
+    encodings: Any
+    """Encoding map for the most common form of charts, which can have either a multi-X or multi-Y
+    encoding."""
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+    mark: MarkSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "line",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.mark:
+            body["mark"] = self.mark.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LineSpec:
+        return cls(
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
+        )
+
+
+class MarkLayout(Enum):
+    GROUP = "group"
+    LAYER = "layer"
+    STACK = "stack"
+
+
+@dataclass
+class MarkSpec:
+    colors: list[str] | None = None
+    layout: MarkLayout | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.colors:
+            body["colors"] = [v for v in self.colors]
+        if self.layout is not None:
+            body["layout"] = self.layout.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MarkSpec:
+        return cls(colors=d.get("colors", None), layout=_enum(d, "layout", MarkLayout))
+
+
+@dataclass
+class MomentTimeFormat:
+    format: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "formatType": "moment",
+        }
+        if self.format is not None:
+            body["format"] = self.format
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MomentTimeFormat:
+        return cls(format=d.get("format", None))
+
+
+@dataclass
+class MultiFieldAxisEncoding:
+    fields: list[RenderFieldEncoding]
+    scale: QuantitativeScale
+    axis: AxisSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.axis:
+            body["axis"] = self.axis.as_dict()
+        if self.fields:
+            body["fields"] = [v.as_dict() for v in self.fields]
+        if self.scale:
+            body["scale"] = self.scale.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MultiFieldAxisEncoding:
+        return cls(
+            axis=_from_dict(d, "axis", AxisSpec),
+            fields=_repeated_dict(d, "fields", RenderFieldEncoding),
+            scale=_from_dict(d, "scale", QuantitativeScale),
+        )
+
+
+@dataclass
+class NamedQuery:
+    name: str
+    query: Order
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.name is not None:
+            body["name"] = self.name
+        if self.query:
+            body["query"] = self.query.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> NamedQuery:
+        return cls(name=d.get("name", None), query=_from_dict(d, "query", Order))
+
+
+@dataclass
+class NumeralNumberFormat:
+    format: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "formatType": "numeral",
+        }
+        if self.format is not None:
+            body["format"] = self.format
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> NumeralNumberFormat:
+        return cls(format=d.get("format", None))
+
+
+@dataclass
+class Order:
+    direction: Direction | None = None
+    expression: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.direction is not None:
+            body["direction"] = self.direction.value
+        if self.expression is not None:
+            body["expression"] = self.expression
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Order:
+        return cls(direction=_enum(d, "direction", Direction), expression=d.get("expression", None))
+
+
+@dataclass
+class Page:
+    name: str
+    layout: list[Layout]
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.layout:
+            body["layout"] = [v.as_dict() for v in self.layout]
+        if self.name is not None:
+            body["name"] = self.name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Page:
+        return cls(
+            display_name=d.get("displayName", None),
+            layout=_repeated_dict(d, "layout", Layout),
+            name=d.get("name", None),
+        )
+
+
+class PaginationSize(Enum):
+    DEFAULT = "default"
+    SMALL = "small"
+
+
+@dataclass
+class ParameterEncoding:
+    dataset_name: str
+    parameter_keyword: str
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.dataset_name is not None:
+            body["datasetName"] = self.dataset_name
+        if self.parameter_keyword is not None:
+            body["parameterKeyword"] = self.parameter_keyword
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ParameterEncoding:
+        return cls(dataset_name=d.get("datasetName", None), parameter_keyword=d.get("parameterKeyword", None))
+
+
+@dataclass
+class PieEncodingMap:
+    angle: AngleFieldEncoding | None = None
+    color: ColorFieldEncoding | None = None
+    label: LabelEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.angle:
+            body["angle"] = self.angle.as_dict()
+        if self.color:
+            body["color"] = self.color.as_dict()
+        if self.label:
+            body["label"] = self.label.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PieEncodingMap:
+        return cls(
+            angle=_from_dict(d, "angle", AngleFieldEncoding),
+            color=_from_dict(d, "color", ColorFieldEncoding),
+            label=_from_dict(d, "label", LabelEncoding),
+        )
+
+
+@dataclass
+class PieSpec:
+    encodings: PieEncodingMap
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+    mark: MarkSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "pie",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.mark:
+            body["mark"] = self.mark.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PieSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", PieEncodingMap),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
+        )
+
+
+@dataclass
+class PivotCellEncoding:
+    field_name: str
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "cellType": "text",
+        }
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PivotCellEncoding:
+        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
+
+
+@dataclass
+class PivotEncodingMap:
+    cell: PivotCellEncoding | None = None
+    columns: list[RenderFieldEncoding] | None = None
+    rows: list[RenderFieldEncoding] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.cell:
+            body["cell"] = self.cell.as_dict()
+        if self.columns:
+            body["columns"] = [v.as_dict() for v in self.columns]
+        if self.rows:
+            body["rows"] = [v.as_dict() for v in self.rows]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PivotEncodingMap:
+        return cls(
+            cell=_from_dict(d, "cell", PivotCellEncoding),
+            columns=_repeated_dict(d, "columns", RenderFieldEncoding),
+            rows=_repeated_dict(d, "rows", RenderFieldEncoding),
+        )
+
+
+@dataclass
+class PivotSpec:
+    encodings: PivotEncodingMap
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "pivot",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> PivotSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", PivotEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+        )
+
+
+@dataclass
+class Position:
+    x: int
+    y: int
+    width: int
+    height: int
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.height is not None:
+            body["height"] = self.height
+        if self.width is not None:
+            body["width"] = self.width
+        if self.x is not None:
+            body["x"] = self.x
+        if self.y is not None:
+            body["y"] = self.y
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Position:
+        return cls(height=d.get("height", None), width=d.get("width", None), x=d.get("x", None), y=d.get("y", None))
+
+
+@dataclass
+class QuantitativeDomain:
+    max: int | None = None
+    min: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.max is not None:
+            body["max"] = self.max
+        if self.min is not None:
+            body["min"] = self.min
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> QuantitativeDomain:
+        return cls(max=d.get("max", None), min=d.get("min", None))
+
+
+@dataclass
+class QuantitativeScale:
+    domain: QuantitativeDomain | None = None
+    """If not specified, domain.min/max is the minimum/maximum value of the data. If specified, any
+    value < domain.min or > domain.max will be clipped for x/y axes."""
+    reverse: bool | None = None
+    """If not specified or false, domainMin is mapped to the range start value, and domainMax is mapped
+    to the range end value. If true, domainMin is mapped to the range end value, and domainMax is
+    mapped to the range start value. Take x-axis for example, if reverse = undefined, domainMin is
+    mapped to x=0 and domainMax is mapped to x=width. If reverse = true, domainMin is mapped to
+    x=width and domainMax is mapped to x=0."""
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "type": "quantitative",
+        }
+        if self.domain:
+            body["domain"] = self.domain.as_dict()
+        if self.reverse is not None:
+            body["reverse"] = self.reverse
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> QuantitativeScale:
+        return cls(domain=_from_dict(d, "domain", QuantitativeDomain), reverse=d.get("reverse", None))
+
+
+@dataclass
+class Query:
+    dataset_name: str
+    fields: list[Field]
+    disaggregated: bool | None = None
+    orders: list[Order] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.dataset_name is not None:
+            body["datasetName"] = self.dataset_name
+        if self.disaggregated is not None:
+            body["disaggregated"] = self.disaggregated
+        if self.fields:
+            body["fields"] = [v.as_dict() for v in self.fields]
+        if self.orders:
+            body["orders"] = [v.as_dict() for v in self.orders]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Query:
+        return cls(
+            dataset_name=d.get("datasetName", None),
+            disaggregated=d.get("disaggregated", None),
+            fields=_repeated_dict(d, "fields", Field),
+            orders=_repeated_dict(d, "orders", Order),
+        )
+
+
+@dataclass
+class RenderFieldEncoding:
+    """Common type that a single-field encoding should (conceptually) extend from"""
+
+    field_name: str
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RenderFieldEncoding:
+        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
+
+
+@dataclass
+class ScatterSpec:
+    encodings: Any
+    """Encoding map for the most common form of charts, which can have either a multi-X or multi-Y
+    encoding."""
+    format: FormatConfig | None = None
+    frame: WidgetFrameSpec | None = None
+    mark: MarkSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 3,
+            "widgetType": "scatter",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings
+        if self.format:
+            body["format"] = self.format.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.mark:
+            body["mark"] = self.mark.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ScatterSpec:
+        return cls(
+            encodings=d.get("encodings", None),
+            format=_from_dict(d, "format", FormatConfig),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            mark=_from_dict(d, "mark", MarkSpec),
+        )
+
+
+@dataclass
+class SingleFieldAxisEncoding:
+    field_name: str
+    scale: Any
+    axis: AxisSpec | None = None
+    display_name: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.axis:
+            body["axis"] = self.axis.as_dict()
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.scale:
+            body["scale"] = self.scale
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SingleFieldAxisEncoding:
+        return cls(
+            axis=_from_dict(d, "axis", AxisSpec),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            scale=d.get("scale", None),
+        )
+
+
+@dataclass
+class SortByChannel:
+    by: SortByChannelBy
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.by is not None:
+            body["by"] = self.by.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SortByChannel:
+        return cls(by=_enum(d, "by", SortByChannelBy))
+
+
+class SortByChannelBy(Enum):
+    X = "x"
+    X_REVERSED = "x-reversed"
+    Y = "y"
+    Y_REVERSED = "y-reversed"
+
+
+@dataclass
+class SortByNaturalOrder:
+    by: SortByNaturalOrderBy
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.by is not None:
+            body["by"] = self.by.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SortByNaturalOrder:
+        return cls(by=_enum(d, "by", SortByNaturalOrderBy))
+
+
+class SortByNaturalOrderBy(Enum):
+    NATURAL_ORDER = "natural-order"
+    NATURAL_ORDER_REVERSED = "natural-order-reversed"
+
+
+@dataclass
+class SymbolMapEncodingMap:
+    latitude: RenderFieldEncoding | None = None
+    longitude: RenderFieldEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.latitude:
+            body["latitude"] = self.latitude.as_dict()
+        if self.longitude:
+            body["longitude"] = self.longitude.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SymbolMapEncodingMap:
+        return cls(
+            latitude=_from_dict(d, "latitude", RenderFieldEncoding),
+            longitude=_from_dict(d, "longitude", RenderFieldEncoding),
+        )
+
+
+@dataclass
+class SymbolMapSpec:
+    encodings: SymbolMapEncodingMap
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "symbol-map",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SymbolMapSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", SymbolMapEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+        )
+
+
+@dataclass
+class TableEncodingMap:
+    columns: list[RenderFieldEncoding] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.columns:
+            body["columns"] = [v.as_dict() for v in self.columns]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableEncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", RenderFieldEncoding))
+
+
+@dataclass
+class TableV1ColumnEncoding:
+    """FieldEncoding for TableV1. Note that `visible?` is true by default, which is `false` in the
+    legacy v1 table."""
+
+    boolean_values: list[str]
+    display_as: DisplayType
+    field_name: str
+    title: str
+    type: ColumnType
+    align_content: Alignment | None = None
+    allow_html: bool | None = None
+    allow_search: bool | None = None
+    date_time_format: str | None = None
+    decimal_format: str | None = None
+    default_column_width: int | None = None
+    description: str | None = None
+    display_name: str | None = None
+    highlight_links: bool | None = None
+    image_height: str | None = None
+    image_title_template: str | None = None
+    image_url_template: str | None = None
+    image_width: str | None = None
+    link_open_in_new_tab: bool | None = None
+    link_text_template: str | None = None
+    link_title_template: str | None = None
+    link_url_template: str | None = None
+    number_format: str | None = None
+    order: int | None = None
+    preserve_whitespace: bool | None = None
+    use_monospace_font: bool | None = None
+    visible: bool | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.align_content is not None:
+            body["alignContent"] = self.align_content.value
+        if self.allow_html is not None:
+            body["allowHTML"] = self.allow_html
+        if self.allow_search is not None:
+            body["allowSearch"] = self.allow_search
+        if self.boolean_values:
+            body["booleanValues"] = [v for v in self.boolean_values]
+        if self.date_time_format is not None:
+            body["dateTimeFormat"] = self.date_time_format
+        if self.decimal_format is not None:
+            body["decimalFormat"] = self.decimal_format
+        if self.default_column_width is not None:
+            body["defaultColumnWidth"] = self.default_column_width
+        if self.description is not None:
+            body["description"] = self.description
+        if self.display_as is not None:
+            body["displayAs"] = self.display_as.value
+        if self.display_name is not None:
+            body["displayName"] = self.display_name
+        if self.field_name is not None:
+            body["fieldName"] = self.field_name
+        if self.highlight_links is not None:
+            body["highlightLinks"] = self.highlight_links
+        if self.image_height is not None:
+            body["imageHeight"] = self.image_height
+        if self.image_title_template is not None:
+            body["imageTitleTemplate"] = self.image_title_template
+        if self.image_url_template is not None:
+            body["imageUrlTemplate"] = self.image_url_template
+        if self.image_width is not None:
+            body["imageWidth"] = self.image_width
+        if self.link_open_in_new_tab is not None:
+            body["linkOpenInNewTab"] = self.link_open_in_new_tab
+        if self.link_text_template is not None:
+            body["linkTextTemplate"] = self.link_text_template
+        if self.link_title_template is not None:
+            body["linkTitleTemplate"] = self.link_title_template
+        if self.link_url_template is not None:
+            body["linkUrlTemplate"] = self.link_url_template
+        if self.number_format is not None:
+            body["numberFormat"] = self.number_format
+        if self.order is not None:
+            body["order"] = self.order
+        if self.preserve_whitespace is not None:
+            body["preserveWhitespace"] = self.preserve_whitespace
+        if self.title is not None:
+            body["title"] = self.title
+        if self.type is not None:
+            body["type"] = self.type.value
+        if self.use_monospace_font is not None:
+            body["useMonospaceFont"] = self.use_monospace_font
+        if self.visible is not None:
+            body["visible"] = self.visible
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableV1ColumnEncoding:
+        return cls(
+            align_content=_enum(d, "alignContent", Alignment),
+            allow_html=d.get("allowHTML", None),
+            allow_search=d.get("allowSearch", None),
+            boolean_values=d.get("booleanValues", None),
+            date_time_format=d.get("dateTimeFormat", None),
+            decimal_format=d.get("decimalFormat", None),
+            default_column_width=d.get("defaultColumnWidth", None),
+            description=d.get("description", None),
+            display_as=_enum(d, "displayAs", DisplayType),
+            display_name=d.get("displayName", None),
+            field_name=d.get("fieldName", None),
+            highlight_links=d.get("highlightLinks", None),
+            image_height=d.get("imageHeight", None),
+            image_title_template=d.get("imageTitleTemplate", None),
+            image_url_template=d.get("imageUrlTemplate", None),
+            image_width=d.get("imageWidth", None),
+            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
+            link_text_template=d.get("linkTextTemplate", None),
+            link_title_template=d.get("linkTitleTemplate", None),
+            link_url_template=d.get("linkUrlTemplate", None),
+            number_format=d.get("numberFormat", None),
+            order=d.get("order", None),
+            preserve_whitespace=d.get("preserveWhitespace", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
+            use_monospace_font=d.get("useMonospaceFont", None),
+            visible=d.get("visible", None),
+        )
+
+
+@dataclass
+class TableV1EncodingMap:
+    columns: list[TableV1ColumnEncoding] | None = None
+    """Used columns. These columns are visible or used for search."""
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.columns:
+            body["columns"] = [v.as_dict() for v in self.columns]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableV1EncodingMap:
+        return cls(columns=_repeated_dict(d, "columns", TableV1ColumnEncoding))
+
+
+@dataclass
+class TableV1Spec:
+    allow_html_by_default: bool
+    """V1 uses `version` to determine if the v1 editor should set `allowHTML` by default."""
+    condensed: bool
+    encodings: TableV1EncodingMap
+    invisible_columns: list[TableV1SpecInvisibleColumnsItem]
+    """Unused columns. These columns are invisible and not referred, and thus should not be include in
+    the queries (be outside of `encodings`). Even when the base query changes not to include these
+    columns, the table still can work without throwing errors."""
+    items_per_page: int
+    frame: WidgetFrameSpec | None = None
+    pagination_size: PaginationSize | None = None
+    with_row_number: bool | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 1,
+            "widgetType": "table",
+        }
+        if self.allow_html_by_default is not None:
+            body["allowHTMLByDefault"] = self.allow_html_by_default
+        if self.condensed is not None:
+            body["condensed"] = self.condensed
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.invisible_columns:
+            body["invisibleColumns"] = [v.as_dict() for v in self.invisible_columns]
+        if self.items_per_page is not None:
+            body["itemsPerPage"] = self.items_per_page
+        if self.pagination_size is not None:
+            body["paginationSize"] = self.pagination_size.value
+        if self.with_row_number is not None:
+            body["withRowNumber"] = self.with_row_number
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableV1Spec:
+        return cls(
+            allow_html_by_default=d.get("allowHTMLByDefault", None),
+            condensed=d.get("condensed", None),
+            encodings=_from_dict(d, "encodings", TableV1EncodingMap),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            invisible_columns=_repeated_dict(d, "invisibleColumns", TableV1SpecInvisibleColumnsItem),
+            items_per_page=d.get("itemsPerPage", None),
+            pagination_size=_enum(d, "paginationSize", PaginationSize),
+            with_row_number=d.get("withRowNumber", None),
+        )
+
+
+@dataclass
+class TableV1SpecInvisibleColumnsItem:
+    name: str
+    display_as: DisplayType
+    type: ColumnType
+    title: str
+    boolean_values: list[str]
+    align_content: Alignment | None = None
+    allow_html: bool | None = None
+    allow_search: bool | None = None
+    date_time_format: str | None = None
+    decimal_format: str | None = None
+    default_column_width: int | None = None
+    description: str | None = None
+    highlight_links: bool | None = None
+    image_height: str | None = None
+    image_title_template: str | None = None
+    image_url_template: str | None = None
+    image_width: str | None = None
+    link_open_in_new_tab: bool | None = None
+    link_text_template: str | None = None
+    link_title_template: str | None = None
+    link_url_template: str | None = None
+    number_format: str | None = None
+    order: int | None = None
+    preserve_whitespace: bool | None = None
+    use_monospace_font: bool | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.align_content is not None:
+            body["alignContent"] = self.align_content.value
+        if self.allow_html is not None:
+            body["allowHTML"] = self.allow_html
+        if self.allow_search is not None:
+            body["allowSearch"] = self.allow_search
+        if self.boolean_values:
+            body["booleanValues"] = [v for v in self.boolean_values]
+        if self.date_time_format is not None:
+            body["dateTimeFormat"] = self.date_time_format
+        if self.decimal_format is not None:
+            body["decimalFormat"] = self.decimal_format
+        if self.default_column_width is not None:
+            body["defaultColumnWidth"] = self.default_column_width
+        if self.description is not None:
+            body["description"] = self.description
+        if self.display_as is not None:
+            body["displayAs"] = self.display_as.value
+        if self.highlight_links is not None:
+            body["highlightLinks"] = self.highlight_links
+        if self.image_height is not None:
+            body["imageHeight"] = self.image_height
+        if self.image_title_template is not None:
+            body["imageTitleTemplate"] = self.image_title_template
+        if self.image_url_template is not None:
+            body["imageUrlTemplate"] = self.image_url_template
+        if self.image_width is not None:
+            body["imageWidth"] = self.image_width
+        if self.link_open_in_new_tab is not None:
+            body["linkOpenInNewTab"] = self.link_open_in_new_tab
+        if self.link_text_template is not None:
+            body["linkTextTemplate"] = self.link_text_template
+        if self.link_title_template is not None:
+            body["linkTitleTemplate"] = self.link_title_template
+        if self.link_url_template is not None:
+            body["linkUrlTemplate"] = self.link_url_template
+        if self.name is not None:
+            body["name"] = self.name
+        if self.number_format is not None:
+            body["numberFormat"] = self.number_format
+        if self.order is not None:
+            body["order"] = self.order
+        if self.preserve_whitespace is not None:
+            body["preserveWhitespace"] = self.preserve_whitespace
+        if self.title is not None:
+            body["title"] = self.title
+        if self.type is not None:
+            body["type"] = self.type.value
+        if self.use_monospace_font is not None:
+            body["useMonospaceFont"] = self.use_monospace_font
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableV1SpecInvisibleColumnsItem:
+        return cls(
+            align_content=_enum(d, "alignContent", Alignment),
+            allow_html=d.get("allowHTML", None),
+            allow_search=d.get("allowSearch", None),
+            boolean_values=d.get("booleanValues", None),
+            date_time_format=d.get("dateTimeFormat", None),
+            decimal_format=d.get("decimalFormat", None),
+            default_column_width=d.get("defaultColumnWidth", None),
+            description=d.get("description", None),
+            display_as=_enum(d, "displayAs", DisplayType),
+            highlight_links=d.get("highlightLinks", None),
+            image_height=d.get("imageHeight", None),
+            image_title_template=d.get("imageTitleTemplate", None),
+            image_url_template=d.get("imageUrlTemplate", None),
+            image_width=d.get("imageWidth", None),
+            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
+            link_text_template=d.get("linkTextTemplate", None),
+            link_title_template=d.get("linkTitleTemplate", None),
+            link_url_template=d.get("linkUrlTemplate", None),
+            name=d.get("name", None),
+            number_format=d.get("numberFormat", None),
+            order=d.get("order", None),
+            preserve_whitespace=d.get("preserveWhitespace", None),
+            title=d.get("title", None),
+            type=_enum(d, "type", ColumnType),
+            use_monospace_font=d.get("useMonospaceFont", None),
+        )
+
+
+@dataclass
+class TableV2Spec:
+    encodings: TableEncodingMap
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "table",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TableV2Spec:
+        return cls(
+            encodings=_from_dict(d, "encodings", TableEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+        )
+
+
+@dataclass
+class TemporalScale:
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "type": "temporal",
+        }
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TemporalScale:
+        return cls()
+
+
+@dataclass
+class TextEntrySpec:
+    encodings: ControlEncodingMap
+    exclude: bool | None = None
+    frame: WidgetFrameSpec | None = None
+    is_case_sensitive: bool | None = None
+    match_mode: TextEntrySpecMatchMode | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "filter-text-entry",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.exclude is not None:
+            body["exclude"] = self.exclude
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        if self.is_case_sensitive is not None:
+            body["isCaseSensitive"] = self.is_case_sensitive
+        if self.match_mode is not None:
+            body["matchMode"] = self.match_mode.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TextEntrySpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", ControlEncodingMap),
+            exclude=d.get("exclude", None),
+            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            is_case_sensitive=d.get("isCaseSensitive", None),
+            match_mode=_enum(d, "matchMode", TextEntrySpecMatchMode),
+        )
+
+
+class TextEntrySpecMatchMode(Enum):
+    CONTAINS = "contains"
+    EXACT_MATCH = "exact-match"
+    STARTS_WITH = "starts-with"
+
+
+@dataclass
+class Widget:
+    name: str
+    queries: list[NamedQuery] | None = None
+    spec: str | None = None
+    textbox_spec: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.name is not None:
+            body["name"] = self.name
+        if self.queries:
+            body["queries"] = [v.as_dict() for v in self.queries]
+        if self.spec is not None:
+            body["spec"] = self.spec
+        if self.textbox_spec is not None:
+            body["textbox_spec"] = self.textbox_spec
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Widget:
+        return cls(
+            name=d.get("name", None),
+            queries=_repeated_dict(d, "queries", NamedQuery),
+            spec=d.get("spec", None),
+            textbox_spec=d.get("textbox_spec", None),
+        )
+
+
+@dataclass
+class WidgetFrameSpec:
+    description: str | None = None
+    show_description: bool | None = None
+    show_title: bool | None = None
+    title: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.description is not None:
+            body["description"] = self.description
+        if self.show_description is not None:
+            body["showDescription"] = self.show_description
+        if self.show_title is not None:
+            body["showTitle"] = self.show_title
+        if self.title is not None:
+            body["title"] = self.title
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> WidgetFrameSpec:
+        return cls(
+            description=d.get("description", None),
+            show_description=d.get("showDescription", None),
+            show_title=d.get("showTitle", None),
+            title=d.get("title", None),
+        )
+
+
+@dataclass
+class WordCloudEncodingMap:
+    size: RenderFieldEncoding | None = None
+    text: RenderFieldEncoding | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if self.size:
+            body["size"] = self.size.as_dict()
+        if self.text:
+            body["text"] = self.text.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> WordCloudEncodingMap:
+        return cls(size=_from_dict(d, "size", RenderFieldEncoding), text=_from_dict(d, "text", RenderFieldEncoding))
+
+
+@dataclass
+class WordCloudSpec:
+    encodings: WordCloudEncodingMap
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "version": 2,
+            "widgetType": "word-cloud",
+        }
+        if self.encodings:
+            body["encodings"] = self.encodings.as_dict()
+        if self.frame:
+            body["frame"] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> WordCloudSpec:
+        return cls(
+            encodings=_from_dict(d, "encodings", WordCloudEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+        )

--- a/src/databricks/labs/ucx/framework/lakeview/model.py
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py
@@ -176,7 +176,7 @@ class CategoricalColorScaleMappingEntry:
 @dataclass
 class CategoricalScale:
     mappings: List[CategoricalColorScaleMappingEntry] | None = None
-    sort: Any | None = None
+    sort: Sort | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
@@ -185,12 +185,14 @@ class CategoricalScale:
         if self.mappings:
             body['mappings'] = [v.as_dict() for v in self.mappings]
         if self.sort:
-            body['sort'] = self.sort
+            body['sort'] = self.sort.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> CategoricalScale:
-        return cls(mappings=_repeated_dict(d, 'mappings', CategoricalColorScaleMappingEntry), sort=d.get('sort', None))
+        return cls(
+            mappings=_repeated_dict(d, 'mappings', CategoricalColorScaleMappingEntry), sort=_from_dict(d, 'sort', Sort)
+        )
 
 
 @dataclass
@@ -1332,8 +1334,8 @@ class SingleFieldAxisEncoding:
 
 
 @dataclass
-class SortByChannel:
-    by: SortByChannelBy
+class Sort:
+    by: SortBy
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
@@ -1342,35 +1344,17 @@ class SortByChannel:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> SortByChannel:
-        return cls(by=_enum(d, 'by', SortByChannelBy))
+    def from_dict(cls, d: Dict[str, Any]) -> Sort:
+        return cls(by=_enum(d, 'by', SortBy))
 
 
-class SortByChannelBy(Enum):
+class SortBy(Enum):
+    NATURAL_ORDER = 'natural-order'
+    NATURAL_ORDER_REVERSED = 'natural-order-reversed'
     X = 'x'
     X_REVERSED = 'x-reversed'
     Y = 'y'
     Y_REVERSED = 'y-reversed'
-
-
-@dataclass
-class SortByNaturalOrder:
-    by: SortByNaturalOrderBy
-
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = {}
-        if self.by is not None:
-            body['by'] = self.by.value
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> SortByNaturalOrder:
-        return cls(by=_enum(d, 'by', SortByNaturalOrderBy))
-
-
-class SortByNaturalOrderBy(Enum):
-    NATURAL_ORDER = 'natural-order'
-    NATURAL_ORDER_REVERSED = 'natural-order-reversed'
 
 
 @dataclass

--- a/src/databricks/labs/ucx/framework/lakeview/model.py
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py
@@ -1,22 +1,20 @@
 # Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 
 from __future__ import annotations
-
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
-from typing import Any
-
-from databricks.sdk.service._internal import (
-    _enum,
-    _from_dict,
-    _repeated_dict,
-)
+from typing import Dict, List, Any, Iterator, Type, Callable, Optional, BinaryIO
+import time
+import random
+import logging
+from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 
 class Alignment(Enum):
-    CENTER = "center"
-    LEFT = "left"
-    RIGHT = "right"
+    CENTER = 'center'
+    LEFT = 'left'
+    RIGHT = 'right'
 
 
 @dataclass
@@ -27,14 +25,14 @@ class AngleAxisSpec:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.hide_title is not None:
-            body["hideTitle"] = self.hide_title
+            body['hideTitle'] = self.hide_title
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AngleAxisSpec:
-        return cls(hide_title=d.get("hideTitle", None), title=d.get("title", None))
+    def from_dict(cls, d: Dict[str, Any]) -> AngleAxisSpec:
+        return cls(hide_title=d.get('hideTitle', None), title=d.get('title', None))
 
 
 @dataclass
@@ -47,22 +45,22 @@ class AngleFieldEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.axis:
-            body["axis"] = self.axis.as_dict()
+            body['axis'] = self.axis.as_dict()
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.scale:
-            body["scale"] = self.scale.as_dict()
+            body['scale'] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AngleFieldEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> AngleFieldEncoding:
         return cls(
-            axis=_from_dict(d, "axis", AngleAxisSpec),
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            scale=_from_dict(d, "scale", QuantitativeScale),
+            axis=_from_dict(d, 'axis', AngleAxisSpec),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            scale=_from_dict(d, 'scale', QuantitativeScale),
         )
 
 
@@ -77,26 +75,26 @@ class AreaSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "area",
+            'version': 3,
+            'widgetType': 'area',
         }
         if self.encodings:
-            body["encodings"] = self.encodings
+            body['encodings'] = self.encodings
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.mark:
-            body["mark"] = self.mark.as_dict()
+            body['mark'] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AreaSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> AreaSpec:
         return cls(
-            encodings=d.get("encodings", None),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            mark=_from_dict(d, "mark", MarkSpec),
+            encodings=d.get('encodings', None),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            mark=_from_dict(d, 'mark', MarkSpec),
         )
 
 
@@ -109,17 +107,17 @@ class AxisSpec:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.hide_labels is not None:
-            body["hideLabels"] = self.hide_labels
+            body['hideLabels'] = self.hide_labels
         if self.hide_title is not None:
-            body["hideTitle"] = self.hide_title
+            body['hideTitle'] = self.hide_title
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AxisSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> AxisSpec:
         return cls(
-            hide_labels=d.get("hideLabels", None), hide_title=d.get("hideTitle", None), title=d.get("title", None)
+            hide_labels=d.get('hideLabels', None), hide_title=d.get('hideTitle', None), title=d.get('title', None)
         )
 
 
@@ -134,26 +132,26 @@ class BarSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "bar",
+            'version': 3,
+            'widgetType': 'bar',
         }
         if self.encodings:
-            body["encodings"] = self.encodings
+            body['encodings'] = self.encodings
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.mark:
-            body["mark"] = self.mark.as_dict()
+            body['mark'] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> BarSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> BarSpec:
         return cls(
-            encodings=d.get("encodings", None),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            mark=_from_dict(d, "mark", MarkSpec),
+            encodings=d.get('encodings', None),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            mark=_from_dict(d, 'mark', MarkSpec),
         )
 
 
@@ -165,34 +163,34 @@ class CategoricalColorScaleMappingEntry:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.color is not None:
-            body["color"] = self.color
+            body['color'] = self.color
         if self.value is not None:
-            body["value"] = self.value.value
+            body['value'] = self.value.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CategoricalColorScaleMappingEntry:
-        return cls(color=d.get("color", None), value=_enum(d, "value", DataDomainValue))
+    def from_dict(cls, d: Dict[str, Any]) -> CategoricalColorScaleMappingEntry:
+        return cls(color=d.get('color', None), value=_enum(d, 'value', DataDomainValue))
 
 
 @dataclass
 class CategoricalScale:
-    mappings: list[CategoricalColorScaleMappingEntry] | None = None
+    mappings: List[CategoricalColorScaleMappingEntry] | None = None
     sort: Any | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "type": "categorical",
+            'type': 'categorical',
         }
         if self.mappings:
-            body["mappings"] = [v.as_dict() for v in self.mappings]
+            body['mappings'] = [v.as_dict() for v in self.mappings]
         if self.sort:
-            body["sort"] = self.sort
+            body['sort'] = self.sort
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CategoricalScale:
-        return cls(mappings=_repeated_dict(d, "mappings", CategoricalColorScaleMappingEntry), sort=d.get("sort", None))
+    def from_dict(cls, d: Dict[str, Any]) -> CategoricalScale:
+        return cls(mappings=_repeated_dict(d, 'mappings', CategoricalColorScaleMappingEntry), sort=d.get('sort', None))
 
 
 @dataclass
@@ -205,22 +203,22 @@ class ChartEncodingMapWithMultiX:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.color:
-            body["color"] = self.color.as_dict()
+            body['color'] = self.color.as_dict()
         if self.label:
-            body["label"] = self.label.as_dict()
+            body['label'] = self.label.as_dict()
         if self.x:
-            body["x"] = self.x.as_dict()
+            body['x'] = self.x.as_dict()
         if self.y:
-            body["y"] = self.y.as_dict()
+            body['y'] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithMultiX:
+    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithMultiX:
         return cls(
-            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
-            label=_from_dict(d, "label", LabelEncoding),
-            x=_from_dict(d, "x", MultiFieldAxisEncoding),
-            y=_from_dict(d, "y", SingleFieldAxisEncoding),
+            color=_from_dict(d, 'color', ColorEncodingForMultiSeries),
+            label=_from_dict(d, 'label', LabelEncoding),
+            x=_from_dict(d, 'x', MultiFieldAxisEncoding),
+            y=_from_dict(d, 'y', SingleFieldAxisEncoding),
         )
 
 
@@ -234,22 +232,22 @@ class ChartEncodingMapWithMultiY:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.color:
-            body["color"] = self.color.as_dict()
+            body['color'] = self.color.as_dict()
         if self.label:
-            body["label"] = self.label.as_dict()
+            body['label'] = self.label.as_dict()
         if self.x:
-            body["x"] = self.x.as_dict()
+            body['x'] = self.x.as_dict()
         if self.y:
-            body["y"] = self.y.as_dict()
+            body['y'] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithMultiY:
+    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithMultiY:
         return cls(
-            color=_from_dict(d, "color", ColorEncodingForMultiSeries),
-            label=_from_dict(d, "label", LabelEncoding),
-            x=_from_dict(d, "x", SingleFieldAxisEncoding),
-            y=_from_dict(d, "y", MultiFieldAxisEncoding),
+            color=_from_dict(d, 'color', ColorEncodingForMultiSeries),
+            label=_from_dict(d, 'label', LabelEncoding),
+            x=_from_dict(d, 'x', SingleFieldAxisEncoding),
+            y=_from_dict(d, 'y', MultiFieldAxisEncoding),
         )
 
 
@@ -263,22 +261,22 @@ class ChartEncodingMapWithSingleXy:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.color:
-            body["color"] = self.color.as_dict()
+            body['color'] = self.color.as_dict()
         if self.label:
-            body["label"] = self.label.as_dict()
+            body['label'] = self.label.as_dict()
         if self.x:
-            body["x"] = self.x.as_dict()
+            body['x'] = self.x.as_dict()
         if self.y:
-            body["y"] = self.y.as_dict()
+            body['y'] = self.y.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ChartEncodingMapWithSingleXy:
+    def from_dict(cls, d: Dict[str, Any]) -> ChartEncodingMapWithSingleXy:
         return cls(
-            color=_from_dict(d, "color", ColorFieldEncoding),
-            label=_from_dict(d, "label", LabelEncoding),
-            x=_from_dict(d, "x", SingleFieldAxisEncoding),
-            y=_from_dict(d, "y", SingleFieldAxisEncoding),
+            color=_from_dict(d, 'color', ColorFieldEncoding),
+            label=_from_dict(d, 'label', LabelEncoding),
+            x=_from_dict(d, 'x', SingleFieldAxisEncoding),
+            y=_from_dict(d, 'y', SingleFieldAxisEncoding),
         )
 
 
@@ -289,12 +287,12 @@ class ColorEncodingForMultiSeries:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.legend:
-            body["legend"] = self.legend.as_dict()
+            body['legend'] = self.legend.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ColorEncodingForMultiSeries:
-        return cls(legend=_from_dict(d, "legend", LegendSpec))
+    def from_dict(cls, d: Dict[str, Any]) -> ColorEncodingForMultiSeries:
+        return cls(legend=_from_dict(d, 'legend', LegendSpec))
 
 
 @dataclass
@@ -307,34 +305,34 @@ class ColorFieldEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.legend:
-            body["legend"] = self.legend.as_dict()
+            body['legend'] = self.legend.as_dict()
         if self.scale:
-            body["scale"] = self.scale
+            body['scale'] = self.scale
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ColorFieldEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> ColorFieldEncoding:
         return cls(
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            legend=_from_dict(d, "legend", LegendSpec),
-            scale=d.get("scale", None),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            legend=_from_dict(d, 'legend', LegendSpec),
+            scale=d.get('scale', None),
         )
 
 
 class ColumnType(Enum):
-    BOOLEAN = "boolean"
-    COMPLEX = "complex"
-    DATE = "date"
-    DATETIME = "datetime"
-    DECIMAL = "decimal"
-    FLOAT = "float"
-    INTEGER = "integer"
-    STRING = "string"
+    BOOLEAN = 'boolean'
+    COMPLEX = 'complex'
+    DATE = 'date'
+    DATETIME = 'datetime'
+    DECIMAL = 'decimal'
+    FLOAT = 'float'
+    INTEGER = 'integer'
+    STRING = 'string'
 
 
 @dataclass
@@ -344,12 +342,12 @@ class ControlEncodingMap:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.fields:
-            body["fields"] = self.fields
+            body['fields'] = self.fields
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ControlEncodingMap:
-        return cls(fields=d.get("fields", None))
+    def from_dict(cls, d: Dict[str, Any]) -> ControlEncodingMap:
+        return cls(fields=d.get('fields', None))
 
 
 @dataclass
@@ -360,15 +358,15 @@ class CounterEncodingMap:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.target:
-            body["target"] = self.target.as_dict()
+            body['target'] = self.target.as_dict()
         if self.value:
-            body["value"] = self.value.as_dict()
+            body['value'] = self.value.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CounterEncodingMap:
+    def from_dict(cls, d: Dict[str, Any]) -> CounterEncodingMap:
         return cls(
-            target=_from_dict(d, "target", CounterFieldEncoding), value=_from_dict(d, "value", CounterFieldEncoding)
+            target=_from_dict(d, 'target', CounterFieldEncoding), value=_from_dict(d, 'value', CounterFieldEncoding)
         )
 
 
@@ -381,19 +379,19 @@ class CounterFieldEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.row_number is not None:
-            body["rowNumber"] = self.row_number
+            body['rowNumber'] = self.row_number
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CounterFieldEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> CounterFieldEncoding:
         return cls(
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            row_number=d.get("rowNumber", None),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            row_number=d.get('rowNumber', None),
         )
 
 
@@ -405,49 +403,49 @@ class CounterSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "counter",
+            'version': 2,
+            'widgetType': 'counter',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CounterSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> CounterSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", CounterEncodingMap),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            encodings=_from_dict(d, 'encodings', CounterEncodingMap),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
         )
 
 
 @dataclass
 class Dashboard:
-    datasets: list[Dataset]
-    pages: list[Page]
+    datasets: List[Dataset]
+    pages: List[Page]
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.datasets:
-            body["datasets"] = [v.as_dict() for v in self.datasets]
+            body['datasets'] = [v.as_dict() for v in self.datasets]
         if self.pages:
-            body["pages"] = [v.as_dict() for v in self.pages]
+            body['pages'] = [v.as_dict() for v in self.pages]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Dashboard:
-        return cls(datasets=_repeated_dict(d, "datasets", Dataset), pages=_repeated_dict(d, "pages", Page))
+    def from_dict(cls, d: Dict[str, Any]) -> Dashboard:
+        return cls(datasets=_repeated_dict(d, 'datasets', Dataset), pages=_repeated_dict(d, 'pages', Page))
 
 
 class DataDomainValue(Enum):
-    BOOLEAN = "boolean"
-    NULL = "null"
-    NUMBER = "number"
-    STRING = "string"
+    BOOLEAN = 'boolean'
+    NULL = 'null'
+    NUMBER = 'number'
+    STRING = 'string'
 
 
 @dataclass
@@ -459,16 +457,16 @@ class Dataset:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         if self.query is not None:
-            body["query"] = self.query
+            body['query'] = self.query
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Dataset:
-        return cls(display_name=d.get("displayName", None), name=d.get("name", None), query=d.get("query", None))
+    def from_dict(cls, d: Dict[str, Any]) -> Dataset:
+        return cls(display_name=d.get('displayName', None), name=d.get('name', None), query=d.get('query', None))
 
 
 @dataclass
@@ -479,23 +477,23 @@ class DatePickerSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "filter-date-picker",
+            'version': 2,
+            'widgetType': 'filter-date-picker',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.exclude is not None:
-            body["exclude"] = self.exclude
+            body['exclude'] = self.exclude
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DatePickerSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> DatePickerSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", ControlEncodingMap),
-            exclude=d.get("exclude", None),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
+            exclude=d.get('exclude', None),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
         )
 
 
@@ -507,23 +505,23 @@ class DateRangePickerSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "filter-date-range-picker",
+            'version': 2,
+            'widgetType': 'filter-date-range-picker',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.exclude is not None:
-            body["exclude"] = self.exclude
+            body['exclude'] = self.exclude
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DateRangePickerSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> DateRangePickerSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", ControlEncodingMap),
-            exclude=d.get("exclude", None),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
+            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
+            exclude=d.get('exclude', None),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
         )
 
 
@@ -537,38 +535,38 @@ class DetailsV1ColumnEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         if self.type is not None:
-            body["type"] = self.type.value
+            body['type'] = self.type.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DetailsV1ColumnEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1ColumnEncoding:
         return cls(
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            title=d.get("title", None),
-            type=_enum(d, "type", ColumnType),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            title=d.get('title', None),
+            type=_enum(d, 'type', ColumnType),
         )
 
 
 @dataclass
 class DetailsV1EncodingMap:
-    columns: list[DetailsV1ColumnEncoding] | None = None
+    columns: List[DetailsV1ColumnEncoding] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.columns:
-            body["columns"] = [v.as_dict() for v in self.columns]
+            body['columns'] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DetailsV1EncodingMap:
-        return cls(columns=_repeated_dict(d, "columns", DetailsV1ColumnEncoding))
+    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1EncodingMap:
+        return cls(columns=_repeated_dict(d, 'columns', DetailsV1ColumnEncoding))
 
 
 @dataclass
@@ -578,72 +576,64 @@ class DetailsV1Spec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 1,
-            "widgetType": "details",
+            'version': 1,
+            'widgetType': 'details',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DetailsV1Spec:
+    def from_dict(cls, d: Dict[str, Any]) -> DetailsV1Spec:
         return cls(
-            encodings=_from_dict(d, "encodings", DetailsV1EncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+            encodings=_from_dict(d, 'encodings', DetailsV1EncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
         )
 
 
 class Direction(Enum):
-    ASC = "ASC"
-    DESC = "DESC"
-    DIRECTION_UNSPECIFIED = "DIRECTION_UNSPECIFIED"
+    ASC = 'ASC'
+    DESC = 'DESC'
+    DIRECTION_UNSPECIFIED = 'DIRECTION_UNSPECIFIED'
 
 
 class DisplayType(Enum):
-    BOOLEAN = "boolean"
-    DATETIME = "datetime"
-    IMAGE = "image"
-    JSON = "json"
-    LINK = "link"
-    NUMBER = "number"
-    STRING = "string"
+    BOOLEAN = 'boolean'
+    DATETIME = 'datetime'
+    IMAGE = 'image'
+    JSON = 'json'
+    LINK = 'link'
+    NUMBER = 'number'
+    STRING = 'string'
 
 
 @dataclass
 class DropdownSpec:
     encodings: ControlEncodingMap
-    widget_type: DropdownSpecWidgetType
     exclude: bool | None = None
     frame: WidgetFrameSpec | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
+            'version': 2,
+            'widgetType': 'filter-single-select',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.exclude is not None:
-            body["exclude"] = self.exclude
+            body['exclude'] = self.exclude
         if self.frame:
-            body["frame"] = self.frame.as_dict()
-        if self.widget_type is not None:
-            body["widgetType"] = self.widget_type.value
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> DropdownSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> DropdownSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", ControlEncodingMap),
-            exclude=d.get("exclude", None),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            widget_type=_enum(d, "widgetType", DropdownSpecWidgetType),
+            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
+            exclude=d.get('exclude', None),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
         )
-
-
-class DropdownSpecWidgetType(Enum):
-    FILTER_MULTI_SELECT = "filter-multi-select"
-    FILTER_SINGLE_SELECT = "filter-single-select"
 
 
 @dataclass
@@ -654,14 +644,14 @@ class Field:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.expression is not None:
-            body["expression"] = self.expression
+            body['expression'] = self.expression
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Field:
-        return cls(expression=d.get("expression", None), name=d.get("name", None))
+    def from_dict(cls, d: Dict[str, Any]) -> Field:
+        return cls(expression=d.get('expression', None), name=d.get('name', None))
 
 
 @dataclass
@@ -673,19 +663,19 @@ class FieldEncodingWithDataFor:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.query_name is not None:
-            body["queryName"] = self.query_name
+            body['queryName'] = self.query_name
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FieldEncodingWithDataFor:
+    def from_dict(cls, d: Dict[str, Any]) -> FieldEncodingWithDataFor:
         return cls(
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            query_name=d.get("queryName", None),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            query_name=d.get('queryName', None),
         )
 
 
@@ -696,12 +686,12 @@ class Format:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.foreground_color is not None:
-            body["foregroundColor"] = self.foreground_color
+            body['foregroundColor'] = self.foreground_color
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Format:
-        return cls(foreground_color=d.get("foregroundColor", None))
+    def from_dict(cls, d: Dict[str, Any]) -> Format:
+        return cls(foreground_color=d.get('foregroundColor', None))
 
 
 @dataclass
@@ -713,19 +703,19 @@ class FormatConfig:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.number_format:
-            body["numberFormat"] = self.number_format.as_dict()
+            body['numberFormat'] = self.number_format.as_dict()
         if self.percent_format:
-            body["percentFormat"] = self.percent_format.as_dict()
+            body['percentFormat'] = self.percent_format.as_dict()
         if self.time_format:
-            body["timeFormat"] = self.time_format.as_dict()
+            body['timeFormat'] = self.time_format.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FormatConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> FormatConfig:
         return cls(
-            number_format=_from_dict(d, "numberFormat", NumeralNumberFormat),
-            percent_format=_from_dict(d, "percentFormat", NumeralNumberFormat),
-            time_format=_from_dict(d, "timeFormat", MomentTimeFormat),
+            number_format=_from_dict(d, 'numberFormat', NumeralNumberFormat),
+            percent_format=_from_dict(d, 'percentFormat', NumeralNumberFormat),
+            time_format=_from_dict(d, 'timeFormat', MomentTimeFormat),
         )
 
 
@@ -736,12 +726,12 @@ class LabelEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.show is not None:
-            body["show"] = self.show
+            body['show'] = self.show
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LabelEncoding:
-        return cls(show=d.get("show", None))
+    def from_dict(cls, d: Dict[str, Any]) -> LabelEncoding:
+        return cls(show=d.get('show', None))
 
 
 @dataclass
@@ -752,14 +742,14 @@ class Layout:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.position:
-            body["position"] = self.position.as_dict()
+            body['position'] = self.position.as_dict()
         if self.widget:
-            body["widget"] = self.widget.as_dict()
+            body['widget'] = self.widget.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Layout:
-        return cls(position=_from_dict(d, "position", Position), widget=_from_dict(d, "widget", Widget))
+    def from_dict(cls, d: Dict[str, Any]) -> Layout:
+        return cls(position=_from_dict(d, 'position', Position), widget=_from_dict(d, 'widget', Widget))
 
 
 @dataclass
@@ -771,25 +761,25 @@ class LegendSpec:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.hide_title is not None:
-            body["hideTitle"] = self.hide_title
+            body['hideTitle'] = self.hide_title
         if self.position is not None:
-            body["position"] = self.position.value
+            body['position'] = self.position.value
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LegendSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> LegendSpec:
         return cls(
-            hide_title=d.get("hideTitle", None),
-            position=_enum(d, "position", LegendSpecPosition),
-            title=d.get("title", None),
+            hide_title=d.get('hideTitle', None),
+            position=_enum(d, 'position', LegendSpecPosition),
+            title=d.get('title', None),
         )
 
 
 class LegendSpecPosition(Enum):
-    BOTTOM = "bottom"
-    RIGHT = "right"
+    BOTTOM = 'bottom'
+    RIGHT = 'right'
 
 
 @dataclass
@@ -803,51 +793,51 @@ class LineSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "line",
+            'version': 3,
+            'widgetType': 'line',
         }
         if self.encodings:
-            body["encodings"] = self.encodings
+            body['encodings'] = self.encodings
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.mark:
-            body["mark"] = self.mark.as_dict()
+            body['mark'] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LineSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> LineSpec:
         return cls(
-            encodings=d.get("encodings", None),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            mark=_from_dict(d, "mark", MarkSpec),
+            encodings=d.get('encodings', None),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            mark=_from_dict(d, 'mark', MarkSpec),
         )
 
 
 class MarkLayout(Enum):
-    GROUP = "group"
-    LAYER = "layer"
-    STACK = "stack"
+    GROUP = 'group'
+    LAYER = 'layer'
+    STACK = 'stack'
 
 
 @dataclass
 class MarkSpec:
-    colors: list[str] | None = None
+    colors: List[str] | None = None
     layout: MarkLayout | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.colors:
-            body["colors"] = [v for v in self.colors]
+            body['colors'] = [v for v in self.colors]
         if self.layout is not None:
-            body["layout"] = self.layout.value
+            body['layout'] = self.layout.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MarkSpec:
-        return cls(colors=d.get("colors", None), layout=_enum(d, "layout", MarkLayout))
+    def from_dict(cls, d: Dict[str, Any]) -> MarkSpec:
+        return cls(colors=d.get('colors', None), layout=_enum(d, 'layout', MarkLayout))
 
 
 @dataclass
@@ -856,39 +846,67 @@ class MomentTimeFormat:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "formatType": "moment",
+            'formatType': 'moment',
         }
         if self.format is not None:
-            body["format"] = self.format
+            body['format'] = self.format
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MomentTimeFormat:
-        return cls(format=d.get("format", None))
+    def from_dict(cls, d: Dict[str, Any]) -> MomentTimeFormat:
+        return cls(format=d.get('format', None))
 
 
 @dataclass
 class MultiFieldAxisEncoding:
-    fields: list[RenderFieldEncoding]
+    fields: List[RenderFieldEncoding]
     scale: QuantitativeScale
     axis: AxisSpec | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.axis:
-            body["axis"] = self.axis.as_dict()
+            body['axis'] = self.axis.as_dict()
         if self.fields:
-            body["fields"] = [v.as_dict() for v in self.fields]
+            body['fields'] = [v.as_dict() for v in self.fields]
         if self.scale:
-            body["scale"] = self.scale.as_dict()
+            body['scale'] = self.scale.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MultiFieldAxisEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> MultiFieldAxisEncoding:
         return cls(
-            axis=_from_dict(d, "axis", AxisSpec),
-            fields=_repeated_dict(d, "fields", RenderFieldEncoding),
-            scale=_from_dict(d, "scale", QuantitativeScale),
+            axis=_from_dict(d, 'axis', AxisSpec),
+            fields=_repeated_dict(d, 'fields', RenderFieldEncoding),
+            scale=_from_dict(d, 'scale', QuantitativeScale),
+        )
+
+
+@dataclass
+class MultiSelectSpec:
+    encodings: ControlEncodingMap
+    exclude: bool | None = None
+    frame: WidgetFrameSpec | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            'version': 2,
+            'widgetType': 'filter-multi-select',
+        }
+        if self.encodings:
+            body['encodings'] = self.encodings.as_dict()
+        if self.exclude is not None:
+            body['exclude'] = self.exclude
+        if self.frame:
+            body['frame'] = self.frame.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> MultiSelectSpec:
+        return cls(
+            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
+            exclude=d.get('exclude', None),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
         )
 
 
@@ -900,14 +918,14 @@ class NamedQuery:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         if self.query:
-            body["query"] = self.query.as_dict()
+            body['query'] = self.query.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> NamedQuery:
-        return cls(name=d.get("name", None), query=_from_dict(d, "query", Order))
+    def from_dict(cls, d: Dict[str, Any]) -> NamedQuery:
+        return cls(name=d.get('name', None), query=_from_dict(d, 'query', Order))
 
 
 @dataclass
@@ -916,15 +934,15 @@ class NumeralNumberFormat:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "formatType": "numeral",
+            'formatType': 'numeral',
         }
         if self.format is not None:
-            body["format"] = self.format
+            body['format'] = self.format
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> NumeralNumberFormat:
-        return cls(format=d.get("format", None))
+    def from_dict(cls, d: Dict[str, Any]) -> NumeralNumberFormat:
+        return cls(format=d.get('format', None))
 
 
 @dataclass
@@ -935,44 +953,44 @@ class Order:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.direction is not None:
-            body["direction"] = self.direction.value
+            body['direction'] = self.direction.value
         if self.expression is not None:
-            body["expression"] = self.expression
+            body['expression'] = self.expression
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Order:
-        return cls(direction=_enum(d, "direction", Direction), expression=d.get("expression", None))
+    def from_dict(cls, d: Dict[str, Any]) -> Order:
+        return cls(direction=_enum(d, 'direction', Direction), expression=d.get('expression', None))
 
 
 @dataclass
 class Page:
     name: str
-    layout: list[Layout]
+    layout: List[Layout]
     display_name: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.layout:
-            body["layout"] = [v.as_dict() for v in self.layout]
+            body['layout'] = [v.as_dict() for v in self.layout]
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Page:
+    def from_dict(cls, d: Dict[str, Any]) -> Page:
         return cls(
-            display_name=d.get("displayName", None),
-            layout=_repeated_dict(d, "layout", Layout),
-            name=d.get("name", None),
+            display_name=d.get('displayName', None),
+            layout=_repeated_dict(d, 'layout', Layout),
+            name=d.get('name', None),
         )
 
 
 class PaginationSize(Enum):
-    DEFAULT = "default"
-    SMALL = "small"
+    DEFAULT = 'default'
+    SMALL = 'small'
 
 
 @dataclass
@@ -983,14 +1001,14 @@ class ParameterEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.dataset_name is not None:
-            body["datasetName"] = self.dataset_name
+            body['datasetName'] = self.dataset_name
         if self.parameter_keyword is not None:
-            body["parameterKeyword"] = self.parameter_keyword
+            body['parameterKeyword'] = self.parameter_keyword
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ParameterEncoding:
-        return cls(dataset_name=d.get("datasetName", None), parameter_keyword=d.get("parameterKeyword", None))
+    def from_dict(cls, d: Dict[str, Any]) -> ParameterEncoding:
+        return cls(dataset_name=d.get('datasetName', None), parameter_keyword=d.get('parameterKeyword', None))
 
 
 @dataclass
@@ -1002,19 +1020,19 @@ class PieEncodingMap:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.angle:
-            body["angle"] = self.angle.as_dict()
+            body['angle'] = self.angle.as_dict()
         if self.color:
-            body["color"] = self.color.as_dict()
+            body['color'] = self.color.as_dict()
         if self.label:
-            body["label"] = self.label.as_dict()
+            body['label'] = self.label.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> PieEncodingMap:
+    def from_dict(cls, d: Dict[str, Any]) -> PieEncodingMap:
         return cls(
-            angle=_from_dict(d, "angle", AngleFieldEncoding),
-            color=_from_dict(d, "color", ColorFieldEncoding),
-            label=_from_dict(d, "label", LabelEncoding),
+            angle=_from_dict(d, 'angle', AngleFieldEncoding),
+            color=_from_dict(d, 'color', ColorFieldEncoding),
+            label=_from_dict(d, 'label', LabelEncoding),
         )
 
 
@@ -1027,26 +1045,26 @@ class PieSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "pie",
+            'version': 3,
+            'widgetType': 'pie',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.mark:
-            body["mark"] = self.mark.as_dict()
+            body['mark'] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> PieSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> PieSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", PieEncodingMap),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            mark=_from_dict(d, "mark", MarkSpec),
+            encodings=_from_dict(d, 'encodings', PieEncodingMap),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            mark=_from_dict(d, 'mark', MarkSpec),
         )
 
 
@@ -1057,41 +1075,41 @@ class PivotCellEncoding:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "cellType": "text",
+            'cellType': 'text',
         }
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> PivotCellEncoding:
-        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
+    def from_dict(cls, d: Dict[str, Any]) -> PivotCellEncoding:
+        return cls(display_name=d.get('displayName', None), field_name=d.get('fieldName', None))
 
 
 @dataclass
 class PivotEncodingMap:
     cell: PivotCellEncoding | None = None
-    columns: list[RenderFieldEncoding] | None = None
-    rows: list[RenderFieldEncoding] | None = None
+    columns: List[RenderFieldEncoding] | None = None
+    rows: List[RenderFieldEncoding] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.cell:
-            body["cell"] = self.cell.as_dict()
+            body['cell'] = self.cell.as_dict()
         if self.columns:
-            body["columns"] = [v.as_dict() for v in self.columns]
+            body['columns'] = [v.as_dict() for v in self.columns]
         if self.rows:
-            body["rows"] = [v.as_dict() for v in self.rows]
+            body['rows'] = [v.as_dict() for v in self.rows]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> PivotEncodingMap:
+    def from_dict(cls, d: Dict[str, Any]) -> PivotEncodingMap:
         return cls(
-            cell=_from_dict(d, "cell", PivotCellEncoding),
-            columns=_repeated_dict(d, "columns", RenderFieldEncoding),
-            rows=_repeated_dict(d, "rows", RenderFieldEncoding),
+            cell=_from_dict(d, 'cell', PivotCellEncoding),
+            columns=_repeated_dict(d, 'columns', RenderFieldEncoding),
+            rows=_repeated_dict(d, 'rows', RenderFieldEncoding),
         )
 
 
@@ -1102,19 +1120,19 @@ class PivotSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "pivot",
+            'version': 3,
+            'widgetType': 'pivot',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> PivotSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> PivotSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", PivotEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+            encodings=_from_dict(d, 'encodings', PivotEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
         )
 
 
@@ -1128,18 +1146,18 @@ class Position:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.height is not None:
-            body["height"] = self.height
+            body['height'] = self.height
         if self.width is not None:
-            body["width"] = self.width
+            body['width'] = self.width
         if self.x is not None:
-            body["x"] = self.x
+            body['x'] = self.x
         if self.y is not None:
-            body["y"] = self.y
+            body['y'] = self.y
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Position:
-        return cls(height=d.get("height", None), width=d.get("width", None), x=d.get("x", None), y=d.get("y", None))
+    def from_dict(cls, d: Dict[str, Any]) -> Position:
+        return cls(height=d.get('height', None), width=d.get('width', None), x=d.get('x', None), y=d.get('y', None))
 
 
 @dataclass
@@ -1150,14 +1168,14 @@ class QuantitativeDomain:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.max is not None:
-            body["max"] = self.max
+            body['max'] = self.max
         if self.min is not None:
-            body["min"] = self.min
+            body['min'] = self.min
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> QuantitativeDomain:
-        return cls(max=d.get("max", None), min=d.get("min", None))
+    def from_dict(cls, d: Dict[str, Any]) -> QuantitativeDomain:
+        return cls(max=d.get('max', None), min=d.get('min', None))
 
 
 @dataclass
@@ -1174,45 +1192,45 @@ class QuantitativeScale:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "type": "quantitative",
+            'type': 'quantitative',
         }
         if self.domain:
-            body["domain"] = self.domain.as_dict()
+            body['domain'] = self.domain.as_dict()
         if self.reverse is not None:
-            body["reverse"] = self.reverse
+            body['reverse'] = self.reverse
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> QuantitativeScale:
-        return cls(domain=_from_dict(d, "domain", QuantitativeDomain), reverse=d.get("reverse", None))
+    def from_dict(cls, d: Dict[str, Any]) -> QuantitativeScale:
+        return cls(domain=_from_dict(d, 'domain', QuantitativeDomain), reverse=d.get('reverse', None))
 
 
 @dataclass
 class Query:
     dataset_name: str
-    fields: list[Field]
+    fields: List[Field]
     disaggregated: bool | None = None
-    orders: list[Order] | None = None
+    orders: List[Order] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.dataset_name is not None:
-            body["datasetName"] = self.dataset_name
+            body['datasetName'] = self.dataset_name
         if self.disaggregated is not None:
-            body["disaggregated"] = self.disaggregated
+            body['disaggregated'] = self.disaggregated
         if self.fields:
-            body["fields"] = [v.as_dict() for v in self.fields]
+            body['fields'] = [v.as_dict() for v in self.fields]
         if self.orders:
-            body["orders"] = [v.as_dict() for v in self.orders]
+            body['orders'] = [v.as_dict() for v in self.orders]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Query:
+    def from_dict(cls, d: Dict[str, Any]) -> Query:
         return cls(
-            dataset_name=d.get("datasetName", None),
-            disaggregated=d.get("disaggregated", None),
-            fields=_repeated_dict(d, "fields", Field),
-            orders=_repeated_dict(d, "orders", Order),
+            dataset_name=d.get('datasetName', None),
+            disaggregated=d.get('disaggregated', None),
+            fields=_repeated_dict(d, 'fields', Field),
+            orders=_repeated_dict(d, 'orders', Order),
         )
 
 
@@ -1226,14 +1244,14 @@ class RenderFieldEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> RenderFieldEncoding:
-        return cls(display_name=d.get("displayName", None), field_name=d.get("fieldName", None))
+    def from_dict(cls, d: Dict[str, Any]) -> RenderFieldEncoding:
+        return cls(display_name=d.get('displayName', None), field_name=d.get('fieldName', None))
 
 
 @dataclass
@@ -1247,26 +1265,26 @@ class ScatterSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 3,
-            "widgetType": "scatter",
+            'version': 3,
+            'widgetType': 'scatter',
         }
         if self.encodings:
-            body["encodings"] = self.encodings
+            body['encodings'] = self.encodings
         if self.format:
-            body["format"] = self.format.as_dict()
+            body['format'] = self.format.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.mark:
-            body["mark"] = self.mark.as_dict()
+            body['mark'] = self.mark.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ScatterSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ScatterSpec:
         return cls(
-            encodings=d.get("encodings", None),
-            format=_from_dict(d, "format", FormatConfig),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            mark=_from_dict(d, "mark", MarkSpec),
+            encodings=d.get('encodings', None),
+            format=_from_dict(d, 'format', FormatConfig),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            mark=_from_dict(d, 'mark', MarkSpec),
         )
 
 
@@ -1280,22 +1298,22 @@ class SingleFieldAxisEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.axis:
-            body["axis"] = self.axis.as_dict()
+            body['axis'] = self.axis.as_dict()
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.scale:
-            body["scale"] = self.scale
+            body['scale'] = self.scale
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> SingleFieldAxisEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> SingleFieldAxisEncoding:
         return cls(
-            axis=_from_dict(d, "axis", AxisSpec),
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            scale=d.get("scale", None),
+            axis=_from_dict(d, 'axis', AxisSpec),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            scale=d.get('scale', None),
         )
 
 
@@ -1306,19 +1324,19 @@ class SortByChannel:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.by is not None:
-            body["by"] = self.by.value
+            body['by'] = self.by.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> SortByChannel:
-        return cls(by=_enum(d, "by", SortByChannelBy))
+    def from_dict(cls, d: Dict[str, Any]) -> SortByChannel:
+        return cls(by=_enum(d, 'by', SortByChannelBy))
 
 
 class SortByChannelBy(Enum):
-    X = "x"
-    X_REVERSED = "x-reversed"
-    Y = "y"
-    Y_REVERSED = "y-reversed"
+    X = 'x'
+    X_REVERSED = 'x-reversed'
+    Y = 'y'
+    Y_REVERSED = 'y-reversed'
 
 
 @dataclass
@@ -1328,17 +1346,17 @@ class SortByNaturalOrder:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.by is not None:
-            body["by"] = self.by.value
+            body['by'] = self.by.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> SortByNaturalOrder:
-        return cls(by=_enum(d, "by", SortByNaturalOrderBy))
+    def from_dict(cls, d: Dict[str, Any]) -> SortByNaturalOrder:
+        return cls(by=_enum(d, 'by', SortByNaturalOrderBy))
 
 
 class SortByNaturalOrderBy(Enum):
-    NATURAL_ORDER = "natural-order"
-    NATURAL_ORDER_REVERSED = "natural-order-reversed"
+    NATURAL_ORDER = 'natural-order'
+    NATURAL_ORDER_REVERSED = 'natural-order-reversed'
 
 
 @dataclass
@@ -1349,16 +1367,16 @@ class SymbolMapEncodingMap:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.latitude:
-            body["latitude"] = self.latitude.as_dict()
+            body['latitude'] = self.latitude.as_dict()
         if self.longitude:
-            body["longitude"] = self.longitude.as_dict()
+            body['longitude'] = self.longitude.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> SymbolMapEncodingMap:
+    def from_dict(cls, d: Dict[str, Any]) -> SymbolMapEncodingMap:
         return cls(
-            latitude=_from_dict(d, "latitude", RenderFieldEncoding),
-            longitude=_from_dict(d, "longitude", RenderFieldEncoding),
+            latitude=_from_dict(d, 'latitude', RenderFieldEncoding),
+            longitude=_from_dict(d, 'longitude', RenderFieldEncoding),
         )
 
 
@@ -1369,35 +1387,35 @@ class SymbolMapSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "symbol-map",
+            'version': 2,
+            'widgetType': 'symbol-map',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> SymbolMapSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> SymbolMapSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", SymbolMapEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+            encodings=_from_dict(d, 'encodings', SymbolMapEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
         )
 
 
 @dataclass
 class TableEncodingMap:
-    columns: list[RenderFieldEncoding] | None = None
+    columns: List[RenderFieldEncoding] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.columns:
-            body["columns"] = [v.as_dict() for v in self.columns]
+            body['columns'] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableEncodingMap:
-        return cls(columns=_repeated_dict(d, "columns", RenderFieldEncoding))
+    def from_dict(cls, d: Dict[str, Any]) -> TableEncodingMap:
+        return cls(columns=_repeated_dict(d, 'columns', RenderFieldEncoding))
 
 
 @dataclass
@@ -1405,7 +1423,7 @@ class TableV1ColumnEncoding:
     """FieldEncoding for TableV1. Note that `visible?` is true by default, which is `false` in the
     legacy v1 table."""
 
-    boolean_values: list[str]
+    boolean_values: List[str]
     display_as: DisplayType
     field_name: str
     title: str
@@ -1436,108 +1454,108 @@ class TableV1ColumnEncoding:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.align_content is not None:
-            body["alignContent"] = self.align_content.value
+            body['alignContent'] = self.align_content.value
         if self.allow_html is not None:
-            body["allowHTML"] = self.allow_html
+            body['allowHTML'] = self.allow_html
         if self.allow_search is not None:
-            body["allowSearch"] = self.allow_search
+            body['allowSearch'] = self.allow_search
         if self.boolean_values:
-            body["booleanValues"] = [v for v in self.boolean_values]
+            body['booleanValues'] = [v for v in self.boolean_values]
         if self.date_time_format is not None:
-            body["dateTimeFormat"] = self.date_time_format
+            body['dateTimeFormat'] = self.date_time_format
         if self.decimal_format is not None:
-            body["decimalFormat"] = self.decimal_format
+            body['decimalFormat'] = self.decimal_format
         if self.default_column_width is not None:
-            body["defaultColumnWidth"] = self.default_column_width
+            body['defaultColumnWidth'] = self.default_column_width
         if self.description is not None:
-            body["description"] = self.description
+            body['description'] = self.description
         if self.display_as is not None:
-            body["displayAs"] = self.display_as.value
+            body['displayAs'] = self.display_as.value
         if self.display_name is not None:
-            body["displayName"] = self.display_name
+            body['displayName'] = self.display_name
         if self.field_name is not None:
-            body["fieldName"] = self.field_name
+            body['fieldName'] = self.field_name
         if self.highlight_links is not None:
-            body["highlightLinks"] = self.highlight_links
+            body['highlightLinks'] = self.highlight_links
         if self.image_height is not None:
-            body["imageHeight"] = self.image_height
+            body['imageHeight'] = self.image_height
         if self.image_title_template is not None:
-            body["imageTitleTemplate"] = self.image_title_template
+            body['imageTitleTemplate'] = self.image_title_template
         if self.image_url_template is not None:
-            body["imageUrlTemplate"] = self.image_url_template
+            body['imageUrlTemplate'] = self.image_url_template
         if self.image_width is not None:
-            body["imageWidth"] = self.image_width
+            body['imageWidth'] = self.image_width
         if self.link_open_in_new_tab is not None:
-            body["linkOpenInNewTab"] = self.link_open_in_new_tab
+            body['linkOpenInNewTab'] = self.link_open_in_new_tab
         if self.link_text_template is not None:
-            body["linkTextTemplate"] = self.link_text_template
+            body['linkTextTemplate'] = self.link_text_template
         if self.link_title_template is not None:
-            body["linkTitleTemplate"] = self.link_title_template
+            body['linkTitleTemplate'] = self.link_title_template
         if self.link_url_template is not None:
-            body["linkUrlTemplate"] = self.link_url_template
+            body['linkUrlTemplate'] = self.link_url_template
         if self.number_format is not None:
-            body["numberFormat"] = self.number_format
+            body['numberFormat'] = self.number_format
         if self.order is not None:
-            body["order"] = self.order
+            body['order'] = self.order
         if self.preserve_whitespace is not None:
-            body["preserveWhitespace"] = self.preserve_whitespace
+            body['preserveWhitespace'] = self.preserve_whitespace
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         if self.type is not None:
-            body["type"] = self.type.value
+            body['type'] = self.type.value
         if self.use_monospace_font is not None:
-            body["useMonospaceFont"] = self.use_monospace_font
+            body['useMonospaceFont'] = self.use_monospace_font
         if self.visible is not None:
-            body["visible"] = self.visible
+            body['visible'] = self.visible
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableV1ColumnEncoding:
+    def from_dict(cls, d: Dict[str, Any]) -> TableV1ColumnEncoding:
         return cls(
-            align_content=_enum(d, "alignContent", Alignment),
-            allow_html=d.get("allowHTML", None),
-            allow_search=d.get("allowSearch", None),
-            boolean_values=d.get("booleanValues", None),
-            date_time_format=d.get("dateTimeFormat", None),
-            decimal_format=d.get("decimalFormat", None),
-            default_column_width=d.get("defaultColumnWidth", None),
-            description=d.get("description", None),
-            display_as=_enum(d, "displayAs", DisplayType),
-            display_name=d.get("displayName", None),
-            field_name=d.get("fieldName", None),
-            highlight_links=d.get("highlightLinks", None),
-            image_height=d.get("imageHeight", None),
-            image_title_template=d.get("imageTitleTemplate", None),
-            image_url_template=d.get("imageUrlTemplate", None),
-            image_width=d.get("imageWidth", None),
-            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
-            link_text_template=d.get("linkTextTemplate", None),
-            link_title_template=d.get("linkTitleTemplate", None),
-            link_url_template=d.get("linkUrlTemplate", None),
-            number_format=d.get("numberFormat", None),
-            order=d.get("order", None),
-            preserve_whitespace=d.get("preserveWhitespace", None),
-            title=d.get("title", None),
-            type=_enum(d, "type", ColumnType),
-            use_monospace_font=d.get("useMonospaceFont", None),
-            visible=d.get("visible", None),
+            align_content=_enum(d, 'alignContent', Alignment),
+            allow_html=d.get('allowHTML', None),
+            allow_search=d.get('allowSearch', None),
+            boolean_values=d.get('booleanValues', None),
+            date_time_format=d.get('dateTimeFormat', None),
+            decimal_format=d.get('decimalFormat', None),
+            default_column_width=d.get('defaultColumnWidth', None),
+            description=d.get('description', None),
+            display_as=_enum(d, 'displayAs', DisplayType),
+            display_name=d.get('displayName', None),
+            field_name=d.get('fieldName', None),
+            highlight_links=d.get('highlightLinks', None),
+            image_height=d.get('imageHeight', None),
+            image_title_template=d.get('imageTitleTemplate', None),
+            image_url_template=d.get('imageUrlTemplate', None),
+            image_width=d.get('imageWidth', None),
+            link_open_in_new_tab=d.get('linkOpenInNewTab', None),
+            link_text_template=d.get('linkTextTemplate', None),
+            link_title_template=d.get('linkTitleTemplate', None),
+            link_url_template=d.get('linkUrlTemplate', None),
+            number_format=d.get('numberFormat', None),
+            order=d.get('order', None),
+            preserve_whitespace=d.get('preserveWhitespace', None),
+            title=d.get('title', None),
+            type=_enum(d, 'type', ColumnType),
+            use_monospace_font=d.get('useMonospaceFont', None),
+            visible=d.get('visible', None),
         )
 
 
 @dataclass
 class TableV1EncodingMap:
-    columns: list[TableV1ColumnEncoding] | None = None
+    columns: List[TableV1ColumnEncoding] | None = None
     """Used columns. These columns are visible or used for search."""
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.columns:
-            body["columns"] = [v.as_dict() for v in self.columns]
+            body['columns'] = [v.as_dict() for v in self.columns]
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableV1EncodingMap:
-        return cls(columns=_repeated_dict(d, "columns", TableV1ColumnEncoding))
+    def from_dict(cls, d: Dict[str, Any]) -> TableV1EncodingMap:
+        return cls(columns=_repeated_dict(d, 'columns', TableV1ColumnEncoding))
 
 
 @dataclass
@@ -1546,7 +1564,7 @@ class TableV1Spec:
     """V1 uses `version` to determine if the v1 editor should set `allowHTML` by default."""
     condensed: bool
     encodings: TableV1EncodingMap
-    invisible_columns: list[TableV1SpecInvisibleColumnsItem]
+    invisible_columns: List[TableV1SpecInvisibleColumnsItem]
     """Unused columns. These columns are invisible and not referred, and thus should not be include in
     the queries (be outside of `encodings`). Even when the base query changes not to include these
     columns, the table still can work without throwing errors."""
@@ -1557,38 +1575,38 @@ class TableV1Spec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 1,
-            "widgetType": "table",
+            'version': 1,
+            'widgetType': 'table',
         }
         if self.allow_html_by_default is not None:
-            body["allowHTMLByDefault"] = self.allow_html_by_default
+            body['allowHTMLByDefault'] = self.allow_html_by_default
         if self.condensed is not None:
-            body["condensed"] = self.condensed
+            body['condensed'] = self.condensed
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.invisible_columns:
-            body["invisibleColumns"] = [v.as_dict() for v in self.invisible_columns]
+            body['invisibleColumns'] = [v.as_dict() for v in self.invisible_columns]
         if self.items_per_page is not None:
-            body["itemsPerPage"] = self.items_per_page
+            body['itemsPerPage'] = self.items_per_page
         if self.pagination_size is not None:
-            body["paginationSize"] = self.pagination_size.value
+            body['paginationSize'] = self.pagination_size.value
         if self.with_row_number is not None:
-            body["withRowNumber"] = self.with_row_number
+            body['withRowNumber'] = self.with_row_number
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableV1Spec:
+    def from_dict(cls, d: Dict[str, Any]) -> TableV1Spec:
         return cls(
-            allow_html_by_default=d.get("allowHTMLByDefault", None),
-            condensed=d.get("condensed", None),
-            encodings=_from_dict(d, "encodings", TableV1EncodingMap),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            invisible_columns=_repeated_dict(d, "invisibleColumns", TableV1SpecInvisibleColumnsItem),
-            items_per_page=d.get("itemsPerPage", None),
-            pagination_size=_enum(d, "paginationSize", PaginationSize),
-            with_row_number=d.get("withRowNumber", None),
+            allow_html_by_default=d.get('allowHTMLByDefault', None),
+            condensed=d.get('condensed', None),
+            encodings=_from_dict(d, 'encodings', TableV1EncodingMap),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            invisible_columns=_repeated_dict(d, 'invisibleColumns', TableV1SpecInvisibleColumnsItem),
+            items_per_page=d.get('itemsPerPage', None),
+            pagination_size=_enum(d, 'paginationSize', PaginationSize),
+            with_row_number=d.get('withRowNumber', None),
         )
 
 
@@ -1598,7 +1616,7 @@ class TableV1SpecInvisibleColumnsItem:
     display_as: DisplayType
     type: ColumnType
     title: str
-    boolean_values: list[str]
+    boolean_values: List[str]
     align_content: Alignment | None = None
     allow_html: bool | None = None
     allow_search: bool | None = None
@@ -1623,85 +1641,85 @@ class TableV1SpecInvisibleColumnsItem:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.align_content is not None:
-            body["alignContent"] = self.align_content.value
+            body['alignContent'] = self.align_content.value
         if self.allow_html is not None:
-            body["allowHTML"] = self.allow_html
+            body['allowHTML'] = self.allow_html
         if self.allow_search is not None:
-            body["allowSearch"] = self.allow_search
+            body['allowSearch'] = self.allow_search
         if self.boolean_values:
-            body["booleanValues"] = [v for v in self.boolean_values]
+            body['booleanValues'] = [v for v in self.boolean_values]
         if self.date_time_format is not None:
-            body["dateTimeFormat"] = self.date_time_format
+            body['dateTimeFormat'] = self.date_time_format
         if self.decimal_format is not None:
-            body["decimalFormat"] = self.decimal_format
+            body['decimalFormat'] = self.decimal_format
         if self.default_column_width is not None:
-            body["defaultColumnWidth"] = self.default_column_width
+            body['defaultColumnWidth'] = self.default_column_width
         if self.description is not None:
-            body["description"] = self.description
+            body['description'] = self.description
         if self.display_as is not None:
-            body["displayAs"] = self.display_as.value
+            body['displayAs'] = self.display_as.value
         if self.highlight_links is not None:
-            body["highlightLinks"] = self.highlight_links
+            body['highlightLinks'] = self.highlight_links
         if self.image_height is not None:
-            body["imageHeight"] = self.image_height
+            body['imageHeight'] = self.image_height
         if self.image_title_template is not None:
-            body["imageTitleTemplate"] = self.image_title_template
+            body['imageTitleTemplate'] = self.image_title_template
         if self.image_url_template is not None:
-            body["imageUrlTemplate"] = self.image_url_template
+            body['imageUrlTemplate'] = self.image_url_template
         if self.image_width is not None:
-            body["imageWidth"] = self.image_width
+            body['imageWidth'] = self.image_width
         if self.link_open_in_new_tab is not None:
-            body["linkOpenInNewTab"] = self.link_open_in_new_tab
+            body['linkOpenInNewTab'] = self.link_open_in_new_tab
         if self.link_text_template is not None:
-            body["linkTextTemplate"] = self.link_text_template
+            body['linkTextTemplate'] = self.link_text_template
         if self.link_title_template is not None:
-            body["linkTitleTemplate"] = self.link_title_template
+            body['linkTitleTemplate'] = self.link_title_template
         if self.link_url_template is not None:
-            body["linkUrlTemplate"] = self.link_url_template
+            body['linkUrlTemplate'] = self.link_url_template
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         if self.number_format is not None:
-            body["numberFormat"] = self.number_format
+            body['numberFormat'] = self.number_format
         if self.order is not None:
-            body["order"] = self.order
+            body['order'] = self.order
         if self.preserve_whitespace is not None:
-            body["preserveWhitespace"] = self.preserve_whitespace
+            body['preserveWhitespace'] = self.preserve_whitespace
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         if self.type is not None:
-            body["type"] = self.type.value
+            body['type'] = self.type.value
         if self.use_monospace_font is not None:
-            body["useMonospaceFont"] = self.use_monospace_font
+            body['useMonospaceFont'] = self.use_monospace_font
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableV1SpecInvisibleColumnsItem:
+    def from_dict(cls, d: Dict[str, Any]) -> TableV1SpecInvisibleColumnsItem:
         return cls(
-            align_content=_enum(d, "alignContent", Alignment),
-            allow_html=d.get("allowHTML", None),
-            allow_search=d.get("allowSearch", None),
-            boolean_values=d.get("booleanValues", None),
-            date_time_format=d.get("dateTimeFormat", None),
-            decimal_format=d.get("decimalFormat", None),
-            default_column_width=d.get("defaultColumnWidth", None),
-            description=d.get("description", None),
-            display_as=_enum(d, "displayAs", DisplayType),
-            highlight_links=d.get("highlightLinks", None),
-            image_height=d.get("imageHeight", None),
-            image_title_template=d.get("imageTitleTemplate", None),
-            image_url_template=d.get("imageUrlTemplate", None),
-            image_width=d.get("imageWidth", None),
-            link_open_in_new_tab=d.get("linkOpenInNewTab", None),
-            link_text_template=d.get("linkTextTemplate", None),
-            link_title_template=d.get("linkTitleTemplate", None),
-            link_url_template=d.get("linkUrlTemplate", None),
-            name=d.get("name", None),
-            number_format=d.get("numberFormat", None),
-            order=d.get("order", None),
-            preserve_whitespace=d.get("preserveWhitespace", None),
-            title=d.get("title", None),
-            type=_enum(d, "type", ColumnType),
-            use_monospace_font=d.get("useMonospaceFont", None),
+            align_content=_enum(d, 'alignContent', Alignment),
+            allow_html=d.get('allowHTML', None),
+            allow_search=d.get('allowSearch', None),
+            boolean_values=d.get('booleanValues', None),
+            date_time_format=d.get('dateTimeFormat', None),
+            decimal_format=d.get('decimalFormat', None),
+            default_column_width=d.get('defaultColumnWidth', None),
+            description=d.get('description', None),
+            display_as=_enum(d, 'displayAs', DisplayType),
+            highlight_links=d.get('highlightLinks', None),
+            image_height=d.get('imageHeight', None),
+            image_title_template=d.get('imageTitleTemplate', None),
+            image_url_template=d.get('imageUrlTemplate', None),
+            image_width=d.get('imageWidth', None),
+            link_open_in_new_tab=d.get('linkOpenInNewTab', None),
+            link_text_template=d.get('linkTextTemplate', None),
+            link_title_template=d.get('linkTitleTemplate', None),
+            link_url_template=d.get('linkUrlTemplate', None),
+            name=d.get('name', None),
+            number_format=d.get('numberFormat', None),
+            order=d.get('order', None),
+            preserve_whitespace=d.get('preserveWhitespace', None),
+            title=d.get('title', None),
+            type=_enum(d, 'type', ColumnType),
+            use_monospace_font=d.get('useMonospaceFont', None),
         )
 
 
@@ -1712,19 +1730,19 @@ class TableV2Spec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "table",
+            'version': 2,
+            'widgetType': 'table',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TableV2Spec:
+    def from_dict(cls, d: Dict[str, Any]) -> TableV2Spec:
         return cls(
-            encodings=_from_dict(d, "encodings", TableEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+            encodings=_from_dict(d, 'encodings', TableEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
         )
 
 
@@ -1732,12 +1750,12 @@ class TableV2Spec:
 class TemporalScale:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "type": "temporal",
+            'type': 'temporal',
         }
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TemporalScale:
+    def from_dict(cls, d: Dict[str, Any]) -> TemporalScale:
         return cls()
 
 
@@ -1751,64 +1769,64 @@ class TextEntrySpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "filter-text-entry",
+            'version': 2,
+            'widgetType': 'filter-text-entry',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.exclude is not None:
-            body["exclude"] = self.exclude
+            body['exclude'] = self.exclude
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         if self.is_case_sensitive is not None:
-            body["isCaseSensitive"] = self.is_case_sensitive
+            body['isCaseSensitive'] = self.is_case_sensitive
         if self.match_mode is not None:
-            body["matchMode"] = self.match_mode.value
+            body['matchMode'] = self.match_mode.value
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> TextEntrySpec:
+    def from_dict(cls, d: Dict[str, Any]) -> TextEntrySpec:
         return cls(
-            encodings=_from_dict(d, "encodings", ControlEncodingMap),
-            exclude=d.get("exclude", None),
-            frame=_from_dict(d, "frame", WidgetFrameSpec),
-            is_case_sensitive=d.get("isCaseSensitive", None),
-            match_mode=_enum(d, "matchMode", TextEntrySpecMatchMode),
+            encodings=_from_dict(d, 'encodings', ControlEncodingMap),
+            exclude=d.get('exclude', None),
+            frame=_from_dict(d, 'frame', WidgetFrameSpec),
+            is_case_sensitive=d.get('isCaseSensitive', None),
+            match_mode=_enum(d, 'matchMode', TextEntrySpecMatchMode),
         )
 
 
 class TextEntrySpecMatchMode(Enum):
-    CONTAINS = "contains"
-    EXACT_MATCH = "exact-match"
-    STARTS_WITH = "starts-with"
+    CONTAINS = 'contains'
+    EXACT_MATCH = 'exact-match'
+    STARTS_WITH = 'starts-with'
 
 
 @dataclass
 class Widget:
     name: str
-    queries: list[NamedQuery] | None = None
-    spec: str | None = None
+    queries: List[NamedQuery] | None = None
+    spec: WidgetSpec | None = None
     textbox_spec: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.name is not None:
-            body["name"] = self.name
+            body['name'] = self.name
         if self.queries:
-            body["queries"] = [v.as_dict() for v in self.queries]
-        if self.spec is not None:
-            body["spec"] = self.spec
+            body['queries'] = [v.as_dict() for v in self.queries]
+        if self.spec:
+            body['spec'] = self.spec.as_dict()
         if self.textbox_spec is not None:
-            body["textbox_spec"] = self.textbox_spec
+            body['textbox_spec'] = self.textbox_spec
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Widget:
+    def from_dict(cls, d: Dict[str, Any]) -> Widget:
         return cls(
-            name=d.get("name", None),
-            queries=_repeated_dict(d, "queries", NamedQuery),
-            spec=d.get("spec", None),
-            textbox_spec=d.get("textbox_spec", None),
+            name=d.get('name', None),
+            queries=_repeated_dict(d, 'queries', NamedQuery),
+            spec=_from_dict(d, 'spec', WidgetSpec),
+            textbox_spec=d.get('textbox_spec', None),
         )
 
 
@@ -1822,23 +1840,65 @@ class WidgetFrameSpec:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.description is not None:
-            body["description"] = self.description
+            body['description'] = self.description
         if self.show_description is not None:
-            body["showDescription"] = self.show_description
+            body['showDescription'] = self.show_description
         if self.show_title is not None:
-            body["showTitle"] = self.show_title
+            body['showTitle'] = self.show_title
         if self.title is not None:
-            body["title"] = self.title
+            body['title'] = self.title
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> WidgetFrameSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> WidgetFrameSpec:
         return cls(
-            description=d.get("description", None),
-            show_description=d.get("showDescription", None),
-            show_title=d.get("showTitle", None),
-            title=d.get("title", None),
+            description=d.get('description', None),
+            show_description=d.get('showDescription', None),
+            show_title=d.get('showTitle', None),
+            title=d.get('title', None),
         )
+
+
+@dataclass
+class WidgetSpec:
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> WidgetSpec:
+        if 'version' == 1 and 'widgetType' == 'details':
+            return DetailsV1Spec.from_dict(d)
+        elif 'version' == 1 and 'widgetType' == 'table':
+            return TableV1Spec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'counter':
+            return CounterSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'filter-date-picker':
+            return DatePickerSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'filter-date-range-picker':
+            return DateRangePickerSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'filter-multi-select':
+            return MultiSelectSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'filter-single-select':
+            return DropdownSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'filter-text-entry':
+            return TextEntrySpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'symbol-map':
+            return SymbolMapSpec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'table':
+            return TableV2Spec.from_dict(d)
+        elif 'version' == 2 and 'widgetType' == 'word-cloud':
+            return WordCloudSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'area':
+            return AreaSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'bar':
+            return BarSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'line':
+            return LineSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'pie':
+            return PieSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'pivot':
+            return PivotSpec.from_dict(d)
+        elif 'version' == 3 and 'widgetType' == 'scatter':
+            return ScatterSpec.from_dict(d)
+        else:
+            raise KeyError(...)
 
 
 @dataclass
@@ -1849,14 +1909,14 @@ class WordCloudEncodingMap:
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {}
         if self.size:
-            body["size"] = self.size.as_dict()
+            body['size'] = self.size.as_dict()
         if self.text:
-            body["text"] = self.text.as_dict()
+            body['text'] = self.text.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> WordCloudEncodingMap:
-        return cls(size=_from_dict(d, "size", RenderFieldEncoding), text=_from_dict(d, "text", RenderFieldEncoding))
+    def from_dict(cls, d: Dict[str, Any]) -> WordCloudEncodingMap:
+        return cls(size=_from_dict(d, 'size', RenderFieldEncoding), text=_from_dict(d, 'text', RenderFieldEncoding))
 
 
 @dataclass
@@ -1866,17 +1926,17 @@ class WordCloudSpec:
 
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = {
-            "version": 2,
-            "widgetType": "word-cloud",
+            'version': 2,
+            'widgetType': 'word-cloud',
         }
         if self.encodings:
-            body["encodings"] = self.encodings.as_dict()
+            body['encodings'] = self.encodings.as_dict()
         if self.frame:
-            body["frame"] = self.frame.as_dict()
+            body['frame'] = self.frame.as_dict()
         return body
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> WordCloudSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> WordCloudSpec:
         return cls(
-            encodings=_from_dict(d, "encodings", WordCloudEncodingMap), frame=_from_dict(d, "frame", WidgetFrameSpec)
+            encodings=_from_dict(d, 'encodings', WordCloudEncodingMap), frame=_from_dict(d, 'frame', WidgetFrameSpec)
         )

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -32,7 +32,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
         return body
     {{end}}
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:
+    def from_dict(cls, d: Dict[str, Any]) -> {{template "type" . }}:
         {{if .ChildTypes -}}
         {{range $i, $_ := .ChildTypes}}{{if $i}}el{{end}}if {{range $j, $_ := .TypeLookup}}{{if $j}} and {{end}}'{{.Name}}' == {{template "const" .Entity}}{{end}}:
             return {{template "type" .Entity}}.from_dict(d)
@@ -75,6 +75,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 	{{- else if .ArrayValue }}List[{{template "type-nq" .ArrayValue}}]
 	{{- else if .MapValue }}Dict[str,{{template "type-nq" .MapValue}}]
 	{{- else if .IsExternal }}{{.Package.Name}}.{{.PascalName}}
+	{{- else if .ChildTypes }}{{range $i, $_ := .ChildTypes}}{{if $i}} | {{end}}{{template "type" .Entity}}{{end}}
 	{{- else if .IsObject }}{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}
 	{{- else if .Enum }}{{.PascalName}}
 	{{- else}}{{template "type-nq" .}}{{- end -}}

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -4,19 +4,83 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Dict, List, Any, Iterator, Type, Callable, Optional, BinaryIO
+from typing import Dict, List, Any, Iterator, Type, Callable, Optional, BinaryIO, get_args, get_type_hints
 import time
 import random
 import logging
+import types
+import dataclasses
+import abc
 from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 Json = dict[str, Any]
+
+
+def _explain_why(type_ref: type, raw: Any, path: list[str]) -> str:
+    if raw is None:
+        raw = 'value is missing'
+    return f'{".".join(path)}: not a {type_ref.__name__}: {raw}'
+
+
+def _snake_to_camel(snake_name: str) -> str:
+    words = snake_name.split('_')
+    return words[0] + ''.join(word.capitalize() for word in words[1:])
+
+
+def _is_assignable(
+    type_ref: type, raw: Any, path: list[str], name_transform: Callable[[str], str]
+) -> tuple[bool, str | None]:
+    if dataclasses.is_dataclass(type_ref):
+        if not isinstance(raw, dict):
+            return False, _explain_why(dict, raw, path)
+        for field, hint in get_type_hints(type_ref).items():
+            field = name_transform(field)
+            valid, why_not = _is_assignable(hint, raw.get(field), [*path, field], name_transform)
+            if not valid:
+                return False, why_not
+        return True, None
+    if isinstance(type_ref, types.GenericAlias):
+        if not isinstance(raw, list):
+            return False, _explain_why(list, raw, path)
+        type_args = get_args(type_ref)
+        if not type_args:
+            raise TypeError(f"Missing type arguments: {type_args}")
+        item_ref = type_args[0]
+        for i, v in enumerate(raw):
+            valid, why_not = _is_assignable(item_ref, v, [*path, f"{i}"], name_transform)
+            if not valid:
+                return False, why_not
+        return True, None
+    if isinstance(type_ref, types.UnionType):
+        combo = []
+        for variant in get_args(type_ref):
+            valid, why_not = _is_assignable(variant, raw, [], name_transform)
+            if valid:
+                return True, None
+            if why_not:
+                combo.append(why_not)
+        return False, f'{".".join(path)}: union: {" or ".join(combo)}'
+    if type_ref == types.NoneType:
+        if raw is None:
+            return True, None
+        return False, None
+    if type_ref in (int, bool, float, str):
+        if type_ref == type(raw):
+            return True, None
+        return False, _explain_why(type_ref, raw, path)
+    return False, f'{".".join(path)}: unknown: {raw}'
+
 
 {{range .Packages}}
 
 {{range .Types}}
 {{if .Fields -}}{{if not .IsRequest}}{{if not .ChildTypes}}@dataclass{{end}}
-class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Description}}
+class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}
+    {{- if .AbstractType -}}
+        ({{.AbstractType.PascalName}})
+    {{- else if .ChildTypes -}}
+        (abc.ABC)
+    {{- end}}:{{if .Description}}
     """{{.Comment "    " 100}}"""
     {{end}}{{- range .RequiredFields | alphanumOnly | noConst}}
     {{template "safe-snake-name" .}}: {{template "type" .Entity}}{{if .Description}}
@@ -26,7 +90,11 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
     {{template "safe-snake-name" .}}: {{template "type" .Entity}} | None = None{{if .Description}}
     """{{.Comment "    " 100 | trimSuffix "\""}}"""{{end}}
     {{- end}}
-    {{if .HasJsonField -}}{{if not .ChildTypes}}
+    {{if .HasJsonField -}}{{if .ChildTypes}}
+    @abc.abstractmethod
+    def as_dict(self) -> Json:
+        raise NotImplemented
+    {{else}}
     def as_dict(self) -> Json:
         body: Json = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }
         {{range .Fields | alphanumOnly | noConst}}if self.{{template "safe-snake-name" .}}{{with .Entity.IsPrimitive}} is not None{{end}}: body['{{.Name}}'] = {{template "as_request_type" .}}
@@ -36,9 +104,18 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
     @classmethod
     def from_dict(cls, d: Json) -> {{template "type" . }}:
         {{if .ChildTypes -}}
+        {{if .ChildTypes.IsConstant}}
         {{range $i, $_ := .ChildTypes}}{{if $i}}el{{end}}if {{range $j, $_ := .TypeLookup}}{{if $j}} and {{end}}d['{{.Name}}'] == {{template "const" .Entity}}{{end}}:
             return {{template "type" .Entity}}.from_dict(d)
-        {{end}}else: raise KeyError(...)
+        {{end}}else: raise KeyError(f'unknown:{{range .ChildTypes.TypeLookup}} {{.Name}}={d["{{.Name}}"]}{{end}}')
+        {{else}}reasons = []
+        {{range .ChildTypes -}}
+        yes, why_not = _is_assignable({{template "type" .Entity}}, d, [], _snake_to_camel)
+        if yes:
+            return {{template "type" .Entity}}.from_dict(d)
+        if why_not:
+            reasons.append(why_not)
+        {{end}}raise KeyError(" and ".join(reasons)){{end}}
         {{- else -}}
         return cls({{range $i, $f := .Fields | alphanumOnly | noConst}}{{if $i}}, {{end}}{{template "safe-snake-name" $f}}={{template "from_dict_type" $f}}{{end}})
         {{- end}}
@@ -77,7 +154,6 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 	{{- else if .ArrayValue }}List[{{template "type-nq" .ArrayValue}}]
 	{{- else if .MapValue }}Dict[str,{{template "type-nq" .MapValue}}]
 	{{- else if .IsExternal }}{{.Package.Name}}.{{.PascalName}}
-	{{- else if .ChildTypes }}{{range $i, $_ := .ChildTypes}}{{if $i}} | {{end}}{{template "type" .Entity}}{{end}}
 	{{- else if .IsObject }}{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}
 	{{- else if .Enum }}{{.PascalName}}
 	{{- else}}{{template "type-nq" .}}{{- end -}}
@@ -137,3 +213,5 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 {{ define "safe-snake-name" -}}
   {{ template "safe-name" .SnakeName }}
 {{- end}}
+
+

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -10,6 +10,8 @@ import random
 import logging
 from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
+Json = dict[str, Any]
+
 {{range .Packages}}
 
 {{range .Types}}
@@ -25,16 +27,16 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
     """{{.Comment "    " 100 | trimSuffix "\""}}"""{{end}}
     {{- end}}
     {{if .HasJsonField -}}{{if not .ChildTypes}}
-    def as_dict(self) -> dict[str, Any]:
-        body: dict[str, Any] = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }
+    def as_dict(self) -> Json:
+        body: Json = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }
         {{range .Fields | alphanumOnly | noConst}}if self.{{template "safe-snake-name" .}}{{with .Entity.IsPrimitive}} is not None{{end}}: body['{{.Name}}'] = {{template "as_request_type" .}}
         {{end -}}
         return body
     {{end}}
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> {{template "type" . }}:
+    def from_dict(cls, d: Json) -> {{template "type" . }}:
         {{if .ChildTypes -}}
-        {{range $i, $_ := .ChildTypes}}{{if $i}}el{{end}}if {{range $j, $_ := .TypeLookup}}{{if $j}} and {{end}}'{{.Name}}' == {{template "const" .Entity}}{{end}}:
+        {{range $i, $_ := .ChildTypes}}{{if $i}}el{{end}}if {{range $j, $_ := .TypeLookup}}{{if $j}} and {{end}}d['{{.Name}}'] == {{template "const" .Entity}}{{end}}:
             return {{template "type" .Entity}}.from_dict(d)
         {{end}}else: raise KeyError(...)
         {{- else -}}

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -9,6 +9,7 @@ import time
 import random
 import logging
 import types
+import enum
 import dataclasses
 import abc
 from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
@@ -60,6 +61,13 @@ def _is_assignable(
             if why_not:
                 combo.append(why_not)
         return False, f'{".".join(path)}: union: {" or ".join(combo)}'
+    if isinstance(type_ref, abc.ABCMeta):
+        # until we generate method that returns subtypes
+        return True, None
+    if isinstance(type_ref, enum.EnumMeta):
+        if raw in type_ref._value2member_map_:
+            return True, None
+        return False, _explain_why(type_ref, raw, path)
     if type_ref == types.NoneType:
         if raw is None:
             return True, None

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -13,7 +13,7 @@ from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, 
 {{range .Packages}}
 
 {{range .Types}}
-{{if .Fields -}}{{if not .IsRequest}}@dataclass
+{{if .Fields -}}{{if not .IsRequest}}{{if not .ChildTypes}}@dataclass{{end}}
 class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Description}}
     """{{.Comment "    " 100}}"""
     {{end}}{{- range .RequiredFields | alphanumOnly | noConst}}

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -1,0 +1,130 @@
+# Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
+
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import Enum
+from typing import Dict, List, Any, Iterator, Type, Callable, Optional, BinaryIO
+import time
+import random
+import logging
+from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
+
+{{range .Packages}}
+
+{{range .Types}}
+{{if .Fields -}}{{if not .IsRequest}}@dataclass
+class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Description}}
+    """{{.Comment "    " 100}}"""
+    {{end}}{{- range .RequiredFields | alphanumOnly | noConst}}
+    {{template "safe-snake-name" .}}: {{template "type" .Entity}}{{if .Description}}
+    """{{.Comment "    " 100 | trimSuffix "\""}}"""{{end}}
+    {{- end}}
+    {{- range .NonRequiredFields | alphanumOnly | noConst}}
+    {{template "safe-snake-name" .}}: {{template "type" .Entity}} | None = None{{if .Description}}
+    """{{.Comment "    " 100 | trimSuffix "\""}}"""{{end}}
+    {{- end}}
+    {{if .HasJsonField -}}
+    def as_dict(self) -> dict[str, Any]:
+        body: dict[str, Any] = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }
+        {{range .Fields | alphanumOnly | noConst}}if self.{{template "safe-snake-name" .}}{{with .Entity.IsPrimitive}} is not None{{end}}: body['{{.Name}}'] = {{template "as_request_type" .}}
+        {{end -}}
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:
+        return cls({{range $i, $f := .Fields | alphanumOnly | noConst}}{{if $i}}, {{end}}{{template "safe-snake-name" $f}}={{template "from_dict_type" $f}}{{end}})
+    {{end}}
+{{end}}
+{{else if .ArrayValue}}type {{.PascalName}} []{{template "type" .ArrayValue}}
+{{else if .MapValue}}{{.PascalName}} = {{template "type-nq" .}}
+{{else if .Enum}}class {{.PascalName}}(Enum):
+    {{if .Description}}"""{{.Comment "    " 100 | trimSuffix "\"" }}"""{{end}}
+    {{range .Enum }}
+    {{.ConstantName}} = '{{.Content}}'{{end}}{{end}}
+{{end}}
+
+{{end}}
+
+{{- define "from_dict_type" -}}
+	{{- if not .Entity }}None
+	{{- else if .Entity.ArrayValue }}
+		{{- if (or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal) }}_repeated_dict(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
+		{{- else if .Entity.ArrayValue.Enum }}_repeated_enum(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
+		{{- else}}d.get('{{.Name}}', None){{- end -}}
+	{{- else if (or .Entity.IsObject .Entity.IsExternal) }}_from_dict(d, '{{.Name}}', {{template "type-nq" .Entity}})
+	{{- else if .Entity.Enum }}_enum(d, '{{.Name}}', {{template "type-nq" .Entity}})
+	{{- else}}d.get('{{.Name}}', None){{- end -}}
+{{- end -}}
+{{- define "as_request_type" -}}
+	{{- if not .Entity }}None # ERROR: No Type
+	{{- /* This should be done recursively, but recursion in text templates is not supported. */ -}}
+	{{- else if .Entity.ArrayValue }}[{{if or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal}}v.as_dict(){{ else if .Entity.ArrayValue.Enum }}v.value{{else}}v{{end}} for v in self.{{template "safe-snake-name" .}}]
+	{{- else if or .Entity.IsObject .Entity.IsExternal }}self.{{template "safe-snake-name" .}}.as_dict()
+	{{- else if .Entity.Enum }}self.{{template "safe-snake-name" .}}.value
+	{{- else}}self.{{template "safe-snake-name" .}}{{- end -}}
+{{- end -}}
+{{- define "type" -}}
+	{{- if not . }}any # ERROR: No Type
+	{{- else if .ArrayValue }}List[{{template "type-nq" .ArrayValue}}]
+	{{- else if .MapValue }}Dict[str,{{template "type-nq" .MapValue}}]
+	{{- else if .IsExternal }}{{.Package.Name}}.{{.PascalName}}
+	{{- else if .IsObject }}{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}
+	{{- else if .Enum }}{{.PascalName}}
+	{{- else}}{{template "type-nq" .}}{{- end -}}
+{{- end -}}
+{{- define "type-nq" -}}
+	{{- if .IsString}}str
+	{{- else if .IsEmpty}}Any
+	{{- else if .IsAny}}Any
+	{{- else if .IsBool}}bool
+	{{- else if .IsInt64}}int
+	{{- else if .IsFloat64}}float
+	{{- else if .IsInt}}int
+	{{- else if .IsByteStream}}BinaryIO
+	{{- else if .ArrayValue }}List[{{template "type-nq" .ArrayValue}}]
+	{{- else if .MapValue }}Dict[str,{{template "type-nq" .MapValue}}]
+	{{- else if .IsExternal }}{{.Package.Name}}.{{.PascalName}}
+	{{- else if .IsObject }}{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}
+	{{- else if .Enum }}{{.PascalName}}
+	{{- else}}any /* MISSING TYPE */
+	{{- end -}}
+{{- end -}}
+
+{{- define "type-doc" -}}
+	{{- if .IsString}}str
+	{{- else if .IsEmpty}}Any
+	{{- else if .IsAny}}Any
+	{{- else if .IsBool}}bool
+	{{- else if .IsInt64}}int
+	{{- else if .IsFloat64}}float
+	{{- else if .IsInt}}int
+	{{- else if .IsByteStream}}BinaryIO
+	{{- else if .ArrayValue }}List[{{template "type-doc" .ArrayValue}}]
+	{{- else if .MapValue }}Dict[str,{{template "type-doc" .MapValue}}]
+	{{- else if .IsExternal }}:class:`{{.PascalName}}`
+	{{- else if .IsObject }}:class:`{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}`
+	{{- else if .Enum }}:class:`{{.PascalName}}`
+	{{- else}}any /* MISSING TYPE */
+	{{- end -}}
+{{- end -}}
+
+{{- define "const" -}}
+	{{- if .IsString}}'{{.Const}}'
+	{{- else if .IsInt}}{{.Const}}
+	{{- else}}None/* MISSING CONST */
+	{{- end -}}
+{{- end -}}
+
+{{ define "safe-name" -}}
+  {{/* https://docs.python.org/3/reference/lexical_analysis.html#keywords */}}
+  {{- $keywords := list	"False" "await" "else" "import" "pass" "None" "break" "except" "in" "raise"
+                       	"True" "class" "finally" "is" "return" "and" "continue" "for" "lambda" "try"
+                       	"as" "def" "from" "nonlocal" "while" "assert" "del" "global" "not" "with"
+                       	"async" "elif" "if" "or" "yield" -}}
+  {{.}}{{ if in $keywords . }}_{{ end }}
+{{- end}}
+
+{{ define "safe-snake-name" -}}
+  {{ template "safe-name" .SnakeName }}
+{{- end}}

--- a/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
+++ b/src/databricks/labs/ucx/framework/lakeview/model.py.tmpl
@@ -24,16 +24,22 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
     {{template "safe-snake-name" .}}: {{template "type" .Entity}} | None = None{{if .Description}}
     """{{.Comment "    " 100 | trimSuffix "\""}}"""{{end}}
     {{- end}}
-    {{if .HasJsonField -}}
+    {{if .HasJsonField -}}{{if not .ChildTypes}}
     def as_dict(self) -> dict[str, Any]:
         body: dict[str, Any] = { {{range .Fields | constOnly}}'{{.Name}}': {{template "const" .Entity}},{{end}} }
         {{range .Fields | alphanumOnly | noConst}}if self.{{template "safe-snake-name" .}}{{with .Entity.IsPrimitive}} is not None{{end}}: body['{{.Name}}'] = {{template "as_request_type" .}}
         {{end -}}
         return body
-
+    {{end}}
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:
+        {{if .ChildTypes -}}
+        {{range $i, $_ := .ChildTypes}}{{if $i}}el{{end}}if {{range $j, $_ := .TypeLookup}}{{if $j}} and {{end}}'{{.Name}}' == {{template "const" .Entity}}{{end}}:
+            return {{template "type" .Entity}}.from_dict(d)
+        {{end}}else: raise KeyError(...)
+        {{- else -}}
         return cls({{range $i, $f := .Fields | alphanumOnly | noConst}}{{if $i}}, {{end}}{{template "safe-snake-name" $f}}={{template "from_dict_type" $f}}{{end}})
+        {{- end}}
     {{end}}
 {{end}}
 {{else if .ArrayValue}}type {{.PascalName}} []{{template "type" .ArrayValue}}

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -367,10 +367,10 @@ class WorkspaceInstaller:
     def _my_username(self):
         if not hasattr(self, "_me"):
             self._me = self._ws.current_user.me()
-            is_workspace_admin = any(g.display == "admins" for g in self._me.groups)
-            if not is_workspace_admin:
-                msg = "Current user is not a workspace admin"
-                raise PermissionError(msg)
+            # is_workspace_admin = any(g.display == "admins" for g in self._me.groups)
+            # if not is_workspace_admin:
+            #     msg = "Current user is not a workspace admin"
+            #     raise PermissionError(msg)
         return self._me.user_name
 
     @property

--- a/tests/integration/framework/test_dashboards.py
+++ b/tests/integration/framework/test_dashboards.py
@@ -8,7 +8,8 @@ from databricks.labs.ucx.install import WorkspaceInstaller
 
 # @pytest.mark.skip("not working")
 def test_lvdash():
-    ws = WorkspaceClient(profile='e2-demo-field-eng')
+    # ws = WorkspaceClient(profile='e2-demo-field-eng')
+    ws = WorkspaceClient(profile='logfood-master')
     installer = WorkspaceInstaller(ws)
     local_query_files = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     install_state = InstallState(ws, product='ucx')

--- a/tests/integration/framework/test_dashboards.py
+++ b/tests/integration/framework/test_dashboards.py
@@ -1,63 +1,25 @@
-import pytest
+from databricks.labs.blueprint.entrypoint import find_project_root
+from databricks.labs.blueprint.installer import InstallState
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.sql import (
-    AccessControl,
-    ObjectTypePlural,
-    PermissionLevel,
-    RunAsRole,
-)
 
-from databricks.labs.ucx.mixins.redash import (
-    DashboardWidgetsAPI,
-    QueryVisualizationsExt,
-    VizColumn,
-    WidgetOptions,
-    WidgetPosition,
-)
+from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
+from databricks.labs.ucx.install import WorkspaceInstaller
 
 
-@pytest.mark.skip("not working")
-def test_creating_widgets(ws: WorkspaceClient, make_warehouse, env_or_skip):
-    dashboard_widgets_api = DashboardWidgetsAPI(ws.api_client)
-    query_visualizations_api = QueryVisualizationsExt(ws.api_client)
-
-    x = ws.dashboards.create(name="test dashboard")
-    assert x.id is not None
-    ws.dbsql_permissions.set(
-        ObjectTypePlural.DASHBOARDS,
-        x.id,
-        access_control_list=[AccessControl(group_name="users", permission_level=PermissionLevel.CAN_MANAGE)],
+# @pytest.mark.skip("not working")
+def test_lvdash():
+    ws = WorkspaceClient(profile='e2-demo-field-eng')
+    installer = WorkspaceInstaller(ws)
+    local_query_files = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
+    install_state = InstallState(ws, product='ucx')
+    dash = DashboardFromFiles(
+        ws,
+        install_state,
+        local_folder=local_query_files,
+        remote_folder=install_state.install_folder(),
+        name_prefix="Assessment",
+        warehouse_id="000000",
+        query_text_callback=installer.current_config.replace_inventory_variable,
     )
-
-    dashboard_widgets_api.create(
-        x.id,
-        WidgetOptions(
-            title="first widget",
-            description="description of the widget",
-            position=WidgetPosition(col=0, row=0, size_x=3, size_y=3),
-        ),
-        text="this is _some_ **markdown**",
-        width=1,
-    )
-
-    dashboard_widgets_api.create(
-        x.id,
-        WidgetOptions(title="second", position=WidgetPosition(col=0, row=3, size_x=3, size_y=3)),
-        text="another text",
-        width=1,
-    )
-
-    data_sources = {x.warehouse_id: x.id for x in ws.data_sources.list()}
-    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
-
-    query = ws.queries.create(
-        data_source_id=data_sources[warehouse_id],
-        description="abc",
-        name="this is a test query",
-        query="SHOW DATABASES",
-        run_as_role=RunAsRole.VIEWER,
-    )
-
-    assert query.id is not None
-    y = query_visualizations_api.create_table(query.id, "ABC Viz", [VizColumn(name="databaseName", title="DB")])
-    print(y)
+    dashboards = dash.create_lakeview()
+    assert dashboards is not None

--- a/tests/integration/framework/test_dashboards.py
+++ b/tests/integration/framework/test_dashboards.py
@@ -8,8 +8,7 @@ from databricks.labs.ucx.install import WorkspaceInstaller
 
 # @pytest.mark.skip("not working")
 def test_lvdash():
-    # ws = WorkspaceClient(profile='e2-demo-field-eng')
-    ws = WorkspaceClient(profile='logfood-master')
+    ws = WorkspaceClient(profile='e2-demo-field-eng')
     installer = WorkspaceInstaller(ws)
     local_query_files = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     install_state = InstallState(ws, product='ucx')

--- a/tests/sql_formatter.py
+++ b/tests/sql_formatter.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 import sqlglot
 
+
 def test_sql():
-    query_folder = Path(__file__).parent / '../src/databricks/labs/ucx/assessment/queries'
-    for query_file in query_folder.glob('*.sql'):
-        with query_file.open('r') as f:
+    query_folder = Path(__file__).parent / "../src/databricks/labs/ucx/queries/assessment/main"
+    for query_file in query_folder.glob("*.sql"):
+        with query_file.open("r") as f:
             sql_query = f.read()
-            sql_ast = sqlglot.parse_one(sql_query, read='spark')
-            formatted = sql_ast.sql(dialect='spark', pretty=True)
+            sql_ast = sqlglot.parse_one(sql_query, read="spark")
+            formatted = sql_ast.sql(dialect="spark", pretty=True)
             print(formatted)
             print()

--- a/tests/sql_formatter.py
+++ b/tests/sql_formatter.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import sqlglot
+
+def test_sql():
+    query_folder = Path(__file__).parent / '../src/databricks/labs/ucx/assessment/queries'
+    for query_file in query_folder.glob('*.sql'):
+        with query_file.open('r') as f:
+            sql_query = f.read()
+            sql_ast = sqlglot.parse_one(sql_query, read='spark')
+            formatted = sql_ast.sql(dialect='spark', pretty=True)
+            print(formatted)
+            print()

--- a/tests/unit/framework/lakeview/test_lvdash.py
+++ b/tests/unit/framework/lakeview/test_lvdash.py
@@ -2,9 +2,43 @@ import json
 
 from databricks.labs.ucx.framework.lakeview.model import Dashboard
 
+# ChartEncodingMapWithSingleXY
+# 	x: SingleFieldAxisEncoding
+# 		fieldName, scale (required)
+# 	y: SingleFieldAxisEncoding
+# 		fieldName, scale (required)
+# 	color: ColorFieldEncoding
+# 		fieldName, scale (required)
+# 	label: LabelEncoding
+# 		show (required)
+#
+# ChartEncodingMapWithMultiX
+# 	x: MultiFieldAxisEncoding
+# 		fields, scale (required)
+# 	y: SingleFieldAxisEncoding
+# 		fieldName, scale (required)
+# 	color: ColorEncodingForMultiSeries
+# 		-
+# 	label: LabelEncoding
+# 		show (required)
+#
+# ChartEncodingMapWithMultiY
+# 	x: SingleFieldAxisEncoding
+# 		fieldName, scale (required)
+# 	y: MultiFieldAxisEncoding
+# 		fields, scale (required)
+# 	color: ColorEncodingForMultiSeries
+# 		-
+# 	label: LabelEncoding
+# 		show (required)
+
+
+def is_assignable():
+    pass
+
 
 def test_lvdash():
-    with open('/Users/serge.smertin/Downloads/Databricks Labs GitHub telemetry.lvdash (1).json') as f:
+    with open("/Users/serge.smertin/Downloads/Databricks Labs GitHub telemetry.lvdash (1).json") as f:
         raw = json.load(f)
         lvdash = Dashboard.from_dict(raw)
         assert lvdash is not None

--- a/tests/unit/framework/lakeview/test_lvdash.py
+++ b/tests/unit/framework/lakeview/test_lvdash.py
@@ -31,10 +31,16 @@ from databricks.labs.ucx.framework.lakeview.model import Dashboard
 # 		-
 # 	label: LabelEncoding
 # 		show (required)
-
-
-def is_assignable():
-    pass
+#
+# def test_xxx():
+#     d = {"y": {"fields": [
+#         {
+#             'fieldName': '..'
+#         }
+#     ], 'scale': {}}, "color": {"fields": [], 'scale': {}}}
+#     res, why = _is_assignable(ChartEncodingMapWithMultiY, d, [], snake_to_camel)
+#     assert not res
+#
 
 
 def test_lvdash():

--- a/tests/unit/framework/lakeview/test_lvdash.py
+++ b/tests/unit/framework/lakeview/test_lvdash.py
@@ -2,47 +2,6 @@ import json
 
 from databricks.labs.ucx.framework.lakeview.model import Dashboard
 
-# ChartEncodingMapWithSingleXY
-# 	x: SingleFieldAxisEncoding
-# 		fieldName, scale (required)
-# 	y: SingleFieldAxisEncoding
-# 		fieldName, scale (required)
-# 	color: ColorFieldEncoding
-# 		fieldName, scale (required)
-# 	label: LabelEncoding
-# 		show (required)
-#
-# ChartEncodingMapWithMultiX
-# 	x: MultiFieldAxisEncoding
-# 		fields, scale (required)
-# 	y: SingleFieldAxisEncoding
-# 		fieldName, scale (required)
-# 	color: ColorEncodingForMultiSeries
-# 		-
-# 	label: LabelEncoding
-# 		show (required)
-#
-# ChartEncodingMapWithMultiY
-# 	x: SingleFieldAxisEncoding
-# 		fieldName, scale (required)
-# 	y: MultiFieldAxisEncoding
-# 		fields, scale (required)
-# 	color: ColorEncodingForMultiSeries
-# 		-
-# 	label: LabelEncoding
-# 		show (required)
-#
-# def test_xxx():
-#     d = {"y": {"fields": [
-#         {
-#             'fieldName': '..'
-#         }
-#     ], 'scale': {}}, "color": {"fields": [], 'scale': {}}}
-#     res, why = _is_assignable(ChartEncodingMapWithMultiY, d, [], snake_to_camel)
-#     assert not res
-#
-
-
 def test_lvdash():
     with open("/Users/serge.smertin/Downloads/Databricks Labs GitHub telemetry.lvdash (1).json") as f:
         raw = json.load(f)

--- a/tests/unit/framework/lakeview/test_lvdash.py
+++ b/tests/unit/framework/lakeview/test_lvdash.py
@@ -1,0 +1,10 @@
+import json
+
+from databricks.labs.ucx.framework.lakeview.model import Dashboard
+
+
+def test_lvdash():
+    with open('/Users/serge.smertin/Downloads/Databricks Labs GitHub telemetry.lvdash (1).json') as f:
+        raw = json.load(f)
+        lvdash = Dashboard.from_dict(raw)
+        assert lvdash is not None


### PR DESCRIPTION
This pull request adds SQLGlot, a SQL parser and reformatter, as a new dependency in the project. It also includes a new test file, `sql_formatter.py`, which contains a test function `test_sql()`. This function reads SQL files from a specified folder and parses each file using SQLGlot. After parsing, it formats the parsed SQL to a more readable version using the `sql()` method from SQLGlot, and then prints out the formatted SQL. The purpose of this test is to ensure that SQL queries can be successfully parsed and formatted by SQLGlot.

In terms of the code changes, the main addition is the inclusion of SQLGlot in the `pyproject.toml` file as a new dependency. Additionally, the `tests/sql_formatter.py` file has been added, which contains a test function that reads SQL files and parses them using SQLGlot. The test function prints out the formatted SQL for each file, which can be used to verify that the SQL queries are being parsed and formatted correctly.

This PR adds `sqlglot` dependency, that would also be required to rewrite views defined in the Hive Metastore to views in UC that follow three-level namespace.

TODO:
- [ ] Add it as dashboard query formatter in `make fmt`
- [ ] Add it as dashboard query linter in `make lint`
- [ ] Fix dashboard framework to understand `/* ... */` comments
- [ ] Pick projected columns from SQL AST instead of defining them in magic comments