### PR TITLE
Added support for migrating Legacy Table ACLs from workspace-local to account-level groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/databrickslabs/ucx/actions/workflows/push.yml/badge.svg)](https://github.com/databrickslabs/ucx/actions/workflows/push.yml) [![codecov](https://codecov.io/github/databrickslabs/ucx/graph/badge.svg?token=p0WKAfW5HQ)](https://codecov.io/github/databrickslabs/ucx)
 
 Your best companion for upgrading to Unity Catalog. It helps you to upgrade all Databricks workspace assets:
-Entitlements, AWS instance profiles, Clusters, Cluster policies, Instance Pools, Databricks SQL warehouses, Delta Live 
+Legacy Table ACLs, Entitlements, AWS instance profiles, Clusters, Cluster policies, Instance Pools, Databricks SQL warehouses, Delta Live 
 Tables, Jobs, MLflow experiments, MLflow registry, SQL Dashboards & Queries, SQL Alerts, Token and Password usage 
 permissions that are set on the workspace level, Secret scopes, Notebooks, Directories, Repos, Files.
 

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -52,8 +52,10 @@ class Grant:
         # Must come last, as it has the lowest priority here but is a required parameter
         if catalog is not None:
             return "CATALOG", catalog
-        msg = f"invalid grant keys: catalog={catalog}, database={database}, view={view}, " \
-              f"any_file={any_file}, anonymous_function={anonymous_function}"
+        msg = (
+            f"invalid grant keys: catalog={catalog}, database={database}, view={view}, "
+            f"any_file={any_file}, anonymous_function={anonymous_function}"
+        )
         raise ValueError(msg)
 
     @property

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -75,6 +75,7 @@ class Grant:
 
     def hive_grant_sql(self) -> str:
         object_type, object_key = self.this_type_and_key()
+        # See https://docs.databricks.com/en/sql/language-manual/security-grant.html
         return f"GRANT {self.action_type} ON {object_type} {object_key} TO `{self.principal}`"
 
     def hive_revoke_sql(self) -> str:
@@ -82,11 +83,11 @@ class Grant:
         return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM `{self.principal}`"
 
     def _set_owner(self, object_type, object_key):
-        return f"ALTER {object_type} {object_key} OWNER TO {self.principal}"
+        return f"ALTER {object_type} {object_key} OWNER TO `{self.principal}`"
 
     def _uc_action(self, action_type):
         def inner(object_type, object_key):
-            return f"GRANT {action_type} ON {object_type} {object_key} TO {self.principal}"
+            return f"GRANT {action_type} ON {object_type} {object_key} TO `{self.principal}`"
 
         return inner
 

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -52,7 +52,8 @@ class Grant:
         # Must come last, as it has the lowest priority here but is a required parameter
         if catalog is not None:
             return "CATALOG", catalog
-        msg = "invalid grant keys"
+        msg = f"invalid grant keys: catalog={catalog}, database={database}, view={view}, " \
+              f"any_file={any_file}, anonymous_function={anonymous_function}"
         raise ValueError(msg)
 
     @property

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -75,11 +75,11 @@ class Grant:
 
     def hive_grant_sql(self) -> str:
         object_type, object_key = self.this_type_and_key()
-        return f"GRANT {self.action_type} ON {object_type} {object_key} TO {self.principal}"
+        return f"GRANT {self.action_type} ON {object_type} {object_key} TO '{self.principal}'"
 
     def hive_revoke_sql(self) -> str:
         object_type, object_key = self.this_type_and_key()
-        return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM {self.principal}"
+        return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM '{self.principal}'"
 
     def _set_owner(self, object_type, object_key):
         return f"ALTER {object_type} {object_key} OWNER TO {self.principal}"

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -75,11 +75,11 @@ class Grant:
 
     def hive_grant_sql(self) -> str:
         object_type, object_key = self.this_type_and_key()
-        return f"GRANT {self.action_type} ON {object_type} {object_key} TO '{self.principal}'"
+        return f"GRANT {self.action_type} ON {object_type} {object_key} TO `{self.principal}`"
 
     def hive_revoke_sql(self) -> str:
         object_type, object_key = self.this_type_and_key()
-        return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM '{self.principal}'"
+        return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM `{self.principal}`"
 
     def _set_owner(self, object_type, object_key):
         return f"ALTER {object_type} {object_key} OWNER TO {self.principal}"

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -1,7 +1,10 @@
 import logging
+from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import partial
+
+from databricks.sdk.service.catalog import SchemaInfo, TableInfo
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
 from databricks.labs.ucx.framework.parallel import Threads
@@ -46,7 +49,7 @@ class Grant:
             return "ANY FILE", ""
         if anonymous_function:
             return "ANONYMOUS FUNCTION", ""
-        # Must come last, as it has lowest priority here but is a required parameter
+        # Must come last, as it has the lowest priority here but is a required parameter
         if catalog is not None:
             return "CATALOG", catalog
         msg = "invalid grant keys"
@@ -54,10 +57,10 @@ class Grant:
 
     @property
     def object_key(self) -> str:
-        _, key = self._this_type_and_key()
+        _, key = self.this_type_and_key()
         return key.lower()
 
-    def _this_type_and_key(self):
+    def this_type_and_key(self):
         return self.type_and_key(
             catalog=self.catalog,
             database=self.database,
@@ -68,11 +71,11 @@ class Grant:
         )
 
     def hive_grant_sql(self) -> str:
-        object_type, object_key = self._this_type_and_key()
+        object_type, object_key = self.this_type_and_key()
         return f"GRANT {self.action_type} ON {object_type} {object_key} TO {self.principal}"
 
     def hive_revoke_sql(self) -> str:
-        object_type, object_key = self._this_type_and_key()
+        object_type, object_key = self.this_type_and_key()
         return f"REVOKE {self.action_type} ON {object_type} {object_key} FROM {self.principal}"
 
     def _set_owner(self, object_type, object_key):
@@ -94,7 +97,7 @@ class Grant:
         # See: https://docs.databricks.com/sql/language-manual/sql-ref-privileges-hms.html
         # See: https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/ownership.html
         # See: https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/privileges.html
-        object_type, object_key = self._this_type_and_key()
+        object_type, object_key = self.this_type_and_key()
         hive_to_uc = {
             ("FUNCTION", "SELECT"): self._uc_action("EXECUTE"),
             ("TABLE", "SELECT"): self._uc_action("SELECT"),
@@ -168,6 +171,19 @@ class GrantsCrawler(CrawlerBase):
             # TODO: https://github.com/databrickslabs/ucx/issues/406
             logger.error(f"Detected {len(errors)} during scanning for grants in {catalog}")
         return [grant for grants in catalog_grants for grant in grants]
+
+    def for_table_info(self, table: TableInfo):
+        # TODO: it does not work yet for views
+        principal_permissions = defaultdict(set)
+        for grant in self._grants(catalog=table.catalog_name, database=table.schema_name, table=table.name):
+            principal_permissions[grant.principal].add(grant.action_type)
+        return principal_permissions
+
+    def for_schema_info(self, schema: SchemaInfo):
+        principal_permissions = defaultdict(set)
+        for grant in self._grants(catalog=schema.catalog_name, database=schema.name):
+            principal_permissions[grant.principal].add(grant.action_type)
+        return principal_permissions
 
     def _grants(
         self,

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -115,7 +115,7 @@ def assess_clusters(cfg: WorkspaceConfig):
     crawler.snapshot()
 
 
-@task("assessment", depends_on=[setup_schema])
+@task("assessment", depends_on=[setup_schema, crawl_grants])
 def crawl_permissions(cfg: WorkspaceConfig):
     """Scans the workspace-local groups and all their permissions. The list is stored in the `$inventory.permissions`
     Delta table.
@@ -143,7 +143,7 @@ def assessment_report(_: WorkspaceConfig):
     dashboard _before_ all tasks have been completed, but then only already completed information is shown."""
 
 
-@task("migrate-groups", depends_on=[crawl_permissions])
+@task("migrate-groups", depends_on=[crawl_permissions], job_cluster="tacl")
 def migrate_permissions(cfg: WorkspaceConfig):
     """Main phase of the group migration process. It does the following:
       - Creates a backup of every workspace-local group, adding a prefix that can be set in the configuration

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -115,7 +115,7 @@ def assess_clusters(cfg: WorkspaceConfig):
     crawler.snapshot()
 
 
-@task("assessment", depends_on=[setup_schema, crawl_grants])
+@task("assessment", depends_on=[crawl_grants])
 def crawl_permissions(cfg: WorkspaceConfig):
     """Scans the workspace-local groups and all their permissions. The list is stored in the `$inventory.permissions`
     Delta table.

--- a/src/databricks/labs/ucx/workspace_access/base.py
+++ b/src/databricks/labs/ucx/workspace_access/base.py
@@ -10,6 +10,7 @@ from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
 logger = Logger(__name__)
 
 
+# TODO: fix order to standard https://github.com/databrickslabs/ucx/issues/411
 @dataclass
 class Permissions:
     object_id: str
@@ -29,12 +30,12 @@ class Crawler:
         """
 
 
+# TODO: this class has to become typing.Protocol and keep only abstract methods
+# See https://www.oreilly.com/library/view/fluent-python-2nd/9781492056348/ch13.html
 class Applier:
     @abstractmethod
     def is_item_relevant(self, item: Permissions, migration_state: GroupMigrationState) -> bool:
-        """
-        This method verifies that the given item is relevant for the given migration state.
-        """
+        """TODO: remove it, see https://github.com/databrickslabs/ucx/issues/410"""
 
     @abstractmethod
     def _get_apply_task(

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -48,6 +48,13 @@ class GroupMigrationState:
         else:
             return found[0]
 
+    def get_target_principal(self, name: str, destination: typing.Literal["backup", "account"]) -> str | None:
+        for info in self.groups:
+            if info.workspace.display_name != name:
+                continue
+            return getattr(info, destination).display_name
+        return None
+
 
 class GroupManager:
     SYSTEM_GROUPS: typing.ClassVar[list[str]] = ["users", "admins", "account users"]

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -9,9 +9,11 @@ from databricks.sdk.service import sql
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
 from databricks.labs.ucx.framework.parallel import Threads
+from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.workspace_access import generic, redash, scim, secrets
 from databricks.labs.ucx.workspace_access.base import Applier, Crawler, Permissions
 from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
 
@@ -57,15 +59,18 @@ class PermissionManager(CrawlerBase):
         sql_support = redash.SqlPermissionsSupport(ws, redash_acl_listing)
         secrets_support = secrets.SecretScopesSupport(ws)
         scim_support = scim.ScimSupport(ws)
+        tables_crawler = TablesCrawler(sql_backend, inventory_database)
+        grants_crawler = GrantsCrawler(tables_crawler)
+        tacl_support = TableAclSupport(grants_crawler, sql_backend)
         return cls(
             sql_backend,
             inventory_database,
-            [generic_support, sql_support, secrets_support, scim_support],
-            cls._object_type_appliers(generic_support, sql_support, secrets_support, scim_support),
+            [generic_support, sql_support, secrets_support, scim_support, tacl_support],
+            cls._object_type_appliers(generic_support, sql_support, secrets_support, scim_support, tacl_support),
         )
 
     @staticmethod
-    def _object_type_appliers(generic_support, sql_support, secrets_support, scim_support):
+    def _object_type_appliers(generic_support, sql_support, secrets_support, scim_support, tacl_support):
         return {
             # SCIM-based API
             "entitlements": scim_support,
@@ -90,6 +95,13 @@ class PermissionManager(CrawlerBase):
             "dashboards": sql_support,
             # Secret Scope ACL API
             "secrets": secrets_support,
+            # Legacy Table ACLs
+            "TABLE": tacl_support,
+            "VIEW": tacl_support,
+            "DATABASE": tacl_support,
+            "ANY FILE": tacl_support,
+            "ANONYMOUS FUNCTION": tacl_support,
+            "CATALOG": tacl_support,
         }
 
     def inventorize_permissions(self):

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -111,7 +111,7 @@ class PermissionManager(CrawlerBase):
         results, errors = Threads.gather("crawl permissions", crawler_tasks)
         if len(errors) > 0:
             # TODO: https://github.com/databrickslabs/ucx/issues/406
-            logger.error(f"Detected {len(errors)} while crawling permissions")
+            logger.error(f"Detected {len(errors)} errors while crawling permissions")
         items = []
         for item in results:
             if item.object_type not in self._appliers:

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -23,7 +23,7 @@ class TableAclSupport(Crawler, Applier):
 
     def get_crawler_tasks(self) -> Iterator[Callable[..., Permissions | None]]:
         def inner(grant: Grant) -> Permissions:
-            object_type, object_key = grant.type_and_key()
+            object_type, object_key = grant.this_type_and_key()
             return Permissions(object_type=object_type, object_id=object_key, raw=json.dumps(dataclasses.asdict(grant)))
 
         for grant in self._grants_crawler.snapshot():

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -1,0 +1,51 @@
+import dataclasses
+import functools
+import json
+from collections.abc import Callable, Iterator
+from functools import partial
+
+from databricks.labs.ucx.framework.crawlers import SqlBackend
+from databricks.labs.ucx.hive_metastore import GrantsCrawler
+from databricks.labs.ucx.hive_metastore.grants import Grant
+from databricks.labs.ucx.workspace_access.base import (
+    Applier,
+    Crawler,
+    Destination,
+    Permissions,
+)
+from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+
+
+class TableAclSupport(Crawler, Applier):
+    def __init__(self, grants_crawler: GrantsCrawler, sql_backend: SqlBackend):
+        self._grants_crawler = grants_crawler
+        self._sql_backend = sql_backend
+
+    def get_crawler_tasks(self) -> Iterator[Callable[..., Permissions | None]]:
+        def inner(grant: Grant) -> Permissions:
+            object_type, object_key = grant.type_and_key()
+            return Permissions(object_type=object_type, object_id=object_key, raw=json.dumps(dataclasses.asdict(grant)))
+
+        for grant in self._grants_crawler.snapshot():
+            yield functools.partial(inner, grant)
+
+    def is_item_relevant(self, _1: Permissions, _2: GroupMigrationState) -> bool:
+        # TODO: this abstract method is a design flaw https://github.com/databrickslabs/ucx/issues/410
+        return True
+
+    def _noop(self):
+        pass
+
+    def _get_apply_task(
+        self, item: Permissions, migration_state: GroupMigrationState, destination: Destination
+    ) -> partial:
+        grant = Grant(**json.loads(item.raw))
+        target_principal = migration_state.get_target_principal(grant.principal, destination)
+        if target_principal is None:
+            # this is a grant for user, service principal, or irrelevant group
+            # technically, we should be able just to `return self._noop`
+            return partial(self._noop)
+        target_grant = dataclasses.replace(grant, principal=target_principal)
+        sql = target_grant.hive_grant_sql()
+        # this has to be executed on tacl cluster, otherwise - use SQLExecutionAPI backend & Warehouse
+        return partial(self._sql_backend.execute, sql)

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -4,8 +4,8 @@ import random
 from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
-from databricks.labs.ucx.hive_metastore.grants import Grant
-from databricks.labs.ucx.hive_metastore.tables import Table
+from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
+from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
 from databricks.labs.ucx.install import WorkspaceInstaller
 
 logger = logging.getLogger(__name__)
@@ -13,8 +13,7 @@ logger = logging.getLogger(__name__)
 
 def test_jobs_with_no_inventory_database(
     ws,
-    sql_exec,
-    sql_fetch_all,
+    sql_backend,
     make_cluster_policy,
     make_cluster_policy_permissions,
     make_ucx_group,
@@ -45,11 +44,11 @@ def test_jobs_with_no_inventory_database(
     table_b = make_table(schema_name=schema_b.name)
     make_table(schema_name=schema_b.name, external=True)
 
-    sql_exec(f"GRANT USAGE ON SCHEMA default TO `{ws_group_a.display_name}`")
-    sql_exec(f"GRANT USAGE ON SCHEMA default TO `{ws_group_b.display_name}`")
-    sql_exec(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{ws_group_a.display_name}`")
-    sql_exec(f"GRANT SELECT ON TABLE {table_b.full_name} TO `{ws_group_b.display_name}`")
-    sql_exec(f"GRANT MODIFY ON SCHEMA {schema_b.full_name} TO `{ws_group_b.display_name}`")
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA default TO `{ws_group_a.display_name}`")
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA default TO `{ws_group_b.display_name}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{ws_group_a.display_name}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_b.full_name} TO `{ws_group_b.display_name}`")
+    sql_backend.execute(f"GRANT MODIFY ON SCHEMA {schema_b.full_name} TO `{ws_group_b.display_name}`")
 
     cluster_policy = make_cluster_policy()
     make_cluster_policy_permissions(
@@ -182,38 +181,26 @@ def test_jobs_with_no_inventory_database(
 
         logger.info("validating tacl")
 
-        tables = sql_fetch_all(f"SELECT * FROM hive_metastore.{inventory_database}.tables")
+        tables_crawler = TablesCrawler(sql_backend, install._config.inventory_database)
+        grants_crawler = GrantsCrawler(tables_crawler)
 
-        all_tables = {}
-        for t_row in tables:
-            table = Table(*t_row)
-            all_tables[table.key] = table
+        table_a_grants = grants_crawler.for_table_info(table_a)
+        assert "SELECT" == table_a_grants.get(ws_group_a.display_name)
 
-        assert len(all_tables) >= 2, "must have at least two tables"
+        table_b_grants = grants_crawler.for_table_info(table_b)
+        assert "SELECT" == table_b_grants.get(ws_group_b.display_name)
 
-        logger.debug(f"all tables={all_tables}, ")
+        schema_b_grants = grants_crawler.for_schema_info(schema_b)
+        assert "MODIFY" == schema_b_grants.get(ws_group_b.display_name)
 
-        grants = sql_fetch_all(f"SELECT * FROM hive_metastore.{inventory_database}.grants")
-        all_grants = {}
-        for g_row in grants:
-            grant = Grant(*g_row)
-            if grant.table:
-                all_grants[f"{grant.principal}.{grant.catalog}.{grant.database}.{grant.table}"] = grant.action_type
-            else:
-                all_grants[f"{grant.principal}.{grant.catalog}.{grant.database}"] = grant.action_type
-
+        all_grants = grants_crawler.snapshot()
         logger.debug(f"all grants={all_grants}, ")
 
-        assert len(all_grants) >= 3, "must have at least three grants"
-        assert all_grants[f"{ws_group_a.display_name}.{table_a.full_name}"] == "SELECT"
-        assert all_grants[f"{ws_group_b.display_name}.{table_b.full_name}"] == "SELECT"
-        assert all_grants[f"{ws_group_b.display_name}.{schema_b.full_name}"] == "MODIFY"
-
         permissions = list(
-            sql_fetch_all(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.permissions")
+            sql_backend.fetch(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.permissions")
         )
-        tables = list(sql_fetch_all(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.tables"))
-        grants = list(sql_fetch_all(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.grants"))
+        tables = list(sql_backend.fetch(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.tables"))
+        grants = list(sql_backend.fetch(f"SELECT * FROM hive_metastore.{install._config.inventory_database}.grants"))
 
         assert len(permissions) > 0
         assert len(tables) >= 2

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -185,13 +185,13 @@ def test_jobs_with_no_inventory_database(
         grants_crawler = GrantsCrawler(tables_crawler)
 
         table_a_grants = grants_crawler.for_table_info(table_a)
-        assert "SELECT" == table_a_grants.get(ws_group_a.display_name)
+        assert {"SELECT"} == table_a_grants.get(ws_group_a.display_name)
 
         table_b_grants = grants_crawler.for_table_info(table_b)
-        assert "SELECT" == table_b_grants.get(ws_group_b.display_name)
+        assert {"SELECT"} == table_b_grants.get(ws_group_b.display_name)
 
         schema_b_grants = grants_crawler.for_schema_info(schema_b)
-        assert "MODIFY" == schema_b_grants.get(ws_group_b.display_name)
+        assert {"MODIFY"} == schema_b_grants.get(ws_group_b.display_name)
 
         all_grants = grants_crawler.snapshot()
         logger.debug(f"all grants={all_grants}, ")

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -1,0 +1,63 @@
+import json
+
+from databricks.sdk.service.iam import Group
+from unit.framework.mocks import MockBackend
+
+from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
+from databricks.labs.ucx.workspace_access.base import Permissions
+from databricks.labs.ucx.workspace_access.groups import (
+    GroupMigrationState,
+    MigrationGroupInfo,
+)
+from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+
+
+def test_tacl_crawler():
+    sql_backend = MockBackend(
+        rows={
+            "SELECT \\* FROM hive_metastore.test.grants": [
+                ("foo@example.com", "SELECT", "catalog_a", "database_b", "table_c", None, False, False)
+            ]
+        }
+    )
+    tables_crawler = TablesCrawler(sql_backend, "test")
+    grants_crawler = GrantsCrawler(tables_crawler)
+    table_acl_support = TableAclSupport(grants_crawler, sql_backend)
+
+    crawler_tasks = table_acl_support.get_crawler_tasks()
+    first_task = next(crawler_tasks)
+    x = first_task()
+
+    assert "TABLE" == x.object_type
+    assert "catalog_a.database_b.table_c" == x.object_id
+
+
+def test_tacl_applier(mocker):
+    sql_backend = MockBackend()
+    table_acl_support = TableAclSupport(mocker.Mock(), sql_backend)
+
+    permissions = Permissions(
+        object_type="TABLE",
+        object_id="catalog_a.database_b.table_c",
+        raw=json.dumps(
+            {
+                "principal": "abc",
+                "action_type": "SELECT",
+                "catalog": "catalog_a",
+                "database": "database_b",
+                "table": "table_c",
+            }
+        ),
+    )
+    migration_state = GroupMigrationState()
+    migration_state.add(
+        MigrationGroupInfo(
+            workspace=Group(display_name="abc"),
+            backup=Group(display_name="tmp-backup-abc"),
+            account=Group(display_name="account-abc"),
+        )
+    )
+    task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
+    task()
+
+    assert ["GRANT SELECT ON TABLE catalog_a.database_b.table_c TO `tmp-backup-abc`"] == sql_backend.queries

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -13,8 +13,10 @@ logger = logging.getLogger(__name__)
 
 def test_workspace_access_e2e(
     ws: WorkspaceClient,
+    sql_backend,
     inventory_schema,
     make_schema,
+    make_table,
     make_ucx_group,
     make_instance_pool,
     make_instance_pool_permissions,
@@ -42,6 +44,17 @@ def test_workspace_access_e2e(
     env_or_skip,
 ):
     ws_group, acc_group = make_ucx_group()
+
+    schema_a = make_schema()
+    schema_b = make_schema()
+    _ = make_schema()
+    table_a = make_table(schema_name=schema_a.name)
+    table_b = make_table(schema_name=schema_b.name)
+    make_table(schema_name=schema_b.name, external=True)
+
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA default TO `{ws_group.display_name}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{ws_group.display_name}`")
+    sql_backend.execute(f"GRANT MODIFY ON TABLE {table_b.full_name} TO `{ws_group.display_name}`")
 
     to_verify = set()
 

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -12,7 +12,7 @@ def test_type_and_key_table():
     assert grant == ("TABLE", "hive_metastore.mydb.mytable")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", database="mydb", table="mytable")
-    assert grant._this_type_and_key()[0] == "TABLE"
+    assert grant.this_type_and_key()[0] == "TABLE"
     assert grant.object_key == "hive_metastore.mydb.mytable"
 
 
@@ -21,7 +21,7 @@ def test_type_and_key_view():
     assert grant == ("VIEW", "hive_metastore.mydb.myview")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", database="mydb", view="myview")
-    assert grant._this_type_and_key()[0] == "VIEW"
+    assert grant.this_type_and_key()[0] == "VIEW"
     assert grant.object_key == "hive_metastore.mydb.myview"
 
 
@@ -30,7 +30,7 @@ def test_type_and_key_database():
     assert grant == ("DATABASE", "hive_metastore.mydb")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", database="mydb")
-    assert grant._this_type_and_key()[0] == "DATABASE"
+    assert grant.this_type_and_key()[0] == "DATABASE"
     assert grant.object_key == "hive_metastore.mydb"
 
 
@@ -39,7 +39,7 @@ def test_type_and_key_catalog():
     assert grant == ("CATALOG", "mycatalog")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="mycatalog")
-    assert grant._this_type_and_key()[0] == "CATALOG"
+    assert grant.this_type_and_key()[0] == "CATALOG"
     assert grant.object_key == "mycatalog"
 
 
@@ -48,7 +48,7 @@ def test_type_and_key_any_file():
     assert grant == ("ANY FILE", "")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", any_file=True)
-    assert grant._this_type_and_key()[0] == "ANY FILE"
+    assert grant.this_type_and_key()[0] == "ANY FILE"
     assert grant.object_key == ""
 
 
@@ -57,7 +57,7 @@ def test_type_and_key_anonymous_function():
     assert grant == ("ANONYMOUS FUNCTION", "")
 
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", anonymous_function=True)
-    assert grant._this_type_and_key()[0] == "ANONYMOUS FUNCTION"
+    assert grant.this_type_and_key()[0] == "ANONYMOUS FUNCTION"
     assert grant.object_key == ""
 
 

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -73,13 +73,13 @@ def test_object_key():
 
 def test_hive_sql():
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", database="mydb", table="mytable")
-    assert grant.hive_grant_sql() == "GRANT SELECT ON TABLE hive_metastore.mydb.mytable TO user"
-    assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM user"
+    assert grant.hive_grant_sql() == "GRANT SELECT ON TABLE hive_metastore.mydb.mytable TO `user`"
+    assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM `user`"
 
 
 def test_hive_revoke_sql():
     grant = Grant(principal="user", action_type="SELECT", catalog="hive_metastore", database="mydb", table="mytable")
-    assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM user"
+    assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM `user`"
 
 
 @pytest.mark.parametrize(
@@ -87,15 +87,15 @@ def test_hive_revoke_sql():
     [
         (
             Grant("user", "READ_METADATA", catalog="hive_metastore", database="mydb", table="mytable"),
-            "GRANT BROWSE ON TABLE hive_metastore.mydb.mytable TO user",
+            "GRANT BROWSE ON TABLE hive_metastore.mydb.mytable TO `user`",
         ),
         (
             Grant("me", "OWN", catalog="hive_metastore", database="mydb", table="mytable"),
-            "ALTER TABLE hive_metastore.mydb.mytable OWNER TO me",
+            "ALTER TABLE hive_metastore.mydb.mytable OWNER TO `me`",
         ),
         (
             Grant("me", "USAGE", catalog="hive_metastore", database="mydb"),
-            "GRANT USE SCHEMA ON DATABASE hive_metastore.mydb TO me",
+            "GRANT USE SCHEMA ON DATABASE hive_metastore.mydb TO `me`",
         ),
         (
             Grant("me", "INVALID", catalog="hive_metastore", database="mydb"),

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -1,7 +1,6 @@
 import json
 
 from databricks.sdk.service.iam import Group
-from unit.framework.mocks import MockBackend
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.workspace_access.base import Permissions
@@ -10,6 +9,7 @@ from databricks.labs.ucx.workspace_access.groups import (
     MigrationGroupInfo,
 )
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+from ..framework.mocks import MockBackend
 
 
 def test_tacl_crawler():
@@ -61,3 +61,34 @@ def test_tacl_applier(mocker):
     task()
 
     assert ["GRANT SELECT ON TABLE catalog_a.database_b.table_c TO `tmp-backup-abc`"] == sql_backend.queries
+
+
+def test_tacl_applier_no_target_principal(mocker):
+    sql_backend = MockBackend()
+    table_acl_support = TableAclSupport(mocker.Mock(), sql_backend)
+
+    permissions = Permissions(
+        object_type="TABLE",
+        object_id="catalog_a.database_b.table_c",
+        raw=json.dumps(
+            {
+                "principal": "foo@example.com",
+                "action_type": "SELECT",
+                "catalog": "catalog_a",
+                "database": "database_b",
+                "table": "table_c",
+            }
+        ),
+    )
+    migration_state = GroupMigrationState()
+    migration_state.add(
+        MigrationGroupInfo(
+            workspace=Group(display_name="abc"),
+            backup=Group(display_name="tmp-backup-abc"),
+            account=Group(display_name="account-abc"),
+        )
+    )
+    task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
+    task()
+
+    assert [] == sql_backend.queries

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -9,6 +9,7 @@ from databricks.labs.ucx.workspace_access.groups import (
     MigrationGroupInfo,
 )
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+
 from ..framework.mocks import MockBackend
 
 


### PR DESCRIPTION
When workspace-local group is replaced with account-level group, Legacy Table ACLs disappear from Hive Metastore objects. This PR plugs HMS grants with `crawler`/`applier` framework on top of `$inventory.permissions`