### PR TITLE
Detect installations of unreleased versions

### DIFF
--- a/src/databricks/labs/ucx/__about__.py
+++ b/src/databricks/labs/ucx/__about__.py
@@ -1,1 +1,2 @@
+# DO NOT MODIFY THIS FILE
 __version__ = "0.3.0"


### PR DESCRIPTION
Any installations that are done from unreleased versions will get a different format. For example, the latest released version is `0.24.0` and there were 15 commits to `main` branch since the last release. `./install.sh` will tell about `Installing v0.24.1+1520231006230102`.