### PR TITLE
Fixed appending to tables by adding filtering of `None` rows

### DIFF
--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -48,13 +48,12 @@ class SqlBackend(ABC):
             row_contains_none = False
             for k, v in dataclasses.asdict(row).items():
                 if v is None:
-                    print(f"Field {k} is None, filtering")
+                    logger.debug(f"Field {k} is None, filtering row")
                     row_contains_none = True
                     break
             if not row_contains_none:
                 results.append(row)
         return results
-
 
 
 class StatementExecutionBackend(SqlBackend):

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -44,13 +44,20 @@ class SqlBackend(ABC):
     @classmethod
     def _filter_none_rows(cls, rows):
         results = []
+        nullable_fields = []
+
+        for field in dataclasses.fields(rows[0]):
+            if field.default is None:
+                nullable_fields.append(field.name)
+
         for row in rows:
             row_contains_none = False
-            for k, v in dataclasses.asdict(row).items():
-                if v is None:
-                    logger.debug(f"Field {k} is None, filtering row")
+            for column, value in dataclasses.asdict(row).items():
+                if value is None and column not in nullable_fields:
+                    logger.debug(f"Field {column} is None, filtering row")
                     row_contains_none = True
                     break
+
             if not row_contains_none:
                 results.append(row)
         return results

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -41,6 +41,21 @@ class SqlBackend(ABC):
             fields.append(f"{f.name} {spark_type}{not_null}")
         return ", ".join(fields)
 
+    @classmethod
+    def _filter_none_rows(cls, rows):
+        results = []
+        for row in rows:
+            row_contains_none = False
+            for k, v in dataclasses.asdict(row).items():
+                if v is None:
+                    print(f"Field {k} is None, filtering")
+                    row_contains_none = True
+                    break
+            if not row_contains_none:
+                results.append(row)
+        return results
+
+
 
 class StatementExecutionBackend(SqlBackend):
     def __init__(self, ws: WorkspaceClient, warehouse_id, *, max_records_per_batch: int = 1000):
@@ -115,6 +130,8 @@ class RuntimeBackend(SqlBackend):
         return self._spark.sql(sql).collect()
 
     def save_table(self, full_name: str, rows: list[any], mode: str = "append"):
+        rows = self._filter_none_rows(rows)
+
         if len(rows) == 0:
             return
         # pyspark deals well with lists of dataclass instances, as long as schema is provided

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -205,7 +205,8 @@ def test_runtime_backend_save_table(mocker):
         )
         rb._spark.createDataFrame().write.saveAsTable.assert_called_with("a.b.c", mode="append")
 
-def test_runtime_backend_save_table_with_row_containing_None(mocker):
+
+def test_runtime_backend_save_table_with_row_containing_none(mocker):
     from unittest import mock
 
     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
@@ -221,4 +222,3 @@ def test_runtime_backend_save_table_with_row_containing_None(mocker):
             "first STRING NOT NULL, second BOOLEAN NOT NULL",
         )
         rb._spark.createDataFrame().write.saveAsTable.assert_called_with("a.b.c", mode="append")
-

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -204,3 +204,21 @@ def test_runtime_backend_save_table(mocker):
             "first STRING NOT NULL, second BOOLEAN NOT NULL",
         )
         rb._spark.createDataFrame().write.saveAsTable.assert_called_with("a.b.c", mode="append")
+
+def test_runtime_backend_save_table_with_row_containing_None(mocker):
+    from unittest import mock
+
+    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
+        pyspark_sql_session = mocker.Mock()
+        sys.modules["pyspark.sql.session"] = pyspark_sql_session
+
+        rb = RuntimeBackend()
+
+        rb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("bbb", None)])
+
+        rb._spark.createDataFrame.assert_called_with(
+            [Foo(first="aaa", second=True), Foo(first="bbb", second=False)],
+            "first STRING NOT NULL, second BOOLEAN NOT NULL",
+        )
+        rb._spark.createDataFrame().write.saveAsTable.assert_called_with("a.b.c", mode="append")
+

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -221,7 +221,7 @@ def test_runtime_backend_save_table_with_row_containing_none(mocker):
 
         rb = RuntimeBackend()
 
-        rb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("bbb", None)])
+        rb.save_table("a.b.c", [Foo("aaa", True), Foo("bbb", False), Foo("ccc", None)])
 
         rb._spark.createDataFrame.assert_called_with(
             [Foo(first="aaa", second=True), Foo(first="bbb", second=False)],


### PR DESCRIPTION
This PR aims to fix https://github.com/databrickslabs/ucx/issues/297 and https://github.com/databrickslabs/ucx/issues/346

It adds a utility method to filter rows that have a column containing None, this will help Crawlers to not throw an error when a column is None.

it also checks if the column in the class is Nullable or not, if it's nullable and the value is None, it's ignored