### PR TITLE
Execute Table ACL Grants serially to mitigate platform limitations

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/base.py
+++ b/src/databricks/labs/ucx/workspace_access/base.py
@@ -38,3 +38,7 @@ class AclSupport:
     @abstractmethod
     def object_types(self) -> set[str]:
         """This method returns a set of strings, that represent object types that are applicable by this instance."""
+
+    @abstractmethod
+    def concurrency_support_for_apply_task(self) -> bool:
+        return True

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -41,3 +41,7 @@ class TableAclSupport(AclSupport):
         sql = target_grant.hive_grant_sql()
         # this has to be executed on tacl cluster, otherwise - use SQLExecutionAPI backend & Warehouse
         return partial(self._sql_backend.execute, sql)
+
+    # TODO: enable once Table ACL Grants concurrency issue is fixed: https://databricks.atlassian.net/browse/ES-908737
+    def concurrency_support_for_apply_task(self):
+        return False


### PR DESCRIPTION
* Added support for applying permissions serially
* Execute grants for Table ACLs serially, fix for issue [499](https://github.com/databrickslabs/ucx/issues/499)