### PR TITLE
Running apply permission task before assessment should display message

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -6,7 +6,6 @@ from itertools import groupby
 from typing import Literal
 
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import sql
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
@@ -150,12 +149,8 @@ class PermissionManager(CrawlerBase):
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
         if self._table not in [d.tableName for d in self._fetch(f"SHOW TABLES IN {self._catalog}.{self._schema}")]:
-            logger.error(
-                f"table {self._full_name} not present for fetching permission info. "
-                f"Please ensure correct table name is set or assessment step is run"
-            )
             msg = f"table {self._full_name} not found error"
-            raise DatabricksError(msg)
+            raise RuntimeError(msg)
         return [
             Permissions(object_id, object_type, raw)
             for object_id, object_type, raw in self._fetch(f"SELECT object_id, object_type, raw FROM {self._full_name}")

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -148,10 +148,10 @@ class PermissionManager(CrawlerBase):
 
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
-        if self._table not in [d.tableName for d in self._fetch(f"SHOW TABLES IN {self._catalog}.{self._schema}")]:
+        if list(self._fetch(f"SELECT COUNT(*) as cnt FROM {self._full_name}"))[0][0] == 0:
             msg = (
-                f"table {self._full_name} not present for fetching permission info. "
-                f"Please ensure correct table name is set or assessment job is run successfully"
+                f"table {self._full_name} is empty for fetching permission info. "
+                f"Please ensure assessment job is run successfully and permissions populated"
             )
             raise RuntimeError(msg)
         return [

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -149,7 +149,10 @@ class PermissionManager(CrawlerBase):
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
         if self._table not in [d.tableName for d in self._fetch(f"SHOW TABLES IN {self._catalog}.{self._schema}")]:
-            msg = f"table {self._full_name} not found error"
+            msg = (
+                f"table {self._full_name} not present for fetching permission info. "
+                f"Please ensure correct table name is set or assessment job is run successfully"
+            )
             raise RuntimeError(msg)
         return [
             Permissions(object_id, object_type, raw)

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -148,7 +148,7 @@ class PermissionManager(CrawlerBase):
 
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
-        if list(self._fetch(f"SELECT COUNT(*) as cnt FROM {self._full_name}"))[0][0] == 0:
+        if next(iter(self._fetch(f"SELECT COUNT(*) as cnt FROM {self._full_name}")))[0] == 0:
             msg = (
                 f"table {self._full_name} is empty for fetching permission info. "
                 f"Please ensure assessment job is run successfully and permissions populated"

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -148,7 +148,7 @@ class PermissionManager(CrawlerBase):
 
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
-        if next(iter(self._fetch(f"SELECT COUNT(*) as cnt FROM {self._full_name}")))[0] == 0:
+        if list(self._fetch(f"SELECT COUNT(*) as cnt FROM {self._full_name}"))[0][0] == 0:  # noqa: RUF015
             msg = (
                 f"table {self._full_name} is empty for fetching permission info. "
                 f"Please ensure assessment job is run successfully and permissions populated"

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -6,6 +6,7 @@ from itertools import groupby
 from typing import Literal
 
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import sql
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
@@ -148,6 +149,13 @@ class PermissionManager(CrawlerBase):
 
     def load_all(self) -> list[Permissions]:
         logger.info(f"Loading inventory table {self._full_name}")
+        if self._table not in [d.tableName for d in self._fetch(f"SHOW TABLES IN {self._catalog}.{self._schema}")]:
+            logger.error(
+                f"table {self._full_name} not present for fetching permission info. "
+                f"Please ensure correct table name is set or assessment step is run"
+            )
+            msg = f"table {self._full_name} not found error"
+            raise DatabricksError(msg)
         return [
             Permissions(object_id, object_type, raw)
             for object_id, object_type, raw in self._fetch(f"SELECT object_id, object_type, raw FROM {self._full_name}")

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -54,16 +54,13 @@ def make_row(data, columns):
 
 
 def test_load_all():
-    data_cols = ["database", "tableName", "isTemporary"]
     b = MockBackend(
         rows={
-            "SELECT": [
+            "SELECT object_id": [
                 permissions_row("object1", "clusters", "test acl"),
             ],
-            "SHOW.*": [
-                make_row(("test_database", "azure_service_principals", "false"), data_cols),
-                make_row(("test_database", "global_init_scripts", "false"), data_cols),
-                make_row(("test_database", "permissions", "false"), data_cols),
+            "SELECT COUNT": [
+                make_row([12], ["cnt"]),
             ],
         }
     )
@@ -73,17 +70,14 @@ def test_load_all():
     assert output[0] == Permissions("object1", "clusters", "test acl")
 
 
-def test_load_all_no_table_present():
-    data_cols = ["database", "tableName", "isTemporary"]
+def test_load_all_no_rows_present():
     b = MockBackend(
         rows={
-            "SELECT": [
+            "SELECT object_id": [
                 permissions_row("object1", "clusters", "test acl"),
             ],
-            "SHOW.*": [
-                make_row(("test_database", "azure_service_principals", "false"), data_cols),
-                make_row(("test_database", "global_init_scripts", "false"), data_cols),
-                make_row(("test_database", "jobs", "false"), data_cols),
+            "SELECT COUNT": [
+                make_row([0], ["cnt"]),
             ],
         }
     )
@@ -107,10 +101,9 @@ def test_manager_inventorize(b, mocker):
 
 
 def test_manager_apply(mocker):
-    data_cols = ["database", "tableName", "isTemporary"]
     b = MockBackend(
         rows={
-            "SELECT": [
+            "SELECT object_id": [
                 permissions_row(
                     "test",
                     "clusters",
@@ -148,10 +141,8 @@ def test_manager_apply(mocker):
                     ),
                 ),
             ],
-            "SHOW.*": [
-                make_row(("test_database", "azure_service_principals", "false"), data_cols),
-                make_row(("test_database", "global_init_scripts", "false"), data_cols),
-                make_row(("test_database", "permissions", "false"), data_cols),
+            "SELECT COUNT": [
+                make_row([12], ["cnt"]),
             ],
         }
     )

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group, ResourceMeta
 
@@ -91,7 +90,7 @@ def test_load_all_no_table_present():
 
     pi = PermissionManager(b, "test_database", [])
 
-    with pytest.raises(DatabricksError):
+    with pytest.raises(RuntimeError):
         pi.load_all()
 
 


### PR DESCRIPTION
If the apply permission task is run before the assessment task, it crashes. This PR checks if the permissions table (which is required for the apply group permission) is present if not raise a Databricks error exception