### PR TITLE
Use `ws.groups.patch` to rename groups instead of creating backup groups

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -102,16 +102,6 @@ class _Config(Generic[T]):
     def from_file(cls, config_file: Path) -> T:
         return cls.from_bytes(config_file.read_text())
 
-    @classmethod
-    def _verify_version(cls, raw):
-        stored_version = raw.pop("version", None)
-        if stored_version != _CONFIG_VERSION:
-            msg = (
-                f"Unsupported config version: {stored_version}. "
-                f"UCX v{__version__} expects config version to be {_CONFIG_VERSION}"
-            )
-            raise ValueError(msg)
-
     def __post_init__(self):
         if self.connect is None:
             self.connect = ConnectConfig()
@@ -202,7 +192,6 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
     @classmethod
     def from_dict(cls, raw: dict):
         raw = cls._migrate_from_v1(raw)
-        cls._verify_version(raw)
         return cls(**raw)
 
     def to_workspace_client(self) -> WorkspaceClient:

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -9,27 +9,7 @@ from databricks.sdk.core import Config
 
 from databricks.labs.ucx.__about__ import __version__
 
-__all__ = ["GroupsConfig", "AccountConfig", "WorkspaceConfig"]
-
-
-# TODO: flatten down
-@dataclass
-class GroupsConfig:
-    selected: list[str] | None = None
-    auto: bool | None = None
-    backup_group_prefix: str | None = "db-temp-"
-
-    def __post_init__(self):
-        if not self.selected and self.auto is None:
-            msg = "Either selected or auto must be set"
-            raise ValueError(msg)
-        if self.selected and self.auto is False:
-            msg = "No selected groups provided, but auto-collection is disabled"
-            raise ValueError(msg)
-
-    @classmethod
-    def from_dict(cls, raw: dict):
-        return cls(**raw)
+__all__ = ["AccountConfig", "WorkspaceConfig"]
 
 
 @dataclass
@@ -97,7 +77,8 @@ class ConnectConfig:
 
 
 # Used to set the right expectation about configuration file schema
-_CONFIG_VERSION = 1
+# TODO: config versions migrate
+_CONFIG_VERSION = 2
 
 T = TypeVar("T")
 
@@ -199,14 +180,19 @@ class AccountConfig(_Config["AccountConfig"]):
 @dataclass
 class WorkspaceConfig(_Config["WorkspaceConfig"]):
     inventory_database: str
-    groups: GroupsConfig
+
+    # Includes group names for migration. If not specified, all matching groups will be picked up
+    include_group_names: list[str] = None
+
+    renamed_group_prefix: str = "ucx-renamed-"
+
     instance_pool_id: str = None
     warehouse_id: str = None
     connect: ConnectConfig | None = None
     num_threads: int | None = 10
-    log_level: str | None = "INFO"
     database_to_catalog_mapping: dict[str, str] = None
     default_catalog: str = "ucx_default"
+    log_level: str = "INFO"
 
     # Starting path for notebooks and directories crawler
     workspace_start_path: str = "/"
@@ -215,24 +201,24 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
 
     @classmethod
     def from_dict(cls, raw: dict):
+        raw = cls._migrate_from_v1(raw)
         cls._verify_version(raw)
-        return cls(
-            inventory_database=raw.get("inventory_database"),
-            groups=GroupsConfig.from_dict(raw.get("groups", {})),
-            connect=ConnectConfig.from_dict(raw.get("connect", {})),
-            instance_pool_id=raw.get("instance_pool_id", None),
-            warehouse_id=raw.get("warehouse_id", None),
-            num_threads=raw.get("num_threads", 10),
-            log_level=raw.get("log_level", "INFO"),
-            database_to_catalog_mapping=raw.get("database_to_catalog_mapping", None),
-            instance_profile=raw.get("instance_profile", None),
-            spark_conf=raw.get("spark_conf", None),
-            default_catalog=raw.get("default_catalog", "main"),
-            workspace_start_path=raw.get("workspace_start_path", "/"),
-        )
+        return cls(**raw)
 
     def to_workspace_client(self) -> WorkspaceClient:
         return WorkspaceClient(config=self.to_databricks_config())
 
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")
+
+    @classmethod
+    def _migrate_from_v1(cls, raw: dict):
+        stored_version = raw.pop("version", None)
+        if stored_version == _CONFIG_VERSION:
+            return raw
+        if stored_version == 1:
+            raw["include_group_names"] = raw.get("groups", {"selected": []})["selected"]
+            raw["renamed_group_prefix"] = raw.get("groups", {"backup_group_prefix": "db-temp-"})["backup_group_prefix"]
+            return raw
+        msg = f"Unknown config version: {stored_version}"
+        raise ValueError(msg)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -720,7 +720,7 @@ class WorkspaceInstaller:
                 num_workers=0,
             )
         )
-        if self._ws.config.is_aws:
+        if self._ws.config.is_aws and spec.aws_attributes is not None:
             aws_attributes = replace(spec.aws_attributes, instance_profile_arn=self._config.instance_profile)
             spec = replace(spec, aws_attributes=aws_attributes)
         if "main" in names:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -30,12 +30,12 @@ from databricks.labs.ucx.assessment.crawlers import (
     JobInfo,
     PipelineInfo,
 )
-from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
 from databricks.labs.ucx.framework.crawlers import (
     SchemaDeployer,
     SqlBackend,
     StatementExecutionBackend,
 )
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.install_state import InstallState
 from databricks.labs.ucx.framework.tasks import _TASKS, Task
@@ -379,10 +379,11 @@ class WorkspaceInstaller:
         groups_config_args = {
             "backup_group_prefix": backup_group_prefix,
         }
+
         if selected_groups != "<ALL>":
             groups_config_args["selected"] = [x.strip() for x in selected_groups.split(",")]
         else:
-            groups_config_args["auto"] = True
+            groups_config_args["selected"] = None
 
         # Checking for external HMS
         instance_profile = None
@@ -408,7 +409,8 @@ class WorkspaceInstaller:
 
         self._config = WorkspaceConfig(
             inventory_database=inventory_database,
-            groups=GroupsConfig(**groups_config_args),
+            include_group_names=groups_config_args["selected"],
+            renamed_group_prefix=groups_config_args["backup_group_prefix"],
             warehouse_id=warehouse_id,
             log_level=log_level,
             num_threads=num_threads,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -30,12 +30,12 @@ from databricks.labs.ucx.assessment.crawlers import (
     JobInfo,
     PipelineInfo,
 )
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.crawlers import (
     SchemaDeployer,
     SqlBackend,
     StatementExecutionBackend,
 )
-from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.install_state import InstallState
 from databricks.labs.ucx.framework.tasks import _TASKS, Task

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -272,7 +272,7 @@ def apply_permissions_to_account_groups(cfg: WorkspaceConfig):
         num_threads=cfg.num_threads,
         workspace_start_path=cfg.workspace_start_path,
     )
-    permission_manager.apply_group_permissions(migration_state, destination="account")
+    permission_manager.apply_group_permissions(migration_state)
 
 
 @task("remove-workspace-local-backup-groups", depends_on=[apply_permissions_to_account_groups])

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -19,8 +19,7 @@ from databricks.labs.ucx.hive_metastore.data_objects import ExternalLocationCraw
 from databricks.labs.ucx.hive_metastore.mounts import Mounts
 from databricks.labs.ucx.workspace_access.generic import WorkspaceListing
 from databricks.labs.ucx.workspace_access.groups import (
-    GroupManager,
-    GroupMigrationState,
+    GroupManager
 )
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 

--- a/src/databricks/labs/ucx/workspace_access/base.py
+++ b/src/databricks/labs/ucx/workspace_access/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from logging import Logger
 from typing import Literal
 
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 logger = Logger(__name__)
 
@@ -30,7 +30,7 @@ class AclSupport:
 
     @abstractmethod
     def get_apply_task(
-        self, item: Permissions, migration_state: GroupMigrationState, destination: Destination
+        self, item: Permissions, migration_state: MigrationState, destination: Destination
     ) -> Callable[[], None] | None:
         """This method returns a Callable, that applies permissions to a destination group, based on
         the group migration state. The callable is required not to have any shared mutable state."""

--- a/src/databricks/labs/ucx/workspace_access/base.py
+++ b/src/databricks/labs/ucx/workspace_access/base.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from logging import Logger
-from typing import Literal
 
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
@@ -17,9 +16,6 @@ class Permissions:
     raw: str
 
 
-Destination = Literal["backup", "account"]
-
-
 class AclSupport:
     @abstractmethod
     def get_crawler_tasks(self) -> Iterator[Callable[..., Permissions | None]]:
@@ -29,9 +25,7 @@ class AclSupport:
         """
 
     @abstractmethod
-    def get_apply_task(
-        self, item: Permissions, migration_state: MigrationState, destination: Destination
-    ) -> Callable[[], None] | None:
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState) -> Callable[[], None] | None:
         """This method returns a Callable, that applies permissions to a destination group, based on
         the group migration state. The callable is required not to have any shared mutable state."""
 

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -20,7 +20,7 @@ from databricks.labs.ucx.workspace_access.base import (
     Destination,
     Permissions,
 )
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class GenericPermissionsSupport(AclSupport):
                 all_object_types.add(object_type)
         return all_object_types
 
-    def get_apply_task(self, item: Permissions, migration_state: GroupMigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
         if not self._is_item_relevant(item, migration_state):
             return None
         object_permissions = iam.ObjectPermissions.from_dict(json.loads(item.raw))
@@ -89,7 +89,7 @@ class GenericPermissionsSupport(AclSupport):
         return partial(self._applier_task, item.object_type, item.object_id, new_acl)
 
     @staticmethod
-    def _is_item_relevant(item: Permissions, migration_state: GroupMigrationState) -> bool:
+    def _is_item_relevant(item: Permissions, migration_state: MigrationState) -> bool:
         # passwords and tokens are represented on the workspace-level
         if item.object_id in ("tokens", "passwords"):
             return True
@@ -239,7 +239,7 @@ class GenericPermissionsSupport(AclSupport):
                 raise RetryableError(message=msg) from e
 
     def _prepare_new_acl(
-        self, permissions: iam.ObjectPermissions, migration_state: GroupMigrationState, destination: Destination
+        self, permissions: iam.ObjectPermissions, migration_state: MigrationState, destination: Destination
     ) -> list[iam.AccessControlRequest]:
         _acl = permissions.access_control_list
         acl_requests = []

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -248,7 +248,7 @@ class GenericPermissionsSupport(AclSupport):
             if not migration_state.is_in_scope(_item.group_name):
                 logger.debug(f"Skipping {_item} for {coord} because it is not in scope")
                 continue
-            new_group_name = migration_state.get_target_principal(_item.group_name, destination)
+            new_group_name = migration_state.get_target_principal(_item.group_name)
             if new_group_name is None:
                 logger.debug(f"Skipping {_item.group_name} for {coord} because it has no target principal")
                 continue

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -15,11 +15,7 @@ from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
 from databricks.labs.ucx.mixins.hardening import rate_limited
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 logger = logging.getLogger(__name__)
@@ -81,11 +77,11 @@ class GenericPermissionsSupport(AclSupport):
                 all_object_types.add(object_type)
         return all_object_types
 
-    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState):
         if not self._is_item_relevant(item, migration_state):
             return None
         object_permissions = iam.ObjectPermissions.from_dict(json.loads(item.raw))
-        new_acl = self._prepare_new_acl(object_permissions, migration_state, destination)
+        new_acl = self._prepare_new_acl(object_permissions, migration_state)
         return partial(self._applier_task, item.object_type, item.object_id, new_acl)
 
     @staticmethod
@@ -239,7 +235,7 @@ class GenericPermissionsSupport(AclSupport):
                 raise RetryableError(message=msg) from e
 
     def _prepare_new_acl(
-        self, permissions: iam.ObjectPermissions, migration_state: MigrationState, destination: Destination
+        self, permissions: iam.ObjectPermissions, migration_state: MigrationState
     ) -> list[iam.AccessControlRequest]:
         _acl = permissions.access_control_list
         acl_requests = []

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -1,4 +1,6 @@
 import collections
+import dataclasses
+import functools
 import json
 import logging
 import typing
@@ -8,15 +10,12 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam
-from databricks.sdk.service.iam import Group
 
-from databricks.labs.ucx.config import GroupsConfig
-from databricks.labs.ucx.framework.crawlers import SqlBackend
+from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
+from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.mixins.hardening import rate_limited
 
 logger = logging.getLogger(__name__)
-
-GroupLevel = typing.Literal["workspace", "account"]
 
 
 # TODO: This class is used to persist MigrationGroupInfo, but Group is a not supported type for backend.save_table()
@@ -28,105 +27,38 @@ class MigrationGroupInfoMock:
 
 
 @dataclass
-class MigrationGroupInfo:
-    workspace: Group = None
-    backup: Group = None
-    account: Group = None
+class MigratedGroup:
+    id_in_workspace: str
+    name_in_workspace: str
+    name_in_account: str
+    temporary_name: str
+    members: str
+    entitlements: str
+    external_id: str
+    roles: str
 
-    def is_name_match(self, name: str) -> bool:
-        if self.workspace is not None:
-            return name == self.workspace.display_name
-        if self.account is not None:
-            return name == self.account.display_name
-        if self.backup is not None:
-            return name == self.backup.display_name
-        return False
-
-    def is_id_match(self, group_id: str) -> bool:
-        if self.workspace is not None:
-            return group_id == self.workspace.id
-        if self.account is not None:
-            return group_id == self.account.id
-        if self.backup is not None:
-            return group_id == self.backup.id
-        return False
+    def as_account_group_without_id(self) -> iam.Group:
+        raw = dataclasses.asdict(self)
+        return iam.Group(
+            display_name=self.name_in_account,
+            external_id=self.external_id,
+            entitlements=iam._repeated(raw, 'entitlements', iam.ComplexValue),  # noqa
+            members=iam._repeated(raw, 'members', iam.ComplexValue),  # noqa
+            roles=iam._repeated(raw, 'roles', iam.ComplexValue),  # noqa
+        )
 
 
-class GroupMigrationState:
+class MigrationState:
     """Holds migration state of workspace-to-account groups"""
 
-    def __init__(self, backup_group_prefix: str = "db-temp-"):
-        self.groups: list[MigrationGroupInfo] = []
-        self._backup_group_prefix = backup_group_prefix
+    def __init__(self, groups: list[MigratedGroup]):
+        self._name_to_group: dict[str, MigratedGroup] = {_.name_in_workspace: _ for _ in groups}
 
-    def add(self, ws_group: Group, backup_group: Group, acc_group: Group):
-        mgi = MigrationGroupInfo(workspace=ws_group, backup=backup_group, account=acc_group)
-        self.groups.append(mgi)
-
-    def persist_migration_state(self, backend: SqlBackend, inventory_database: str):
-        rows = []
-        for group in self.groups:
-            account = self.group_to_str(group.account) if group.account else None
-            backup = self.group_to_str(group.backup) if group.backup else None
-            workspace = self.group_to_str(group.workspace) if group.workspace else None
-            rows.append(MigrationGroupInfoMock(workspace, backup, account))
-        logger.info(f"Persisting {len(rows)} to migration state hive_metastore.{inventory_database}.migration_state")
-        backend.save_table(f"hive_metastore.{inventory_database}.migration_state", rows, MigrationGroupInfoMock)
-
-    def group_to_str(self, group: Group):
-        if group.schemas:
-            # TODO: Remove this when https://github.com/databricks/databricks-sdk-py/issues/420 is done
-            group = replace(group, schemas=None)
-        return json.dumps(group.as_dict())
-
-    def fetch_migration_state(self, backend: SqlBackend, inventory_database: str):
-        migration_group_infos = backend.fetch(f"SELECT * FROM hive_metastore.{inventory_database}.migration_state")
-
-        state = GroupMigrationState()
-        for workspace, backup, account in migration_group_infos:
-            workspace_group = Group().from_dict(json.loads(workspace)) if workspace else None
-            backup_group = Group().from_dict(json.loads(backup)) if backup else None
-            account_group = Group().from_dict(json.loads(account)) if account else None
-            state.add(workspace_group, backup_group, account_group)
-        logger.info(
-            f"{len(list(state.groups))} found to migration state hive_metastore.{inventory_database}.migration_state"
-        )
-        return state
-
-    def is_in_scope(self, name: str) -> bool:
-        if name is None:
-            return False
-        for info in self.groups:
-            if info.is_name_match(name):
-                return True
-        return False
-
-    def is_id_in_scope(self, group_id: str) -> bool:
-        if group_id is None:
-            return False
-        for info in self.groups:
-            if info.is_id_match(group_id):
-                return True
-        return False
-
-    def get_by_workspace_group_name(self, workspace_group_name: str) -> MigrationGroupInfo | None:
-        # TODO: this method is deprecated, replace all usages by get_target_principal()
-        found = [g for g in self.groups if g.workspace.display_name == workspace_group_name]
-        if len(found) == 0:
+    def get_target_principal(self, name: str) -> str | None:
+        mg = self._name_to_group.get(name)
+        if mg is None:
             return None
-        else:
-            return found[0]
-
-    def get_target_principal(self, name: str, destination: typing.Literal["backup", "account"]) -> str | None:
-        for info in self.groups:
-            # TODO: this logic has to be changed, once we crawl all wslocal accgroups into a table
-            group_for_match = info.workspace
-            if group_for_match is None:
-                group_for_match = info.account
-            if group_for_match.display_name != name:
-                continue
-            return getattr(info, destination).display_name
-        return None
+        return mg.name_in_account
 
     def get_target_id(self, group_id: str, destination: typing.Literal["backup", "account"]) -> str | None:
         for info in self.groups:
@@ -140,106 +72,73 @@ class GroupMigrationState:
         return None
 
     def __len__(self):
-        return len(self.groups)
+        return len(self._name_to_group)
 
 
-class GroupManager:
+class GroupManager(CrawlerBase):
     _SYSTEM_GROUPS: typing.ClassVar[list[str]] = ["users", "admins", "account users"]
-    _SCIM_ATTRIBUTES = "id,displayName,meta,members"
 
-    def __init__(self, ws: WorkspaceClient, groups: GroupsConfig):
-        self._ws = ws
-        # TODO: remove groups param in favor of _include_group_names and _backup_group_prefix
-        self._include_group_names = groups.selected
-        self._backup_group_prefix = groups.backup_group_prefix
-        self._migration_state = GroupMigrationState(backup_group_prefix=groups.backup_group_prefix)
-        self._account_groups = self._list_account_groups(ws, self._SCIM_ATTRIBUTES)
-        self._workspace_groups = self._list_workspace_groups()
-
-    @classmethod
-    def prepare_apply_permissions_to_account_groups(
-        cls, ws: WorkspaceClient, remote_state: GroupMigrationState, backup_group_prefix: str = "db-temp-"
+    def __init__(
+        self,
+        sql_backend: SqlBackend,
+        ws: WorkspaceClient,
+        inventory_database: str,
+        include_group_names: list[str] | None = None,
+        renamed_group_prefix: str = "ucx-renamed-",
     ):
-        scim_attributes = "id,displayName,meta"
+        super().__init__(sql_backend, "hive_metastore", inventory_database, "groups", MigratedGroup)
+        self._ws = ws
+        self._include_group_names = include_group_names
+        self._renamed_group_prefix = renamed_group_prefix
+        self._migration_state: MigrationState = MigrationState()
 
-        account_groups_by_name = {}
-        for g in cls._list_account_groups(ws, scim_attributes):
-            account_groups_by_name[g.display_name] = g
-
-        remote_state_by_backup_group = {}
-        for g in remote_state.groups:
-            remote_state_by_backup_group[(g.backup.display_name, g.account.display_name)] = g
-
-        workspace_groups_by_name = {}
-        account_groups_in_workspace_by_name = {}
-        for g in ws.groups.list(attributes=scim_attributes):
-            if g.display_name in cls._SYSTEM_GROUPS:
-                continue
-            if g.meta.resource_type == "WorkspaceGroup":
-                workspace_groups_by_name[g.display_name] = g
-            else:
-                account_groups_in_workspace_by_name[g.display_name] = g
-
-        migration_state = GroupMigrationState(backup_group_prefix=backup_group_prefix)
-        for display_name in account_groups_by_name.keys():
-            if display_name not in account_groups_in_workspace_by_name:
-                logger.info(f"Skipping account group `{display_name}`: not added to a workspace")
-                continue
-            backup_group_name = f"{backup_group_prefix}{display_name}"
-            if backup_group_name not in workspace_groups_by_name:
-                logger.info(f"Skipping account group `{display_name}`: no backup group in workspace")
-                continue
-            if (backup_group_name, display_name) not in remote_state_by_backup_group:
-                logger.info(f"Skipping account group `{display_name}`: not present in the state")
-                continue
-            workspace_group = remote_state_by_backup_group[(backup_group_name, display_name)].workspace
-            backup_group = workspace_groups_by_name[backup_group_name]
-            account_group = account_groups_in_workspace_by_name[display_name]
-            migration_state.add(workspace_group, backup_group, account_group)
-
-        return migration_state
-
-    def prepare_groups_in_environment(self):
-        logger.info(
-            "Preparing groups in the current environment. At this step we'll verify that all groups "
-            "exist and are of the correct type. If some temporary groups are missing, they'll be created"
-        )
-        valid_group_names = self._get_valid_group_names_to_migrate()
-        self._set_migration_groups_with_backup(valid_group_names)
-        logger.info("Environment prepared successfully")
+    def snapshot(self) -> list[MigratedGroup]:
+        return self._snapshot(self._fetcher, self._crawler)
 
     def has_groups(self) -> bool:
-        return len(self._migration_state.groups) > 0
+        return len(self.snapshot()) > 0
 
-    @property
-    def migration_state(self) -> GroupMigrationState:
-        if len(self._migration_state) == 0:
-            logger.info("No groups were loaded or initialized, nothing to do")
-        return self._migration_state
+    def rename_groups(self):
+        tasks = []
+        account_groups_in_workspace = self._account_groups_in_workspace()
+        workspace_groups_in_workspace = self._workspace_groups_in_workspace()
+        for mg in self.snapshot():
+            if mg.name_in_account in account_groups_in_workspace:
+                logger.info(f"Skipping {mg.name_in_account}: already in workspace")
+                continue
+            if mg.temporary_name in workspace_groups_in_workspace:
+                logger.info(f"Skipping {mg.name_in_workspace}: already renamed")
+                continue
+            logger.info(f"Renaming: {mg.name_in_workspace} -> {mg.temporary_name}")
+            tasks.append(functools.partial(self._rename_group, mg.id_in_workspace, mg.temporary_name))
+        _, errors = Threads.gather("rename groups in the workspace", tasks)
+        if len(errors) > 0:
+            msg = f"During rename of workspace groups got {len(errors)} errors. See debug logs"
+            raise RuntimeWarning(msg)
+    def reflect_account_groups_on_workspace(self):
+        tasks = []
+        account_groups_in_account = self._account_groups_in_account()
+        account_groups_in_workspace = self._account_groups_in_workspace()
+        for mg in self.snapshot():
+            if mg.name_in_account in account_groups_in_workspace:
+                logger.info(f"Skipping {mg.name_in_account}: already in workspace")
+                continue
+            if mg.name_in_account not in account_groups_in_account:
+                logger.warning(f"Skipping {mg.name_in_account}: not in account")
+                continue
+            group_id = account_groups_in_account[mg.name_in_account]
+            tasks.append(functools.partial(self._reflect_account_group_to_workspace, group_id))
+        _, errors = Threads.gather("reflect account groups on this workspace", tasks)
+        if len(errors) > 0:
+            msg = f"During account-to-workspace reflection got {len(errors)} errors. See debug logs"
+            raise RuntimeWarning(msg)
 
-    def replace_workspace_groups_with_account_groups(self, migration_state: GroupMigrationState):
-        logger.info("Replacing the workspace groups with account-level groups")
-        if len(migration_state) == 0:
-            logger.info("No groups were loaded or initialized, nothing to do")
-            return
-        for migration_info in migration_state.groups:
-            self._replace_group(migration_info)
-        logger.info("Workspace groups were successfully replaced with account-level groups")
-
-    def delete_backup_groups(self):
-        backup_groups = self._get_backup_groups()
-        if len(backup_groups) == 0:
-            logger.info("No backup group found, nothing to do")
-            return
-
-        logger.info(f"Deleting {len(backup_groups)} backup workspace-level groups")
-        for group in backup_groups:
-            self._delete_workspace_group(group)
-        logger.info("Backup groups were successfully deleted")
+    def get_migration_state(self) -> MigrationState:
+        return MigrationState(self.snapshot())
 
     def get_workspace_membership(self, resource_type: str = "WorkspaceGroup"):
         membership = collections.defaultdict(set)
-        for g in self._ws.groups.list(attributes=self._SCIM_ATTRIBUTES):
+        for g in self._ws.groups.list(attributes="id,displayName,meta,members"):
             if g.display_name in self._SYSTEM_GROUPS:
                 continue
             if g.meta.resource_type != resource_type:
@@ -252,204 +151,162 @@ class GroupManager:
 
     def get_account_membership(self):
         membership = collections.defaultdict(set)
-        for g in self._account_groups:
+        for g in self._list_account_groups("id,displayName,members"):
             if g.members is None:
                 continue
             for m in g.members:
                 membership[g.display_name].add(m.display)
         return membership
 
-    def _list_workspace_groups(self) -> list[iam.Group]:
-        logger.info("Listing workspace groups...")
-        workspace_groups = [
-            g
-            for g in self._ws.groups.list(attributes=self._SCIM_ATTRIBUTES)
-            if g.meta.resource_type == "WorkspaceGroup" and g.display_name not in self._SYSTEM_GROUPS
-        ]
-        logger.info(f"Found {len(workspace_groups)} workspace groups")
-        return sorted(workspace_groups, key=lambda _: _.display_name)
+    def delete_original_workspace_groups(self):
+        tasks = []
+        workspace_groups_in_workspace = self._workspace_groups_in_workspace()
+        for mg in self.snapshot():
+            if mg.name_in_workspace not in workspace_groups_in_workspace:
+                logger.info(f"Skipping {mg.name_in_workspace}: no longer in workspace")
+                continue
+            tasks.append(functools.partial(self._delete_workspace_group, mg.id_in_workspace))
+        _, errors = Threads.gather("removing original workspace groups", tasks)
+        if len(errors) > 0:
+            msg = f"During account-to-workspace reflection got {len(errors)} errors. See debug logs"
+            raise RuntimeWarning(msg)
 
-    @classmethod
-    def _list_account_groups(
-        cls, ws: WorkspaceClient, attributes: str = "id,displayName,meta,members"
-    ) -> list[iam.Group]:
+    def _fetcher(self) -> typing.Iterator[MigratedGroup]:
+        for row in self._backend.fetch(f"SELECT * FROM {self._full_name}"):
+            yield MigratedGroup(*row)
+
+    def _crawler(self) -> typing.Iterator[MigratedGroup]:
+        workspace_groups = self._list_workspace_groups("WorkspaceGroup", "id,displayName,meta,members")
+        account_groups_in_account = self._account_groups_in_account()
+        names_in_scope = self._get_valid_group_names_to_migrate(workspace_groups, account_groups_in_account)
+        for g in workspace_groups:
+            if g.display_name not in names_in_scope:
+                logger.info(f"Skipping {g.display_name}: out of scope")
+                continue
+            temporary_name = f"{self._renamed_group_prefix}{g.display_name}"
+            yield MigratedGroup(
+                id_in_workspace=g.id,
+                name_in_workspace=g.display_name,
+                name_in_account=g.display_name,
+                temporary_name=temporary_name,
+                external_id=g.external_id,
+                members=json.dumps(g.members),
+                roles=json.dumps(g.roles),
+                entitlements=json.dumps(g.entitlements),
+            )
+
+    def _workspace_groups_in_workspace(self) -> dict[str, str]:
+        by_name = {}
+        for g in self._list_workspace_groups("WorkspaceGroup", "id,displayName,meta"):
+            by_name[g.display_name] = g.id
+        return by_name
+
+    def _account_groups_in_workspace(self) -> dict[str, str]:
+        by_name = {}
+        for g in self._list_workspace_groups("Group", "id,displayName,meta"):
+            by_name[g.display_name] = g.id
+        return by_name
+
+    def _rename_group(self, group_id: str, new_group_name: str):
+        ops = [iam.Patch(iam.PatchOp.REPLACE, "displayName", new_group_name)]
+        self._ws.groups.patch(group_id, operations=ops)
+        return True
+
+    def _account_groups_in_account(self) -> dict[str, str]:
+        by_name = {}
+        for g in self._list_account_groups("id,displayName"):
+            by_name[g.display_name] = g.id
+        return by_name
+
+    def _list_workspace_groups(self, resource_type: str, scim_attributes: str) -> list[iam.Group]:
+        results = []
+        logger.info(f"Listing workspace groups (resource_type={resource_type}) with {scim_attributes}...")
+        for g in self._ws.groups.list(attributes=scim_attributes):
+            if g.display_name in self._SYSTEM_GROUPS:
+                continue
+            if g.meta.resource_type != resource_type:
+                continue
+            results.append(g)
+        logger.info(f"Found {len(results)} {resource_type}")
+        return results
+
+    def _list_account_groups(self, scim_attributes: str) -> list[iam.Group]:
         # TODO: we should avoid using this method, as it's not documented
         # get account-level groups even if they're not (yet) assigned to a workspace
-        logger.info("Listing account groups...")
+        logger.info(f"Listing account groups with {scim_attributes}...")
         account_groups = [
             iam.Group.from_dict(r)
             for r in ws.api_client.do(
                 "get",
                 "/api/2.0/account/scim/v2/Groups",
-                query={"attributes": attributes},
+                query={"attributes": scim_attributes},
             ).get("Resources", [])
         ]
         account_groups = [g for g in account_groups if g.display_name not in cls._SYSTEM_GROUPS]
         logger.info(f"Found {len(account_groups)} account groups")
         return sorted(account_groups, key=lambda _: _.display_name)
 
-    def _get_group(self, group_name, level: GroupLevel) -> iam.Group | None:
-        relevant_level_groups = self._workspace_groups if level == "workspace" else self._account_groups
-        for group in relevant_level_groups:
-            if group.display_name == group_name:
-                return group
-
-    @retried(on=[DatabricksError])
-    @rate_limited(max_requests=35, burst_period_seconds=60)
-    def _get_or_create_backup_group(self, source_group_name: str, source_group: iam.Group) -> iam.Group:
-        backup_group_name = f"{self._backup_group_prefix}{source_group_name}"
-        backup_group = self._get_group(backup_group_name, "workspace")
-
-        if backup_group:
-            logger.info(f"Backup group {backup_group_name} already exists, no action required")
-            return backup_group
-
-        logger.info(f"Creating backup group {backup_group_name}")
-        backup_group = self._ws.groups.create(
-            display_name=backup_group_name,
-            meta=source_group.meta,
-            entitlements=source_group.entitlements,
-            roles=source_group.roles,
-            members=source_group.members,
-        )  # TODO: there still could be a corner case, where we get `Group with name db-temp-XXX already exists.`
-        self._workspace_groups.append(backup_group)
-        logger.info(f"Backup group {backup_group_name} successfully created")
-
-        return backup_group
-
-    def _set_migration_groups_with_backup(self, groups_names: list[str]):
-        for name in groups_names:
-            ws_group = self._get_group(name, "workspace")
-            assert ws_group, f"Group {name} not found on the workspace level"
-            acc_group = self._get_group(name, "account")
-            assert acc_group, f"Group {name} not found on the account level"
-            backup_group = self._get_or_create_backup_group(source_group_name=name, source_group=ws_group)
-            self._migration_state.add(ws_group, backup_group, acc_group)
-        logger.info(f"Prepared {len(self._migration_state)} groups for migration")
-
-    def _replace_group(self, migration_info: MigrationGroupInfo):
-        if migration_info.workspace is not None:
-            ws_group = migration_info.workspace
-            self._delete_workspace_group(ws_group)
-            # delete ws_group from the list of workspace groups
-            self._workspace_groups = [g for g in self._workspace_groups if g.id != ws_group.id]
-        self._reflect_account_group_to_workspace(migration_info.account)
-
-    @retried(on=[DatabricksError])
-    @rate_limited(max_requests=35, burst_period_seconds=60)
-    def _delete_workspace_group(self, ws_group: iam.Group) -> None:
-        logger.info(f"Deleting the workspace-level group {ws_group.display_name} with id {ws_group.id}")
-        self._ws.groups.delete(id=ws_group.id)
-        logger.info(f"Workspace-level group {ws_group.display_name} with id {ws_group.id} was deleted")
-
     @retried(on=[DatabricksError])
     @rate_limited(max_requests=5)
-    def _reflect_account_group_to_workspace(self, acc_group: iam.Group) -> None:
-        logger.info(f"Reflecting group {acc_group.display_name} to workspace")
+    def _delete_workspace_group(self, group_id: str):
+        try:
+            logger.info(f"Deleting the workspace-level group: {group_id}")
+            self._ws.groups.delete(group_id)
+            return True
+        except DatabricksError as err:
+            if "not found" in str(err):
+                return True
+            raise
 
+    @retried(on=[DatabricksError])
+    @rate_limited(max_requests=10)
+    def _reflect_account_group_to_workspace(self, account_group_id: str):
         # TODO: add OpenAPI spec for it
-        principal_id = acc_group.id
-        permissions = ["USER"]
-        path = f"/api/2.0/preview/permissionassignments/principals/{principal_id}"
-        self._ws.api_client.do("PUT", path, data=json.dumps({"permissions": permissions}))
+        path = f"/api/2.0/preview/permissionassignments/principals/{account_group_id}"
+        self._ws.api_client.do("PUT", path, data=json.dumps({"permissions": ["USER"]}))
+        return True
 
-        logger.info(f"Group {acc_group.display_name} successfully reflected to workspace")
-
-    def _get_backup_groups(self) -> list[iam.Group]:
-        ac_group_names = []
-        for g in self._account_groups:
-            if self._include_group_names and g.display_name not in self._include_group_names:
-                logger.debug(f"skipping {g.display_name} as it is not in {self._include_group_names}")
-                continue
-            ac_group_names.append(g.display_name)
-
-        backup_groups = []
-        for g in self._workspace_groups:
-            if not g.display_name.startswith(self._backup_group_prefix):
-                continue
-            # backup groups are only created for workspace groups that have corresponding account group
-            if g.display_name.removeprefix(self._backup_group_prefix) not in ac_group_names:
-                continue
-            backup_groups.append(g)
-        logger.info(f"Found {len(backup_groups)} backup groups")
-
-        return backup_groups
-
-    def _get_valid_group_names_to_migrate(self):
+    def _get_valid_group_names_to_migrate(
+        self, workspace_groups: list[iam.Group], account_groups_in_account: dict[str, str]
+    ) -> set[str]:
         if self._include_group_names:
-            return self._validate_selected_groups(self._include_group_names)
-        return self._detect_overlapping_group_names()
+            return self._validate_selected_groups(
+                self._include_group_names, workspace_groups, account_groups_in_account
+            )
+        return self._detect_overlapping_group_names(workspace_groups, account_groups_in_account)
 
-    def _detect_overlapping_group_names(self):
+    @staticmethod
+    def _detect_overlapping_group_names(
+        workspace_groups: list[iam.Group], account_groups_in_account: dict[str, str]
+    ) -> set[str]:
         logger.info(
             "No group listing provided, all available workspace-level groups that have an account-level "
             "group with the same name will be used"
         )
-        ws_group_names = {_.display_name for _ in self._workspace_groups}
-        ac_group_names = {_.display_name for _ in self._account_groups}
-        valid_group_names = list(ws_group_names.intersection(ac_group_names))
+        ws_group_names = {_.display_name for _ in workspace_groups}
+        ac_group_names = account_groups_in_account.keys()
+        valid_group_names = ws_group_names.intersection(ac_group_names)
         logger.info(f"Found {len(valid_group_names)} workspace groups that have corresponding account groups")
         return valid_group_names
 
-    def _validate_selected_groups(self, group_names: list[str]):
-        valid_group_names = []
+    @classmethod
+    def _validate_selected_groups(
+        cls, group_names: list[str], workspace_groups: list[iam.Group], account_groups_in_account: dict[str, str]
+    ) -> set[str]:
+        valid_group_names = set()
         logger.info("Using the provided group listing")
-        for g in group_names:
-            if g in self._SYSTEM_GROUPS:
-                logger.info(f"Cannot migrate system group {g}. {g} will be skipped.")
+        for name in group_names:
+            if name in cls._SYSTEM_GROUPS:
+                logger.info(f"Cannot migrate system group {name}. {name} will be skipped.")
                 continue
-            if not self._get_group(g, "workspace"):
-                logger.info(f"Group {g} not found on the workspace level. {g} will be skipped.")
+            if name not in workspace_groups:
+                logger.info(f"Group {name} not found on the workspace level. {name} will be skipped.")
                 continue
-            if not self._get_group(g, "account"):
+            if name not in account_groups_in_account:
                 logger.info(
-                    f"Group {g} not found on the account level. {g} will be skipped. You can add {g} "
+                    f"Group {name} not found on the account level. {name} will be skipped. You can add {name} "
                     f"to the account and rerun the job."
                 )
                 continue
-            valid_group_names.append(g)
+            valid_group_names.add(name)
         return valid_group_names
-
-    def ws_local_group_deletion_recovery(self):
-        account_groups_reflected_on_the_workspace = {
-            g.display_name
-            for g in self._ws.groups.list(attributes="id,displayName,meta")
-            if g.meta.resource_type == "Group" and g.display_name not in self._SYSTEM_GROUPS
-        }
-
-        workspace_groups = {_.display_name for _ in self._workspace_groups}
-        source_groups = [
-            g
-            for g in self._workspace_groups
-            if g.display_name.removeprefix(self._backup_group_prefix) not in workspace_groups
-        ]
-
-        logger.info(
-            f"Recovering from workspace-local group deletion. "
-            f"In total, {len(source_groups)} temporary groups found, which do not have corresponding workspace groups"
-        )
-
-        for backup_group in source_groups:
-            source_groups_name = backup_group.display_name.removeprefix(self._backup_group_prefix)
-            if source_groups_name in account_groups_reflected_on_the_workspace:
-                logger.info(f"Group {source_groups_name} already exists on the workspace level, skipping")
-                continue
-            ws_local_group = self._ws.groups.create(
-                display_name=source_groups_name,
-                meta=backup_group.meta,
-                entitlements=backup_group.entitlements,
-                roles=backup_group.roles,
-                members=backup_group.members,
-            )
-            self._workspace_groups.append(ws_local_group)
-
-            account_groups = [_ for _ in self._account_groups if _.display_name == ws_local_group.display_name]
-            if len(account_groups) == 0:
-                logger.error(f"Cannot find matching group on account level: {ws_local_group.display_name}")
-                continue
-
-            account_group = account_groups[0]
-            self._migration_state.add(ws_local_group, backup_group, account_group)
-            logger.info(f"Workspace-local group {ws_local_group} successfully recovered")
-
-        logger.info("Workspace-local group recovery completed")

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -1,4 +1,3 @@
-import dataclasses
 import functools
 import json
 import logging
@@ -35,16 +34,6 @@ class MigratedGroup:
     entitlements: str = None
     external_id: str = None
     roles: str = None
-
-    def as_account_group_without_id(self) -> iam.Group:
-        raw = dataclasses.asdict(self)
-        return iam.Group(
-            display_name=self.name_in_account,
-            external_id=self.external_id,
-            entitlements=iam._repeated(raw, 'entitlements', iam.ComplexValue),  # noqa
-            members=iam._repeated(raw, 'members', iam.ComplexValue),  # noqa
-            roles=iam._repeated(raw, 'roles', iam.ComplexValue),  # noqa
-        )
 
 
 class MigrationState:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -170,9 +170,13 @@ class GroupManager(CrawlerBase):
     def delete_original_workspace_groups(self):
         tasks = []
         workspace_groups_in_workspace = self._workspace_groups_in_workspace()
+        account_groups_in_workspace = self._account_groups_in_workspace()
         for mg in self.snapshot():
             if mg.temporary_name not in workspace_groups_in_workspace:
                 logger.info(f"Skipping {mg.name_in_workspace}: no longer in workspace")
+                continue
+            if mg.name_in_account not in account_groups_in_workspace:
+                logger.info(f"Skipping {mg.name_in_account}: not reflected in workspace")
                 continue
             tasks.append(functools.partial(self._delete_workspace_group, mg.id_in_workspace))
         _, errors = Threads.gather("removing original workspace groups", tasks)

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -158,15 +158,6 @@ class GroupManager(CrawlerBase):
                 membership[g.display_name].add(m.display)
         return membership
 
-    def get_account_membership(self):
-        membership = collections.defaultdict(set)
-        for g in self._list_account_groups("id,displayName,members"):
-            if g.members is None:
-                continue
-            for m in g.members:
-                membership[g.display_name].add(m.display)
-        return membership
-
     def delete_original_workspace_groups(self):
         tasks = []
         workspace_groups_in_workspace = self._workspace_groups_in_workspace()

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -171,7 +171,7 @@ class GroupManager(CrawlerBase):
         tasks = []
         workspace_groups_in_workspace = self._workspace_groups_in_workspace()
         for mg in self.snapshot():
-            if mg.name_in_workspace not in workspace_groups_in_workspace:
+            if mg.temporary_name not in workspace_groups_in_workspace:
                 logger.info(f"Skipping {mg.name_in_workspace}: no longer in workspace")
                 continue
             tasks.append(functools.partial(self._delete_workspace_group, mg.id_in_workspace))

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -3,7 +3,6 @@ import logging
 import os
 from collections.abc import Callable, Iterator
 from itertools import groupby
-from typing import Literal
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import sql
@@ -82,14 +81,14 @@ class PermissionManager(CrawlerBase):
         self._save(items)
         logger.info(f"Saved {len(items)} to {self._full_name}")
 
-    def apply_group_permissions(self, migration_state: MigrationState, destination: Literal["backup", "account"]):
+    def apply_group_permissions(self, migration_state: MigrationState):
         # list shall be sorted prior to using group by
         if len(migration_state) == 0:
             logger.info("No valid groups selected, nothing to do.")
             return True
         items = sorted(self.load_all(), key=lambda i: i.object_type)
         logger.info(
-            f"Applying the permissions to {destination} groups. "
+            f"Applying the permissions to account groups. "
             f"Total groups to apply permissions: {len(migration_state)}. "
             f"Total permissions found: {len(items)}"
         )
@@ -108,18 +107,16 @@ class PermissionManager(CrawlerBase):
 
         for object_type, items_subset in supports_to_items.items():
             relevant_support = appliers[object_type]
-            tasks_for_support = [
-                relevant_support.get_apply_task(item, migration_state, destination) for item in items_subset
-            ]
+            tasks_for_support = [relevant_support.get_apply_task(item, migration_state) for item in items_subset]
             tasks_for_support = [_ for _ in tasks_for_support if _ is not None]
             if len(tasks_for_support) == 0:
                 continue
             logger.info(f"Total tasks for {object_type}: {len(tasks_for_support)}")
             applier_tasks.extend(tasks_for_support)
 
-        logger.info(f"Starting to apply permissions on {destination} groups. Total tasks: {len(applier_tasks)}")
+        logger.info(f"Starting to apply permissions on account groups. Total tasks: {len(applier_tasks)}")
 
-        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks)
+        _, errors = Threads.gather("apply account group permissions", applier_tasks)
         if len(errors) > 0:
             # TODO: https://github.com/databrickslabs/ucx/issues/406
             logger.error(f"Detected {len(errors)} while applying permissions")

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.workspace_access import generic, redash, scim, secrets
 from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ class PermissionManager(CrawlerBase):
         self._save(items)
         logger.info(f"Saved {len(items)} to {self._full_name}")
 
-    def apply_group_permissions(self, migration_state: GroupMigrationState, destination: Literal["backup", "account"]):
+    def apply_group_permissions(self, migration_state: MigrationState, destination: Literal["backup", "account"]):
         # list shall be sorted prior to using group by
         if len(migration_state) == 0:
             logger.info("No valid groups selected, nothing to do.")

--- a/src/databricks/labs/ucx/workspace_access/migration.py
+++ b/src/databricks/labs/ucx/workspace_access/migration.py
@@ -30,7 +30,13 @@ class GroupMigrationToolkit:
             num_threads=config.num_threads,
             workspace_start_path=config.workspace_start_path,
         )
-        self._group_manager = GroupManager(ws, config.groups)
+        self._group_manager = GroupManager(
+            self._backend(ws, warehouse_id),
+            ws,
+            config.inventory_database,
+            config.include_group_names,
+            config.renamed_group_prefix,
+        )
         # TODO: remove VerificationManager in scope of https://github.com/databrickslabs/ucx/issues/36,
         # where we probably should add verify() abstract method to every Applier
         self._verification_manager = VerificationManager(ws, secrets_support)
@@ -85,9 +91,6 @@ class GroupMigrationToolkit:
     def has_groups(self) -> bool:
         return self._group_manager.has_groups()
 
-    def prepare_environment(self):
-        self._group_manager.prepare_groups_in_environment()
-
     def cleanup_inventory_table(self):
         self._permissions_manager.cleanup()
 
@@ -95,19 +98,19 @@ class GroupMigrationToolkit:
         self._permissions_manager.inventorize_permissions()
 
     def apply_permissions_to_backup_groups(self):
-        self._permissions_manager.apply_group_permissions(self._group_manager.migration_state, destination="backup")
+        self._group_manager.rename_groups()
 
     def verify_permissions_on_backup_groups(self, to_verify):
-        self._verification_manager.verify(self._group_manager.migration_state, "backup", to_verify)
+        self._verification_manager.verify(self._group_manager.get_migration_state(), "backup", to_verify)
 
-    def replace_workspace_groups_with_account_groups(self, migration_state):
-        self._group_manager.replace_workspace_groups_with_account_groups(migration_state)
+    def replace_workspace_groups_with_account_groups(self):
+        self._group_manager.reflect_account_groups_on_workspace()
 
     def apply_permissions_to_account_groups(self):
-        self._permissions_manager.apply_group_permissions(self._group_manager.migration_state, destination="account")
+        self._permissions_manager.apply_group_permissions(self._group_manager.get_migration_state())
 
     def verify_permissions_on_account_groups(self, to_verify):
-        self._verification_manager.verify(self._group_manager.migration_state, "account", to_verify)
+        self._verification_manager.verify(self._group_manager.get_migration_state(), "account", to_verify)
 
     def delete_backup_groups(self):
         self._group_manager.delete_original_workspace_groups()

--- a/src/databricks/labs/ucx/workspace_access/migration.py
+++ b/src/databricks/labs/ucx/workspace_access/migration.py
@@ -88,9 +88,6 @@ class GroupMigrationToolkit:
         ucx_logger = logging.getLogger("databricks.labs.ucx")
         ucx_logger.setLevel(level)
 
-    def has_groups(self) -> bool:
-        return self._group_manager.has_groups()
-
     def cleanup_inventory_table(self):
         self._permissions_manager.cleanup()
 

--- a/src/databricks/labs/ucx/workspace_access/migration.py
+++ b/src/databricks/labs/ucx/workspace_access/migration.py
@@ -110,4 +110,4 @@ class GroupMigrationToolkit:
         self._verification_manager.verify(self._group_manager.migration_state, "account", to_verify)
 
     def delete_backup_groups(self):
-        self._group_manager.delete_backup_groups()
+        self._group_manager.delete_original_workspace_groups()

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -19,8 +19,6 @@ from databricks.labs.ucx.workspace_access.base import (
     Permissions,
 )
 from databricks.labs.ucx.workspace_access.generic import RetryableError
-
-from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 logger = logging.getLogger(__name__)

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -13,11 +13,7 @@ from databricks.sdk.service import sql
 from databricks.sdk.service.sql import ObjectTypePlural, SetResponse
 
 from databricks.labs.ucx.mixins.hardening import rate_limited
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
@@ -70,13 +66,11 @@ class RedashPermissionsSupport(AclSupport):
             all_object_types.add(listing.object_type)
         return all_object_types
 
-    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState):
         if not self._is_item_relevant(item, migration_state):
             return None
         new_acl = self._prepare_new_acl(
-            sql.GetResponse.from_dict(json.loads(item.raw)).access_control_list,
-            migration_state,
-            destination,
+            sql.GetResponse.from_dict(json.loads(item.raw)).access_control_list, migration_state
         )
         return partial(
             self._applier_task,
@@ -138,7 +132,7 @@ class RedashPermissionsSupport(AclSupport):
         return retried_check(object_id, object_id, acl)
 
     def _prepare_new_acl(
-        self, acl: list[sql.AccessControl], migration_state: MigrationState, destination: Destination
+        self, acl: list[sql.AccessControl], migration_state: MigrationState
     ) -> list[sql.AccessControl]:
         """
         Please note the comment above on how we apply these permissions.

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -18,6 +18,7 @@ from databricks.labs.ucx.workspace_access.base import (
     Destination,
     Permissions,
 )
+from databricks.labs.ucx.workspace_access.generic import RetryableError
 
 from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.groups import MigrationState
@@ -58,7 +59,7 @@ class RedashPermissionsSupport(AclSupport):
         mentioned_groups = [
             acl.group_name for acl in sql.GetResponse.from_dict(json.loads(item.raw)).access_control_list
         ]
-        return any(g in mentioned_groups for g in [info.workspace.display_name for info in migration_state.groups])
+        return any(g in mentioned_groups for g in [info.name_in_workspace for info in migration_state.groups])
 
     def get_crawler_tasks(self):
         for listing in self._listings:
@@ -150,7 +151,7 @@ class RedashPermissionsSupport(AclSupport):
                 logger.debug(f"Skipping redash item for `{access_control.group_name}`: not in scope")
                 acl_requests.append(access_control)
                 continue
-            target_principal = migration_state.get_target_principal(access_control.group_name, destination)
+            target_principal = migration_state.get_target_principal(access_control.group_name)
             if target_principal is None:
                 logger.debug(f"Skipping redash item for `{access_control.group_name}`: no target principal")
                 acl_requests.append(access_control)

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -14,7 +14,6 @@ from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -41,7 +41,7 @@ class ScimSupport(AclSupport):
     # TODO remove after ES-892977 is fixed
     @retried(on=[DatabricksError])
     def _get_groups(self):
-        return self._ws.groups.list(attributes="id,displayName,roles,entitlements")
+        return list(self._ws.groups.list(attributes="id,displayName,roles,entitlements"))
 
     def object_types(self) -> set[str]:
         return {"roles", "entitlements"}

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -50,7 +50,7 @@ class ScimSupport(AclSupport):
         if not self._is_item_relevant(item, migration_state):
             return None
         value = [iam.ComplexValue.from_dict(e) for e in json.loads(item.raw)]
-        target_group_id = migration_state.get_target_id(item.object_id, destination)
+        target_group_id = migration_state.get_target_id(item.object_id)
         return partial(self._applier_task, group_id=target_group_id, value=value, property_name=item.object_type)
 
     @staticmethod

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -29,7 +29,7 @@ class ScimSupport(AclSupport):
 
     @staticmethod
     def _is_item_relevant(item: Permissions, migration_state: MigrationState) -> bool:
-        return any(g.workspace.id == item.object_id for g in migration_state.groups)
+        return any(g.id_in_workspace == item.object_id for g in migration_state.groups)
 
     def get_crawler_tasks(self):
         for g in self._get_groups():

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -10,11 +10,7 @@ from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group, Patch, PatchSchema
 
 from databricks.labs.ucx.mixins.hardening import rate_limited
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
@@ -46,7 +42,7 @@ class ScimSupport(AclSupport):
     def object_types(self) -> set[str]:
         return {"roles", "entitlements"}
 
-    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState):
         if not self._is_item_relevant(item, migration_state):
             return None
         value = [iam.ComplexValue.from_dict(e) for e in json.loads(item.raw)]

--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -68,7 +68,6 @@ class SecretScopesSupport(AclSupport):
         mentioned_groups = [acl.principal for acl in acls]
         return any(g in mentioned_groups for g in [info.name_in_workspace for info in migration_state.groups])
 
-
     def secret_scope_permission(self, scope_name: str, group_name: str) -> workspace.AclPermission | None:
         for acl in self._ws.secrets.list_acls(scope=scope_name):
             if acl.principal == group_name:

--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -53,7 +53,7 @@ class SecretScopesSupport(AclSupport):
             if not migration_state.is_in_scope(acl.principal):
                 new_acls.append(acl)
                 continue
-            target_principal = migration_state.get_target_principal(acl.principal, destination)
+            target_principal = migration_state.get_target_principal(acl.principal)
             if target_principal is None:
                 logger.debug(f"Skipping {acl.principal} because of no target principal")
                 continue
@@ -70,7 +70,7 @@ class SecretScopesSupport(AclSupport):
     def _is_item_relevant(item: Permissions, migration_state: MigrationState) -> bool:
         acls = [workspace.AclItem.from_dict(acl) for acl in json.loads(item.raw)]
         mentioned_groups = [acl.principal for acl in acls]
-        return any(g in mentioned_groups for g in [info.workspace.display_name for info in migration_state.groups])
+        return any(g in mentioned_groups for g in [info.name_in_workspace for info in migration_state.groups])
 
 
     def secret_scope_permission(self, scope_name: str, group_name: str) -> workspace.AclPermission | None:

--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -8,11 +8,7 @@ from databricks.sdk.retries import retried
 from databricks.sdk.service import workspace
 
 from databricks.labs.ucx.mixins.hardening import rate_limited
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 logger = logging.getLogger(__name__)
@@ -42,7 +38,7 @@ class SecretScopesSupport(AclSupport):
     def object_types(self) -> set[str]:
         return {"secrets"}
 
-    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState):
         if not self._is_item_relevant(item, migration_state):
             return None
 

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -8,11 +8,7 @@ from functools import partial
 from databricks.labs.ucx.framework.crawlers import SqlBackend
 from databricks.labs.ucx.hive_metastore import GrantsCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 
@@ -87,7 +83,7 @@ class TableAclSupport(AclSupport):
     def object_types(self) -> set[str]:
         return {"TABLE", "DATABASE", "VIEW", "CATALOG", "ANONYMOUS FUNCTION", "ANY FILE"}
 
-    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState):
         grant = Grant(**json.loads(item.raw))
         target_principal = migration_state.get_target_principal(grant.principal)
         if target_principal is None:

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -89,7 +89,7 @@ class TableAclSupport(AclSupport):
 
     def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
         grant = Grant(**json.loads(item.raw))
-        target_principal = migration_state.get_target_principal(grant.principal, destination)
+        target_principal = migration_state.get_target_principal(grant.principal)
         if target_principal is None:
             # this is a grant for user, service principal, or irrelevant group
             return None

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.workspace_access.base import (
     Destination,
     Permissions,
 )
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 
 class TableAclSupport(AclSupport):
@@ -87,7 +87,7 @@ class TableAclSupport(AclSupport):
     def object_types(self) -> set[str]:
         return {"TABLE", "DATABASE", "VIEW", "CATALOG", "ANONYMOUS FUNCTION", "ANY FILE"}
 
-    def get_apply_task(self, item: Permissions, migration_state: GroupMigrationState, destination: Destination):
+    def get_apply_task(self, item: Permissions, migration_state: MigrationState, destination: Destination):
         grant = Grant(**json.loads(item.raw))
         target_principal = migration_state.get_target_principal(grant.principal, destination)
         if target_principal is None:

--- a/src/databricks/labs/ucx/workspace_access/verification.py
+++ b/src/databricks/labs/ucx/workspace_access/verification.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from databricks.sdk import WorkspaceClient
 
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 from databricks.labs.ucx.workspace_access.secrets import SecretScopesSupport
 
 
@@ -12,7 +12,7 @@ class VerificationManager:
         self._secrets_support = secrets_support
 
     def verify(
-        self, migration_state: GroupMigrationState, target: Literal["backup", "account"], tuples: list[tuple[str, str]]
+        self, migration_state: MigrationState, target: Literal["backup", "account"], tuples: list[tuple[str, str]]
     ):
         for object_type, object_id in tuples:
             if object_type == "secrets":
@@ -25,7 +25,7 @@ class VerificationManager:
         self,
         object_type: str,
         object_id: str,
-        migration_state: GroupMigrationState,
+        migration_state: MigrationState,
         target: Literal["backup", "account"],
     ):
         op = self._ws.permissions.get(object_type, object_id)
@@ -46,7 +46,7 @@ class VerificationManager:
             ], f"Target permissions were not applied correctly for {object_type}/{object_id}"
 
     def verify_applied_scope_acls(
-        self, scope_name: str, migration_state: GroupMigrationState, target: Literal["backup", "account"]
+        self, scope_name: str, migration_state: MigrationState, target: Literal["backup", "account"]
     ):
         base_attr = "workspace" if target == "backup" else "backup"
         for mi in migration_state.groups:
@@ -56,7 +56,7 @@ class VerificationManager:
             dst_permission = self._secrets_support.secret_scope_permission(scope_name, dst_name)
             assert src_permission == dst_permission, "Scope ACLs were not applied correctly"
 
-    def verify_roles_and_entitlements(self, migration_state: GroupMigrationState, target: Literal["backup", "account"]):
+    def verify_roles_and_entitlements(self, migration_state: MigrationState, target: Literal["backup", "account"]):
         for el in migration_state.groups:
             comparison_base = getattr(el, "workspace" if target == "backup" else "backup")
             comparison_target = getattr(el, target)

--- a/tests/integration/assessment/test_assessment.py
+++ b/tests/integration/assessment/test_assessment.py
@@ -206,12 +206,3 @@ def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backe
 
     assert notebook in workspace_objects
     assert "NOTEBOOK" == workspace_objects[notebook].object_type
-
-
-def test_ta_mere():
-    from databricks.sdk import WorkspaceClient
-    import time
-
-    w = WorkspaceClient(host="https://e2-demo-field-eng.cloud.databricks.com/", token="dapi012a0d29fe0ba512dc16a23ad75745cc")
-
-    w.groups.list("id,displayName,meta,members,roles,entitlements")

--- a/tests/integration/assessment/test_assessment.py
+++ b/tests/integration/assessment/test_assessment.py
@@ -206,3 +206,12 @@ def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backe
 
     assert notebook in workspace_objects
     assert "NOTEBOOK" == workspace_objects[notebook].object_type
+
+
+def test_ta_mere():
+    from databricks.sdk import WorkspaceClient
+    import time
+
+    w = WorkspaceClient(host="https://e2-demo-field-eng.cloud.databricks.com/", token="dapi012a0d29fe0ba512dc16a23ad75745cc")
+
+    w.groups.list("id,displayName,meta,members,roles,entitlements")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 import random
 from functools import partial
@@ -18,6 +19,20 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def debug_env_name():
     return "ucws"
+
+
+def get_workspace_membership(ws, resource_type: str = "WorkspaceGroup"):
+    membership = collections.defaultdict(set)
+    for g in ws.groups.list(attributes="id,displayName,meta,members"):
+        if g.display_name in ["users", "admins", "account users"]:
+            continue
+        if g.meta.resource_type != resource_type:
+            continue
+        if g.members is None:
+            continue
+        for m in g.members:
+            membership[g.display_name].add(m.display)
+    return membership
 
 
 def account_host(self: databricks.sdk.core.Config) -> str:

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -7,7 +7,7 @@ from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import SchemaInfo
 from databricks.sdk.service.iam import PermissionLevel
 
-from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
 from databricks.labs.ucx.hive_metastore.tables import TablesCrawler

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -29,7 +29,9 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
     install = WorkspaceInstaller.run_for_config(
         ws,
         WorkspaceConfig(
-            inventory_database=inventory_database, log_level="DEBUG", renamed_group_prefix=backup_group_prefix
+            inventory_database=inventory_database,
+            renamed_group_prefix=backup_group_prefix,
+            log_level="DEBUG",
         ),
         sql_backend=sql_backend,
         prefix=make_random(4),

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -6,6 +6,7 @@ from databricks.sdk.errors import NotFound, OperationFailed
 from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import SchemaInfo
 from databricks.sdk.service.iam import PermissionLevel
+from integration.conftest import get_workspace_membership
 
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.parallel import Threads
@@ -13,7 +14,6 @@ from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
 from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
 from databricks.labs.ucx.install import WorkspaceInstaller
 from databricks.labs.ucx.workspace_access.generic import GenericPermissionsSupport
-from databricks.labs.ucx.workspace_access.groups import GroupManager
 
 logger = logging.getLogger(__name__)
 
@@ -161,8 +161,7 @@ def test_jobs_with_no_inventory_database(
 
         @retried(on=[AssertionError], timeout=timedelta(minutes=2))
         def validate_groups():
-            group_manager = GroupManager(sql_backend, ws, inventory_database)
-            acc_membership = group_manager.get_workspace_membership("Group")
+            acc_membership = get_workspace_membership(ws, "Group")
 
             logger.info("validating replaced account groups")
             assert acc_group_a.display_name in acc_membership, f"{acc_group_a.display_name} not found in workspace"

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -29,12 +29,7 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
     install = WorkspaceInstaller.run_for_config(
         ws,
         WorkspaceConfig(
-            inventory_database=inventory_database,
-            groups=GroupsConfig(
-                backup_group_prefix=backup_group_prefix,
-                auto=True,
-            ),
-            log_level="DEBUG",
+            inventory_database=inventory_database, log_level="DEBUG", renamed_group_prefix=backup_group_prefix
         ),
         sql_backend=sql_backend,
         prefix=make_random(4),
@@ -147,10 +142,8 @@ def test_jobs_with_no_inventory_database(
         WorkspaceConfig(
             inventory_database=inventory_database,
             instance_pool_id=env_or_skip("TEST_INSTANCE_POOL_ID"),
-            groups=GroupsConfig(
-                selected=[ws_group_a.display_name, ws_group_b.display_name, ws_group_c.display_name],
-                backup_group_prefix=backup_group_prefix,
-            ),
+            include_group_names=[ws_group_a.display_name, ws_group_b.display_name, ws_group_c.display_name],
+            renamed_group_prefix=backup_group_prefix,
             log_level="DEBUG",
         ),
         sql_backend=sql_backend,
@@ -162,19 +155,13 @@ def test_jobs_with_no_inventory_database(
     )
 
     try:
-        required_workflows = [
-            "assessment",
-            "002-apply-permissions-to-backup-groups",
-            "003-replace-workspace-local-with-account-groups",
-            "004-apply-permissions-to-account-groups",
-            "005-remove-workspace-local-backup-groups",
-        ]
+        required_workflows = ["assessment", "migrate-groups", "remove-workspace-local-backup-groups"]
         for step in required_workflows:
             install.run_workflow(step)
 
         @retried(on=[AssertionError], timeout=timedelta(minutes=2))
         def validate_groups():
-            group_manager = GroupManager(ws, GroupsConfig(auto=True))
+            group_manager = GroupManager(sql_backend, ws, inventory_database)
             acc_membership = group_manager.get_workspace_membership("Group")
 
             logger.info("validating replaced account groups")

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -13,33 +13,31 @@ from databricks.sdk.service.iam import (
 )
 from databricks.sdk.service import iam
 
+from databricks.sdk.service.iam import PermissionLevel
 
-from databricks.labs.ucx.config import GroupsConfig
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
 )
-from databricks.labs.ucx.workspace_access.groups import (
-    GroupManager,
-    GroupMigrationState,
-)
+from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
 
+
 def test_renaming_groups(
-        ws,
-        sql_backend,
-        inventory_schema,
-        make_ucx_group,
-        make_group,
-        make_acc_group,
-        make_cluster_policy,
-        make_cluster_policy_permissions,
-        make_table,
+    ws,
+    sql_backend,
+    inventory_schema,
+    make_ucx_group,
+    make_group,
+    make_acc_group,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+    make_table,
 ):
     ws_group, acc_group = make_ucx_group()
     cluster_policy = make_cluster_policy()
@@ -52,9 +50,10 @@ def test_renaming_groups(
     dummy_table = make_table()
     sql_backend.execute(f"GRANT SELECT ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
 
-    ws.groups.patch(ws_group.id, operations=[
-        iam.Patch(op=iam.PatchOp.REPLACE, path='displayName', value=f'UPDATED_{ws_group.display_name}')
-    ])
+    ws.groups.patch(
+        ws_group.id,
+        operations=[iam.Patch(op=iam.PatchOp.REPLACE, path="displayName", value=f"UPDATED_{ws_group.display_name}")],
+    )
 
     # group_manager = GroupManager(ws, GroupsConfig(auto=True))
     # group_manager.prepare_groups_in_environment()
@@ -63,16 +62,15 @@ def test_renaming_groups(
 
     generic_permissions = GenericPermissionsSupport(ws, [])
 
-    xxx = generic_permissions.load_as_dict('cluster-policies', cluster_policy.policy_id)
+    generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
 
     tables = TablesCrawler(sql_backend, inventory_schema)
     grants = GrantsCrawler(tables)
-    yyy = grants.for_table_info(dummy_table)
+    grants.for_table_info(dummy_table)
 
     tacl = TableAclSupport(grants, sql_backend)
 
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [generic_permissions, tacl])
-
+    PermissionManager(sql_backend, inventory_schema, [generic_permissions, tacl])
 
 
 def test_prepare_environment(ws, make_ucx_group):

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import timedelta
+
 import pytest
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
@@ -115,6 +116,7 @@ def test_delete_ws_groups_should_not_delete_non_reflected_acc_groups(ws, make_uc
     group_manager.delete_original_workspace_groups()
 
     assert ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
+
 
 def test_replace_workspace_groups_with_account_groups(
     ws,
@@ -236,7 +238,7 @@ def test_replace_workspace_groups_with_account_groups(
         assert "SELECT" in table_permissions[group_info.name_in_account]
 
     check_table_permissions_after_backup_delete()
- 
+
 
 @retried(on=[NotFound], timeout=timedelta(minutes=10))
 def test_set_owner_permission(

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -201,7 +201,7 @@ def test_replace_workspace_groups_with_account_groups(
 
     check_permissions_after_replace()
 
-    permission_manager.apply_group_permissions(state, destination="account")
+    permission_manager.apply_group_permissions(state)
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_account_group():
@@ -307,7 +307,7 @@ def test_set_owner_permission(
 
     check_permissions_after_replace()
 
-    permission_manager.apply_group_permissions(state, destination="account")
+    permission_manager.apply_group_permissions(state)
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_account_group():

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -4,10 +4,7 @@ from datetime import timedelta
 import pytest
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
-from databricks.sdk.service.iam import (
-    PermissionLevel,
-    ResourceMeta,
-)
+from databricks.sdk.service.iam import PermissionLevel, ResourceMeta
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
@@ -77,8 +74,8 @@ def test_reflect_account_groups_on_workspace(ws, make_ucx_group, sql_backend, in
 
     reflected_group = ws.groups.get(acc_group.id)
     assert reflected_group.display_name == ws_group.display_name == acc_group.display_name
-    assert set(info.display for info in reflected_group.members) == set(info.display for info in ws_group.members)
-    assert set(info.display for info in reflected_group.members) == set(info.display for info in acc_group.members)
+    assert {info.display for info in reflected_group.members} == {info.display for info in ws_group.members}
+    assert {info.display for info in reflected_group.members} == {info.display for info in acc_group.members}
     assert reflected_group.meta == ResourceMeta(resource_type="Group")
     assert not reflected_group.roles  # Cannot create roles currently
     assert not reflected_group.entitlements  # Entitlements aren't reflected there

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -8,8 +8,11 @@ from databricks.sdk.service.iam import (
     ComplexValue,
     Group,
     PermissionLevel,
+    Patch,
     ResourceMeta,
 )
+from databricks.sdk.service import iam
+
 
 from databricks.labs.ucx.config import GroupsConfig
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
@@ -26,6 +29,50 @@ from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
+
+def test_renaming_groups(
+        ws,
+        sql_backend,
+        inventory_schema,
+        make_ucx_group,
+        make_group,
+        make_acc_group,
+        make_cluster_policy,
+        make_cluster_policy_permissions,
+        make_table,
+):
+    ws_group, acc_group = make_ucx_group()
+    cluster_policy = make_cluster_policy()
+    make_cluster_policy_permissions(
+        object_id=cluster_policy.policy_id,
+        permission_level=PermissionLevel.CAN_USE,
+        group_name=ws_group.display_name,
+    )
+
+    dummy_table = make_table()
+    sql_backend.execute(f"GRANT SELECT ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
+
+    ws.groups.patch(ws_group.id, operations=[
+        iam.Patch(op=iam.PatchOp.REPLACE, path='displayName', value=f'UPDATED_{ws_group.display_name}')
+    ])
+
+    # group_manager = GroupManager(ws, GroupsConfig(auto=True))
+    # group_manager.prepare_groups_in_environment()
+
+    # group_info = group_manager.migration_state.get_by_workspace_group_name(ws_group.display_name)
+
+    generic_permissions = GenericPermissionsSupport(ws, [])
+
+    xxx = generic_permissions.load_as_dict('cluster-policies', cluster_policy.policy_id)
+
+    tables = TablesCrawler(sql_backend, inventory_schema)
+    grants = GrantsCrawler(tables)
+    yyy = grants.for_table_info(dummy_table)
+
+    tacl = TableAclSupport(grants, sql_backend)
+
+    permission_manager = PermissionManager(sql_backend, inventory_schema, [generic_permissions, tacl])
+
 
 
 def test_prepare_environment(ws, make_ucx_group):

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -1,19 +1,13 @@
+import json
 import logging
 from datetime import timedelta
-
-from databricks.sdk import WorkspaceClient
+import pytest
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.iam import (
-    ComplexValue,
-    Group,
     PermissionLevel,
-    Patch,
     ResourceMeta,
 )
-from databricks.sdk.service import iam
-
-from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
@@ -28,99 +22,103 @@ from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 logger = logging.getLogger(__name__)
 
 
-def test_renaming_groups(
-    ws,
-    sql_backend,
-    inventory_schema,
-    make_ucx_group,
-    make_group,
-    make_acc_group,
-    make_cluster_policy,
-    make_cluster_policy_permissions,
-    make_table,
+def test_prepare_environment(ws, make_ucx_group, sql_backend, inventory_schema):
+    ws_group, acc_group = make_ucx_group()
+
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_migration_state = group_manager.snapshot()
+
+    assert len(group_migration_state) == 1
+    assert group_migration_state[0].id_in_workspace == ws_group.id
+    assert group_migration_state[0].external_id == acc_group.id
+    assert group_migration_state[0].name_in_workspace == ws_group.display_name
+    assert group_migration_state[0].name_in_account == acc_group.display_name
+    assert group_migration_state[0].temporary_name == "ucx-temp-" + ws_group.display_name
+    assert len(group_migration_state[0].members) == len(json.dumps([gg.as_dict() for gg in ws_group.members]))
+    assert not group_migration_state[0].roles
+    assert len(group_migration_state[0].entitlements) == len(json.dumps([gg.as_dict() for gg in ws_group.entitlements]))
+
+
+def test_prepare_environment_no_groups_selected(ws, make_ucx_group, sql_backend, inventory_schema):
+    ws_group, acc_group = make_ucx_group()
+
+    group_manager = GroupManager(sql_backend, ws, inventory_schema)
+    group_migration_state = group_manager.snapshot()
+
+    names = {info.name_in_workspace: info for info in group_migration_state}
+    assert ws_group.display_name in names
+
+
+def test_rename_groups(ws, make_ucx_group, sql_backend, inventory_schema):
+    ws_group, acc_group = make_ucx_group()
+
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager.rename_groups()
+
+    assert ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
+
+
+def test_reflect_account_groups_on_workspace_throws_when_group_already_exists(
+    ws, make_ucx_group, sql_backend, inventory_schema
 ):
     ws_group, acc_group = make_ucx_group()
-    cluster_policy = make_cluster_policy()
-    make_cluster_policy_permissions(
-        object_id=cluster_policy.policy_id,
-        permission_level=PermissionLevel.CAN_USE,
-        group_name=ws_group.display_name,
-    )
 
-    dummy_table = make_table()
-    sql_backend.execute(f"GRANT SELECT ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
-
-    ws.groups.patch(
-        ws_group.id,
-        operations=[iam.Patch(op=iam.PatchOp.REPLACE, path="displayName", value=f"UPDATED_{ws_group.display_name}")],
-    )
-
-    # group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    # group_manager.prepare_groups_in_environment()
-
-    # group_info = group_manager.migration_state.get_by_workspace_group_name(ws_group.display_name)
-
-    generic_permissions = GenericPermissionsSupport(ws, [])
-
-    generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
-
-    tables = TablesCrawler(sql_backend, inventory_schema)
-    grants = GrantsCrawler(tables)
-    grants.for_table_info(dummy_table)
-
-    tacl = TableAclSupport(grants, sql_backend)
-
-    PermissionManager(sql_backend, inventory_schema, [generic_permissions, tacl])
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    with pytest.raises(RuntimeWarning):
+        group_manager.reflect_account_groups_on_workspace()
 
 
-def test_prepare_environment(ws, make_ucx_group):
+def test_reflect_account_groups_on_workspace(ws, make_ucx_group, sql_backend, inventory_schema):
     ws_group, acc_group = make_ucx_group()
 
-    group_manager = GroupManager(ws, GroupsConfig(selected=[ws_group.display_name]))
-    group_manager.prepare_groups_in_environment()
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager.rename_groups()
+    group_manager.reflect_account_groups_on_workspace()
 
-    group_migration_state = group_manager.migration_state
-    for _info in group_migration_state.groups:
-        try:
-            _ws = ws.groups.get(id=_info.workspace.id)
-            _backup = ws.groups.get(id=_info.backup.id)
-            _ws_members = sorted([m.value for m in _ws.members])
-            _backup_members = sorted([m.value for m in _backup.members])
-            assert _ws_members == _backup_members
-        except NotFound:
-            continue
+    reflected_group = ws.groups.get(acc_group.id)
+    assert reflected_group.display_name == ws_group.display_name == acc_group.display_name
+    assert set(info.display for info in reflected_group.members) == set(info.display for info in ws_group.members)
+    assert set(info.display for info in reflected_group.members) == set(info.display for info in acc_group.members)
+    assert reflected_group.meta == ResourceMeta(resource_type="Group")
+    assert not reflected_group.roles  # Cannot create roles currently
+    assert not reflected_group.entitlements  # Entitlements aren't reflected there
 
-    for _info in group_migration_state.groups:
-        try:
-            # cleanup side-effect
-            ws.groups.delete(_info.backup.id)
-        except NotFound:
-            continue
+    assert (
+        ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
+    )  # At this time previous ws level groups aren't deleted
 
 
-def test_prepare_environment_no_groups_selected(ws, make_ucx_group, make_group, make_acc_group):
-    make_group()
-    make_acc_group()
-    for_test = [make_ucx_group(), make_ucx_group()]
+def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
+    ws, make_ucx_group, sql_backend, inventory_schema
+):
+    ws_group, acc_group = make_ucx_group()
 
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.prepare_groups_in_environment()
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager.rename_groups()
+    group_manager.reflect_account_groups_on_workspace()
+    group_manager.delete_original_workspace_groups()
 
-    group_migration_state = group_manager.migration_state
-    for _info in group_migration_state.groups:
-        _ws = ws.groups.get(id=_info.workspace.id)
-        _backup = ws.groups.get(id=_info.backup.id)
-        # https://github.com/databricks/databricks-sdk-py/pull/361 may fix the NPE gotcha with empty members
-        _ws_members = sorted([m.value for m in _ws.members]) if _ws.members is not None else []
-        _backup_members = sorted([m.value for m in _backup.members]) if _backup.members is not None else []
-        assert _ws_members == _backup_members
+    with pytest.raises(NotFound):
+        ws.groups.get(ws_group.id)
 
-    for g, _ in for_test:
-        assert group_migration_state.get_by_workspace_group_name(g.display_name) is not None
 
-    for _info in group_migration_state.groups:
-        # cleanup side-effect
-        ws.groups.delete(_info.backup.id)
+def test_delete_ws_groups_should_not_delete_current_ws_groups(ws, make_ucx_group, sql_backend, inventory_schema):
+    ws_group, acc_group = make_ucx_group()
+
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager.delete_original_workspace_groups()
+
+    assert ws.groups.get(ws_group.id).display_name == ws_group.display_name
+
+
+def test_delete_ws_groups_should_not_delete_non_reflected_acc_groups(ws, make_ucx_group, sql_backend, inventory_schema):
+    ws_group, acc_group = make_ucx_group()
+
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager.rename_groups()
+    group_manager.delete_original_workspace_groups()
+
+    assert ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
 
 
 def test_replace_workspace_groups_with_account_groups(
@@ -146,10 +144,7 @@ def test_replace_workspace_groups_with_account_groups(
     dummy_table = make_table()
     sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
 
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.prepare_groups_in_environment()
-
-    group_info = group_manager.migration_state.get_by_workspace_group_name(ws_group.display_name)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
 
     generic_permissions = GenericPermissionsSupport(
         ws, [Listing(ws.cluster_policies.list, "policy_id", "cluster-policies")]
@@ -169,165 +164,81 @@ def test_replace_workspace_groups_with_account_groups(
     assert "MODIFY" in table_permissions[ws_group.display_name]
     assert "SELECT" in table_permissions[ws_group.display_name]
 
-    permission_manager.apply_group_permissions(group_manager.migration_state, destination="backup")
+    state = group_manager.get_migration_state()
+    assert len(state) == 1
+
+    group_manager.rename_groups()
+
+    group_info = state.groups[0]
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_backup_group():
         logger.info("check_permissions_for_backup_group()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.workspace.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.workspace.display_name]
-        assert "SELECT" in table_permissions[group_info.workspace.display_name]
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
+        assert group_info.name_in_workspace not in table_permissions
+        assert group_info.temporary_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
-        assert PermissionLevel.CAN_USE == policy_permissions[group_info.workspace.display_name]
-        assert PermissionLevel.CAN_USE == policy_permissions[group_info.backup.display_name]
+        assert PermissionLevel.CAN_USE == policy_permissions[group_info.temporary_name]
 
     check_permissions_for_backup_group()
 
-    group_manager.replace_workspace_groups_with_account_groups(group_manager.migration_state)
+    group_manager.reflect_account_groups_on_workspace()
 
     @retried(on=[AssertionError], timeout=timedelta(minutes=1))
     def check_permissions_after_replace():
         logger.info("check_permissions_after_replace()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
+        assert group_info.name_in_account not in table_permissions
+        assert group_info.temporary_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
-        assert group_info.workspace.display_name not in policy_permissions
-        assert PermissionLevel.CAN_USE == policy_permissions[group_info.backup.display_name]
+        assert group_info.name_in_workspace not in policy_permissions
+        assert PermissionLevel.CAN_USE == policy_permissions[group_info.temporary_name]
 
     check_permissions_after_replace()
 
-    permission_manager.apply_group_permissions(group_manager.migration_state, destination="account")
+    permission_manager.apply_group_permissions(state, destination="account")
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_account_group():
         logger.info("check_permissions_for_account_group()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
-        assert "MODIFY" in table_permissions[group_info.account.display_name]
-        assert "SELECT" in table_permissions[group_info.account.display_name]
+        assert group_info.name_in_account in table_permissions
+        assert group_info.temporary_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
+        assert "MODIFY" in table_permissions[group_info.name_in_account]
+        assert "SELECT" in table_permissions[group_info.name_in_account]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
-        assert PermissionLevel.CAN_USE == policy_permissions[group_info.account.display_name]
-        assert PermissionLevel.CAN_USE == policy_permissions[group_info.backup.display_name]
+        assert PermissionLevel.CAN_USE == policy_permissions[group_info.name_in_account]
+        assert PermissionLevel.CAN_USE == policy_permissions[group_info.temporary_name]
 
     check_permissions_for_account_group()
 
-    for _info in group_manager.migration_state.groups:
-        ws.groups.delete(_info.backup.id)
+    group_manager.delete_original_workspace_groups()
 
     @retried(on=[AssertionError], timeout=timedelta(minutes=1))
     def check_table_permissions_after_backup_delete():
         logger.info("check_table_permissions_after_backup_delete()")
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
-        assert group_info.backup.display_name not in policy_permissions
+        assert group_info.temporary_name not in policy_permissions
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.account.display_name]
-        assert "SELECT" in table_permissions[group_info.account.display_name]
+        assert group_info.name_in_account in table_permissions
+        assert "MODIFY" in table_permissions[group_info.name_in_account]
+        assert "SELECT" in table_permissions[group_info.name_in_account]
 
     check_table_permissions_after_backup_delete()
-
-
-def test_group_listing(ws: WorkspaceClient, make_ucx_group):
-    ws_group, acc_group = make_ucx_group()
-    manager = GroupManager(ws, GroupsConfig(selected=[ws_group.display_name]))
-    assert ws_group.display_name in [g.display_name for g in manager._workspace_groups]
-    assert acc_group.display_name in [g.display_name for g in manager._account_groups]
-
-
-def test_id_validity(ws: WorkspaceClient, make_ucx_group):
-    ws_group, acc_group = make_ucx_group()
-    manager = GroupManager(ws, GroupsConfig(selected=[ws_group.display_name]))
-    assert ws_group.id == manager._get_group(ws_group.display_name, "workspace").id
-    assert acc_group.id == manager._get_group(acc_group.display_name, "account").id
-
-
-def test_recover_from_ws_local_deletion(ws, make_ucx_group):
-    ws_group, acc_group = make_ucx_group()
-    ws_group_two, _ = make_ucx_group()
-
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.prepare_groups_in_environment()
-
-    # simulate disaster
-    ws.groups.delete(ws_group.id)
-    ws.groups.delete(ws_group_two.id)
-    group_manager._reflect_account_group_to_workspace(acc_group)
-
-    # recovery run from a debug notebook
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.ws_local_group_deletion_recovery()
-
-    # normal run after from a job
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.prepare_groups_in_environment()
-
-    recovered_state = {}
-    for gi in group_manager.migration_state.groups:
-        recovered_state[gi.workspace.display_name] = gi.workspace
-
-    assert sorted([member.display for member in ws_group_two.members]) == sorted(
-        [member.display for member in recovered_state[ws_group_two.display_name].members]
-    )
-
-    assert sorted([member.value for member in ws_group_two.members]) == sorted(
-        [member.value for member in recovered_state[ws_group_two.display_name].members]
-    )
-
-
-def test_migration_state_should_be_saved_with_proper_values(sql_backend, make_schema):
-    inventory_database = make_schema()
-
-    workspace = Group(
-        display_name="workspace", entitlements=[ComplexValue(display="entitlements", value="allow-cluster-create")]
-    )
-    backup = Group(display_name="db-temp-workspace", meta=ResourceMeta("test"))
-    account = Group(display_name="account")
-
-    state = GroupMigrationState()
-    state.add(workspace, backup, account)
-
-    state.persist_migration_state(sql_backend, inventory_database.name)
-    new_state = state.fetch_migration_state(sql_backend, inventory_database.name)
-
-    assert new_state.groups == state.groups
-
-
-def test_migration_state_should_be_saved_without_missing_anything(sql_backend, make_schema):
-    inventory_database = make_schema()
-
-    workspace = Group("workspace")
-    backup = Group("db-temp-workspace")
-    account = Group("workspace")
-
-    state = GroupMigrationState()
-    state.add(workspace, backup, account)
-    state.add(workspace, backup, None)
-    state.add(workspace, None, account)
-    state.add(None, None, account)
-    state.add(None, None, None)
-
-    state.persist_migration_state(sql_backend, inventory_database.name)
-    new_state = state.fetch_migration_state(sql_backend, inventory_database.name)
-
-    assert len(new_state.groups) == len(state.groups)
 
 
 def test_set_owner_permission(
@@ -348,10 +259,7 @@ def test_set_owner_permission(
     sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
     sql_backend.execute(f"ALTER {dummy_table.full_name} OWNER TO `{ws_group.display_name}`")
 
-    group_manager = GroupManager(ws, GroupsConfig(auto=True))
-    group_manager.prepare_groups_in_environment()
-
-    group_info = group_manager.migration_state.get_by_workspace_group_name(ws_group.display_name)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
 
     tables = TablesCrawler(sql_backend, inventory_schema)
     grants = GrantsCrawler(tables)
@@ -369,66 +277,67 @@ def test_set_owner_permission(
     assert "SELECT" in table_permissions[ws_group.display_name]
     assert "OWN" in table_permissions[ws_group.display_name]
 
-    permission_manager.apply_group_permissions(group_manager.migration_state, destination="backup")
+    state = group_manager.get_migration_state()
+    assert len(state.groups) == 1
+
+    group_manager.rename_groups()
+
+    group_info = state.groups[0]
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_backup_group():
         logger.info("check_permissions_for_backup_group()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.workspace.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.workspace.display_name]
-        assert "SELECT" in table_permissions[group_info.workspace.display_name]
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
-        assert "OWN" in table_permissions[group_info.backup.display_name]
+        assert group_info.name_in_workspace not in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
+        assert "OWN" in table_permissions[group_info.temporary_name]
 
     check_permissions_for_backup_group()
 
-    group_manager.replace_workspace_groups_with_account_groups(group_manager.migration_state)
+    group_manager.reflect_account_groups_on_workspace()
 
     @retried(on=[AssertionError], timeout=timedelta(minutes=1))
     def check_permissions_after_replace():
         logger.info("check_permissions_after_replace()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
-        assert "OWN" in table_permissions[group_info.backup.display_name]
+        assert group_info.name_in_account not in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
+        assert "OWN" in table_permissions[group_info.temporary_name]
 
     check_permissions_after_replace()
 
-    permission_manager.apply_group_permissions(group_manager.migration_state, destination="account")
+    permission_manager.apply_group_permissions(state, destination="account")
 
     @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_account_group():
         logger.info("check_permissions_for_account_group()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert group_info.backup.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.backup.display_name]
-        assert "SELECT" in table_permissions[group_info.backup.display_name]
-        assert "MODIFY" in table_permissions[group_info.account.display_name]
-        assert "SELECT" in table_permissions[group_info.account.display_name]
-        assert "OWN" in table_permissions[group_info.account.display_name]
+        assert group_info.name_in_account in table_permissions
+        assert group_info.temporary_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.temporary_name]
+        assert "SELECT" in table_permissions[group_info.temporary_name]
+        assert "MODIFY" in table_permissions[group_info.name_in_account]
+        assert "SELECT" in table_permissions[group_info.name_in_account]
+        assert "OWN" in table_permissions[group_info.name_in_account]
 
     check_permissions_for_account_group()
 
-    for _info in group_manager.migration_state.groups:
-        ws.groups.delete(_info.backup.id)
+    group_manager.delete_original_workspace_groups()
 
     @retried(on=[AssertionError], timeout=timedelta(minutes=1))
     def check_table_permissions_after_backup_delete():
         logger.info("check_table_permissions_after_backup_delete()")
 
         table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.account.display_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.account.display_name]
-        assert "SELECT" in table_permissions[group_info.account.display_name]
-        assert "OWN" in table_permissions[group_info.account.display_name]
+        assert group_info.name_in_account in table_permissions
+        assert group_info.temporary_name not in table_permissions
+        assert "MODIFY" in table_permissions[group_info.name_in_account]
+        assert "SELECT" in table_permissions[group_info.name_in_account]
+        assert "OWN" in table_permissions[group_info.name_in_account]
 
     check_table_permissions_after_backup_delete()

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -5,6 +5,7 @@ from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
 
+
 # TODO: (nfx) databricks.sdk.errors.mapping.ResourceConflict: None Group with name db-temp-ucx_QSFR already exists.
 def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema, make_pipeline):
     """

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -50,7 +50,7 @@ def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema
     group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[ws_group.display_name])
     migration_state = group_manager.get_migration_state()
     permission_manager = PermissionManager.factory(ws, sql_backend, inventory_database=inventory_schema)
-    permission_manager.apply_group_permissions(migration_state, destination="account")
+    permission_manager.apply_group_permissions(migration_state)
 
     old_group = ws.groups.get(ws_group.id)
     reflected_group = ws.groups.get(acc_group.id)

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -1,10 +1,8 @@
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 
-from databricks.labs.ucx.config import GroupsConfig
 from databricks.labs.ucx.workspace_access.groups import (
     GroupManager,
-    GroupMigrationState,
 )
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
@@ -55,8 +53,5 @@ def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema
         ws, remote_state, groups_config.backup_group_prefix
     )
     pi.apply_group_permissions(migration_state, destination="account")
-    assert [
-        iam.ComplexValue(display=None, primary=None, type=None, value="databricks-sql-access"),
-        iam.ComplexValue(display=None, primary=None, type=None, value="allow-cluster-create"),
-    ] == ws.groups.get(acc_group.id).entitlements
+
     assert len(ws.groups.get(acc_group.id).members) == len(ws_group.members)

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -6,7 +6,7 @@ from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
 
 
-def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema):
+def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema, make_pipeline):
     """
     This test does the following:
     * create a ws group with roles and entitlements
@@ -26,6 +26,7 @@ def test_scim(ws: WorkspaceClient, make_ucx_group, sql_backend, inventory_schema
         ],
         schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
     )
+    make_pipeline()
 
     # Task 1 - crawl_permissions
     scim_support = ScimSupport(ws)

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -4,6 +4,7 @@ import random
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import workspace
 from databricks.sdk.service.iam import PermissionLevel
+from integration.conftest import get_workspace_membership
 
 from databricks.labs.ucx.config import ConnectConfig, WorkspaceConfig
 from databricks.labs.ucx.workspace_access import GroupMigrationToolkit
@@ -188,7 +189,7 @@ def test_workspace_access_e2e(
 
     toolkit.replace_workspace_groups_with_account_groups()
 
-    workspace_acc_membership = toolkit._group_manager.get_workspace_membership("Group")
+    workspace_acc_membership = get_workspace_membership(ws, "Group")
     assert acc_group.display_name in workspace_acc_membership
 
     toolkit.apply_permissions_to_account_groups()
@@ -197,7 +198,7 @@ def test_workspace_access_e2e(
 
     toolkit.delete_backup_groups()
 
-    workspace_membership = toolkit._group_manager.get_workspace_membership()
+    workspace_membership = get_workspace_membership(ws)
     assert f"db-temp-{ws_group.display_name}" not in workspace_membership
 
     toolkit.cleanup_inventory_table()

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -5,7 +5,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import workspace
 from databricks.sdk.service.iam import PermissionLevel
 
-from databricks.labs.ucx.config import ConnectConfig, GroupsConfig, WorkspaceConfig
+from databricks.labs.ucx.config import ConnectConfig, WorkspaceConfig
 from databricks.labs.ucx.workspace_access import GroupMigrationToolkit
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -169,10 +169,10 @@ def test_workspace_access_e2e(
     config = WorkspaceConfig(
         connect=ConnectConfig.from_databricks_config(ws.config),
         inventory_database=inventory_schema,
-        groups=GroupsConfig(selected=[ws_group.display_name]),
         workspace_start_path=directory,
         log_level="DEBUG",
         num_threads=8,
+        include_group_names=[ws_group.display_name],
     )
 
     warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")

--- a/tests/integration/workspace_access/test_workspace_access.py
+++ b/tests/integration/workspace_access/test_workspace_access.py
@@ -177,15 +177,6 @@ def test_workspace_access_e2e(
 
     warehouse_id = env_or_skip("TEST_DEFAULT_WAREHOUSE_ID")
     toolkit = GroupMigrationToolkit(config, warehouse_id=warehouse_id)
-    toolkit.prepare_environment()
-
-    group_migration_state = toolkit._group_manager.migration_state
-    for _info in group_migration_state.groups:
-        _ws = ws.groups.get(id=_info.workspace.id)
-        _backup = ws.groups.get(id=_info.backup.id)
-        _ws_members = sorted([m.value for m in _ws.members])
-        _backup_members = sorted([m.value for m in _backup.members])
-        assert _ws_members == _backup_members
 
     logger.debug("Verifying that the groups were created - done")
 
@@ -195,9 +186,7 @@ def test_workspace_access_e2e(
 
     toolkit.apply_permissions_to_backup_groups()
 
-    toolkit.verify_permissions_on_backup_groups(to_verify)
-
-    toolkit.replace_workspace_groups_with_account_groups(group_migration_state)
+    toolkit.replace_workspace_groups_with_account_groups()
 
     workspace_acc_membership = toolkit._group_manager.get_workspace_membership("Group")
     assert acc_group.display_name in workspace_acc_membership

--- a/tests/unit/assessment/test_dashboard.py
+++ b/tests/unit/assessment/test_dashboard.py
@@ -10,7 +10,7 @@ from databricks.sdk.service.sql import (
     Widget,
 )
 
-from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.install_state import InstallState
 from databricks.labs.ucx.install import WorkspaceInstaller
@@ -21,7 +21,7 @@ def test_dashboard(mocker):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
     ws.config.is_aws = True
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a", groups=GroupsConfig(auto=True)).as_dict()).encode(
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
         "utf8"
     )
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)

--- a/tests/unit/assessment/test_dashboard.py
+++ b/tests/unit/assessment/test_dashboard.py
@@ -21,9 +21,7 @@ def test_dashboard(mocker):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
     ws.config.is_aws = True
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
-        "utf8"
-    )
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode("utf8")
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
     ws.data_sources.list = lambda: [DataSource(id="bcd", warehouse_id="000000")]
     ws.dashboards.create.return_value = Dashboard(id="abc")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,14 +5,13 @@ from pathlib import Path
 
 import yaml
 
-from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
+from databricks.labs.ucx.config import WorkspaceConfig
 
 
 def test_initialization():
     mc = partial(
         WorkspaceConfig,
         inventory_database="abc",
-        groups=GroupsConfig(auto=True),
     )
     mc()
 
@@ -43,7 +42,6 @@ def test_reader(tmp_path: Path):
         mc = partial(
             WorkspaceConfig,
             inventory_database="abc",
-            groups=GroupsConfig(auto=True),
             database_to_catalog_mapping={"db1": "cat1", "db2": "cat2"},
             spark_conf={"key1": "val1", "key2": "val2"},
         )

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -26,7 +26,7 @@ from databricks.sdk.service.sql import (
 )
 from databricks.sdk.service.workspace import ImportFormat, ObjectInfo
 
-from databricks.labs.ucx.config import GroupsConfig, WorkspaceConfig
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.install_state import InstallState
 from databricks.labs.ucx.install import WorkspaceInstaller
@@ -41,7 +41,7 @@ def ws(mocker):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
     ws.config.is_aws = True
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a", groups=GroupsConfig(auto=True)).as_dict()).encode(
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
         "utf8"
     )
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
@@ -59,7 +59,7 @@ def ws(mocker):
 def test_replace_clusters_for_integration_tests(ws):
     return_value = WorkspaceInstaller.run_for_config(
         ws,
-        WorkspaceConfig(inventory_database="a", groups=GroupsConfig(auto=True)),
+        WorkspaceConfig(inventory_database="a"),
         override_clusters={"main": "abc"},
         sql_backend=MockBackend(),
     )
@@ -139,14 +139,13 @@ def test_save_config(ws, mocker):
     ws.workspace.upload.assert_called_with(
         "/Users/me@example.com/.ucx/config.yml",
         b"""default_catalog: ucx_default
-groups:
-  backup_group_prefix: '42'
-  selected:
-  - '42'
+include_group_names:
+- '42'
 inventory_database: '42'
 log_level: '42'
 num_threads: 42
-version: 1
+renamed_group_prefix: '42'
+version: 2
 warehouse_id: abc
 workspace_start_path: /
 """,
@@ -195,13 +194,11 @@ def test_save_config_auto_groups(ws, mocker):
     ws.workspace.upload.assert_called_with(
         "/Users/me@example.com/.ucx/config.yml",
         b"""default_catalog: ucx_default
-groups:
-  auto: true
-  backup_group_prefix: '42'
 inventory_database: '42'
 log_level: '42'
 num_threads: 42
-version: 1
+renamed_group_prefix: '42'
+version: 2
 warehouse_id: abc
 workspace_start_path: /
 """,
@@ -235,16 +232,15 @@ def test_save_config_strip_group_names(ws, mocker):
     ws.workspace.upload.assert_called_with(
         "/Users/me@example.com/.ucx/config.yml",
         b"""default_catalog: ucx_default
-groups:
-  backup_group_prefix: '42'
-  selected:
-  - g1
-  - g2
-  - g99
+include_group_names:
+- g1
+- g2
+- g99
 inventory_database: '42'
 log_level: '42'
 num_threads: 42
-version: 1
+renamed_group_prefix: '42'
+version: 2
 warehouse_id: abc
 workspace_start_path: /
 """,
@@ -299,17 +295,16 @@ def test_save_config_with_glue(ws, mocker):
     ws.workspace.upload.assert_called_with(
         "/Users/me@example.com/.ucx/config.yml",
         b"""default_catalog: ucx_default
-groups:
-  backup_group_prefix: '42'
-  selected:
-  - '42'
+include_group_names:
+- '42'
 instance_profile: arn:aws:iam::111222333:instance-profile/foo-instance-profile
 inventory_database: '42'
 log_level: '42'
 num_threads: 42
+renamed_group_prefix: '42'
 spark_conf:
   spark.databricks.hive.metastore.glueCatalog.enabled: 'true'
-version: 1
+version: 2
 warehouse_id: abc
 workspace_start_path: /
 """,
@@ -324,9 +319,24 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker):
     mocker.patch("base64.b64encode")
     webbrowser_open = mocker.patch("webbrowser.open")
 
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a", groups=GroupsConfig(auto=True)).as_dict()).encode(
-        "utf8"
-    )
+    ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
+    ws.config.host = "https://foo"
+    ws.config.is_aws = True
+    config_bytes = b"""default_catalog: ucx_default
+include_group_names:
+- '42'
+instance_profile: arn:aws:iam::111222333:instance-profile/foo-instance-profile
+inventory_database: '42'
+log_level: '42'
+num_threads: 42
+renamed_group_prefix: '42'
+spark_conf:
+  spark.databricks.hive.metastore.glueCatalog.enabled: 'true'
+version: 1
+warehouse_id: abc
+workspace_start_path: /
+"""
+
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
     ws.workspace.get_status = lambda _: ObjectInfo(object_id=123)
     ws.data_sources.list = lambda: [DataSource(id="bcd", warehouse_id="abc")]
@@ -390,7 +400,9 @@ def test_create_readme(ws, mocker):
     mocker.patch("builtins.input", return_value="yes")
     webbrowser_open = mocker.patch("webbrowser.open")
 
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a", groups=GroupsConfig(auto=True)).as_dict()).encode(
+    ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
+    ws.config.host = "https://foo"
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
         "utf8"
     )
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -41,9 +41,7 @@ def ws(mocker):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
     ws.config.is_aws = True
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
-        "utf8"
-    )
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode("utf8")
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
     ws.workspace.get_status = lambda _: ObjectInfo(object_id=123)
     ws.data_sources.list = lambda: [DataSource(id="bcd", warehouse_id="abc")]
@@ -402,9 +400,7 @@ def test_create_readme(ws, mocker):
 
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
-    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode(
-        "utf8"
-    )
+    config_bytes = yaml.dump(WorkspaceConfig(inventory_database="a").as_dict()).encode("utf8")
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
 
     from databricks.labs.ucx.framework.tasks import Task

--- a/tests/unit/workspace_access/conftest.py
+++ b/tests/unit/workspace_access/conftest.py
@@ -1,15 +1,11 @@
 import pytest
 from databricks.sdk.service import iam
 
-from databricks.labs.ucx.workspace_access.groups import MigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
 
 
 @pytest.fixture(scope="function")
 def migration_state() -> MigrationState:
-    ms = MigrationState()
-    ms.add(
-        iam.Group(display_name="test", id="test-ws"),
-        iam.Group(display_name="db-temp-test", id="test-backup"),
-        iam.Group(display_name="test", id="test-acc"),
-    )
+    grp = [MigratedGroup(id_in_workspace="test-ws", name_in_workspace="test", name_in_account="test", temporary_name="db-temp-test", members=None, entitlements=None, external_id=None, roles=None)]
+    ms = MigrationState(grp)
     return ms

--- a/tests/unit/workspace_access/conftest.py
+++ b/tests/unit/workspace_access/conftest.py
@@ -1,11 +1,21 @@
 import pytest
-from databricks.sdk.service import iam
 
-from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 
 
 @pytest.fixture(scope="function")
 def migration_state() -> MigrationState:
-    grp = [MigratedGroup(id_in_workspace="test-ws", name_in_workspace="test", name_in_account="test", temporary_name="db-temp-test", members=None, entitlements=None, external_id=None, roles=None)]
+    grp = [
+        MigratedGroup(
+            id_in_workspace="test-ws",
+            name_in_workspace="test",
+            name_in_account="test",
+            temporary_name="db-temp-test",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None,
+        )
+    ]
     ms = MigrationState(grp)
     return ms

--- a/tests/unit/workspace_access/conftest.py
+++ b/tests/unit/workspace_access/conftest.py
@@ -1,12 +1,12 @@
 import pytest
 from databricks.sdk.service import iam
 
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 
 @pytest.fixture(scope="function")
-def migration_state() -> GroupMigrationState:
-    ms = GroupMigrationState()
+def migration_state() -> MigrationState:
+    ms = MigrationState()
     ms.add(
         iam.Group(display_name="test", id="test-ws"),
         iam.Group(display_name="db-temp-test", id="test-backup"),

--- a/tests/unit/workspace_access/test_base.py
+++ b/tests/unit/workspace_access/test_base.py
@@ -1,14 +1,13 @@
 from collections.abc import Callable, Iterator
 from functools import partial
 
-from databricks.sdk.service import iam
 
 from databricks.labs.ucx.workspace_access.base import (
     AclSupport,
     Destination,
     Permissions,
 )
-from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 
 
 def test_applier():
@@ -39,18 +38,20 @@ def test_applier():
 
     applier = SampleApplier()
     positive_item = Permissions(object_id="test", object_type="test", raw="test")
-    migration_state = MigrationState([
-        MigratedGroup(
-            id_in_workspace=None,
-            name_in_workspace="test",
-            name_in_account="test",
-            temporary_name="db-temp-test",
-            members=None,
-            entitlements=None,
-            external_id=None,
-            roles=None
-        )
-    ])
+    migration_state = MigrationState(
+        [
+            MigratedGroup(
+                id_in_workspace=None,
+                name_in_workspace="test",
+                name_in_account="test",
+                temporary_name="db-temp-test",
+                members=None,
+                entitlements=None,
+                external_id=None,
+                roles=None,
+            )
+        ]
+    )
 
     task = applier.get_apply_task(positive_item, migration_state, "backup")
     task()

--- a/tests/unit/workspace_access/test_base.py
+++ b/tests/unit/workspace_access/test_base.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.workspace_access.base import (
     Destination,
     Permissions,
 )
-from databricks.labs.ucx.workspace_access.groups import MigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
 
 
 def test_applier():
@@ -24,7 +24,7 @@ def test_applier():
 
         @staticmethod
         def _is_item_relevant(item: Permissions, migration_state: MigrationState) -> bool:
-            workspace_groups = [info.workspace.display_name for info in migration_state.groups]
+            workspace_groups = [info.name_in_workspace for info in migration_state.groups]
             return item.object_id in workspace_groups
 
         def get_apply_task(self, item: Permissions, migration_state: MigrationState, _: Destination):
@@ -39,12 +39,18 @@ def test_applier():
 
     applier = SampleApplier()
     positive_item = Permissions(object_id="test", object_type="test", raw="test")
-    migration_state = MigrationState()
-    migration_state.add(
-        iam.Group(display_name="test", id="test"),
-        iam.Group(display_name="db-temp-test", id="test-backup"),
-        iam.Group(display_name="test", id="test-acc"),
-    )
+    migration_state = MigrationState([
+        MigratedGroup(
+            id_in_workspace=None,
+            name_in_workspace="test",
+            name_in_account="test",
+            temporary_name="db-temp-test",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None
+        )
+    ])
 
     task = applier.get_apply_task(positive_item, migration_state, "backup")
     task()

--- a/tests/unit/workspace_access/test_base.py
+++ b/tests/unit/workspace_access/test_base.py
@@ -1,11 +1,7 @@
 from collections.abc import Callable, Iterator
 from functools import partial
 
-from databricks.labs.ucx.workspace_access.base import (
-    AclSupport,
-    Destination,
-    Permissions,
-)
+from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 
 
@@ -25,7 +21,7 @@ def test_applier():
             workspace_groups = [info.name_in_workspace for info in migration_state.groups]
             return item.object_id in workspace_groups
 
-        def get_apply_task(self, item: Permissions, migration_state: MigrationState, _: Destination):
+        def get_apply_task(self, item: Permissions, migration_state: MigrationState):
             if not self._is_item_relevant(item, migration_state):
                 return None
 
@@ -52,10 +48,10 @@ def test_applier():
         ]
     )
 
-    task = applier.get_apply_task(positive_item, migration_state, "backup")
+    task = applier.get_apply_task(positive_item, migration_state)
     task()
     assert applier.called
 
     negative_item = Permissions(object_id="not-here", object_type="test", raw="test")
-    task = applier.get_apply_task(negative_item, migration_state, "backup")
+    task = applier.get_apply_task(negative_item, migration_state)
     assert task is None

--- a/tests/unit/workspace_access/test_base.py
+++ b/tests/unit/workspace_access/test_base.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.workspace_access.base import (
     Destination,
     Permissions,
 )
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 
 
 def test_applier():
@@ -23,11 +23,11 @@ def test_applier():
             return {"test"}
 
         @staticmethod
-        def _is_item_relevant(item: Permissions, migration_state: GroupMigrationState) -> bool:
+        def _is_item_relevant(item: Permissions, migration_state: MigrationState) -> bool:
             workspace_groups = [info.workspace.display_name for info in migration_state.groups]
             return item.object_id in workspace_groups
 
-        def get_apply_task(self, item: Permissions, migration_state: GroupMigrationState, _: Destination):
+        def get_apply_task(self, item: Permissions, migration_state: MigrationState, _: Destination):
             if not self._is_item_relevant(item, migration_state):
                 return None
 
@@ -39,7 +39,7 @@ def test_applier():
 
     applier = SampleApplier()
     positive_item = Permissions(object_id="test", object_type="test", raw="test")
-    migration_state = GroupMigrationState()
+    migration_state = MigrationState()
     migration_state.add(
         iam.Group(display_name="test", id="test"),
         iam.Group(display_name="db-temp-test", id="test-backup"),

--- a/tests/unit/workspace_access/test_base.py
+++ b/tests/unit/workspace_access/test_base.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Iterator
 from functools import partial
 
-
 from databricks.labs.ucx.workspace_access.base import (
     AclSupport,
     Destination,

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -102,7 +102,7 @@ def test_apply(migration_state):
         ),
     )
 
-    _task = sup.get_apply_task(item, migration_state, "backup")
+    _task = sup.get_apply_task(item, migration_state)
     _task()
     ws.permissions.update.assert_called_once()
 
@@ -200,7 +200,7 @@ def test_passwords_tokens_crawler(migration_state):
     for item in auth_items:
         assert item.object_id in ["tokens", "passwords"]
         assert item.object_type == "authorization"
-        applier = sup.get_apply_task(item, migration_state, "backup")
+        applier = sup.get_apply_task(item, migration_state)
         applier()
         ws.permissions.update.assert_called_once_with(
             item.object_type,

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -74,7 +74,7 @@ def test_apply(migration_state):
     ws = MagicMock()
 
     acl1 = iam.AccessControlResponse(
-        all_permissions=[iam.Permission(permission_level=iam.PermissionLevel.CAN_USE)], group_name="db-temp-test"
+        all_permissions=[iam.Permission(permission_level=iam.PermissionLevel.CAN_USE)], group_name="test"
     )
     ws.permissions.get.return_value = iam.ObjectPermissions(access_control_list=[acl1])
     sup = GenericPermissionsSupport(ws=ws, listings=[])  # no listings since only apply is tested
@@ -108,7 +108,7 @@ def test_apply(migration_state):
 
     expected_acl_payload = [
         iam.AccessControlRequest(
-            group_name="db-temp-test",
+            group_name="test",
             permission_level=iam.PermissionLevel.CAN_USE,
         )
     ]
@@ -182,7 +182,7 @@ def test_passwords_tokens_crawler(migration_state):
 
     temp_acl = [
         iam.AccessControlResponse(
-            group_name="db-temp-test",
+            group_name="test",
             all_permissions=[iam.Permission(inherited=False, permission_level=iam.PermissionLevel.CAN_USE)],
         )
     ]
@@ -206,7 +206,7 @@ def test_passwords_tokens_crawler(migration_state):
             item.object_type,
             item.object_id,
             access_control_list=[
-                iam.AccessControlRequest(group_name="db-temp-test", permission_level=iam.PermissionLevel.CAN_USE)
+                iam.AccessControlRequest(group_name="test", permission_level=iam.PermissionLevel.CAN_USE)
             ],
         )
         ws.permissions.update.reset_mock()

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -367,7 +367,7 @@ def test_delete_original_workspace_groups_should_delete_relected_acc_groups_in_w
     wsclient.groups.list.return_value = [temp_group, reflected_group]
 
     GroupManager(backend, wsclient, inventory_database="inv").delete_original_workspace_groups()
-    wsclient.groups.delete.assert_called_with(ws_id)
+    wsclient.groups.delete.assert_called_with(id=ws_id)
 
 
 def test_delete_original_workspace_groups_should_not_delete_groups_not_renamed():

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta
 
@@ -114,21 +115,11 @@ def test_snapshot_should_filter_account_system_groups():
 def test_snapshot_should_filter_workspace_system_groups():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(
-        id="1",
-        display_name="admins",
-        meta=ResourceMeta(resource_type="WorkspaceGroup"),
-        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
-        roles=[
-            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
-            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
-        ],
-        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
-    )
+    group = Group(id="1", display_name="admins", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     wsclient.groups.list.return_value = [group]
-    account_admins_group = Group(id="1234", display_name="de")
+    acc_group = Group(id="1234", display_name="de")
     wsclient.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account_admins_group]],
+        "Resources": [g.as_dict() for g in [acc_group]],
     }
     res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
     assert res == []
@@ -140,10 +131,10 @@ def test_snapshot_should_consider_groups_defined_in_conf():
     group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     wsclient.groups.list.return_value = [group1, group2]
-    account_admins_group_1 = Group(id="11", display_name="de")
-    account_admins_group_2 = Group(id="12", display_name="ds")
+    acc_group_1 = Group(id="11", display_name="de")
+    acc_group_2 = Group(id="12", display_name="ds")
     wsclient.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account_admins_group_1, account_admins_group_2]],
+        "Resources": [g.as_dict() for g in [acc_group_1, acc_group_2]],
     }
     res = GroupManager(backend, wsclient, inventory_database="inv", include_group_names=["de"]).snapshot()
     assert res == [
@@ -158,6 +149,45 @@ def test_snapshot_should_consider_groups_defined_in_conf():
             entitlements=None,
         )
     ]
+
+
+def test_snapshot_should_filter_system_groups_defined_in_conf():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [group1]
+    acc_group_1 = Group(id="11", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [acc_group_1]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv", include_group_names=["admins"]).snapshot()
+    assert res == []
+
+
+def test_snapshot_should_filter_groups_defined_in_conf_not_present_in_workspace():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [group1]
+    acc_group_1 = Group(id="11", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [acc_group_1]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv", include_group_names=["de"]).snapshot()
+    assert res == []
+
+
+def test_snapshot_should_filter_groups_defined_in_conf_not_present_in_account():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [group1]
+    acc_group_1 = Group(id="11", display_name="ds")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [acc_group_1]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv", include_group_names=["de"]).snapshot()
+    assert res == []
 
 
 def test_snapshot_should_rename_groups_defined_in_conf():
@@ -215,7 +245,7 @@ def test_rename_groups_should_patch_eligible_groups():
 
 
 def test_rename_groups_should_filter_account_groups_in_workspace():
-    backend = MockBackend()
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
     wsclient = MagicMock()
     group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"))
     wsclient.groups.list.return_value = [group1]
@@ -253,3 +283,74 @@ def test_reflect_account_groups_on_workspace_should_be_called_for_eligible_group
     wsclient.api_client.do.assert_called_with(
         "PUT", "/api/2.0/preview/permissionassignments/principals/1", data='{"permissions": ["USER"]}'
     )
+
+
+def test_reflect_account_groups_on_workspace_should_filter_account_groups_in_workspace():
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"))
+    wsclient.groups.list.return_value = [group1]
+    account_group1 = Group(id="11", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_group1]],
+    }
+    GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace()
+
+    with pytest.raises(AssertionError):
+        wsclient.api_client.do.assert_called_with("PUT")
+
+
+def test_reflect_account_groups_on_workspace_should_filter_account_groups_not_in_account():
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"))
+    wsclient.groups.list.return_value = [group1]
+    account_group1 = Group(id="11", display_name="ds")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_group1]],
+    }
+    GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace()
+
+    with pytest.raises(AssertionError):
+        wsclient.api_client.do.assert_called_with("PUT")
+
+
+def test_delete_original_workspace_groups_should_delete_relected_acc_groups_in_workspace():
+    account_id = "11"
+    ws_id = "1"
+    backend = MockBackend(rows={"SELECT": [(ws_id, "de", "de", "test-group-de", account_id, "", "", "")]})
+    wsclient = MagicMock()
+
+    temp_group = Group(id=ws_id, display_name="test-group-de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    reflected_group = Group(id=account_id, display_name="de", meta=ResourceMeta(resource_type="Group"))
+    wsclient.groups.list.return_value = [temp_group, reflected_group]
+
+    GroupManager(backend, wsclient, inventory_database="inv").delete_original_workspace_groups()
+    wsclient.groups.delete.assert_called_with(ws_id)
+
+
+def test_delete_original_workspace_groups_should_not_delete_groups_not_renamed():
+    account_id = "11"
+    ws_id = "1"
+    backend = MockBackend(rows={"SELECT": [(ws_id, "de", "de", "test-group-de", account_id, "", "", "")]})
+    wsclient = MagicMock()
+
+    temp_group = Group(id=ws_id, display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    reflected_group = Group(id=account_id, display_name="de", meta=ResourceMeta(resource_type="Group"))
+    wsclient.groups.list.return_value = [temp_group, reflected_group]
+
+    GroupManager(backend, wsclient, inventory_database="inv").delete_original_workspace_groups()
+    wsclient.groups.delete.assert_not_called()
+
+
+def test_delete_original_workspace_groups_should_not_delete_groups_not_reflected_to_workspace():
+    account_id = "11"
+    ws_id = "1"
+    backend = MockBackend(rows={"SELECT": [(ws_id, "de", "de", "test-group-de", account_id, "", "", "")]})
+    wsclient = MagicMock()
+
+    temp_group = Group(id=ws_id, display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [temp_group]
+
+    GroupManager(backend, wsclient, inventory_database="inv").delete_original_workspace_groups()
+    wsclient.groups.delete.assert_not_called()

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -426,7 +426,7 @@ def test_delete_backup_groups():
 
     group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
     manager = GroupManager(client, group_conf)
-    manager.delete_backup_groups()
+    manager.delete_original_workspace_groups()
     client.groups.delete.assert_called_with(id=backup_group_id)
 
 
@@ -454,7 +454,7 @@ def test_delete_selected_backup_groups():
 
     group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", selected=["de"])
     manager = GroupManager(client, group_conf)
-    manager.delete_backup_groups()
+    manager.delete_original_workspace_groups()
     client.groups.delete.assert_called_with(id=backup_group_id)
 
 

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -1,31 +1,30 @@
-import json
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
-import pytest
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta
 
 from databricks.labs.ucx.workspace_access.groups import (
     GroupManager,
-    MigrationGroupInfoMock, MigratedGroup,
+    MigratedGroup,
 )
-from databricks.labs.ucx.workspace_access.scim import Permissions, ScimSupport
 from tests.unit.framework.mocks import MockBackend
 
 
 def test_snapshot_with_group_created_in_account_console_should_be_considered():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
-                  members=[ComplexValue(display='test-user-1', value='20'),
-                           ComplexValue(display='test-user-2', value='21')],
-                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
-                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
-                  entitlements=[ComplexValue(value='allow-cluster-create'),
-                                ComplexValue(value='allow-instance-pool-create')])
-    wsclient.groups.list.return_value = [
-        group
-    ]
+    group = Group(
+        id="1",
+        display_name="de",
+        meta=ResourceMeta(resource_type="WorkspaceGroup"),
+        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
+        roles=[
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
+        ],
+        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
+    )
+    wsclient.groups.list.return_value = [group]
     account_admins_group = Group(id="1234", display_name="de")
     wsclient.api_client.do.return_value = {
         "Resources": [g.as_dict() for g in [account_admins_group]],
@@ -38,7 +37,7 @@ def test_snapshot_with_group_created_in_account_console_should_be_considered():
             name_in_account="de",
             temporary_name="ucx-renamed-de",
             members='[{"display": "test-user-1", "value": "20"}, {"display": "test-user-2", "value": "21"}]',
-            external_id=None,
+            external_id='1234',
             roles='[{"value": "arn:aws:iam::123456789098:instance-profile/ip1"}, {"value": "arn:aws:iam::123456789098:instance-profile/ip2"}]',
             entitlements='[{"value": "allow-cluster-create"}, {"value": "allow-instance-pool-create"}]',
         )
@@ -48,16 +47,18 @@ def test_snapshot_with_group_created_in_account_console_should_be_considered():
 def test_snapshot_with_group_not_created_in_account_console_should_be_filtered():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
-                  members=[ComplexValue(display='test-user-1', value='20'),
-                           ComplexValue(display='test-user-2', value='21')],
-                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
-                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
-                  entitlements=[ComplexValue(value='allow-cluster-create'),
-                                ComplexValue(value='allow-instance-pool-create')])
-    wsclient.groups.list.return_value = [
-        group
-    ]
+    group = Group(
+        id="1",
+        display_name="de",
+        meta=ResourceMeta(resource_type="WorkspaceGroup"),
+        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
+        roles=[
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
+        ],
+        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
+    )
+    wsclient.groups.list.return_value = [group]
     account_admins_group = Group(id="1234", display_name="ds")
     wsclient.api_client.do.return_value = {
         "Resources": [g.as_dict() for g in [account_admins_group]],
@@ -69,16 +70,18 @@ def test_snapshot_with_group_not_created_in_account_console_should_be_filtered()
 def test_snapshot_with_group_already_migrated_should_be_filtered():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"),
-                  members=[ComplexValue(display='test-user-1', value='20'),
-                           ComplexValue(display='test-user-2', value='21')],
-                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
-                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
-                  entitlements=[ComplexValue(value='allow-cluster-create'),
-                                ComplexValue(value='allow-instance-pool-create')])
-    wsclient.groups.list.return_value = [
-        group
-    ]
+    group = Group(
+        id="1",
+        display_name="de",
+        meta=ResourceMeta(resource_type="Group"),
+        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
+        roles=[
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
+        ],
+        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
+    )
+    wsclient.groups.list.return_value = [group]
     account_admins_group = Group(id="1234", display_name="de")
     wsclient.api_client.do.return_value = {
         "Resources": [g.as_dict() for g in [account_admins_group]],
@@ -90,16 +93,18 @@ def test_snapshot_with_group_already_migrated_should_be_filtered():
 def test_snapshot_should_filter_account_system_groups():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
-                  members=[ComplexValue(display='test-user-1', value='20'),
-                           ComplexValue(display='test-user-2', value='21')],
-                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
-                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
-                  entitlements=[ComplexValue(value='allow-cluster-create'),
-                                ComplexValue(value='allow-instance-pool-create')])
-    wsclient.groups.list.return_value = [
-        group
-    ]
+    group = Group(
+        id="1",
+        display_name="de",
+        meta=ResourceMeta(resource_type="WorkspaceGroup"),
+        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
+        roles=[
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
+        ],
+        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
+    )
+    wsclient.groups.list.return_value = [group]
     account_admins_group = Group(id="1234", display_name="account users")
     wsclient.api_client.do.return_value = {
         "Resources": [g.as_dict() for g in [account_admins_group]],
@@ -111,16 +116,18 @@ def test_snapshot_should_filter_account_system_groups():
 def test_snapshot_should_filter_workspace_system_groups():
     backend = MockBackend()
     wsclient = MagicMock()
-    group = Group(id="1", display_name="admins", meta=ResourceMeta(resource_type="WorkspaceGroup"),
-                  members=[ComplexValue(display='test-user-1', value='20'),
-                           ComplexValue(display='test-user-2', value='21')],
-                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
-                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
-                  entitlements=[ComplexValue(value='allow-cluster-create'),
-                                ComplexValue(value='allow-instance-pool-create')])
-    wsclient.groups.list.return_value = [
-        group
-    ]
+    group = Group(
+        id="1",
+        display_name="admins",
+        meta=ResourceMeta(resource_type="WorkspaceGroup"),
+        members=[ComplexValue(display="test-user-1", value="20"), ComplexValue(display="test-user-2", value="21")],
+        roles=[
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip1"),
+            ComplexValue(value="arn:aws:iam::123456789098:instance-profile/ip2"),
+        ],
+        entitlements=[ComplexValue(value="allow-cluster-create"), ComplexValue(value="allow-instance-pool-create")],
+    )
+    wsclient.groups.list.return_value = [group]
     account_admins_group = Group(id="1234", display_name="de")
     wsclient.api_client.do.return_value = {
         "Resources": [g.as_dict() for g in [account_admins_group]],
@@ -134,10 +141,7 @@ def test_snapshot_should_consider_groups_defined_in_conf():
     wsclient = MagicMock()
     group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    wsclient.groups.list.return_value = [
-        group1,
-        group2
-    ]
+    wsclient.groups.list.return_value = [group1, group2]
     account_admins_group_1 = Group(id="11", display_name="de")
     account_admins_group_2 = Group(id="12", display_name="ds")
     wsclient.api_client.do.return_value = {
@@ -151,7 +155,7 @@ def test_snapshot_should_consider_groups_defined_in_conf():
             name_in_account="de",
             temporary_name="ucx-renamed-de",
             members=None,
-            external_id=None,
+            external_id='11',
             roles=None,
             entitlements=None,
         )
@@ -163,10 +167,7 @@ def test_snapshot_should_rename_groups_defined_in_conf():
     wsclient = MagicMock()
     group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    wsclient.groups.list.return_value = [
-        group1,
-        group2
-    ]
+    wsclient.groups.list.return_value = [group1, group2]
     account_admins_group_1 = Group(id="11", display_name="de")
     account_admins_group_2 = Group(id="12", display_name="ds")
     wsclient.api_client.do.return_value = {
@@ -180,7 +181,7 @@ def test_snapshot_should_rename_groups_defined_in_conf():
             name_in_account="de",
             temporary_name="test-group-de",
             members=None,
-            external_id=None,
+            external_id='11',
             roles=None,
             entitlements=None,
         ),
@@ -190,10 +191,10 @@ def test_snapshot_should_rename_groups_defined_in_conf():
             name_in_account="ds",
             temporary_name="test-group-ds",
             members=None,
-            external_id=None,
+            external_id="12",
             roles=None,
             entitlements=None,
-        )
+        ),
     ]
 
 
@@ -229,11 +230,7 @@ def test_rename_groups_should_filter_account_groups_in_workspace():
 
 
 def test_rename_groups_should_filter_already_renamed_groups():
-    backend = MockBackend(rows={
-        "SELECT": [
-            ("1", "de", "de", "test-group-de", "", "", "", "")
-        ]
-    })
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
     wsclient = MagicMock()
     group1 = Group(id="1", display_name="test-group-de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     wsclient.groups.list.return_value = [group1]
@@ -243,11 +240,7 @@ def test_rename_groups_should_filter_already_renamed_groups():
 
 
 def test_reflect_account_groups_on_workspace_should_be_called_for_eligible_groups():
-    backend = MockBackend(rows={
-        "SELECT": [
-            ("1", "de", "de", "test-group-de", "", "", "", "")
-        ]
-    })
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
     wsclient = MagicMock()
     account_group = Group(id="1", display_name="de")
     wsclient.api_client.do.return_value = {
@@ -257,10 +250,8 @@ def test_reflect_account_groups_on_workspace_should_be_called_for_eligible_group
     group1 = Group(id="1", display_name="test-dfd-de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     wsclient.groups.list.return_value = [group1]
 
-    (GroupManager(backend, wsclient, inventory_database="inv")
-     .reflect_account_groups_on_workspace())
+    (GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace())
 
-    wsclient.api_client.do.assert_called_with('PUT', '/api/2.0/preview/permissionassignments/principals/1', data='{"permissions": ["USER"]}')
-
-
-
+    wsclient.api_client.do.assert_called_with(
+        "PUT", "/api/2.0/preview/permissionassignments/principals/1", data='{"permissions": ["USER"]}'
+    )

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -5,636 +5,262 @@ import pytest
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta
 
-from databricks.labs.ucx.config import GroupsConfig
 from databricks.labs.ucx.workspace_access.groups import (
     GroupManager,
-    GroupMigrationState,
-    MigrationGroupInfo,
-    MigrationGroupInfoMock,
+    MigrationGroupInfoMock, MigratedGroup,
 )
 from databricks.labs.ucx.workspace_access.scim import Permissions, ScimSupport
 from tests.unit.framework.mocks import MockBackend
 
 
-def test_scim_crawler():
-    ws = MagicMock()
-    ws.groups.list.return_value = [
-        iam.Group(
-            id="1",
-            display_name="group1",
-            roles=[],  # verify that empty roles and entitlements are not returned
-        ),
-        iam.Group(
-            id="2",
-            display_name="group2",
-            roles=[iam.ComplexValue(value="role1")],
-            entitlements=[iam.ComplexValue(value="entitlement1")],
-        ),
-        iam.Group(
-            id="3",
-            display_name="group3",
-            roles=[iam.ComplexValue(value="role1"), iam.ComplexValue(value="role2")],
-            entitlements=[],
-        ),
-    ]
-    sup = ScimSupport(ws=ws)
-    tasks = list(sup.get_crawler_tasks())
-    assert len(tasks) == 3
-    ws.groups.list.assert_called_once()
-    for task in tasks:
-        item = task()
-        if item.object_id == "1":
-            assert item is None
-        else:
-            assert item.object_id in ["2", "3"]
-            assert item.object_type in ["roles", "entitlements"]
-            assert item.raw is not None
-
-
-@pytest.mark.parametrize(
-    "item",
-    [
-        Permissions(
-            object_id="test-ws",
-            object_type="roles",
-            raw=json.dumps(
-                [
-                    iam.ComplexValue(value="role1").as_dict(),
-                    iam.ComplexValue(value="role2").as_dict(),
-                ]
-            ),
-        ),
-        Permissions(
-            object_id="test-ws",
-            object_type="entitlements",
-            raw=json.dumps(
-                [
-                    iam.ComplexValue(value="sql-access").as_dict(),
-                    iam.ComplexValue(value="workspace-admin").as_dict(),
-                ]
-            ),
-        ),
-    ],
-    ids=["roles", "entitlements"],
-)
-def test_scim_apply(item, migration_state):
-    ws = MagicMock()
-    value_payload: list[dict] = json.loads(item.raw)
-    ws.groups.get.return_value = Group(
-        **{"id": "test-backup", item.object_type: [iam.ComplexValue.from_dict(value) for value in value_payload]}
-    )
-    sup = ScimSupport(ws=ws)
-
-    apply_to_backup_task = sup.get_apply_task(item, migration_state, "backup")
-    apply_to_backup_task()
-
-    ws.groups.patch.assert_called_once_with(
-        id="test-backup",
-        operations=[iam.Patch(op=iam.PatchOp.ADD, path=item.object_type, value=value_payload)],
-        schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-    )
-
-    apply_to_account_task = sup.get_apply_task(item, migration_state, "account")
-    apply_to_account_task()
-    ws.groups.patch.assert_called_with(
-        id="test-acc",
-        operations=[iam.Patch(op=iam.PatchOp.ADD, path=item.object_type, value=value_payload)],
-        schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-    )
-
-
-def test_no_group_in_migration_state(migration_state):
-    ws = MagicMock()
-    sup = ScimSupport(ws=ws)
-    sample_permissions = [iam.ComplexValue(value="role1"), iam.ComplexValue(value="role2")]
-    item = Permissions(
-        object_id="test-non-existent",
-        object_type="roles",
-        raw=json.dumps([p.as_dict() for p in sample_permissions]),
-    )
-    task = sup.get_apply_task(item, migration_state, "backup")
-    assert task is None
-
-
-def test_non_relevant(migration_state):
-    ws = MagicMock()
-    sup = ScimSupport(ws=ws)
-    sample_permissions = [iam.ComplexValue(value="role1")]
-    relevant_item = Permissions(
-        object_id="test-ws",
-        object_type="roles",
-        raw=json.dumps([p.as_dict() for p in sample_permissions]),
-    )
-    irrelevant_item = Permissions(
-        object_id="something-non-relevant",
-        object_type="roles",
-        raw=json.dumps([p.as_dict() for p in sample_permissions]),
-    )
-    assert sup._is_item_relevant(relevant_item, migration_state)
-    assert not sup._is_item_relevant(irrelevant_item, migration_state)
-
-
-def compare(s, t):
-    t = list(t)  # make a mutable copy
-    try:
-        for elem in s:
-            t.remove(elem)
-    except ValueError:
-        return False
-    return not t
-
-
-def test_account_groups_should_not_be_considered():
-    client = Mock()
-    users_group = Group(display_name="analysts", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account_admins_group = Group(display_name="account admins", meta=ResourceMeta(resource_type="Group"))
-    client.groups.list.return_value = [users_group, account_admins_group]
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account_admins_group]],
-    }
-
-    group_conf = GroupsConfig(selected=[""])
-    gm = GroupManager(client, group_conf)
-    assert gm._list_workspace_groups() == [users_group]
-    assert gm._list_account_groups(client) == [account_admins_group]
-
-
-def test_if_only_account_groups_it_should_return_empty_value():
-    client = Mock()
-    Group(display_name="analysts", meta=ResourceMeta(resource_type="Group"))
-    account_admins_group = Group(display_name="account admins", meta=ResourceMeta(resource_type="Group"))
-    client.groups.list.return_value = []
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account_admins_group]],
-    }
-    group_conf = GroupsConfig(auto=True)
-    gm = GroupManager(client, group_conf)
-    assert gm._list_workspace_groups() == []
-    assert gm._list_account_groups(client) == [account_admins_group]
-
-
-def test_backup_group_should_be_created_with_name_defined_in_conf():
-    client = Mock()
-
-    analysts_group = Group(display_name="analysts", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    client.groups.list.return_value = []
-
-    analysts_group_backup = Group(
-        display_name="dbr_backup_analysts_group_backup", meta=ResourceMeta(resource_type="WorkspaceGroup")
-    )
-    client.groups.create.return_value = analysts_group_backup
-    client.api_client.do.return_value = {}
-
-    group_conf = GroupsConfig(selected=[""], backup_group_prefix="dbr_backup_")
-    assert (
-        GroupManager(client, group_conf)._get_or_create_backup_group("analysts", analysts_group)
-        == analysts_group_backup
-    )
-
-
-def test_backup_group_should_not_be_created_if_already_exists():
-    client = Mock()
-
-    analysts_group_backup = Group(
-        display_name="dbr_backup_analysts_group_backup", meta=ResourceMeta(resource_type="WorkspaceGroup")
-    )
-    client.groups.list.return_value = [analysts_group_backup]
-    client.api_client.do.return_value = {}
-
-    group_conf = GroupsConfig(auto=True, backup_group_prefix="dbr_backup_")
-    assert (
-        GroupManager(client, group_conf)._get_or_create_backup_group("analysts_group_backup", analysts_group_backup)
-        == analysts_group_backup
-    )
-
-
-def test_prepare_groups_in_environment_with_one_group_in_conf_should_return_migrationgroupinfo_object():
-    ws_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    acc_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    backup_de_group = Group(display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client = Mock()
-    client.groups.list.return_value = [ws_de_group]
-    client.groups.create.return_value = backup_de_group
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [acc_de_group]],
-    }
-
-    group_conf = GroupsConfig(selected=["de"], backup_group_prefix="dbr_backup_")
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-
-    group_info = MigrationGroupInfo(workspace=ws_de_group, account=acc_de_group, backup=backup_de_group)
-    assert manager._migration_state.groups == [group_info]
-    assert len(manager._workspace_groups) == 2  # created backup group should be added to the list
-
-
-def test_prepare_groups_in_environment_with_multiple_groups_in_conf_should_return_two_migrationgroupinfo_object():
-    ws_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    ws_ds_group = Group(display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    acc_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    acc_ds_group = Group(display_name="ds", meta=ResourceMeta(resource_type="Group"))
-
-    backup_de_group = Group(display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup_ds_group = Group(display_name="dbr_backup_ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client = Mock()
-    client.groups.list.return_value = iter([ws_de_group, ws_ds_group])
-    client.groups.create.side_effect = [backup_de_group, backup_ds_group]
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [acc_de_group, acc_ds_group]],
-    }
-    group_conf = GroupsConfig(selected=["de", "ds"], backup_group_prefix="dbr_backup_")
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-
-    de_group_info = MigrationGroupInfo(workspace=ws_de_group, account=acc_de_group, backup=backup_de_group)
-    ds_group_info = MigrationGroupInfo(workspace=ws_ds_group, account=acc_ds_group, backup=backup_ds_group)
-
-    assert compare(manager._migration_state.groups, [ds_group_info, de_group_info])
-
-
-def test_prepare_groups_in_environment_should_not_throw_when_account_group_doesnt_exist():
-    de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client = Mock()
-    client.api_client.do.return_value = {}
-    client.groups.list.return_value = [de_group]
-    client.api_client.do.return_value = {}
-
-    group_conf = GroupsConfig(selected=["de"], backup_group_prefix="dbr_backup_")
-    manager = GroupManager(client, group_conf)
-
-    manager.prepare_groups_in_environment()
-    assert len(manager.migration_state.groups) == 0
-
-
-def test_prepare_groups_in_environment_should_throw_when_workspace_group_doesnt_exist():
-    client = Mock()
-    client.api_client.do.side_effect = [{}, {}]
-    client.groups.list.return_value = []
-
-    group_conf = GroupsConfig(selected=["de"], backup_group_prefix="dbr_backup_")
-    manager = GroupManager(client, group_conf)
-    with pytest.raises(AssertionError) as e_info:
-        manager.prepare_groups_in_environment()
-        assert str(e_info.value) == "Group de not found on the workspace level"
-
-
-def test_prepare_groups_in_environment_with_backup_group_not_created_should_create_it():
-    ws_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    acc_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-
-    backup_de_group = Group(display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client = Mock()
-    client.groups.list.return_value = iter([ws_de_group])
-    client.groups.create.return_value = backup_de_group
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [acc_de_group]],
-    }
-
-    group_conf = GroupsConfig(selected=["de"], backup_group_prefix="dbr_backup_")
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-    group_info = MigrationGroupInfo(workspace=ws_de_group, account=acc_de_group, backup=backup_de_group)
-    assert manager._migration_state.groups == [group_info]
-
-
-def test_prepare_groups_in_environment_with_conf_in_auto_mode_should_populate_migrationgroupinfo_object():
-    client = Mock()
-
-    ws_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    acc_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-
-    backup_de_group = Group(display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client.groups.list.return_value = iter([ws_de_group])
-    client.groups.create.return_value = backup_de_group
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [acc_de_group]],
-    }
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-
-    group_info = MigrationGroupInfo(workspace=ws_de_group, account=acc_de_group, backup=backup_de_group)
-    assert manager._migration_state.groups == [group_info]
-
-
-def test_prepare_groups_in_environment_with_no_groups():
-    client = Mock()
-    client.groups.list.return_value = iter([])
-    client.api_client.do.return_value = {
-        "Resources": [],
-    }
-
-    group_conf = GroupsConfig(auto=True)
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-    assert not manager.has_groups()
-
-
-def test_replace_workspace_groups_with_account_groups_should_call_delete_and_do():
-    client = Mock()
-
-    test_ws_group_id = "100"
-    test_acc_group_id = "200"
-    ws_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"), id=test_ws_group_id)
-    acc_de_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"), id=test_acc_group_id)
-
-    backup_de_group = Group(display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-
-    client.groups.list.return_value = [ws_de_group]
-    client.api_client.do.side_effect = [
-        {
-            "Resources": [g.as_dict() for g in [acc_de_group]],
-        },
-        {},
-    ]
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    manager = GroupManager(client, group_conf)
-
-    state = GroupMigrationState()
-    state.add(ws_group=ws_de_group, acc_group=acc_de_group, backup_group=backup_de_group)
-    manager.replace_workspace_groups_with_account_groups(state)
-
-    client.groups.delete.assert_called_with(id=test_ws_group_id)
-    client.api_client.do.assert_called_with(
-        "PUT",
-        f"/api/2.0/preview/permissionassignments/principals/{test_acc_group_id}",
-        data='{"permissions": ["USER"]}',
-    )
-
-
-def test_system_groups():
-    client = Mock()
-    test_ws_group = Group(display_name="admins", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    test_acc_group = Group(display_name="admins", meta=ResourceMeta(resource_type="Group"))
-    backup_group_id = "100"
-    client.groups.list.return_value = [test_ws_group]
-    client.groups.create.return_value = Group(
-        display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"), id=backup_group_id
-    )
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [test_acc_group]],
-    }
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", selected=["admins"])
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-    assert len(manager._migration_state.groups) == 0
-
-
-def test_workspace_only_groups():
-    client = Mock()
-    test_ws_group = Group(display_name="ws_group", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    test_acc_group = Group(display_name="acc_group", meta=ResourceMeta(resource_type="Group"))
-    backup_group_id = "100"
-    client.groups.list.return_value = [test_ws_group, test_acc_group]
-    client.groups.create.return_value = Group(
-        display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"), id=backup_group_id
-    )
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [test_acc_group]],
-    }
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", selected=["ws_group"])
-    manager = GroupManager(client, group_conf)
-    manager.prepare_groups_in_environment()
-    assert len(manager._migration_state.groups) == 0
-
-
-def test_delete_backup_groups():
-    client = Mock()
-
-    backup_group_id = "100"
-    ws_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    test_ws_backup_group = Group(
-        display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"), id=backup_group_id
-    )
-
-    client.groups.list.return_value = [ws_group, test_ws_backup_group]
-
-    test_acc_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [test_acc_group]],
-    }
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    manager = GroupManager(client, group_conf)
-    manager.delete_original_workspace_groups()
-    client.groups.delete.assert_called_with(id=backup_group_id)
-
-
-def test_delete_selected_backup_groups():
-    client = Mock()
-
-    backup_group_id = "100"
-    ws_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    test_ws_backup_group = Group(
-        display_name="dbr_backup_de", meta=ResourceMeta(resource_type="WorkspaceGroup"), id=backup_group_id
-    )
-
-    ws_group_to_skip = Group(display_name="de2", meta=ResourceMeta(resource_type="Group"))
-    test_ws_backup_group_to_skip = Group(
-        display_name="dbr_backup_de2", meta=ResourceMeta(resource_type="WorkspaceGroup"), id="1"
-    )
-
-    client.groups.list.return_value = [ws_group, test_ws_backup_group, ws_group_to_skip, test_ws_backup_group_to_skip]
-
-    test_acc_group = Group(display_name="de", meta=ResourceMeta(resource_type="Group"))
-    test_acc_group_to_skip = Group(display_name="de2", meta=ResourceMeta(resource_type="Group"))
-    client.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [test_acc_group, test_acc_group_to_skip]],
-    }
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", selected=["de"])
-    manager = GroupManager(client, group_conf)
-    manager.delete_original_workspace_groups()
-    client.groups.delete.assert_called_with(id=backup_group_id)
-
-
-def test_migration_state_should_be_saved_with_proper_values():
-    workspace = Group(
-        display_name="workspace", entitlements=[ComplexValue(display="entitlements", value="allow-cluster-create")]
-    )
-    backup = Group(display_name="db-temp-workspace", meta=ResourceMeta("test"))
-    account = Group(display_name="account")
-    schema = "test_schema"
-
-    state = GroupMigrationState()
-    state.add(workspace, backup, account)
+def test_snapshot_with_group_created_in_account_console_should_be_considered():
     backend = MockBackend()
-
-    state.persist_migration_state(backend, schema)
-    rows = backend.rows_written_for(f"hive_metastore.{schema}.migration_state", "append")
-    assert rows == [
-        MigrationGroupInfoMock(
-            workspace='{"displayName": "workspace", "entitlements": ['
-            '{"display": "entitlements", "value": "allow-cluster-create"}'
-            ']}',
-            backup='{"displayName": "db-temp-workspace", "meta": {"resourceType": "test"}}',
-            account='{"displayName": "account"}',
+    wsclient = MagicMock()
+    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
+                  members=[ComplexValue(display='test-user-1', value='20'),
+                           ComplexValue(display='test-user-2', value='21')],
+                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
+                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
+                  entitlements=[ComplexValue(value='allow-cluster-create'),
+                                ComplexValue(value='allow-instance-pool-create')])
+    wsclient.groups.list.return_value = [
+        group
+    ]
+    account_admins_group = Group(id="1234", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
+    assert res == [
+        MigratedGroup(
+            id_in_workspace="1",
+            name_in_workspace="de",
+            name_in_account="de",
+            temporary_name="ucx-renamed-de",
+            members='[{"display": "test-user-1", "value": "20"}, {"display": "test-user-2", "value": "21"}]',
+            external_id=None,
+            roles='[{"value": "arn:aws:iam::123456789098:instance-profile/ip1"}, {"value": "arn:aws:iam::123456789098:instance-profile/ip2"}]',
+            entitlements='[{"value": "allow-cluster-create"}, {"value": "allow-instance-pool-create"}]',
         )
     ]
 
 
-def test_migration_state_should_be_saved_without_schema():
-    account = Group(display_name="account", schemas=[iam.GroupSchema.URN_IETF_PARAMS_SCIM_SCHEMAS_CORE_2_0_GROUP])
-    schema = "test_schema"
-
-    state = GroupMigrationState()
-    state.add(None, None, account)
+def test_snapshot_with_group_not_created_in_account_console_should_be_filtered():
     backend = MockBackend()
-
-    state.persist_migration_state(backend, schema)
-    rows = backend.rows_written_for(f"hive_metastore.{schema}.migration_state", "append")
-    assert rows == [MigrationGroupInfoMock(workspace=None, backup=None, account='{"displayName": "account"}')]
-
-
-def test_migration_state_should_not_filter_any_rows():
-    schema = "test_schema"
-    workspace = Group("workspace")
-    backup = Group("db-temp-workspace")
-    account = Group("workspace")
-
-    state = GroupMigrationState()
-    state.add(workspace, backup, account)
-    state.add(workspace, backup, None)
-    state.add(workspace, None, account)
-    state.add(None, None, account)
-    state.add(None, None, None)
-
-    backend = MockBackend()
-    state.persist_migration_state(backend, schema)
-    rows = backend.rows_written_for(f"hive_metastore.{schema}.migration_state", "append")
-
-    assert len(rows) == 5
-
-
-def test_fetch_migration_state_should_return_all():
-    schema = "test_schema"
-
-    rows = {
-        "SELECT": [
-            (
-                '{"displayName": "workspace", "entitlements": ['
-                '{"display": "entitlements", "value": "allow-cluster-create"}'
-                ']}',
-                '{"displayName": "db-temp-workspace", "meta": {"resourceType": "test"}}',
-                '{"displayName": "account"}',
-            ),
-        ]
+    wsclient = MagicMock()
+    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
+                  members=[ComplexValue(display='test-user-1', value='20'),
+                           ComplexValue(display='test-user-2', value='21')],
+                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
+                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
+                  entitlements=[ComplexValue(value='allow-cluster-create'),
+                                ComplexValue(value='allow-instance-pool-create')])
+    wsclient.groups.list.return_value = [
+        group
+    ]
+    account_admins_group = Group(id="1234", display_name="ds")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group]],
     }
+    res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
+    assert res == []
 
-    backend = MockBackend(rows=rows)
-    rows = GroupMigrationState().fetch_migration_state(backend, schema)
 
-    state = GroupMigrationState()
-    state.add(
-        ws_group=Group(
-            display_name="workspace", entitlements=[ComplexValue(display="entitlements", value="allow-cluster-create")]
+def test_snapshot_with_group_already_migrated_should_be_filtered():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"),
+                  members=[ComplexValue(display='test-user-1', value='20'),
+                           ComplexValue(display='test-user-2', value='21')],
+                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
+                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
+                  entitlements=[ComplexValue(value='allow-cluster-create'),
+                                ComplexValue(value='allow-instance-pool-create')])
+    wsclient.groups.list.return_value = [
+        group
+    ]
+    account_admins_group = Group(id="1234", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
+    assert res == []
+
+
+def test_snapshot_should_filter_account_system_groups():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"),
+                  members=[ComplexValue(display='test-user-1', value='20'),
+                           ComplexValue(display='test-user-2', value='21')],
+                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
+                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
+                  entitlements=[ComplexValue(value='allow-cluster-create'),
+                                ComplexValue(value='allow-instance-pool-create')])
+    wsclient.groups.list.return_value = [
+        group
+    ]
+    account_admins_group = Group(id="1234", display_name="account users")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
+    assert res == []
+
+
+def test_snapshot_should_filter_workspace_system_groups():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group = Group(id="1", display_name="admins", meta=ResourceMeta(resource_type="WorkspaceGroup"),
+                  members=[ComplexValue(display='test-user-1', value='20'),
+                           ComplexValue(display='test-user-2', value='21')],
+                  roles=[ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip1'),
+                         ComplexValue(value='arn:aws:iam::123456789098:instance-profile/ip2')],
+                  entitlements=[ComplexValue(value='allow-cluster-create'),
+                                ComplexValue(value='allow-instance-pool-create')])
+    wsclient.groups.list.return_value = [
+        group
+    ]
+    account_admins_group = Group(id="1234", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv").snapshot()
+    assert res == []
+
+
+def test_snapshot_should_consider_groups_defined_in_conf():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [
+        group1,
+        group2
+    ]
+    account_admins_group_1 = Group(id="11", display_name="de")
+    account_admins_group_2 = Group(id="12", display_name="ds")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group_1, account_admins_group_2]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv", include_group_names=["de"]).snapshot()
+    assert res == [
+        MigratedGroup(
+            id_in_workspace="1",
+            name_in_workspace="de",
+            name_in_account="de",
+            temporary_name="ucx-renamed-de",
+            members=None,
+            external_id=None,
+            roles=None,
+            entitlements=None,
+        )
+    ]
+
+
+def test_snapshot_should_rename_groups_defined_in_conf():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [
+        group1,
+        group2
+    ]
+    account_admins_group_1 = Group(id="11", display_name="de")
+    account_admins_group_2 = Group(id="12", display_name="ds")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group_1, account_admins_group_2]],
+    }
+    res = GroupManager(backend, wsclient, inventory_database="inv", renamed_group_prefix="test-group-").snapshot()
+    assert res == [
+        MigratedGroup(
+            id_in_workspace="1",
+            name_in_workspace="de",
+            name_in_account="de",
+            temporary_name="test-group-de",
+            members=None,
+            external_id=None,
+            roles=None,
+            entitlements=None,
         ),
-        backup_group=Group(display_name="db-temp-workspace", meta=ResourceMeta(resource_type="test")),
-        acc_group=Group(display_name="account"),
+        MigratedGroup(
+            id_in_workspace="2",
+            name_in_workspace="ds",
+            name_in_account="ds",
+            temporary_name="test-group-ds",
+            members=None,
+            external_id=None,
+            roles=None,
+            entitlements=None,
+        )
+    ]
+
+
+def test_rename_groups_should_patch_eligible_groups():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [
+        group1,
+    ]
+    account_admins_group_1 = Group(id="11", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_admins_group_1]],
+    }
+    GroupManager(backend, wsclient, inventory_database="inv", renamed_group_prefix="test-group-").rename_groups()
+    wsclient.groups.patch.assert_called_with(
+        "1",
+        operations=[iam.Patch(iam.PatchOp.REPLACE, "displayName", "test-group-de")],
     )
 
-    assert rows.groups == state.groups
+
+def test_rename_groups_should_filter_account_groups_in_workspace():
+    backend = MockBackend()
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="Group"))
+    wsclient.groups.list.return_value = [group1]
+    account_group1 = Group(id="11", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_group1]],
+    }
+    GroupManager(backend, wsclient, inventory_database="inv").rename_groups()
+    wsclient.groups.patch.assert_not_called()
 
 
-def test_fetch_all():
-    ws = MagicMock()
+def test_rename_groups_should_filter_already_renamed_groups():
+    backend = MockBackend(rows={
+        "SELECT": [
+            ("1", "de", "de", "test-group-de", "", "", "", "")
+        ]
+    })
+    wsclient = MagicMock()
+    group1 = Group(id="1", display_name="test-group-de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [group1]
 
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    workspace = Group(display_name="data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup = Group(display_name="dbr_backup_data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account = Group(display_name="data_engs", meta=ResourceMeta(resource_type="Group"))
-    remote_state = GroupMigrationState()
-    remote_state.add(workspace, backup, account)
+    GroupManager(backend, wsclient, inventory_database="inv", renamed_group_prefix="test-group-").rename_groups()
+    wsclient.groups.patch.assert_not_called()
 
-    ws.groups.list.return_value = [backup, account]
-    ws.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account]],
+
+def test_reflect_account_groups_on_workspace_should_be_called_for_eligible_groups():
+    backend = MockBackend(rows={
+        "SELECT": [
+            ("1", "de", "de", "test-group-de", "", "", "", "")
+        ]
+    })
+    wsclient = MagicMock()
+    account_group = Group(id="1", display_name="de")
+    wsclient.api_client.do.return_value = {
+        "Resources": [g.as_dict() for g in [account_group]],
     }
 
-    manager = GroupManager(ws, group_conf)
-    new_state = manager.prepare_apply_permissions_to_account_groups(ws, remote_state, group_conf.backup_group_prefix)
+    group1 = Group(id="1", display_name="test-dfd-de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
+    wsclient.groups.list.return_value = [group1]
 
-    assert len(new_state) == 1
+    (GroupManager(backend, wsclient, inventory_database="inv")
+     .reflect_account_groups_on_workspace())
 
-
-def test_group_present_in_state_but_not_in_workspace():
-    ws = MagicMock()
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    workspace = Group(display_name="data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup = Group(display_name="dbr_backup_data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account = Group(display_name="data_engs", meta=ResourceMeta(resource_type="Group"))
-    remote_state = GroupMigrationState()
-    remote_state.add(workspace, backup, account)
-
-    ws.groups.list.return_value = [backup]
-    ws.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account]],
-    }
-
-    manager = GroupManager(ws, group_conf)
-    new_state = manager.prepare_apply_permissions_to_account_groups(ws, remote_state, group_conf.backup_group_prefix)
-
-    assert len(new_state) == 0
+    wsclient.api_client.do.assert_called_with('PUT', '/api/2.0/preview/permissionassignments/principals/1', data='{"permissions": ["USER"]}')
 
 
-def test_group_not_synced_in_workspace_properly():
-    ws = MagicMock()
 
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    workspace = Group(display_name="data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup = Group(display_name="dbr_backup_data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account = Group(display_name="data_engs", meta=ResourceMeta(resource_type="Group"))
-
-    workspace_ds = Group(display_name="data_science", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup_ds = Group(display_name="dbr_backup_data_science", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account_ds = Group(display_name="data_science", meta=ResourceMeta(resource_type="Group"))
-
-    remote_state = GroupMigrationState()
-    remote_state.add(workspace, backup, account)
-    remote_state.add(workspace_ds, backup_ds, account_ds)
-
-    ws.groups.list.return_value = [backup_ds, account_ds]
-    ws.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account, account_ds]],
-    }
-
-    manager = GroupManager(ws, group_conf)
-    new_state = manager.prepare_apply_permissions_to_account_groups(ws, remote_state, group_conf.backup_group_prefix)
-
-    assert new_state.groups[0].workspace.display_name == "data_science"
-
-
-def test_group_not_present_in_remote_state():
-    ws = MagicMock()
-
-    group_conf = GroupsConfig(backup_group_prefix="dbr_backup_", auto=True)
-    backup = Group(display_name="dbr_backup_data_engs", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account = Group(display_name="data_engs", meta=ResourceMeta(resource_type="Group"))
-
-    workspace_ds = Group(display_name="data_science", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    backup_ds = Group(display_name="dbr_backup_data_science", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    account_ds = Group(display_name="data_science", meta=ResourceMeta(resource_type="Group"))
-
-    remote_state = GroupMigrationState()
-    remote_state.add(workspace_ds, backup_ds, account_ds)
-
-    ws.groups.list.return_value = [backup, account, backup_ds, account_ds]
-    ws.api_client.do.return_value = {
-        "Resources": [g.as_dict() for g in [account, account_ds]],
-    }
-
-    manager = GroupManager(ws, group_conf)
-    new_state = manager.prepare_apply_permissions_to_account_groups(ws, remote_state, group_conf.backup_group_prefix)
-
-    assert len(new_state) == 1

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -35,7 +35,8 @@ def test_snapshot_with_group_created_in_account_console_should_be_considered():
             temporary_name="ucx-renamed-de",
             members='[{"display": "test-user-1", "value": "20"}, {"display": "test-user-2", "value": "21"}]',
             external_id="1234",
-            roles='[{"value": "arn:aws:iam::123456789098:instance-profile/ip1"}, {"value": "arn:aws:iam::123456789098:instance-profile/ip2"}]',
+            roles='[{"value": "arn:aws:iam::123456789098:instance-profile/ip1"}, '
+            '{"value": "arn:aws:iam::123456789098:instance-profile/ip2"}]',
             entitlements='[{"value": "allow-cluster-create"}, {"value": "allow-instance-pool-create"}]',
         )
     ]

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -3,10 +3,7 @@ from unittest.mock import MagicMock
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta
 
-from databricks.labs.ucx.workspace_access.groups import (
-    GroupManager,
-    MigratedGroup,
-)
+from databricks.labs.ucx.workspace_access.groups import GroupManager, MigratedGroup
 from tests.unit.framework.mocks import MockBackend
 
 
@@ -37,7 +34,7 @@ def test_snapshot_with_group_created_in_account_console_should_be_considered():
             name_in_account="de",
             temporary_name="ucx-renamed-de",
             members='[{"display": "test-user-1", "value": "20"}, {"display": "test-user-2", "value": "21"}]',
-            external_id='1234',
+            external_id="1234",
             roles='[{"value": "arn:aws:iam::123456789098:instance-profile/ip1"}, {"value": "arn:aws:iam::123456789098:instance-profile/ip2"}]',
             entitlements='[{"value": "allow-cluster-create"}, {"value": "allow-instance-pool-create"}]',
         )
@@ -155,7 +152,7 @@ def test_snapshot_should_consider_groups_defined_in_conf():
             name_in_account="de",
             temporary_name="ucx-renamed-de",
             members=None,
-            external_id='11',
+            external_id="11",
             roles=None,
             entitlements=None,
         )
@@ -181,7 +178,7 @@ def test_snapshot_should_rename_groups_defined_in_conf():
             name_in_account="de",
             temporary_name="test-group-de",
             members=None,
-            external_id='11',
+            external_id="11",
             roles=None,
             entitlements=None,
         ),

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -6,14 +6,9 @@ from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group, ResourceMeta
 
 from databricks.labs.ucx.mixins.sql import Row
-<<<<<<< HEAD
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
-=======
 from databricks.labs.ucx.workspace_access.groups import (
-    MigrationGroupInfo,
-    MigrationState,
+    MigrationState, MigratedGroup,
 )
->>>>>>> 0f2c0a5 ((WIP) rewritten group manager to rename groups instead of creating backups)
 from databricks.labs.ucx.workspace_access.manager import PermissionManager, Permissions
 
 from ..framework.mocks import MockBackend
@@ -164,14 +159,18 @@ def test_manager_apply(mocker):
     )
 
     pm = PermissionManager(b, "test_database", [mock_applier])
-    group_migration_state: MigrationState = MagicMock()
-    group_migration_state.groups = [
-        MigrationGroupInfo(
-            Group(display_name="group", meta=ResourceMeta(resource_type="WorkspaceGroup")),
-            Group(display_name="group_backup", meta=ResourceMeta(resource_type="WorkspaceGroup")),
-            Group(display_name="group", meta=ResourceMeta(resource_type="AccountGroup")),
+    group_migration_state = MigrationState([
+        MigratedGroup(
+            id_in_workspace=None,
+            name_in_workspace="group",
+            name_in_account="group",
+            temporary_name="group_backup",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None
         )
-    ]
+    ])
 
     pm.apply_group_permissions(group_migration_state, "backup")
 

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -6,7 +6,14 @@ from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group, ResourceMeta
 
 from databricks.labs.ucx.mixins.sql import Row
+<<<<<<< HEAD
 from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+=======
+from databricks.labs.ucx.workspace_access.groups import (
+    MigrationGroupInfo,
+    MigrationState,
+)
+>>>>>>> 0f2c0a5 ((WIP) rewritten group manager to rename groups instead of creating backups)
 from databricks.labs.ucx.workspace_access.manager import PermissionManager, Permissions
 
 from ..framework.mocks import MockBackend
@@ -157,12 +164,14 @@ def test_manager_apply(mocker):
     )
 
     pm = PermissionManager(b, "test_database", [mock_applier])
-    group_migration_state = GroupMigrationState()
-    group_migration_state.add(
-        Group(display_name="group", meta=ResourceMeta(resource_type="WorkspaceGroup")),
-        Group(display_name="group_backup", meta=ResourceMeta(resource_type="WorkspaceGroup")),
-        Group(display_name="group", meta=ResourceMeta(resource_type="Group")),
-    )
+    group_migration_state: MigrationState = MagicMock()
+    group_migration_state.groups = [
+        MigrationGroupInfo(
+            Group(display_name="group", meta=ResourceMeta(resource_type="WorkspaceGroup")),
+            Group(display_name="group_backup", meta=ResourceMeta(resource_type="WorkspaceGroup")),
+            Group(display_name="group", meta=ResourceMeta(resource_type="AccountGroup")),
+        )
+    ]
 
     pm.apply_group_permissions(group_migration_state, "backup")
 

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -3,12 +3,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from databricks.sdk.service import iam
-from databricks.sdk.service.iam import Group, ResourceMeta
 
 from databricks.labs.ucx.mixins.sql import Row
-from databricks.labs.ucx.workspace_access.groups import (
-    MigrationState, MigratedGroup,
-)
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.manager import PermissionManager, Permissions
 
 from ..framework.mocks import MockBackend
@@ -159,18 +156,20 @@ def test_manager_apply(mocker):
     )
 
     pm = PermissionManager(b, "test_database", [mock_applier])
-    group_migration_state = MigrationState([
-        MigratedGroup(
-            id_in_workspace=None,
-            name_in_workspace="group",
-            name_in_account="group",
-            temporary_name="group_backup",
-            members=None,
-            entitlements=None,
-            external_id=None,
-            roles=None
-        )
-    ])
+    group_migration_state = MigrationState(
+        [
+            MigratedGroup(
+                id_in_workspace=None,
+                name_in_workspace="group",
+                name_in_account="group",
+                temporary_name="group_backup",
+                members=None,
+                entitlements=None,
+                external_id=None,
+                roles=None,
+            )
+        ]
+    )
 
     pm.apply_group_permissions(group_migration_state, "backup")
 

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -151,9 +151,7 @@ def test_manager_apply(mocker):
     mock_applier = mocker.Mock()
     mock_applier.object_types = lambda: {"clusters", "cluster-policies"}
     # this emulates a real applier and call to an API
-    mock_applier.get_apply_task = lambda item, _, dst: lambda: applied_items.add(
-        f"{item.object_id} {item.object_id} {dst}"
-    )
+    mock_applier.get_apply_task = lambda item, _: lambda: applied_items.add(f"{item.object_id} {item.object_id}")
 
     pm = PermissionManager(b, "test_database", [mock_applier])
     group_migration_state = MigrationState(
@@ -171,9 +169,9 @@ def test_manager_apply(mocker):
         ]
     )
 
-    pm.apply_group_permissions(group_migration_state, "backup")
+    pm.apply_group_permissions(group_migration_state)
 
-    assert {"test2 test2 backup", "test test backup"} == applied_items
+    assert {"test2 test2", "test test"} == applied_items
 
 
 def test_unregistered_support():
@@ -185,7 +183,7 @@ def test_unregistered_support():
         }
     )
     pm = PermissionManager(b, "test", [])
-    pm.apply_group_permissions(migration_state=MagicMock(), destination="backup")
+    pm.apply_group_permissions(migration_state=MagicMock())
 
 
 def test_factory(mocker):

--- a/tests/unit/workspace_access/test_redash.py
+++ b/tests/unit/workspace_access/test_redash.py
@@ -99,7 +99,7 @@ def test_apply(migration_state):
             ).as_dict()
         ),
     )
-    task = sup.get_apply_task(item, migration_state, "backup")
+    task = sup.get_apply_task(item, migration_state)
     task()
     assert ws.dbsql_permissions.set.call_count == 1
     expected_payload = [

--- a/tests/unit/workspace_access/test_redash.py
+++ b/tests/unit/workspace_access/test_redash.py
@@ -69,7 +69,7 @@ def test_apply(migration_state):
         object_id="test",
         access_control_list=[
             sql.AccessControl(
-                group_name="db-temp-test",
+                group_name="test",
                 permission_level=sql.PermissionLevel.CAN_MANAGE,
             ),
             sql.AccessControl(
@@ -104,7 +104,7 @@ def test_apply(migration_state):
     assert ws.dbsql_permissions.set.call_count == 1
     expected_payload = [
         sql.AccessControl(
-            group_name="db-temp-test",
+            group_name="test",
             permission_level=sql.PermissionLevel.CAN_MANAGE,
         ),
         sql.AccessControl(

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -1,12 +1,15 @@
 from datetime import timedelta
+from typing import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import iam
-from databricks.sdk.service.iam import Group
+from databricks.sdk.service.iam import Group, PatchOp, PatchSchema
 
+from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.generic import RetryableError
+from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
 
 
@@ -120,3 +123,63 @@ def test_safe_get_group_when_error_retriable():
     with pytest.raises(RetryableError) as e:
         sup._safe_get_group(group_id="1")
     assert error_code in str(e)
+
+
+def test_get_crawler_task_with_roles_and_entitlements_should_be_crawled():
+    ws = MagicMock()
+    ws.groups.list.return_value = [Group(id="1", display_name="de", roles=[iam.ComplexValue(value="role1"), iam.ComplexValue(value="role2")], entitlements=[iam.ComplexValue(value="forbidden-cluster-create")])]
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+
+    result = list(sup.get_crawler_tasks())
+    assert len(result) == 2
+    assert result[0]() == Permissions(object_id='1', object_type='roles', raw='[{"value": "role1"}, {"value": "role2"}]')
+    assert result[1]() == Permissions(object_id='1', object_type='entitlements', raw='[{"value": "forbidden-cluster-create"}]')
+
+
+def test_groups_without_roles_and_entitlements_should_be_ignored():
+    ws = MagicMock()
+    ws.groups.list.return_value = [Group(id="1", display_name="de")]
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+
+    result = list(sup.get_crawler_tasks())
+    assert len(result) == 0
+
+
+def test_get_apply_task_should_call_patch_on_group_external_id():
+    ws = MagicMock()
+    ws.groups.get.return_value = Group(id="1", display_name="de", entitlements=[iam.ComplexValue(value="forbidden-cluster-create")])
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+
+    item = Permissions(object_id='1', object_type='entitlements', raw='[{"value": "forbidden-cluster-create"}]')
+    mggrp = MigratedGroup(
+        id_in_workspace="1",
+        name_in_workspace="de",
+        name_in_account="de",
+        temporary_name="ucx-temp-de",
+        external_id="12",
+    )
+    appliers = sup.get_apply_task(item, MigrationState([mggrp]))
+    appliers()
+
+    ws.groups.patch.assert_called_once_with(id="12",operations=[iam.Patch(op=PatchOp.ADD,path='entitlements',value=[{'value': 'forbidden-cluster-create'}])],schemas=[PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP])
+
+
+def test_get_apply_task_should_ignore_groups_not_in_migration_state():
+    ws = MagicMock()
+    ws.groups.get.return_value = Group(id="1", display_name="de", entitlements=[iam.ComplexValue(value="forbidden-cluster-create")])
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+
+    item = Permissions(object_id='1', object_type='entitlements', raw='[{"value": "forbidden-cluster-create"}]')
+    mggrp = MigratedGroup(
+        id_in_workspace="2",
+        name_in_workspace="de",
+        name_in_account="de",
+        temporary_name="ucx-temp-de",
+        external_id="12",
+    )
+    assert sup.get_apply_task(item, MigrationState([mggrp])) is None
+
+
+
+
+

--- a/tests/unit/workspace_access/test_secrets.py
+++ b/tests/unit/workspace_access/test_secrets.py
@@ -71,7 +71,7 @@ def test_secret_scopes_apply(migration_state: MigrationState):
         ),
     ]
 
-    task = sup.get_apply_task(item, migration_state, "backup")
+    task = sup.get_apply_task(item, migration_state)
     task()
     assert ws.secrets.put_acl.call_count == 2
 

--- a/tests/unit/workspace_access/test_secrets.py
+++ b/tests/unit/workspace_access/test_secrets.py
@@ -62,7 +62,7 @@ def test_secret_scopes_apply(migration_state: MigrationState):
     # positive case - permissions are applied correctly
     ws.secrets.list_acls.return_value = [
         workspace.AclItem(
-            principal="db-temp-test",
+            principal="test",
             permission=workspace.AclPermission.MANAGE,
         ),
         workspace.AclItem(
@@ -76,7 +76,7 @@ def test_secret_scopes_apply(migration_state: MigrationState):
     assert ws.secrets.put_acl.call_count == 2
 
     calls = [
-        call("test", "db-temp-test", workspace.AclPermission.MANAGE),
+        call("test", "test", workspace.AclPermission.MANAGE),
         call("test", "irrelevant", workspace.AclPermission.MANAGE),
     ]
     ws.secrets.put_acl.assert_has_calls(calls, any_order=False)

--- a/tests/unit/workspace_access/test_secrets.py
+++ b/tests/unit/workspace_access/test_secrets.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call
 import pytest
 from databricks.sdk.service import workspace
 
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 from databricks.labs.ucx.workspace_access.secrets import (
     Permissions,
     SecretScopesSupport,
@@ -39,7 +39,7 @@ def test_secret_scopes_crawler():
     assert item.raw == '[{"permission": "MANAGE", "principal": "test"}]'
 
 
-def test_secret_scopes_apply(migration_state: GroupMigrationState):
+def test_secret_scopes_apply(migration_state: MigrationState):
     ws = MagicMock()
     sup = SecretScopesSupport(ws=ws)
     item = Permissions(

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -5,7 +5,7 @@ from databricks.sdk.service.iam import Group
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.base import Permissions
-from databricks.labs.ucx.workspace_access.groups import MigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 from ..framework.mocks import MockBackend
@@ -216,14 +216,13 @@ def test_tacl_applier(mocker):
             }
         ),
     )
-    migration_state = MigrationState()
-    migration_state.add(
-        Group(display_name="abc"), Group(display_name="tmp-backup-abc"), Group(display_name="account-abc")
-    )
+    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
+                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None, roles=None)]
+    migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     task()
 
-    assert ["GRANT SELECT ON TABLE catalog_a.database_b.table_c TO `tmp-backup-abc`"] == sql_backend.queries
+    assert ["GRANT SELECT ON TABLE catalog_a.database_b.table_c TO `account-abc`"] == sql_backend.queries
 
 
 def test_tacl_applier_multiple_actions(mocker):
@@ -243,14 +242,14 @@ def test_tacl_applier_multiple_actions(mocker):
             }
         ),
     )
-    migration_state = GroupMigrationState()
-    migration_state.add(
-        Group(display_name="abc"), Group(display_name="tmp-backup-abc"), Group(display_name="account-abc")
-    )
+    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
+                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None,
+                         roles=None)]
+    migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     task()
 
-    assert ["GRANT SELECT, MODIFY ON TABLE catalog_a.database_b.table_c TO `tmp-backup-abc`"] == sql_backend.queries
+    assert ["GRANT SELECT, MODIFY ON TABLE catalog_a.database_b.table_c TO `account-abc`"] == sql_backend.queries
 
 
 def test_tacl_applier_no_target_principal(mocker):
@@ -270,10 +269,10 @@ def test_tacl_applier_no_target_principal(mocker):
             }
         ),
     )
-    migration_state = MigrationState()
-    migration_state.add(
-        Group(display_name="abc"), Group(display_name="tmp-backup-abc"), Group(display_name="account-abc")
-    )
+    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
+                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None,
+                         roles=None)]
+    migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     assert task is None
 

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -5,7 +5,7 @@ from databricks.sdk.service.iam import Group
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.base import Permissions
-from databricks.labs.ucx.workspace_access.groups import GroupMigrationState
+from databricks.labs.ucx.workspace_access.groups import MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 from ..framework.mocks import MockBackend
@@ -216,7 +216,7 @@ def test_tacl_applier(mocker):
             }
         ),
     )
-    migration_state = GroupMigrationState()
+    migration_state = MigrationState()
     migration_state.add(
         Group(display_name="abc"), Group(display_name="tmp-backup-abc"), Group(display_name="account-abc")
     )
@@ -270,7 +270,7 @@ def test_tacl_applier_no_target_principal(mocker):
             }
         ),
     )
-    migration_state = GroupMigrationState()
+    migration_state = MigrationState()
     migration_state.add(
         Group(display_name="abc"), Group(display_name="tmp-backup-abc"), Group(display_name="account-abc")
     )

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -227,7 +227,7 @@ def test_tacl_applier(mocker):
         )
     ]
     migration_state = MigrationState(grp)
-    task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
+    task = table_acl_support.get_apply_task(permissions, migration_state)
     task()
 
     assert ["GRANT SELECT ON TABLE catalog_a.database_b.table_c TO `account-abc`"] == sql_backend.queries
@@ -263,7 +263,7 @@ def test_tacl_applier_multiple_actions(mocker):
         )
     ]
     migration_state = MigrationState(grp)
-    task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
+    task = table_acl_support.get_apply_task(permissions, migration_state)
     task()
 
     assert ["GRANT SELECT, MODIFY ON TABLE catalog_a.database_b.table_c TO `account-abc`"] == sql_backend.queries
@@ -299,7 +299,7 @@ def test_tacl_applier_no_target_principal(mocker):
         )
     ]
     migration_state = MigrationState(grp)
-    task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
+    task = table_acl_support.get_apply_task(permissions, migration_state)
     assert task is None
 
     assert [] == sql_backend.queries

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -1,6 +1,5 @@
 import json
 
-
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.base import Permissions

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -1,11 +1,10 @@
 import json
 
-from databricks.sdk.service.iam import Group
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.base import Permissions
-from databricks.labs.ucx.workspace_access.groups import MigrationState, MigratedGroup
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 from ..framework.mocks import MockBackend
@@ -216,8 +215,18 @@ def test_tacl_applier(mocker):
             }
         ),
     )
-    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
-                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None, roles=None)]
+    grp = [
+        MigratedGroup(
+            id_in_workspace=None,
+            name_in_workspace="abc",
+            name_in_account="account-abc",
+            temporary_name="tmp-backup-abc",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None,
+        )
+    ]
     migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     task()
@@ -242,9 +251,18 @@ def test_tacl_applier_multiple_actions(mocker):
             }
         ),
     )
-    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
-                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None,
-                         roles=None)]
+    grp = [
+        MigratedGroup(
+            id_in_workspace=None,
+            name_in_workspace="abc",
+            name_in_account="account-abc",
+            temporary_name="tmp-backup-abc",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None,
+        )
+    ]
     migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     task()
@@ -269,9 +287,18 @@ def test_tacl_applier_no_target_principal(mocker):
             }
         ),
     )
-    grp = [MigratedGroup(id_in_workspace=None, name_in_workspace="abc", name_in_account="account-abc",
-                         temporary_name="tmp-backup-abc", members=None, entitlements=None, external_id=None,
-                         roles=None)]
+    grp = [
+        MigratedGroup(
+            id_in_workspace=None,
+            name_in_workspace="abc",
+            name_in_account="account-abc",
+            temporary_name="tmp-backup-abc",
+            members=None,
+            entitlements=None,
+            external_id=None,
+            roles=None,
+        )
+    ]
     migration_state = MigrationState(grp)
     task = table_acl_support.get_apply_task(permissions, migration_state, "backup")
     assert task is None


### PR DESCRIPTION
we can use patch to rename groups, so that we can simplify the local group migration step.
<img width="646" alt="image" src="https://github.com/databrickslabs/ucx/assets/259697/b0f54013-3366-4fd2-a1a4-236c7f033f6b">
<img width="325" alt="image" src="https://github.com/databrickslabs/ucx/assets/259697/3b2ea9e1-5b4c-4b34-94b4-8e25267fd5ef">

Closes #218