### PR TITLE
Introduce deterministic `env_or_skip` fixture for integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 from functools import partial
 
@@ -15,8 +14,6 @@ logging.getLogger("tests").setLevel("DEBUG")
 logging.getLogger("databricks.labs.ucx").setLevel("DEBUG")
 
 logger = logging.getLogger(__name__)
-
-load_debug_env_if_runs_from_ide("ucws")  # noqa: F405
 
 
 def account_host(self: databricks.sdk.core.Config) -> str:
@@ -52,15 +49,15 @@ def acc(ws) -> AccountClient:
 
 
 @pytest.fixture
-def sql_exec(ws: WorkspaceClient):
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+def sql_exec(ws: WorkspaceClient, env_or_skip):
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
     statement_execution = StatementExecutionExt(ws.api_client)
     return partial(statement_execution.execute, warehouse_id)
 
 
 @pytest.fixture
-def sql_fetch_all(ws: WorkspaceClient):
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+def sql_fetch_all(ws: WorkspaceClient, env_or_skip):
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
     statement_execution = StatementExecutionExt(ws.api_client)
     return partial(statement_execution.execute_fetch_all, warehouse_id)
 

--- a/tests/integration/framework/test_dashboards.py
+++ b/tests/integration/framework/test_dashboards.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import AccessControl, ObjectTypePlural, PermissionLevel
@@ -12,10 +10,8 @@ from databricks.labs.ucx.mixins.redash import (
     WidgetPosition,
 )
 
-# logging.getLogger("databricks").setLevel("DEBUG")
 
-
-def test_creating_widgets(ws: WorkspaceClient, make_warehouse, make_schema):
+def test_creating_widgets(ws: WorkspaceClient, make_warehouse, make_schema, env_or_skip):
     pytest.skip()
     dashboard_widgets_api = DashboardWidgetsAPI(ws.api_client)
     query_visualizations_api = QueryVisualizationsExt(ws.api_client)
@@ -46,7 +42,7 @@ def test_creating_widgets(ws: WorkspaceClient, make_warehouse, make_schema):
     )
 
     data_sources = {x.warehouse_id: x.id for x in ws.data_sources.list()}
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
 
     query = ws.queries.create(
         data_source_id=data_sources[warehouse_id],

--- a/tests/integration/framework/test_fixtures.py
+++ b/tests/integration/framework/test_fixtures.py
@@ -1,14 +1,18 @@
 import logging
-import os
 
+import pytest
+from _pytest.outcomes import Failed, Skipped
 from databricks.sdk.service.workspace import AclPermission
 
 from databricks.labs.ucx.mixins.compute import CommandExecutor
 from databricks.labs.ucx.mixins.fixtures import *  # noqa: F403
 
-load_debug_env_if_runs_from_ide("ucws")  # noqa: F405
-
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def debug_env_name():
+    return "ucws"
 
 
 def test_user(make_user):
@@ -53,8 +57,8 @@ def test_cluster_policy(make_cluster_policy):
     logger.info(f"created {make_cluster_policy()}")
 
 
-def test_cluster(make_cluster):
-    logger.info(f"created {make_cluster(single_node=True, instance_pool_id=os.environ['TEST_INSTANCE_POOL_ID'])}")
+def test_cluster(make_cluster, env_or_skip):
+    logger.info(f"created {make_cluster(single_node=True, instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'))}")
 
 
 def test_instance_pool(make_instance_pool):
@@ -96,3 +100,8 @@ def test_sql_backend_works(ws, wsfs_wheel):
     )
 
     assert len(database_names) > 0
+
+
+def test_env_or_skip(env_or_skip):
+    with pytest.raises((Skipped, Failed)):
+        env_or_skip("NO_ENV_VAR_HERE")

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
 from databricks.labs.ucx.hive_metastore.data_objects import ExternalLocationCrawler
@@ -9,8 +8,8 @@ from databricks.labs.ucx.hive_metastore.tables import Table
 logger = logging.getLogger(__name__)
 
 
-def test_external_locations(ws, make_warehouse, make_schema):
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+def test_external_locations(ws, make_warehouse, make_schema, env_or_skip):
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
 
     logger.info("setting up fixtures")
     sbe = StatementExecutionBackend(ws, warehouse_id)

--- a/tests/integration/hive_metastore/test_grants.py
+++ b/tests/integration/hive_metastore/test_grants.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from databricks.sdk import WorkspaceClient
 
@@ -9,8 +8,10 @@ from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 logger = logging.getLogger(__name__)
 
 
-def test_all_grants_in_databases(ws: WorkspaceClient, sql_exec, make_catalog, make_schema, make_table, make_group):
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+def test_all_grants_in_databases(
+    ws: WorkspaceClient, sql_exec, make_catalog, make_schema, make_table, make_group, env_or_skip
+):
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
 
     group_a = make_group()
     group_b = make_group()

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import pytest
 
@@ -10,7 +9,7 @@ from databricks.labs.ucx.hive_metastore.tables import TablesMigrate
 logger = logging.getLogger(__name__)
 
 
-def test_migrate_managed_tables(ws, make_catalog, make_schema, make_table):
+def test_migrate_managed_tables(ws, make_catalog, make_schema, make_table, env_or_skip):
     target_catalog = make_catalog()
     schema_a = make_schema(catalog="hive_metastore")
     _, target_schema = schema_a.split(".")
@@ -24,7 +23,7 @@ def test_migrate_managed_tables(ws, make_catalog, make_schema, make_table):
     inventory_schema = make_schema(catalog="hive_metastore")
     _, inventory_schema = inventory_schema.split(".")
 
-    backend = StatementExecutionBackend(ws, os.environ["TEST_DEFAULT_WAREHOUSE_ID"])
+    backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
     crawler = TablesCrawler(backend, inventory_schema)
     tm = TablesMigrate(crawler, ws, backend, target_catalog)
     tm.migrate_tables()
@@ -38,7 +37,9 @@ def test_migrate_managed_tables(ws, make_catalog, make_schema, make_table):
     assert target_table_properties["upgraded_from"] == managed_table
 
 
-def test_migrate_tables_with_cache_should_not_create_table(ws, make_random, make_catalog, make_schema, make_table):
+def test_migrate_tables_with_cache_should_not_create_table(
+    ws, make_random, make_catalog, make_schema, make_table, env_or_skip
+):
     target_catalog = make_catalog()
     schema_a = make_schema(catalog="hive_metastore")
     _, target_schema = schema_a.split(".")
@@ -61,7 +62,7 @@ def test_migrate_tables_with_cache_should_not_create_table(ws, make_random, make
     inventory_schema = make_schema(catalog="hive_metastore")
     _, inventory_schema = inventory_schema.split(".")
 
-    backend = StatementExecutionBackend(ws, os.environ["TEST_DEFAULT_WAREHOUSE_ID"])
+    backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
     crawler = TablesCrawler(backend, inventory_schema)
     tm = TablesMigrate(crawler, ws, backend, target_catalog)
     tm.migrate_tables()
@@ -73,7 +74,7 @@ def test_migrate_tables_with_cache_should_not_create_table(ws, make_random, make
 
 
 @pytest.mark.skip(reason="Needs Storage credential + External Location in place")
-def test_migrate_external_table(ws, make_catalog, make_schema, make_table):
+def test_migrate_external_table(ws, make_catalog, make_schema, make_table, env_or_skip):
     target_catalog = make_catalog()
     schema_a = make_schema(catalog="hive_metastore")
     _, target_schema = schema_a.split(".")
@@ -87,9 +88,9 @@ def test_migrate_external_table(ws, make_catalog, make_schema, make_table):
     inventory_schema = make_schema(catalog="hive_metastore")
     _, inventory_schema = inventory_schema.split(".")
 
-    backend = StatementExecutionBackend(ws, os.environ["TEST_DEFAULT_WAREHOUSE_ID"])
+    backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
 
-    backend = StatementExecutionBackend(ws, os.environ["TEST_DEFAULT_WAREHOUSE_ID"])
+    backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
     crawler = TablesCrawler(backend, inventory_schema)
     tm = TablesMigrate(crawler, ws, backend, target_catalog, inventory_schema)
     tm.migrate_tables()

--- a/tests/integration/hive_metastore/test_tables.py
+++ b/tests/integration/hive_metastore/test_tables.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from databricks.sdk import WorkspaceClient
 
@@ -9,8 +8,8 @@ from databricks.labs.ucx.hive_metastore import TablesCrawler
 logger = logging.getLogger(__name__)
 
 
-def test_describe_all_tables_in_databases(ws: WorkspaceClient, make_catalog, make_schema, make_table):
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+def test_describe_all_tables_in_databases(ws: WorkspaceClient, make_catalog, make_schema, make_table, env_or_skip):
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
 
     logger.info("setting up fixtures")
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 
 from databricks.sdk.service.iam import PermissionLevel
@@ -24,6 +23,7 @@ def test_jobs_with_no_inventory_database(
     make_random,
     make_schema,
     make_table,
+    env_or_skip,
 ):
     ws_group_a, acc_group_a = make_ucx_group()
     ws_group_b, acc_group_b = make_ucx_group()
@@ -79,7 +79,7 @@ def test_jobs_with_no_inventory_database(
         ws,
         WorkspaceConfig(
             inventory_database=inventory_database,
-            instance_pool_id=os.environ["TEST_INSTANCE_POOL_ID"],
+            instance_pool_id=env_or_skip("TEST_INSTANCE_POOL_ID"),
             groups=GroupsConfig(
                 selected=[ws_group_a.display_name, ws_group_b.display_name, ws_group_c.display_name],
                 backup_group_prefix=backup_group_prefix,

--- a/tests/integration/workspace_access/test_permissions_manager.py
+++ b/tests/integration/workspace_access/test_permissions_manager.py
@@ -1,13 +1,11 @@
-import os
-
 from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 
 
-def test_permissions_save_and_load(ws, make_schema):
+def test_permissions_save_and_load(ws, make_schema, env_or_skip):
     schema = make_schema().split(".")[-1]
-    backend = StatementExecutionBackend(ws, os.environ["TEST_DEFAULT_WAREHOUSE_ID"])
+    backend = StatementExecutionBackend(ws, env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"))
     pi = PermissionManager(backend, schema, [], {})
 
     saved = [

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 
 from databricks.sdk import WorkspaceClient
@@ -39,6 +38,7 @@ def test_workspace_access_e2e(
     make_authorization_permissions,
     make_warehouse,
     make_warehouse_permissions,
+    env_or_skip,
 ):
     ws_group, acc_group = make_ucx_group()
 
@@ -52,7 +52,7 @@ def test_workspace_access_e2e(
     )
     to_verify.add(("instance-pools", pool.instance_pool_id))
 
-    cluster = make_cluster(instance_pool_id=os.environ["TEST_INSTANCE_POOL_ID"], single_node=True)
+    cluster = make_cluster(instance_pool_id=env_or_skip("TEST_INSTANCE_POOL_ID"), single_node=True)
     make_cluster_permissions(
         object_id=cluster.cluster_id,
         permission_level=random.choice(
@@ -161,7 +161,7 @@ def test_workspace_access_e2e(
         num_threads=8,
     )
 
-    warehouse_id = os.environ["TEST_DEFAULT_WAREHOUSE_ID"]
+    warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
     toolkit = GroupMigrationToolkit(config, warehouse_id=warehouse_id)
     toolkit.prepare_environment()
 


### PR DESCRIPTION
Make this testing framework behave the same way as in Java SDK - https://github.com/databricks/databricks-sdk-java/blob/main/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/framework/EnvTest.java