### PR TITLE
Breaking change: Mitigate permissions loss in Table ACLs by folding grants belonging to the same principal, object id and object type together

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "databricks-sdk~=0.11.0",
+    "databricks-sdk~=0.12.0",
     "PyYAML>=6.0.0,<7.0.0",
 ]
 

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -157,7 +157,12 @@ def _permissions_mapping():
         (
             "pipeline",
             "pipelines",
-            [PermissionLevel.CAN_VIEW, PermissionLevel.CAN_RUN, PermissionLevel.CAN_MANAGE, PermissionLevel.IS_OWNER],
+            [
+                PermissionLevel.CAN_VIEW,
+                PermissionLevel.CAN_RUN,
+                PermissionLevel.CAN_MANAGE,
+                PermissionLevel.IS_OWNER  # cannot be a group
+            ],
             _simple,
         ),
         (
@@ -166,8 +171,8 @@ def _permissions_mapping():
             [
                 PermissionLevel.CAN_VIEW,
                 PermissionLevel.CAN_MANAGE_RUN,
-                PermissionLevel.IS_OWNER,
                 PermissionLevel.CAN_MANAGE,
+                PermissionLevel.IS_OWNER,  # cannot be a group
             ],
             _simple,
         ),

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -161,7 +161,7 @@ def _permissions_mapping():
                 PermissionLevel.CAN_VIEW,
                 PermissionLevel.CAN_RUN,
                 PermissionLevel.CAN_MANAGE,
-                PermissionLevel.IS_OWNER  # cannot be a group
+                PermissionLevel.IS_OWNER,  # cannot be a group
             ],
             _simple,
         ),

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -118,9 +118,8 @@ class PermissionManager(CrawlerBase):
             applier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to apply permissions on {destination} groups. Total tasks: {len(applier_tasks)}")
-        # run with 1 thread to temp bugfix TableACL grants issue in the platform
-        # see: https://databricks.atlassian.net/browse/ES-908737
-        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks, num_threads=1)
+
+        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks)
         if len(errors) > 0:
             # TODO: https://github.com/databrickslabs/ucx/issues/406
             logger.error(f"Detected {len(errors)} while applying permissions")

--- a/src/databricks/labs/ucx/workspace_access/tacl.py
+++ b/src/databricks/labs/ucx/workspace_access/tacl.py
@@ -42,7 +42,7 @@ class TableAclSupport(AclSupport):
             key = (grant.principal, grant.this_type_and_key())
             folded_actions[key].add(grant.action_type)
 
-            # use one of the grant objects for all actions per principal, object type and id
+            # use one of the grants with actions folded per principal, object type and id
             grant_dict = dataclasses.asdict(grant)
             grant_dict["action_type"] = ", ".join(sorted(folded_actions[key]))
             grant_folded_actions[key] = grant_dict

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from datetime import timedelta
 
 import pytest
@@ -115,8 +114,7 @@ def test_jobs_with_no_inventory_database(
     )
     sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{ws_group_a.display_name}`")
     sql_backend.execute(
-        f"GRANT SELECT, MODIFY, READ_METADATA ON TABLE "
-        f"{table_b.full_name} TO `{ws_group_b.display_name}`"
+        f"GRANT SELECT, MODIFY, READ_METADATA ON TABLE {table_b.full_name} TO `{ws_group_b.display_name}`"
     )
     sql_backend.execute(f"ALTER TABLE {table_b.full_name} OWNER TO `{ws_group_b.display_name}`")
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -109,6 +109,7 @@ def test_jobs_with_no_inventory_database(
     sql_backend.execute(f"GRANT USAGE ON SCHEMA default TO `{ws_group_a.display_name}`")
     sql_backend.execute(f"GRANT USAGE ON SCHEMA default TO `{ws_group_b.display_name}`")
     sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{ws_group_a.display_name}`")
+    sql_backend.execute(f"GRANT MODIFY ON TABLE {table_a.full_name} TO `{ws_group_a.display_name}`")
     sql_backend.execute(f"GRANT SELECT ON TABLE {table_b.full_name} TO `{ws_group_b.display_name}`")
     sql_backend.execute(f"GRANT MODIFY ON SCHEMA {schema_b.full_name} TO `{ws_group_b.display_name}`")
 

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -84,7 +84,7 @@ def test_replace_workspace_groups_with_account_groups(
     logger.info(f"Cluster policy: {ws.config.host}#setting/clusters/cluster-policies/view/{cluster_policy.policy_id}")
 
     dummy_table = make_table()
-    sql_backend.execute(f"GRANT SELECT ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
+    sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
 
     group_manager = GroupManager(ws, GroupsConfig(auto=True))
     group_manager.prepare_groups_in_environment()
@@ -106,6 +106,7 @@ def test_replace_workspace_groups_with_account_groups(
 
     table_permissions = grants.for_table_info(dummy_table)
     assert ws_group.display_name in table_permissions
+    assert "MODIFY" in table_permissions[ws_group.display_name]
     assert "SELECT" in table_permissions[ws_group.display_name]
 
     permission_manager.apply_group_permissions(group_manager.migration_state, destination="backup")
@@ -117,7 +118,9 @@ def test_replace_workspace_groups_with_account_groups(
         table_permissions = grants.for_table_info(dummy_table)
         assert group_info.workspace.display_name in table_permissions
         assert group_info.backup.display_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.workspace.display_name]
         assert "SELECT" in table_permissions[group_info.workspace.display_name]
+        assert "MODIFY" in table_permissions[group_info.backup.display_name]
         assert "SELECT" in table_permissions[group_info.backup.display_name]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
@@ -135,6 +138,7 @@ def test_replace_workspace_groups_with_account_groups(
         table_permissions = grants.for_table_info(dummy_table)
         assert group_info.account.display_name in table_permissions
         assert group_info.backup.display_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.backup.display_name]
         assert "SELECT" in table_permissions[group_info.backup.display_name]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
@@ -152,7 +156,9 @@ def test_replace_workspace_groups_with_account_groups(
         table_permissions = grants.for_table_info(dummy_table)
         assert group_info.account.display_name in table_permissions
         assert group_info.backup.display_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.backup.display_name]
         assert "SELECT" in table_permissions[group_info.backup.display_name]
+        assert "MODIFY" in table_permissions[group_info.account.display_name]
         assert "SELECT" in table_permissions[group_info.account.display_name]
 
         policy_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
@@ -173,6 +179,7 @@ def test_replace_workspace_groups_with_account_groups(
 
         table_permissions = grants.for_table_info(dummy_table)
         assert group_info.account.display_name in table_permissions
+        assert "MODIFY" in table_permissions[group_info.account.display_name]
         assert "SELECT" in table_permissions[group_info.account.display_name]
 
     check_table_permissions_after_backup_delete()

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -4,6 +4,7 @@ import logging
 from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
+from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
@@ -75,9 +76,13 @@ def test_recover_permissions_from_grants(
         and json.loads(obj.raw)["principal"] == ws_group.display_name
     )
 
-    assert (
-        f'{{"principal": "{ws_group.display_name}", "action_type": "MODIFY, SELECT", '
-        f'"catalog": "{dummy_table.catalog_name.lower()}", "database": "{dummy_table.schema_name.lower()}", '
-        f'"table": "{dummy_table.name.lower()}", "view": null, "any_file": false, "anonymous_function": false}}'
-        == actual_raw_permissions
-    )
+    assert Grant(
+        principal=ws_group.display_name,
+        action_type="MODIFY, SELECT",
+        catalog=dummy_table.catalog_name.lower(),
+        database=dummy_table.schema_name.lower(),
+        table=dummy_table.name.lower(),
+        view=None,
+        any_file=False,
+        anonymous_function=False,
+    ) == Grant(**json.loads(actual_raw_permissions))

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -44,6 +44,16 @@ def test_tacl_crawler_multiple_permissions():
                 ("foo2@example.com", "SELECT", "catalog_a", "database_b", "table_c", None, False, False),
                 # duplicate
                 ("foo2@example.com", "SELECT", "catalog_a", "database_b", "table_c", None, False, False),
+                # view
+                ("foo3@example.com", "SELECT", "catalog_a", "database_b", None, "view_c", False, False),
+                # database
+                ("foo3@example.com", "SELECT", "catalog_a", "database_b", None, None, False, False),
+                # catalog
+                ("foo3@example.com", "SELECT", "catalog_a", None, None, None, False, False),
+                # any file
+                ("foo3@example.com", "SELECT", None, None, None, None, True, False),
+                # function
+                ("foo3@example.com", "SELECT", None, None, None, None, False, True),
             ]
         }
     )
@@ -96,6 +106,81 @@ def test_tacl_crawler_multiple_permissions():
         view=None,
         any_file=False,
         anonymous_function=False,
+    ) == Grant(**json.loads(permissions.raw))
+
+    permissions = next(crawler_tasks)()
+
+    assert "VIEW" == permissions.object_type
+    assert "catalog_a.database_b.view_c" == permissions.object_id
+    assert Grant(
+        principal="foo3@example.com",
+        action_type="SELECT",
+        catalog="catalog_a",
+        database="database_b",
+        table=None,
+        view="view_c",
+        any_file=False,
+        anonymous_function=False,
+    ) == Grant(**json.loads(permissions.raw))
+
+    permissions = next(crawler_tasks)()
+
+    assert "DATABASE" == permissions.object_type
+    assert "catalog_a.database_b" == permissions.object_id
+    assert Grant(
+        principal="foo3@example.com",
+        action_type="SELECT",
+        catalog="catalog_a",
+        database="database_b",
+        table=None,
+        view=None,
+        any_file=False,
+        anonymous_function=False,
+    ) == Grant(**json.loads(permissions.raw))
+
+    permissions = next(crawler_tasks)()
+
+    assert "CATALOG" == permissions.object_type
+    assert "catalog_a" == permissions.object_id
+    assert Grant(
+        principal="foo3@example.com",
+        action_type="SELECT",
+        catalog="catalog_a",
+        database=None,
+        table=None,
+        view=None,
+        any_file=False,
+        anonymous_function=False,
+    ) == Grant(**json.loads(permissions.raw))
+
+    permissions = next(crawler_tasks)()
+
+    assert "ANY FILE" == permissions.object_type
+    assert permissions.object_id == ""
+    assert Grant(
+        principal="foo3@example.com",
+        action_type="SELECT",
+        catalog="",
+        database=None,
+        table=None,
+        view=None,
+        any_file=True,
+        anonymous_function=False,
+    ) == Grant(**json.loads(permissions.raw))
+
+    permissions = next(crawler_tasks)()
+
+    assert "ANONYMOUS FUNCTION" == permissions.object_type
+    assert permissions.object_id == ""
+    assert Grant(
+        principal="foo3@example.com",
+        action_type="SELECT",
+        catalog="",
+        database=None,
+        table=None,
+        view=None,
+        any_file=False,
+        anonymous_function=True,
     ) == Grant(**json.loads(permissions.raw))
 
 

--- a/tests/unit/workspace_access/test_tacl.py
+++ b/tests/unit/workspace_access/test_tacl.py
@@ -37,6 +37,7 @@ def test_tacl_crawler_multiple_permissions():
             "SELECT \\* FROM hive_metastore.test.grants": [
                 ("foo@example.com", "SELECT", "catalog_a", "database_b", "table_c", None, False, False),
                 ("foo@example.com", "MODIFY", "catalog_a", "database_b", "table_c", None, False, False),
+                ("foo@example.com", "OWN", "catalog_a", "database_b", "table_c", None, False, False),
                 # different table name (object_id)
                 ("foo@example.com", "SELECT", "catalog_a", "database_b", "table_d", None, False, False),
                 # different principal
@@ -58,7 +59,7 @@ def test_tacl_crawler_multiple_permissions():
     assert "catalog_a.database_b.table_c" == permissions.object_id
     assert Grant(
         principal="foo@example.com",
-        action_type="MODIFY, SELECT",
+        action_type="MODIFY, OWN, SELECT",
         catalog="catalog_a",
         database="database_b",
         table="table_c",


### PR DESCRIPTION
Applying grants that belong to the same principle, object id, and object type concurrently is not supported in legacy Table ACLs currently:

> TableAcl grant/revoke operations are not atomic. When granting the permissions, the service would first get all existing permissions, append with the new permissions, and set the full list in the database. If there are concurrent grant requests, both requests might succeed and emit the audit logs, but what actually happens could be that the new permission list from one request overrides the other one, causing permission loss.

This PR will:
* Resolve issue [499](https://github.com/databrickslabs/ucx/issues/499). 
* Improve performance of migrating Table ACLs permissions
* Added tests covering objects ownership
* Increased test coverage around Table ACLs

**Example**

Instead of executing grants in separate transactions:
`GRANT SELECT ON TABLE hive_metastore.db_a.table_a TO group_a`
`GRANT MODIFY ON TABLE hive_metastore.db_a.table_a TO group_a`

Folding and executing in one statement:
`GRANT SELECT, MODIFY ON TABLE hive_metastore.db_a.table_a TO group_a`