### PR TITLE
Fixed broken logic in `parallel` module and applied hardened error handling design for parallel code

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from functools import partial
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.parallel import ThreadedExecution
+from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class GrantsCrawler(CrawlerBase):
           table/view-specific grants.
         - Iterates through tables in the specified database using the `_tc.snapshot` method.
         - For each table, adds tasks to fetch grants for the table or its view, depending on the kind of the table.
-        - Executes the tasks concurrently using ThreadedExecution.gather.
+        - Executes the tasks concurrently using Threads.gather.
         - Flattens the list of retrieved grant lists into a single list of Grant objects.
 
         Note:
@@ -163,9 +163,7 @@ class GrantsCrawler(CrawlerBase):
                 tasks.append(partial(fn, view=table.name))
             else:
                 tasks.append(partial(fn, table=table.name))
-        return [
-            grant for grants in ThreadedExecution.gather(f"listing grants for {catalog}", tasks) for grant in grants
-        ]
+        return [grant for grants in Threads.gather(f"listing grants for {catalog}", tasks) for grant in grants]
 
     def _grants(
         self,

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -163,7 +163,11 @@ class GrantsCrawler(CrawlerBase):
                 tasks.append(partial(fn, view=table.name))
             else:
                 tasks.append(partial(fn, table=table.name))
-        return [grant for grants in Threads.gather(f"listing grants for {catalog}", tasks) for grant in grants]
+        catalog_grants, errors = Threads.gather(f"listing grants for {catalog}", tasks)
+        if len(errors) > 0:
+            # TODO: https://github.com/databrickslabs/ucx/issues/406
+            logger.error(f"Detected {len(errors)} during scanning for grants in {catalog}")
+        return [grant for grants in catalog_grants for grant in grants]
 
     def _grants(
         self,

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -8,7 +8,7 @@ from functools import partial
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
-from databricks.labs.ucx.framework.parallel import ThreadedExecution
+from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.mixins.sql import Row
 
 logger = logging.getLogger(__name__)
@@ -128,8 +128,7 @@ class TablesCrawler(CrawlerBase):
             logger.debug(f"[{catalog}.{database}] listing tables")
             for _, table, _is_tmp in self._fetch(f"SHOW TABLES FROM {catalog}.{database}"):
                 tasks.append(partial(self._describe, catalog, database, table))
-        results = ThreadedExecution.gather(f"listing tables in {catalog}", tasks)
-        return [x for x in results if x is not None]
+        return Threads.gather(f"listing tables in {catalog}", tasks)
 
     def _describe(self, catalog: str, database: str, table: str) -> Table | None:
         """Fetches metadata like table type, data format, external table location,
@@ -188,25 +187,23 @@ class TablesMigrate:
             if self._database_to_catalog_mapping:
                 target_catalog = self._database_to_catalog_mapping[table.database]
             tasks.append(partial(self._migrate_table, target_catalog, table))
-        ThreadedExecution.gather("migrate tables", tasks)
+        Threads.gather("migrate tables", tasks)
 
     def _migrate_table(self, target_catalog, table):
-        try:
-            sql = table.uc_create_sql(target_catalog)
-            logger.debug(f"Migrating table {table.key} to using SQL query: {sql}")
-            target = f"{target_catalog}.{table.database}.{table.name}".lower()
+        sql = table.uc_create_sql(target_catalog)
+        logger.debug(f"Migrating table {table.key} to using SQL query: {sql}")
+        target = f"{target_catalog}.{table.database}.{table.name}".lower()
 
-            if self._table_already_upgraded(target):
-                logger.info(f"Table {table.key} already upgraded to {self._seen_tables[target]}")
-            elif table.object_type == "MANAGED":
-                self._backend.execute(sql)
-                self._backend.execute(table.sql_alter_to(target_catalog))
-                self._backend.execute(table.sql_alter_from(target_catalog))
-                self._seen_tables[target] = table.key
-            else:
-                logger.info(f"Table {table.key} is a {table.object_type} and is not supported for migration yet ")
-        except Exception as e:
-            logger.error(f"Could not create table {table.name} because: {e}")
+        if self._table_already_upgraded(target):
+            logger.info(f"Table {table.key} already upgraded to {self._seen_tables[target]}")
+        elif table.object_type == "MANAGED":
+            self._backend.execute(sql)
+            self._backend.execute(table.sql_alter_to(target_catalog))
+            self._backend.execute(table.sql_alter_from(target_catalog))
+            self._seen_tables[target] = table.key
+        else:
+            logger.info(f"Table {table.key} is a {table.object_type} and is not supported for migration yet ")
+        return True
 
     def _init_seen_tables(self):
         for catalog in self._ws.catalogs.list():

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -61,6 +61,7 @@ class GenericPermissionsSupport(Crawler, Applier):
     @rate_limited(max_requests=30)
     def _applier_task(self, object_type: str, object_id: str, acl: list[iam.AccessControlRequest]):
         self._ws.permissions.update(object_type, object_id, access_control_list=acl)
+        return True
 
     @rate_limited(max_requests=100)
     def _crawler_task(self, object_type: str, object_id: str) -> Permissions | None:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -124,9 +124,11 @@ class GroupManager:
             backup_group = self._get_or_create_backup_group(source_group_name=name, source_group=ws_group)
             return MigrationGroupInfo(workspace=ws_group, backup=backup_group, account=acc_group)
 
-        collected_groups = Threads.gather(
-            "get group info", [partial(get_group_info, group_name) for group_name in groups_names]
-        )
+        groups_names_ = [partial(get_group_info, group_name) for group_name in groups_names]
+        collected_groups, errors = Threads.gather("get group info", groups_names_)
+        if len(errors) > 0:
+            # TODO: https://github.com/databrickslabs/ucx/issues/406
+            logger.error(f"Detected {len(errors)} while collecting groups")
         for g in collected_groups:
             self._migration_state.add(g)
 
@@ -236,12 +238,17 @@ class GroupManager:
         logger.info("Replacing the workspace groups with account-level groups")
         if len(self._migration_state.groups) == 0:
             logger.info("No groups were loaded or initialized, nothing to do")
-            return
-        Threads.gather(
-            "groups: workspace -> account",
-            [partial(self._replace_group, migration_info) for migration_info in self.migration_groups_provider.groups],
-        )
+            return True
+        groups_ = [
+            partial(self._replace_group, migration_info) for migration_info in self.migration_groups_provider.groups
+        ]
+        _, errors = Threads.gather("groups: workspace -> account", groups_)
+        if len(errors) > 0:
+            # TODO: https://github.com/databrickslabs/ucx/issues/406
+            logger.error(f"Detected {len(errors)} while replacing groups")
+            return False
         logger.info("Workspace groups were successfully replaced with account-level groups")
+        return True
 
     def delete_backup_groups(self):
         backup_groups = self._get_backup_groups()

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from typing import Literal
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
-from databricks.labs.ucx.framework.parallel import ThreadedExecution
+from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.workspace_access.base import Applier, Crawler, Permissions
 from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
 
@@ -23,7 +23,7 @@ class PermissionManager(CrawlerBase):
         logger.debug("Crawling permissions")
         crawler_tasks = list(self._get_crawler_tasks())
         logger.info(f"Starting to crawl permissions. Total tasks: {len(crawler_tasks)}")
-        results = ThreadedExecution.gather("crawl permissions", crawler_tasks)
+        results = Threads.gather("crawl permissions", crawler_tasks)
         items = []
         for item in results:
             if item is None:
@@ -67,7 +67,7 @@ class PermissionManager(CrawlerBase):
             applier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to apply permissions on {destination} groups. Total tasks: {len(applier_tasks)}")
-        ThreadedExecution.gather(f"apply {destination} group permissions", applier_tasks)
+        Threads.gather(f"apply {destination} group permissions", applier_tasks)
         logger.info("Permissions were applied")
 
     def cleanup(self):

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -23,11 +23,12 @@ class PermissionManager(CrawlerBase):
         logger.debug("Crawling permissions")
         crawler_tasks = list(self._get_crawler_tasks())
         logger.info(f"Starting to crawl permissions. Total tasks: {len(crawler_tasks)}")
-        results = Threads.gather("crawl permissions", crawler_tasks)
+        results, errors = Threads.gather("crawl permissions", crawler_tasks)
+        if len(errors) > 0:
+            # TODO: https://github.com/databrickslabs/ucx/issues/406
+            logger.error(f"Detected {len(errors)} while crawling permissions")
         items = []
         for item in results:
-            if item is None:
-                continue
             if item.object_type not in self._appliers:
                 msg = f"unknown object_type: {item.object_type}"
                 raise KeyError(msg)
@@ -40,7 +41,7 @@ class PermissionManager(CrawlerBase):
         # list shall be sorted prior to using group by
         if len(migration_state.groups) == 0:
             logger.info("No valid groups selected, nothing to do.")
-            return
+            return True
         items = sorted(self._load_all(), key=lambda i: i.object_type)
         logger.info(
             f"Applying the permissions to {destination} groups. "
@@ -67,8 +68,13 @@ class PermissionManager(CrawlerBase):
             applier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to apply permissions on {destination} groups. Total tasks: {len(applier_tasks)}")
-        Threads.gather(f"apply {destination} group permissions", applier_tasks)
+        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks)
+        if len(errors) > 0:
+            # TODO: https://github.com/databrickslabs/ucx/issues/406
+            logger.error(f"Detected {len(errors)} while applying permissions")
+            return False
         logger.info("Permissions were applied")
+        return True
 
     def cleanup(self):
         logger.info(f"Cleaning up inventory table {self._full_name}")

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -84,6 +84,7 @@ class SqlPermissionsSupport(Crawler, Applier):
         This affects the way how we prepare the new ACL request.
         """
         self._ws.dbsql_permissions.set(object_type=object_type, object_id=object_id, access_control_list=acl)
+        return True
 
     def _prepare_new_acl(
         self, acl: list[sql.AccessControl], migration_state: GroupMigrationState, destination: Destination

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -59,3 +59,4 @@ class ScimSupport(Crawler, Applier):
         operations = [iam.Patch(op=iam.PatchOp.ADD, path=property_name, value=[e.as_dict() for e in value])]
         schemas = [iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP]
         self._ws.groups.patch(id=group_id, operations=operations, schemas=schemas)
+        return True

--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -92,5 +92,6 @@ class SecretScopesSupport(Crawler, Applier):
         def apply_acls():
             for acl in new_acls:
                 self._rate_limited_put_acl(item.object_id, acl.principal, acl.permission)
+            return True
 
         return partial(apply_acls)

--- a/tests/integration/workspace_access/test_setup.py
+++ b/tests/integration/workspace_access/test_setup.py
@@ -5,10 +5,10 @@ import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.iam import ComplexValue
 
-from databricks.labs.ucx.framework.parallel import ThreadedExecution
+from databricks.labs.ucx.framework.parallel import Threads
 
 logger = logging.getLogger(__name__)
-Threader = partial(ThreadedExecution, num_threads=40)
+Threader = partial(Threads, num_threads=40)
 
 
 def _create_user(ws: WorkspaceClient, uid: str):
@@ -29,4 +29,4 @@ def _create_user(ws: WorkspaceClient, uid: str):
 def test_create_users(ws):
     pytest.skip("run only in debug")
     executables = [partial(_create_user, ws, uid) for uid in range(200)]
-    Threader(executables).run()
+    Threader(executables)._run()

--- a/tests/unit/framework/test_parallel.py
+++ b/tests/unit/framework/test_parallel.py
@@ -24,9 +24,10 @@ def test_gather_with_failed_task(caplog):
         raise DatabricksError(msg)
 
     tasks = [works, fails, works, fails, works, fails, works, fails]
-    results = Threads.gather("testing", tasks)
+    results, errors = Threads.gather("testing", tasks)
 
     assert [True, True, True, True] == results
+    assert 4 == len(errors)
     assert [
         "More than half 'testing' tasks failed: 50% (4/8)",
         "testing task failed: failed",
@@ -50,9 +51,10 @@ def test_gather_with_failed_task_no_message(caplog):
         raise OSError(1, msg)
 
     tasks = [works, not_really_but_fine, works, fails, works, works]
-    results = Threads.gather("testing", tasks)
+    results, errors = Threads.gather("testing", tasks)
 
     assert [True, True, True, True] == results
+    assert 1 == len(errors)
     assert [
         "Some 'testing' tasks failed: 17% (1/6)",
         "did something, but returned None",
@@ -67,9 +69,10 @@ def test_all_none(caplog):
         logging.info("did something, but returned None")
 
     tasks = [not_really_but_fine, not_really_but_fine, not_really_but_fine, not_really_but_fine]
-    results = Threads.gather("testing", tasks)
+    results, errors = Threads.gather("testing", tasks)
 
     assert [] == results
+    assert [] == errors
     assert [
         "Finished 'testing' tasks: non-empty 0% (0/4)",
         "did something, but returned None",
@@ -85,9 +88,10 @@ def test_all_failed(caplog):
         raise DatabricksError(msg)
 
     tasks = [fails, fails, fails, fails]
-    results = Threads.gather("testing", tasks)
+    results, errors = Threads.gather("testing", tasks)
 
     assert [] == results
+    assert 4 == len(errors)
     assert [
         "All 'testing' tasks failed!!!",
         "testing task failed: failed",

--- a/tests/unit/framework/test_parallel.py
+++ b/tests/unit/framework/test_parallel.py
@@ -1,9 +1,21 @@
+import logging
+
 from databricks.sdk.core import DatabricksError
 
-from databricks.labs.ucx.framework.parallel import ThreadedExecution
+from databricks.labs.ucx.framework.parallel import Threads
 
 
-def test_threaded_execution_gather_with_failed_task():
+def _predictable_messages(caplog):
+    res = []
+    for msg in caplog.messages:
+        if "rps" in msg:
+            continue
+        msg = msg.split(". Took ")[0]  # noqa: PLW2901
+        res.append(msg)
+    return sorted(res)
+
+
+def test_gather_with_failed_task(caplog):
     def works():
         return True
 
@@ -11,19 +23,75 @@ def test_threaded_execution_gather_with_failed_task():
         msg = "failed"
         raise DatabricksError(msg)
 
-    tasks = [works, works, fails, works, works]
-    futures = ThreadedExecution.gather("testing", tasks)
-    assert len(futures) == 4
+    tasks = [works, fails, works, fails, works, fails, works, fails]
+    results = Threads.gather("testing", tasks)
+
+    assert [True, True, True, True] == results
+    assert [
+        "More than half 'testing' tasks failed: 50% (4/8)",
+        "testing task failed: failed",
+        "testing task failed: failed",
+        "testing task failed: failed",
+        "testing task failed: failed",
+    ] == _predictable_messages(caplog)
 
 
-def test_threaded_execution_gather_with_failed_task_no_message():
+def test_gather_with_failed_task_no_message(caplog):
+    caplog.set_level(logging.INFO)
+
     def works():
         return True
+
+    def not_really_but_fine():
+        logging.info("did something, but returned None")
 
     def fails():
         msg = "failed"
         raise OSError(1, msg)
 
-    tasks = [works, works, fails, works, works]
-    futures = ThreadedExecution.gather("testing", tasks)
-    assert len(futures) == 4
+    tasks = [works, not_really_but_fine, works, fails, works, works]
+    results = Threads.gather("testing", tasks)
+
+    assert [True, True, True, True] == results
+    assert [
+        "Some 'testing' tasks failed: 17% (1/6)",
+        "did something, but returned None",
+        "testing task failed: [Errno 1] failed",
+    ] == _predictable_messages(caplog)
+
+
+def test_all_none(caplog):
+    caplog.set_level(logging.INFO)
+
+    def not_really_but_fine():
+        logging.info("did something, but returned None")
+
+    tasks = [not_really_but_fine, not_really_but_fine, not_really_but_fine, not_really_but_fine]
+    results = Threads.gather("testing", tasks)
+
+    assert [] == results
+    assert [
+        "Finished 'testing' tasks: non-empty 0% (0/4)",
+        "did something, but returned None",
+        "did something, but returned None",
+        "did something, but returned None",
+        "did something, but returned None",
+    ] == _predictable_messages(caplog)
+
+
+def test_all_failed(caplog):
+    def fails():
+        msg = "failed"
+        raise DatabricksError(msg)
+
+    tasks = [fails, fails, fails, fails]
+    results = Threads.gather("testing", tasks)
+
+    assert [] == results
+    assert [
+        "All 'testing' tasks failed!!!",
+        "testing task failed: failed",
+        "testing task failed: failed",
+        "testing task failed: failed",
+        "testing task failed: failed",
+    ] == _predictable_messages(caplog)


### PR DESCRIPTION
- explicitly propagate thread pool errors to calling code in GoLang style
- fixed bug with data race related to progress reporter on task completions
- removed `ProgressReporter` class, which was confined only to this module anyway
- added total time reporting for all parallel tasks
- added different levels of error reporting depending on percentage of failed tasks
- ensured that collected results are always non-None
- ensured that all existing parallel code returns some value as a result. `true` is better than `void`.

Fixes #402