### PR TITLE
implement _safe_* calls for applier_task in redash, scim, generic

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -200,7 +200,6 @@ class GenericPermissionsSupport(AclSupport):
                 "PERMISSION_DENIED",
                 "FEATURE_DISABLED",
                 "RESOURCE_DOES_NOT_EXIST",
-                "INTERNAL_SERVER_ERROR",
             ]:
                 logger.warning(f"Could not update permissions for {object_type} {object_id} due to {e.error_code}")
                 return None

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -136,7 +136,7 @@ class GenericPermissionsSupport(AclSupport):
 
         retry_on_value_error = retried(on=[ValueError, RetryableError], timeout=self._verify_timeout)
         retried_check = retry_on_value_error(self._inflight_check)
-        return retried_check(object_id, object_id, acl)
+        return retried_check(object_type, object_id, acl)
 
     @rate_limited(max_requests=100)
     def _crawler_task(self, object_type: str, object_id: str) -> Permissions | None:
@@ -193,6 +193,7 @@ class GenericPermissionsSupport(AclSupport):
                 "RESOURCE_NOT_FOUND",
                 "PERMISSION_DENIED",
                 "FEATURE_DISABLED",
+                "BAD_REQUEST",
             ]:
                 logger.warning(f"Could not get permissions for {object_type} {object_id} due to {e.error_code}")
                 return None

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -39,7 +39,8 @@ class WorkspaceObjectInfo:
 
 
 class RetryableError(DatabricksError):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class Listing:
@@ -196,7 +197,8 @@ class GenericPermissionsSupport(AclSupport):
                 logger.warning(f"Could not get permissions for {object_type} {object_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e
 
     def _safe_update_permissions(
         self, object_type: str, object_id: str, acl: list[iam.AccessControlRequest]
@@ -215,7 +217,8 @@ class GenericPermissionsSupport(AclSupport):
                 logger.warning(f"Could not update permissions for {object_type} {object_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e
 
     def _prepare_new_acl(
         self, permissions: iam.ObjectPermissions, migration_state: GroupMigrationState, destination: Destination

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -114,9 +114,9 @@ class GenericPermissionsSupport(AclSupport):
     def _inflight_check(self, object_type: str, object_id: str, acl: list[iam.AccessControlRequest]):
         # in-flight check for the applied permissions
         # the api might be inconsistent, therefore we need to check that the permissions were applied
-        set_retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
-        set_retried_check = set_retry_on_value_error(self._safe_get_permissions)
-        remote_permission = set_retried_check(object_type, object_id)
+        retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
+        retried_check = retry_on_value_error(self._safe_get_permissions)
+        remote_permission = retried_check(object_type, object_id)
         remote_permission_as_request = self._response_to_request(remote_permission.access_control_list)
         if all(elem in remote_permission_as_request for elem in acl):
             return True

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -109,7 +109,7 @@ class GenericPermissionsSupport(AclSupport):
 
     @rate_limited(max_requests=30)
     def _applier_task(self, object_type: str, object_id: str, acl: list[iam.AccessControlRequest]):
-        self._safe_update_permissions(object_type, object_id, access_control_list=acl)
+        self._safe_update_permissions(object_type, object_id, acl=acl)
 
         remote_permission = self._safe_get_permissions(object_type, object_id)
         remote_permission_as_request = self._response_to_request(remote_permission.access_control_list)
@@ -186,7 +186,6 @@ class GenericPermissionsSupport(AclSupport):
             else:
                 raise RetryableError() from e
 
-    # TODO remove after ES-892977 is fixed
     @retried(on=[RetryableError])
     def _safe_update_permissions(
         self, object_type: str, object_id: str, acl: list[iam.AccessControlRequest]

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -61,7 +61,7 @@ class Listing:
 
 class GenericPermissionsSupport(AclSupport):
     def __init__(
-        self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=20)
+        self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=1)
     ):
         self._ws = ws
         self._listings = listings

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -110,9 +110,9 @@ class RedashPermissionsSupport(AclSupport):
     def _inflight_check(self, object_type: sql.ObjectTypePlural, object_id: str, acl: list[sql.AccessControl]):
         # in-flight check for the applied permissions
         # the api might be inconsistent, therefore we need to check that the permissions were applied
-        set_retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
-        set_retried_check = set_retry_on_value_error(self._safe_get_dbsql_permissions)
-        remote_permission = set_retried_check(object_type, object_id)
+        retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
+        retried_check = retry_on_value_error(self._safe_get_dbsql_permissions)
+        remote_permission = retried_check(object_type, object_id)
         if all(elem in remote_permission.access_control_list for elem in acl):
             return True
         else:

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -46,7 +46,7 @@ class Listing:
 
 class RedashPermissionsSupport(AclSupport):
     def __init__(
-        self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=20)
+        self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=1)
     ):
         self._ws = ws
         self._listings = listings

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -45,7 +45,9 @@ class Listing:
 
 
 class RedashPermissionsSupport(AclSupport):
-    def __init__(self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=20)):
+    def __init__(
+        self, ws: WorkspaceClient, listings: list[Listing], verify_timeout: timedelta | None = timedelta(minutes=20)
+    ):
         self._ws = ws
         self._listings = listings
         self._verify_timeout = verify_timeout
@@ -121,7 +123,6 @@ class RedashPermissionsSupport(AclSupport):
             """
             raise ValueError(msg)
 
-
     @rate_limited(max_requests=30)
     def _applier_task(self, object_type: sql.ObjectTypePlural, object_id: str, acl: list[sql.AccessControl]):
         """
@@ -137,9 +138,8 @@ class RedashPermissionsSupport(AclSupport):
         retried_check = retry_on_value_error(self._inflight_check)
         return retried_check(object_id, object_id, acl)
 
-
     def _prepare_new_acl(
-            self, acl: list[sql.AccessControl], migration_state: GroupMigrationState, destination: Destination
+        self, acl: list[sql.AccessControl], migration_state: GroupMigrationState, destination: Destination
     ) -> list[sql.AccessControl]:
         """
         Please note the comment above on how we apply these permissions.
@@ -160,7 +160,7 @@ class RedashPermissionsSupport(AclSupport):
         return acl_requests
 
     def _safe_set_permissions(
-            self, object_type: ObjectTypePlural, object_id: str, acl: list[sql.AccessControl] | None
+        self, object_type: ObjectTypePlural, object_id: str, acl: list[sql.AccessControl] | None
     ) -> SetResponse | None:
         try:
             return self._ws.dbsql_permissions.set(object_type=object_type, object_id=object_id, access_control_list=acl)
@@ -178,7 +178,7 @@ class RedashPermissionsSupport(AclSupport):
 
 
 def redash_listing_wrapper(
-        func: Callable[..., list], object_type: sql.ObjectTypePlural
+    func: Callable[..., list], object_type: sql.ObjectTypePlural
 ) -> Callable[..., list[SqlPermissionsInfo]]:
     def wrapper() -> list[SqlPermissionsInfo]:
         for item in func():

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -158,7 +158,6 @@ class RedashPermissionsSupport(AclSupport):
                 "UNAUTHORIZED",
                 "PERMISSION_DENIED",
                 "NOT_FOUND",
-                "INTERNAL_ERROR",
             ]:
                 logger.warning(f"Could not update permissions for {object_type} {object_id} due to {e.error_code}")
                 return None

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -95,7 +95,8 @@ class RedashPermissionsSupport(AclSupport):
                 logger.warning(f"Could not get permissions for {object_type} {object_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e
 
     @rate_limited(max_requests=100)
     def _crawler_task(self, object_id: str, object_type: sql.ObjectTypePlural) -> Permissions | None:
@@ -174,7 +175,8 @@ class RedashPermissionsSupport(AclSupport):
                 logger.warning(f"Could not update permissions for {object_type} {object_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e
 
 
 def redash_listing_wrapper(

--- a/src/databricks/labs/ucx/workspace_access/redash.py
+++ b/src/databricks/labs/ucx/workspace_access/redash.py
@@ -1,17 +1,15 @@
 import dataclasses
 import json
 import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import List, Optional
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.retries import retried
 from databricks.sdk.service import sql
-from databricks.sdk.service.sql import ObjectTypePlural, AccessControl, SetResponse
+from databricks.sdk.service.sql import ObjectTypePlural, SetResponse
 
 from databricks.labs.ucx.mixins.hardening import rate_limited
 from databricks.labs.ucx.workspace_access.base import (
@@ -148,7 +146,7 @@ class RedashPermissionsSupport(AclSupport):
 
     @retried(on=[RetryableError])
     def _safe_set_permissions(
-            self, object_type: ObjectTypePlural, object_id: str, acl: Optional[List[AccessControl]] = None
+        self, object_type: ObjectTypePlural, object_id: str, acl: list[sql.AccessControl] | None
     ) -> SetResponse | None:
         try:
             return self._ws.dbsql_permissions.set(object_type=object_type, object_id=object_id, access_control_list=acl)
@@ -163,8 +161,6 @@ class RedashPermissionsSupport(AclSupport):
                 return None
             else:
                 raise RetryableError() from e
-
-
 
 
 def redash_listing_wrapper(

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -99,7 +99,6 @@ class ScimSupport(AclSupport):
                 "PERMISSION_DENIED",
                 "FEATURE_DISABLED",
                 "RESOURCE_DOES_NOT_EXIST",
-                "INTERNAL_SERVER_ERROR",
             ]:
                 logger.warning(f"Could not apply changes to group {id} due to {e.error_code}")
                 return None
@@ -120,7 +119,6 @@ class ScimSupport(AclSupport):
                 "PERMISSION_DENIED",
                 "FEATURE_DISABLED",
                 "RESOURCE_DOES_NOT_EXIST",
-                "INTERNAL_SERVER_ERROR",
             ]:
                 logger.warning(f"Could not get details of group {id} due to {e.error_code}")
                 return None

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -111,7 +111,8 @@ class ScimSupport(AclSupport):
                 logger.warning(f"Could not apply changes to group {group_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e
 
     def _safe_get_group(self, group_id: str) -> Group | None:
         try:
@@ -128,4 +129,5 @@ class ScimSupport(AclSupport):
                 logger.warning(f"Could not get details of group {group_id} due to {e.error_code}")
                 return None
             else:
-                raise RetryableError() from e
+                msg = f"{e.error_code} can be retried, doing another attempt..."
+                raise RetryableError(message=msg) from e

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -66,9 +66,9 @@ class ScimSupport(AclSupport):
     def _inflight_check(self, group_id: str, value: list[iam.ComplexValue], property_name: str):
         # in-flight check for the applied permissions
         # the api might be inconsistent, therefore we need to check that the permissions were applied
-        set_retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
-        set_retried_check = set_retry_on_value_error(self._safe_get_group)
-        group = set_retried_check(group_id)
+        retry_on_value_error = retried(on=[RetryableError], timeout=self._verify_timeout)
+        retried_check = retry_on_value_error(self._safe_get_group)
+        group = retried_check(group_id)
         if property_name == "roles" and group.roles:
             if all(elem in group.roles for elem in value):
                 return True

--- a/src/databricks/labs/ucx/workspace_access/scim.py
+++ b/src/databricks/labs/ucx/workspace_access/scim.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class ScimSupport(AclSupport):
-    def __init__(self, ws: WorkspaceClient, verify_timeout: timedelta | None = timedelta(minutes=20)):
+    def __init__(self, ws: WorkspaceClient, verify_timeout: timedelta | None = timedelta(minutes=1)):
         self._ws = ws
         self._verify_timeout = verify_timeout
 

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -361,7 +361,7 @@ def test_applier_task_should_be_called_three_times_if_permission_couldnt_be_appl
         acl=input_acl,
     )
 
-    assert len(ws.permissions.update.mock_calls) == 3
+    assert len(ws.permissions.update.mock_calls) == 1
     assert ws.permissions.update.has_calls(
         [
             unittest.mock.call(object_type="clusters", object_id="cluster_id", acl=input_acl),
@@ -369,7 +369,7 @@ def test_applier_task_should_be_called_three_times_if_permission_couldnt_be_appl
             unittest.mock.call(object_type="clusters", object_id="cluster_id", acl=input_acl),
         ]
     )
-    assert len(ws.permissions.get.mock_calls) == 3
+    assert len(ws.permissions.get.mock_calls) == 1
     assert ws.permissions.get.has_calls(
         [
             unittest.mock.call(object_type="clusters", object_id="cluster_id"),

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -7,7 +7,6 @@ from databricks.sdk.service import compute, iam, ml
 from databricks.sdk.service.workspace import Language, ObjectInfo, ObjectType
 
 from databricks.labs.ucx.mixins.sql import Row
-
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,

--- a/tests/unit/workspace_access/test_redash.py
+++ b/tests/unit/workspace_access/test_redash.py
@@ -227,8 +227,10 @@ def test_safe_set_permissions_when_error_non_retriable():
 
 def test_safe_set_permissions_when_error_retriable():
     ws = MagicMock()
-    ws.dbsql_permissions.set.side_effect = DatabricksError(error_code="INTERNAL_SERVER_ERROR")
+    error_code = "INTERNAL_SERVER_ERROR"
+    ws.dbsql_permissions.set.side_effect = DatabricksError(error_code=error_code)
     sup = RedashPermissionsSupport(ws=ws, listings=[], verify_timeout=timedelta(seconds=1))
     acl = [sql.AccessControl(group_name="group_1", permission_level=sql.PermissionLevel.CAN_MANAGE)]
-    with pytest.raises(RetryableError):
+    with pytest.raises(RetryableError) as e:
         sup._safe_set_permissions(sql.ObjectTypePlural.QUERIES, "test", acl)
+    assert error_code in str(e)

--- a/tests/unit/workspace_access/test_redash.py
+++ b/tests/unit/workspace_access/test_redash.py
@@ -232,15 +232,11 @@ def test_applier_task_should_be_called_three_times_if_permission_is_not_up_to_da
         [input_acl],
     )
 
-    assert len(ws.dbsql_permissions.set.mock_calls) == 3
+    assert len(ws.dbsql_permissions.set.mock_calls) == 1
     assert ws.dbsql_permissions.set.mock_calls == [
-        call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
-        call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
         call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
     ]
-    assert len(ws.dbsql_permissions.get.mock_calls) == 3
+    assert len(ws.dbsql_permissions.get.mock_calls) == 1
     assert ws.dbsql_permissions.set.mock_calls == [
-        call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
-        call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
         call(object_type=sql.ObjectTypePlural.QUERIES, object_id="test", access_control_list=[input_acl]),
     ]

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
+from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group
 
@@ -37,19 +38,21 @@ def test_applier_task_should_return_false_if_roles_are_not_properly_applied():
     assert not result
 
 
-def test_applier_task_should_be_called_three_times_if_roles_are_not_properly_applied():
+def test_safe_patch_group_when_error_non_retriable():
     ws = MagicMock()
-    ws.groups.get.return_value = Group(id="1", roles=[iam.ComplexValue(value="role2")])
+    ws.groups.patch.side_effect = DatabricksError(error_code="PERMISSION_DENIED")
     sup = ScimSupport(ws=ws)
-
-    sup._applier_task(group_id="1", value=[iam.ComplexValue(value="role1")], property_name="roles")
-    assert len(ws.groups.patch.mock_calls) == 1
-    assert ws.groups.patch.mock_calls == [
-        call(
-            id="1",
-            operations=[iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[{"value": "role1"}])],
-            schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-        )
+    operations = [
+        iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[e.as_dict() for e in [iam.ComplexValue(value="role1")]])
     ]
-    assert len(ws.groups.get.mock_calls) == 1
-    assert ws.groups.get.mock_calls == [call("1")]
+    schemas = [iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP]
+    result = sup._safe_patch_group(id="1", operations=operations, schemas=schemas)
+    assert result is None
+
+
+def test_safe_get_group_when_error_non_retriable():
+    ws = MagicMock()
+    ws.groups.get.side_effect = DatabricksError(error_code="PERMISSION_DENIED")
+    sup = ScimSupport(ws=ws)
+    result = sup._safe_get_group(id="1")
+    assert result is None

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -68,14 +68,16 @@ def test_safe_patch_group_when_error_non_retriable():
 
 def test_safe_patch_group_when_error_retriable():
     ws = MagicMock()
-    ws.groups.patch.side_effect = DatabricksError(error_code="INTERNAL_SERVER_ERROR")
+    error_code = "INTERNAL_SERVER_ERROR"
+    ws.groups.patch.side_effect = DatabricksError(error_code=error_code)
     sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
     operations = [
         iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[e.as_dict() for e in [iam.ComplexValue(value="role1")]])
     ]
     schemas = [iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP]
-    with pytest.raises(RetryableError):
+    with pytest.raises(RetryableError) as e:
         sup._safe_patch_group(group_id="1", operations=operations, schemas=schemas)
+    assert error_code in str(e)
 
 
 def test_safe_get_group_when_error_non_retriable():
@@ -88,7 +90,9 @@ def test_safe_get_group_when_error_non_retriable():
 
 def test_safe_get_group_when_error_retriable():
     ws = MagicMock()
-    ws.groups.get.side_effect = DatabricksError(error_code="INTERNAL_SERVER_ERROR")
+    error_code = "INTERNAL_SERVER_ERROR"
+    ws.groups.get.side_effect = DatabricksError(error_code=error_code)
     sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
-    with pytest.raises(RetryableError):
+    with pytest.raises(RetryableError) as e:
         sup._safe_get_group(group_id="1")
+    assert error_code in str(e)

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -46,7 +46,7 @@ def test_safe_patch_group_when_error_non_retriable():
         iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[e.as_dict() for e in [iam.ComplexValue(value="role1")]])
     ]
     schemas = [iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP]
-    result = sup._safe_patch_group(id="1", operations=operations, schemas=schemas)
+    result = sup._safe_patch_group(group_id="1", operations=operations, schemas=schemas)
     assert result is None
 
 
@@ -54,5 +54,5 @@ def test_safe_get_group_when_error_non_retriable():
     ws = MagicMock()
     ws.groups.get.side_effect = DatabricksError(error_code="PERMISSION_DENIED")
     sup = ScimSupport(ws=ws)
-    result = sup._safe_get_group(id="1")
+    result = sup._safe_get_group(group_id="1")
     assert result is None

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -43,23 +43,13 @@ def test_applier_task_should_be_called_three_times_if_roles_are_not_properly_app
     sup = ScimSupport(ws=ws)
 
     sup._applier_task(group_id="1", value=[iam.ComplexValue(value="role1")], property_name="roles")
-    assert len(ws.groups.patch.mock_calls) == 3
+    assert len(ws.groups.patch.mock_calls) == 1
     assert ws.groups.patch.mock_calls == [
         call(
             id="1",
             operations=[iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[{"value": "role1"}])],
             schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-        ),
-        call(
-            id="1",
-            operations=[iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[{"value": "role1"}])],
-            schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-        ),
-        call(
-            id="1",
-            operations=[iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[{"value": "role1"}])],
-            schemas=[iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP],
-        ),
+        )
     ]
-    assert len(ws.groups.get.mock_calls) == 3
-    assert ws.groups.get.mock_calls == [call("1"), call("1"), call("1")]
+    assert len(ws.groups.get.mock_calls) == 1
+    assert ws.groups.get.mock_calls == [call("1")]

--- a/tests/unit/workspace_access/test_scim.py
+++ b/tests/unit/workspace_access/test_scim.py
@@ -1,16 +1,19 @@
+from datetime import timedelta
 from unittest.mock import MagicMock
 
+import pytest
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import Group
 
+from databricks.labs.ucx.workspace_access.generic import RetryableError
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
 
 
 def test_applier_task_should_return_true_if_roles_are_properly_applied():
     ws = MagicMock()
     ws.groups.get.return_value = Group(id="1", roles=[iam.ComplexValue(value="role1"), iam.ComplexValue(value="role2")])
-    sup = ScimSupport(ws=ws)
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
 
     result = sup._applier_task(group_id="1", value=[iam.ComplexValue(value="role1")], property_name="roles")
     assert result
@@ -21,7 +24,7 @@ def test_applier_task_should_return_true_if_entitlements_are_properly_applied():
     ws.groups.get.return_value = Group(
         id="1", roles=[iam.ComplexValue(value="role1")], entitlements=[iam.ComplexValue(value="allow-cluster-create")]
     )
-    sup = ScimSupport(ws=ws)
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
 
     result = sup._applier_task(
         group_id="1", value=[iam.ComplexValue(value="allow-cluster-create")], property_name="entitlements"
@@ -32,16 +35,29 @@ def test_applier_task_should_return_true_if_entitlements_are_properly_applied():
 def test_applier_task_should_return_false_if_roles_are_not_properly_applied():
     ws = MagicMock()
     ws.groups.get.return_value = Group(id="1", roles=[iam.ComplexValue(value="role2")])
-    sup = ScimSupport(ws=ws)
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
 
-    result = sup._applier_task(group_id="1", value=[iam.ComplexValue(value="role1")], property_name="roles")
-    assert not result
+    with pytest.raises(TimeoutError) as e:
+        sup._applier_task(group_id="1", value=[iam.ComplexValue(value="role1")], property_name="roles")
+    assert "Timed out after" in str(e.value)
+
+
+def test_applier_task_should_return_false_if_entitlements_are_not_properly_applied():
+    ws = MagicMock()
+    ws.groups.get.return_value = Group(id="1", entitlements=[iam.ComplexValue(value="allow-cluster-create")])
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+
+    with pytest.raises(TimeoutError) as e:
+        sup._applier_task(
+            group_id="1", value=[iam.ComplexValue(value="forbidden-cluster-create")], property_name="entitlements"
+        )
+    assert "Timed out after" in str(e.value)
 
 
 def test_safe_patch_group_when_error_non_retriable():
     ws = MagicMock()
     ws.groups.patch.side_effect = DatabricksError(error_code="PERMISSION_DENIED")
-    sup = ScimSupport(ws=ws)
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
     operations = [
         iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[e.as_dict() for e in [iam.ComplexValue(value="role1")]])
     ]
@@ -50,9 +66,29 @@ def test_safe_patch_group_when_error_non_retriable():
     assert result is None
 
 
+def test_safe_patch_group_when_error_retriable():
+    ws = MagicMock()
+    ws.groups.patch.side_effect = DatabricksError(error_code="INTERNAL_SERVER_ERROR")
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+    operations = [
+        iam.Patch(op=iam.PatchOp.ADD, path="roles", value=[e.as_dict() for e in [iam.ComplexValue(value="role1")]])
+    ]
+    schemas = [iam.PatchSchema.URN_IETF_PARAMS_SCIM_API_MESSAGES_2_0_PATCH_OP]
+    with pytest.raises(RetryableError):
+        sup._safe_patch_group(group_id="1", operations=operations, schemas=schemas)
+
+
 def test_safe_get_group_when_error_non_retriable():
     ws = MagicMock()
     ws.groups.get.side_effect = DatabricksError(error_code="PERMISSION_DENIED")
-    sup = ScimSupport(ws=ws)
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
     result = sup._safe_get_group(group_id="1")
     assert result is None
+
+
+def test_safe_get_group_when_error_retriable():
+    ws = MagicMock()
+    ws.groups.get.side_effect = DatabricksError(error_code="INTERNAL_SERVER_ERROR")
+    sup = ScimSupport(ws=ws, verify_timeout=timedelta(seconds=1))
+    with pytest.raises(RetryableError):
+        sup._safe_get_group(group_id="1")


### PR DESCRIPTION
* Resolves https://github.com/databrickslabs/ucx/issues/489
* Removes for loop in applier_task in redash, scim, generic
* Sets the right rate for each
* Implements _safe_* calls 