### PR TITLE
Mitigate permissions loss in Table ACLs by running appliers with single thread

### DIFF
--- a/src/databricks/labs/ucx/framework/parallel.py
+++ b/src/databricks/labs/ucx/framework/parallel.py
@@ -27,8 +27,9 @@ class Threads(Generic[Result]):
         self._default_log_every = 100
 
     @classmethod
-    def gather(cls, name: str, tasks: list[Callable[..., Result]], num_threads: int = None) \
-            -> (list[Result], list[Exception]):
+    def gather(
+        cls, name: str, tasks: list[Callable[..., Result]], num_threads: int | None = None
+    ) -> (list[Result], list[Exception]):
         if num_threads is None:
             num_threads = os.cpu_count() * 2
             if num_threads < MIN_THREADS:

--- a/src/databricks/labs/ucx/framework/parallel.py
+++ b/src/databricks/labs/ucx/framework/parallel.py
@@ -27,8 +27,10 @@ class Threads(Generic[Result]):
         self._default_log_every = 100
 
     @classmethod
-    def gather(cls, name: str, tasks: list[Callable[..., Result]]) -> (list[Result], list[Exception]):
-        num_threads = os.cpu_count() * 2
+    def gather(cls, name: str, tasks: list[Callable[..., Result]], num_threads: int = None) \
+            -> (list[Result], list[Exception]):
+        if num_threads is None:
+            num_threads = os.cpu_count() * 2
         if num_threads < MIN_THREADS:
             num_threads = MIN_THREADS
         return cls(name, tasks, num_threads=num_threads)._run()

--- a/src/databricks/labs/ucx/framework/parallel.py
+++ b/src/databricks/labs/ucx/framework/parallel.py
@@ -31,8 +31,8 @@ class Threads(Generic[Result]):
             -> (list[Result], list[Exception]):
         if num_threads is None:
             num_threads = os.cpu_count() * 2
-        if num_threads < MIN_THREADS:
-            num_threads = MIN_THREADS
+            if num_threads < MIN_THREADS:
+                num_threads = MIN_THREADS
         return cls(name, tasks, num_threads=num_threads)._run()
 
     def _run(self) -> (list[Result], list[Exception]):

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -118,7 +118,9 @@ class PermissionManager(CrawlerBase):
             applier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to apply permissions on {destination} groups. Total tasks: {len(applier_tasks)}")
-        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks)
+        # run with 1 thread to temp bugfix TableACL grants issue in the platform
+        # see: https://databricks.atlassian.net/browse/ES-908737
+        _, errors = Threads.gather(f"apply {destination} group permissions", applier_tasks, num_threads=1)
         if len(errors) > 0:
             # TODO: https://github.com/databrickslabs/ucx/issues/406
             logger.error(f"Detected {len(errors)} while applying permissions")


### PR DESCRIPTION
Applying grants that belong to the same principle, object id, and object type concurrently is not supported in legacy Table ACLs currently:

> TableAcl grant/revoke operations are not atomic. When granting the permissions, the service would first get all existing permissions, append with the new permissions, and set the full list in the database. If there are concurrent grant requests, both requests might succeed and emit the audit logs, but what actually happens could be that the new permission list from one request overrides the other one, causing permission loss.

This PR will:
* Resolve issue https://github.com/databrickslabs/ucx/issues/499.