### PR TITLE
Fixed issue with workspace listing process on None type object_type

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -246,17 +246,15 @@ class WorkspaceListing(Listing, CrawlerBase):
 
         ws_listing = WorkspaceListing(self._ws, num_threads=self._num_threads, with_directories=False)
         for obj in ws_listing.walk(self._start_path):
-            if obj is None:
+            if obj is None or obj.object_type is None:
                 continue
-            request_type = self._convert_object_type_to_request_type(obj)
-            if request_type:
-                raw = obj.as_dict()
-                yield WorkspaceObjectInfo(
-                    object_type=raw["object_type"],
-                    object_id=str(raw["object_id"]),
-                    path=raw["path"],
-                    language=raw.get("language", None),
-                )
+            raw = obj.as_dict()
+            yield WorkspaceObjectInfo(
+                object_type=raw["object_type"],
+                object_id=str(raw["object_id"]),
+                path=raw["path"],
+                language=raw.get("language", None),
+            )
 
     def snapshot(self) -> list[WorkspaceObjectInfo]:
         return self._snapshot(self._try_fetch, self._crawl)

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -248,13 +248,15 @@ class WorkspaceListing(Listing, CrawlerBase):
         for obj in ws_listing.walk(self._start_path):
             if obj is None:
                 continue
-            raw = obj.as_dict()
-            yield WorkspaceObjectInfo(
-                object_type=raw["object_type"],
-                object_id=str(raw["object_id"]),
-                path=raw["path"],
-                language=raw.get("language", None),
-            )
+            request_type = self._convert_object_type_to_request_type(obj)
+            if request_type:
+                raw = obj.as_dict()
+                yield WorkspaceObjectInfo(
+                    object_type=raw["object_type"],
+                    object_id=str(raw["object_id"]),
+                    path=raw["path"],
+                    language=raw.get("language", None),
+                )
 
     def snapshot(self) -> list[WorkspaceObjectInfo]:
         return self._snapshot(self._try_fetch, self._crawl)

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -490,6 +490,33 @@ def test_workspaceobject_crawl():
     assert result_set[0] == WorkspaceObjectInfo("NOTEBOOK", "123", "/rootobj/notebook1", "PYTHON")
 
 
+def test_workspaceobject_withexperiment_crawl():
+    sample_objects = [
+        ObjectInfo(
+            object_type=ObjectType.NOTEBOOK,
+            path="/rootobj/notebook1",
+            language=Language.PYTHON,
+            created_at=0,
+            modified_at=0,
+            object_id=123,
+            size=0,
+        ),
+        ObjectInfo(
+            path="/rootobj/experiment1",
+            created_at=0,
+            modified_at=0,
+            object_id=456,
+        ),
+    ]
+    ws = Mock()
+    with patch("databricks.labs.ucx.workspace_access.listing.WorkspaceListing.walk", return_value=sample_objects):
+        crawler = WorkspaceListing(ws, MockBackend(), "ucx")._crawl()
+        result_set = list(crawler)
+
+    assert len(result_set) == 1
+    assert result_set[0] == WorkspaceObjectInfo("NOTEBOOK", "123", "/rootobj/notebook1", "PYTHON")
+
+
 def test_workspace_snapshot():
     sample_objects = [
         WorkspaceObjectInfo(


### PR DESCRIPTION
When running the assessment job, the tasks workspace listing, fails with the error "KeyError: 'object_type'"
the object_type property is not set for experiment objects and while listing it throws this error. Since scope of workspace listing is limited to Notebooks, Directories, Repos, Files, Libraries, suggesting a code change will will filter out cases where object_type is None.