### PR TITLE
Added handling for workspaces that have write protected DBFS.

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -198,36 +198,36 @@ class AccountConfig(_Config["AccountConfig"]):
 
 @dataclass
 class WorkspaceConfig(_Config["WorkspaceConfig"]):
-    inventory_database: str
-    groups: GroupsConfig
-    instance_pool_id: str = None
-    warehouse_id: str = None
-    connect: ConnectConfig | None = None
-    num_threads: int | None = 10
-    log_level: str | None = "INFO"
+    connect: ConnectConfig = None
     database_to_catalog_mapping: dict[str, str] = None
     default_catalog: str = "ucx_default"
-
-    # Starting path for notebooks and directories crawler
-    workspace_start_path: str = "/"
+    groups: GroupsConfig = None
+    instance_pool_id: str = None
     instance_profile: str = None
+    inventory_database: str = None
+    log_level: str = "INFO"
+    num_threads: int = 10
+    override_clusters: dict[Any, Any] = None
     spark_conf: dict[str, str] = None
+    warehouse_id: str = None
+    workspace_start_path: str = "/"  # Starting path for notebooks and directories crawler
 
     @classmethod
     def from_dict(cls, raw: dict):
         cls._verify_version(raw)
         return cls(
-            inventory_database=raw.get("inventory_database"),
+            database_to_catalog_mapping=raw.get("database_to_catalog_mapping", None),
+            default_catalog=raw.get("default_catalog", "main"),
             groups=GroupsConfig.from_dict(raw.get("groups", {})),
             connect=ConnectConfig.from_dict(raw.get("connect", {})),
             instance_pool_id=raw.get("instance_pool_id", None),
-            warehouse_id=raw.get("warehouse_id", None),
-            num_threads=raw.get("num_threads", 10),
-            log_level=raw.get("log_level", "INFO"),
-            database_to_catalog_mapping=raw.get("database_to_catalog_mapping", None),
             instance_profile=raw.get("instance_profile", None),
+            inventory_database=raw.get("inventory_database"),
+            log_level=raw.get("log_level", "INFO"),
+            num_threads=raw.get("num_threads", 10),
+            override_clusters=raw.get("override_clusters", None),
             spark_conf=raw.get("spark_conf", None),
-            default_catalog=raw.get("default_catalog", "main"),
+            warehouse_id=raw.get("warehouse_id", None),
             workspace_start_path=raw.get("workspace_start_path", "/"),
         )
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -556,7 +556,7 @@ class WorkspaceInstaller:
             if job_task.job_cluster_key in overrides:
                 job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
                 job_task.job_cluster_key = None
-                job_task.libraries = None # Job libraries not loading from Workspace FS
+                job_task.libraries = None  # Job libraries not loading from Workspace FS
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None
                 params = {"task": job_task.task_key} | EXTRA_TASK_PARAMS

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -556,18 +556,6 @@ class WorkspaceInstaller:
             "write_protected_dbfs": self._write_protected_dbfs,
         }
 
-    @staticmethod
-    def _apply_cluster_overrides(settings: dict[str, any], overrides: dict[str, str]) -> dict:
-        settings["job_clusters"] = [_ for _ in settings["job_clusters"] if _.job_cluster_key not in overrides]
-        for job_task in settings["tasks"]:
-            if job_task.job_cluster_key is None:
-                continue
-            if job_task.job_cluster_key in overrides:
-                job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
-                job_task.job_cluster_key = None
-
-        return settings
-
     def _upload_wheel_runner(self, remote_wheel: str):
         # TODO: we have to be doing this workaround until ES-897453 is solved in the platform
         path = f"{self._install_folder}/wheels/wheel-test-runner-{self._version}.py"

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -239,14 +239,21 @@ class WorkspaceInstaller:
     def _configure_override_clusters(self):
         """User may override standard job clusters with interactive clusters"""
         default_val = ""
-        cluster_id = self._question("Pick default and we'll create a compatible job cluster (recommended) or enter pre-existing HMS Legacy cluster ID", default=default_val)
-        tacl_cluster_id = self._question("Pick default and we'll create a compatible job cluster (recommended) or enter pre-existing Table Access Control cluster ID", default=default_val)
+        preamble = "Pick default and we'll create a compatible job cluster (recommended) or "
+        cluster_id = self._question(
+            preamble + "enter pre-existing HMS Legacy cluster ID",
+            default=default_val,
+        )
+        tacl_cluster_id = self._question(
+            preamble + "enter pre-existing Table Access Control cluster ID",
+            default=default_val,
+        )
         overrides = None
-        if cluster_id != default_val and tacl_cluster_id != default_val:
-            overrides =  {
-                    "main": cluster_id,
-                    "tacl": tacl_cluster_id,
-                }
+        if default_val not in (cluster_id, tacl_cluster_id):
+            overrides = {
+                "main": cluster_id,
+                "tacl": tacl_cluster_id,
+            }
         return overrides
 
     def _configure(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -574,9 +574,9 @@ class WorkspaceInstaller:
             if job_task.job_cluster_key in overrides:
                 job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
                 job_task.job_cluster_key = None
-                if settings[
-                    "write_protected_dbfs"
-                ]:  # If DBFS is write protected, libraries need to be installed on override cluster
+                if settings.get(
+                    "write_protected_dbfs", None
+                ):  # If DBFS is write protected, libraries need to be installed on override cluster
                     job_task.libraries = None
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -620,6 +620,7 @@ class WorkspaceInstaller:
                     "write_protected_dbfs", None
                 ):  # If DBFS is write protected, libraries need to be installed on override cluster
                     job_task.libraries = None
+                    del settings["write_protected_dbfs"]
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None
                 params = {"task": job_task.task_key} | EXTRA_TASK_PARAMS

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -426,6 +426,8 @@ class WorkspaceInstaller:
             settings = self._job_settings(step_name, remote_wheel)
             if self._override_clusters:
                 settings = self._apply_cluster_overrides(settings, self._override_clusters, wheel_runner)
+            if settings.get("write_protected_dbfs", None):
+                del settings["write_protected_dbfs"]
             if step_name in self._deployed_steps:
                 job_id = self._deployed_steps[step_name]
                 logger.info(f"Updating configuration for step={step_name} job_id={job_id}")
@@ -616,11 +618,6 @@ class WorkspaceInstaller:
             if job_task.job_cluster_key in overrides:
                 job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
                 job_task.job_cluster_key = None
-                if settings.get(
-                    "write_protected_dbfs", None
-                ):  # If DBFS is write protected, libraries need to be installed on override cluster
-                    job_task.libraries = None
-                    del settings["write_protected_dbfs"]
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None
                 params = {"task": job_task.task_key} | EXTRA_TASK_PARAMS

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -30,6 +30,7 @@ from databricks.labs.ucx.runtime import main
 TAG_STEP = "step"
 TAG_APP = "App"
 NUM_USER_ATTEMPTS = 10  # number of attempts user gets at answering a question
+CLUSTER_ID_LENGTH = 20  # number of characters in a valid cluster_id
 EXTRA_TASK_PARAMS = {
     "job_id": "{{job_id}}",
     "run_id": "{{run_id}}",
@@ -236,6 +237,10 @@ class WorkspaceInstaller:
                     raise SystemExit(msg)
         return inventory_database
 
+    def _valid_cluster_id(self, cluster_id: str) -> bool:
+        """Lite validation of user supplied cluster id"""
+        return CLUSTER_ID_LENGTH == len(cluster_id)
+
     def _configure_override_clusters(self):
         """User may override standard job clusters with interactive clusters"""
         default_val = ""
@@ -249,7 +254,11 @@ class WorkspaceInstaller:
             default=default_val,
         )
         overrides = None
-        if default_val not in (cluster_id, tacl_cluster_id):
+        if (
+            default_val not in (cluster_id, tacl_cluster_id)
+            and self._valid_cluster_id(cluster_id)
+            and self._valid_cluster_id(tacl_cluster_id)
+        ):
             overrides = {
                 "main": cluster_id,
                 "tacl": tacl_cluster_id,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,14 +38,35 @@ def set_directory(path: Path):
         os.chdir(origin)
 
 
+def test_workspace_config(tmp_path: Path):
+    with set_directory(tmp_path):
+        mc = partial(
+            WorkspaceConfig,
+            database_to_catalog_mapping={"db1": "cat1", "db2": "cat2"},
+            groups=GroupsConfig(auto=True),
+            instance_profile="arn:aws:iam::111222333:instance-profile/foo-instance-profile",
+            inventory_database="abc",
+            log_level="INFO",
+            num_threads=10,
+            spark_conf={"key1": "val1", "key2": "val2"},
+            override_clusters={"main": "abcd-192345-eadeadbeaf", "tacl": "efgh-999999-eadeadbeaf"},
+        )
+        config: WorkspaceConfig = mc()
+        assert config.override_clusters is not None
+
+
 def test_reader(tmp_path: Path):
     with set_directory(tmp_path):
         mc = partial(
             WorkspaceConfig,
-            inventory_database="abc",
-            groups=GroupsConfig(auto=True),
             database_to_catalog_mapping={"db1": "cat1", "db2": "cat2"},
+            groups=GroupsConfig(auto=True),
+            instance_profile="arn:aws:iam::111222333:instance-profile/foo-instance-profile",
+            inventory_database="abc",
+            log_level="INFO",
+            num_threads=10,
             spark_conf={"key1": "val1", "key2": "val2"},
+            override_clusters={"main": "abcd-192345-eadeadbeaf", "tacl": "efgh-999999-eadeadbeaf"},
         )
 
         config: WorkspaceConfig = mc()

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -394,6 +394,24 @@ def test_step_list(mocker):
     assert len(steps) == 2
     assert steps[0] == "wl_1" and steps[1] == "wl_2"
 
+def test_step_run(mocker):
+    ws = mock_ws(mocker)
+    from databricks.labs.ucx.framework.tasks import Task
+
+    tasks = [
+        Task(task_id=0, workflow="wl_1", name="n3", doc="d3", fn=lambda: None),
+        Task(task_id=1, workflow="wl_2", name="n2", doc="d2", fn=lambda: None),
+        Task(task_id=2, workflow="wl_1", name="n1", doc="d1", fn=lambda: None),
+    ]
+    mocker.patch("builtins.input", return_value="42")
+    with mocker.patch.object(WorkspaceInstaller, attribute="_sorted_tasks", return_value=tasks):
+        install = WorkspaceInstaller(ws)
+        steps = install._step_list()
+        install._override_clusters = {
+            'main':'clusterid1',
+            'tacl':'clusterid_tacl'
+        }
+        install.run()
 
 def test_create_readme(mocker):
     mocker.patch("builtins.input", return_value="yes")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -123,7 +123,6 @@ def test_install_dbfs_write_protect(mocker, tmp_path):
         assert "write_protected_dbfs" not in kwargs, f"{kwargs}"
         return MagicMock(job_id="bar")
 
-
     jobs_mock.create = jobs_create
     ws.jobs = jobs_mock
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -103,6 +103,32 @@ def test_install_override_clusters(mocker, tmp_path):
     assert res["tacl"] == cluster_id
 
     install._configure()
+    install.run()
+
+
+def test_install_dbfs_write_protect(mocker, tmp_path):
+    "Verify flag isn't in jobs create api call"
+    ws = mock_ws(mocker)
+    install = WorkspaceInstaller(ws)
+    cluster_id = "9999-999999-abcdefgh"
+    mocker.patch("builtins.input", return_value=cluster_id)
+    res = install._configure_override_clusters()
+    assert res["main"] == cluster_id
+    assert res["tacl"] == cluster_id
+
+    jobs_mock = MagicMock()
+
+    def jobs_create(*args, **kwargs):
+        assert "write_protected_dbfs" not in args, f"{args}"
+        assert "write_protected_dbfs" not in kwargs, f"{kwargs}"
+        return MagicMock(job_id="bar")
+
+
+    jobs_mock.create = jobs_create
+    ws.jobs = jobs_mock
+
+    install._configure()
+    install.run()
 
 
 def test_install_database_happy(mocker, tmp_path):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -89,13 +89,15 @@ def test_run_workflow_creates_proper_failure(mocker):
 
 
 def test_install_override_clusters(mocker, tmp_path):
-    ws = mocker.Mock()
+    ws = mock_ws(mocker)
     install = WorkspaceInstaller(ws)
     cluster_id = "9999-999999-abcdefgh"
     mocker.patch("builtins.input", return_value=cluster_id)
     res = install._configure_override_clusters()
     assert res["main"] == cluster_id
     assert res["tacl"] == cluster_id
+
+    install._configure()
 
 
 def test_install_database_happy(mocker, tmp_path):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -410,7 +410,7 @@ def test_step_run(mocker):
         steps = install._step_list()
         assert len(steps) == 2
         assert steps[0] == "wl_1" and steps[1] == "wl_2"
-    
+
         install._override_clusters = {"main": "clusterid1", "tacl": "clusterid_tacl"}
         install.run()
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -88,6 +88,16 @@ def test_run_workflow_creates_proper_failure(mocker):
     assert "Stuff happens: stuff: does not compute" == str(failure.value)
 
 
+def test_install_override_clusters(mocker, tmp_path):
+    ws = mocker.Mock()
+    install = WorkspaceInstaller(ws)
+    cluster_id = "9999-999999-abcdefgh"
+    mocker.patch("builtins.input", return_value=cluster_id)
+    res = install._configure_override_clusters()
+    assert res["main"] == cluster_id
+    assert res["tacl"] == cluster_id
+
+
 def test_install_database_happy(mocker, tmp_path):
     ws = mocker.Mock()
     install = WorkspaceInstaller(ws)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -394,6 +394,7 @@ def test_step_list(mocker):
     assert len(steps) == 2
     assert steps[0] == "wl_1" and steps[1] == "wl_2"
 
+
 def test_step_run(mocker):
     ws = mock_ws(mocker)
     from databricks.labs.ucx.framework.tasks import Task
@@ -407,11 +408,12 @@ def test_step_run(mocker):
     with mocker.patch.object(WorkspaceInstaller, attribute="_sorted_tasks", return_value=tasks):
         install = WorkspaceInstaller(ws)
         steps = install._step_list()
-        install._override_clusters = {
-            'main':'clusterid1',
-            'tacl':'clusterid_tacl'
-        }
+        assert len(steps) == 2
+        assert steps[0] == "wl_1" and steps[1] == "wl_2"
+    
+        install._override_clusters = {"main": "clusterid1", "tacl": "clusterid_tacl"}
         install.run()
+
 
 def test_create_readme(mocker):
     mocker.patch("builtins.input", return_value="yes")


### PR DESCRIPTION
This may close #493 and #531.

Implemented cluster overrides in installer. User is prompted for cluster ids for a legacy unassigned cluster and a Legacy TACL cluster, then these clusters are used for jobs.
The reason for using interactive clusters is to have compute where the UCX admin has manually loaded the python wheel file as the the wheel file can't be read from Workspace FS and used in python tasks with the current platform release.
