### PR TITLE
Fixed `crawl_permissions` task to respect 'workspace_start_path' config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ hatch env create
 
 To install development dependencies, including testing and database connection packages, use the following command:
 ```shell
-hatch run pip install -e '.[test,dbconnect]'
+hatch run pip install -e '.[test]'
 ```
 
 To ensure your integrated development environment (IDE) uses the newly created virtual environment, you can retrieve the Python path with this command:

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -224,6 +224,7 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
             log_level=raw.get("log_level", "INFO"),
             database_to_catalog_mapping=raw.get("database_to_catalog_mapping", None),
             default_catalog=raw.get("default_catalog", "main"),
+            workspace_start_path=raw.get("workspace_start_path", "/")
         )
 
     def to_workspace_client(self) -> WorkspaceClient:


### PR DESCRIPTION
The crawl_permissions task in assessment would not respect the config value of workspace_start_path as it was not present in the 'from_dict' classmethod. Added an extraction for the config.

Removed dbconnect from Contributing README as it is no longer needed.