### PR TITLE
fix/issue_545: Include hostname in jdbc:/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,32 @@ for the latest reference of environment variables related to authentication.
 - `TEST_USER_ISOLATION_CLUSTER_ID`: This environment variable contains the identifier for the cluster used in testing
   user isolation. The value is a unique cluster ID, like "0825-164947-...".
 
+With the final results looking like (Note, for Azure Cloud, no `DATABRICKS_TOKEN` value):
+```shell
+export DATABRICKS_ACCOUNT_ID=999f9f99-89ba-4dd2-9999-a3301d0f21c0
+export DATABRICKS_HOST=https://adb-8590162618999999.14.azuredatabricks.net
+export DATABRICKS_CLUSTER_ID=8888-999999-6w1gh5v6
+export TEST_DEFAULT_WAREHOUSE_ID=a73e69a521a9c91c
+export TEST_DEFAULT_CLUSTER_ID=8888-999999-6w1gh5v6
+export TEST_LEGACY_TABLE_ACL_CLUSTER_ID=8888-999999-9fafnezi
+export TEST_INSTANCE_POOL_ID=7777-999999-save46-pool-cghrk21s
+```
+
+The test workspace must have test user accounts, matching displayName pattern `test-uesr-*`
+To create test users:
+
+```shell
+databricks users create --active --display-name "test-user-1" --user-name "first.last-t1@example.com"
+databricks users create --active --display-name "test-user-2" --user-name "first.last-t2@example.com"
+```
+
+Before running integration tests on Azure Cloud, you must login (and clear any TOKEN authenticaton):
+
+```shell
+az login
+unset DATABRICKS_TOKEN
+```
+
 Use the following command to run the integration tests:
 
 ```shell

--- a/src/databricks/labs/ucx/assessment/crawlers.py
+++ b/src/databricks/labs/ucx/assessment/crawlers.py
@@ -125,13 +125,23 @@ def spark_version_compatibility(spark_version: str) -> str:
     first_comp_custom_x = 2
     dbr_version_components = spark_version.split("-")
     first_components = dbr_version_components[0].split(".")
+    if "custom" in spark_version:
+        # custom runtime
+        return "unsupported"
+    if "dlt" in spark_version:
+        # shouldn't hit this? Does show up in cluster list
+        return "dlt"
     if len(first_components) != first_comp_custom_rt:
         # custom runtime
         return "unsupported"
     if first_components[first_comp_custom_x] != "x":
         # custom runtime
         return "unsupported"
-    version = int(first_components[0]), int(first_components[1])
+
+    try:
+        version = int(first_components[0]), int(first_components[1])
+    except ValueError:
+        version = 0, 0
     if version < (10, 0):
         return "unsupported"
     if (10, 0) <= version < (11, 3):

--- a/src/databricks/labs/ucx/hive_metastore/data_objects.py
+++ b/src/databricks/labs/ucx/hive_metastore/data_objects.py
@@ -74,7 +74,7 @@ class ExternalLocationCrawler(CrawlerBase):
                     port = result_dict.get("port", "")
                     database = result_dict.get("database", "")
                     httppath = result_dict.get("httpPath", "")
-
+                    provider = result_dict.get("provider", "")
                     # dbtable = result_dict.get("dbtable", "")
 
                     # currently supporting databricks and mysql external tables
@@ -83,7 +83,12 @@ class ExternalLocationCrawler(CrawlerBase):
                         jdbc_location = f"jdbc:databricks://{host};httpPath={httppath}"
                     elif "mysql" in location.lower():
                         jdbc_location = f"jdbc:mysql://{host}:{port}/{database}"
+                    elif not provider == "":
+                        jdbc_location = f"jdbc:{provider.lower()}://{host}:{port}/{database}"
+                    else:
+                        jdbc_location = f"{location.lower()}/{host}:{port}/{database}"
                     external_locations.append(ExternalLocation(jdbc_location))
+
         return external_locations
 
     def _external_location_list(self):

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -26,6 +26,8 @@ class Table:
     view_text: str = None
     upgraded_to: str = None
 
+    storage_properties: str = None
+
     @property
     def is_delta(self) -> bool:
         if self.table_format is None:
@@ -162,6 +164,7 @@ class TablesCrawler(CrawlerBase):
                 location=describe.get("Location", None),
                 view_text=describe.get("View Text", None),
                 upgraded_to=self._parse_table_props(describe.get("Table Properties", "")).get("upgraded_to", None),
+                storage_properties=self._parse_table_props(describe.get("Storage Properties", "")),
             )
         except Exception as e:
             # TODO: https://github.com/databrickslabs/ucx/issues/406

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.DataFrame
 
 // must follow the same structure as databricks.labs.ucx.hive_metastore.tables.Table
 case class TableDetails(catalog: String, database: String, name: String, object_type: String,
-                        table_format: String, location: String, view_text: String, upgraded_to: String)
+                        table_format: String, location: String, view_text: String, upgraded_to: String, storage_properties: String)
 
 // recording error log in the database
 case class TableError(catalog: String, database: String, name: String, error: String)
@@ -36,10 +36,20 @@ def metadataForAllTables(databases: Seq[String], queue: ConcurrentLinkedQueue[Ta
           failures.add(TableError("hive_metastore", databaseName, tableName, s"result is null"))
           None
         } else {
-          val upgraded_to=table.properties.get("upgraded_to")
+          val upgraded_to = table.properties.get("upgraded_to")
+          val redactedKey = "*********"
+
+          val formattedString = table.storage.properties.map {
+            case (key, value) =>
+              if (key == "personalAccessToken")
+                s"$key=$redactedKey(redacted)"
+              else
+                s"$key=$value"
+          }.mkString("[", ", ", "]")
+
           Some(TableDetails("hive_metastore", databaseName, tableName, table.tableType.name, table.provider.orNull,
             table.storage.locationUri.map(_.toString).orNull, table.viewText.orNull,
-              upgraded_to match {case Some(target) => target case None => null}))
+            upgraded_to match { case Some(target) => target case None => null }, formattedString))
         }
       } catch {
         case err: Throwable =>

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -43,6 +43,8 @@ def metadataForAllTables(databases: Seq[String], queue: ConcurrentLinkedQueue[Ta
             case (key, value) =>
               if (key == "personalAccessToken")
                 s"$key=$redactedKey(redacted)"
+              else if (key.equalsIgnoreCase("password"))
+                s"$key=$redactedKey(redacted)"
               else
                 s"$key=$value"
           }.mkString("[", ", ", "]")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -240,8 +240,12 @@ class WorkspaceInstaller:
                     continue
                 run_output = self._ws.jobs.get_run_output(run_task.run_id)
                 if logger.isEnabledFor(logging.DEBUG):
-                    sys.stderr.write(run_output.error_trace)
-                messages.append(f"{run_task.task_key}: {run_output.error}")
+                    if run_output and run_output.error_trace:
+                        sys.stderr.write(run_output.error_trace)
+                if run_output and run_output.error:
+                    messages.append(f"{run_task.task_key}: {run_output.error}")
+                else:
+                    messages.append(f"{run_task.task_key}: output unavailable")
             msg = f'{job_run.state.state_message.rstrip(".")}: {", ".join(messages)}'
             raise OperationFailed(msg) from None
 

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -16,7 +16,11 @@ from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import compute, iam, jobs, pipelines, workspace
 from databricks.sdk.service.catalog import CatalogInfo, SchemaInfo, TableInfo
-from databricks.sdk.service.sql import CreateWarehouseRequestWarehouseType
+from databricks.sdk.service.sql import (
+    CreateWarehouseRequestWarehouseType,
+    Query,
+    QueryInfo,
+)
 from databricks.sdk.service.workspace import ImportFormat
 
 from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
@@ -821,3 +825,25 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Callable[..., Table
                 raise e
 
     yield from factory("table", create, remove)
+
+
+@pytest.fixture
+def make_query(ws, make_table, make_random):
+    def create() -> QueryInfo:
+        table = make_table()
+        query_name = f"ucx_query_Q{make_random(4)}"
+        query = ws.queries.create(
+            name=f"{query_name}",
+            description="TEST QUERY FOR UCX",
+            query=f"SELECT * FROM {table.schema_name}.{table.name}",
+        )
+        logger.info(f"Query Created {query_name}: {ws.config.host}/sql/editor/{query.id}")
+        return query
+
+    def remove(query: Query):
+        try:
+            ws.queries.delete(query_id=query.id)
+        except RuntimeError as e:
+            logger.info(f"Can't drop query {e}")
+
+    yield from factory("query", create, remove)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,6 +92,10 @@ def user_pool(ws):
 
 @pytest.fixture
 def make_ucx_group(make_random, make_group, make_acc_group, user_pool):
+    assert (
+        len(user_pool) >= 1
+    ), "must have 'test-user-*' test users with id, userName and displayName in your test workspace"
+
     def inner():
         display_name = f"ucx_{make_random(4)}"
         members = [_.id for _ in random.choices(user_pool, k=random.randint(1, 40))]

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -34,16 +34,39 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
             storage_properties="[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
         ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://providerknown/",
+            storage_properties="[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted), \
+            provider=providerknown]",
+        ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://providerunknown/",
+            storage_properties="[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted)]",
+        ),
     ]
     sql_backend.save_table(f"{inventory_schema}.tables", tables, Table)
     sql_backend.save_table(f"{inventory_schema}.mounts", [Mount("/mnt/foo", "s3://bar")], Mount)
 
     crawler = ExternalLocationCrawler(ws, sql_backend, inventory_schema)
     results = crawler.snapshot()
-    assert len(results) == 4
+    assert len(results) == 6
     assert results[1].location == "s3://bar/test3/"
     assert (
         results[2].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
     assert results[3].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    assert results[4].location == "jdbc:providerknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
+    assert results[5].location == "jdbc://providerunknown//somedb.us-east-1.rds.amazonaws.com:1234/test_db"

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -46,7 +46,4 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
         results[2].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
-    assert (
-            results[3].location
-            == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
-    )
+    assert results[3].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -24,6 +24,16 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
             httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com, \
             dbtable=samples.nyctaxi.trips]",
         ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://MYSQL/",
+            storage_properties="[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
+            port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+        ),
     ]
     sql_backend.save_table(f"{inventory_schema}.tables", tables, Table)
     sql_backend.save_table(f"{inventory_schema}.mounts", [Mount("/mnt/foo", "s3://bar")], Mount)
@@ -32,4 +42,11 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
     results = crawler.snapshot()
     assert len(results) == 4
     assert results[1].location == "s3://bar/test3/"
-    assert results[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert (
+        results[2].location
+        == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
+    )
+    assert (
+            results[3].location
+            == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    )

--- a/tests/integration/test_conftest.py
+++ b/tests/integration/test_conftest.py
@@ -1,0 +1,4 @@
+def test_make_ucx_group(make_ucx_group):
+    ws_group_a, acc_group_a = make_ucx_group()
+    assert ws_group_a is not None
+    assert acc_group_a is not None

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -54,7 +54,7 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
     assert len(workflow_run_logs) == 1
 
 
-@retried(on=[NotFound, TimeoutError, OperationFailed, InvalidParameterValue], timeout=timedelta(minutes=15))
+@retried(on=[NotFound, TimeoutError, OperationFailed, InvalidParameterValue], timeout=timedelta(minutes=25))
 def test_jobs_with_no_inventory_database(
     ws,
     sql_backend,

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -121,7 +121,7 @@ def test_delete_ws_groups_should_not_delete_non_reflected_acc_groups(ws, make_uc
     assert ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
 
 
-@retried(on=[NotFound, TimeoutError, AssertionError], timeout=timedelta(minutes=10))
+@retried(on=[NotFound, TimeoutError, AssertionError], timeout=timedelta(minutes=20))
 def test_replace_workspace_groups_with_account_groups(
     ws,
     sql_backend,

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -5,16 +5,19 @@ from datetime import timedelta
 import pytest
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
+from databricks.sdk.service import sql
 from databricks.sdk.service.iam import PermissionLevel, ResourceMeta
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
+from databricks.labs.ucx.workspace_access import redash
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
 )
 from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
+from databricks.labs.ucx.workspace_access.redash import RedashPermissionsSupport
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
@@ -304,7 +307,7 @@ def test_set_owner_permission(ws, sql_backend, inventory_schema, make_ucx_group,
 
     permission_manager.apply_group_permissions(state)
 
-    @retried(on=[AssertionError], timeout=timedelta(minutes=1))
+    @retried(on=[AssertionError], timeout=timedelta(seconds=30))
     def check_permissions_for_account_group():
         logger.info("check_permissions_for_account_group()")
 
@@ -333,3 +336,61 @@ def test_set_owner_permission(ws, sql_backend, inventory_schema, make_ucx_group,
         assert "OWN" in table_permissions[group_info.name_in_account]
 
     check_table_permissions_after_backup_delete()
+
+
+def test_query_permission(ws, sql_backend, inventory_schema, make_table, make_query, make_ucx_group, make_group):
+    @retried(on=[AssertionError], timeout=timedelta(seconds=60))
+    def check_permission_in_sql_object(
+        sup: RedashPermissionsSupport, group_name: str, obj_id: str, permission_level, *, omit: bool = False
+    ):
+        permissions = sup._safe_get_dbsql_permissions(sql.ObjectTypePlural.QUERIES, obj_id)
+        assert (not omit) == (
+            len(
+                [
+                    permission
+                    for permission in permissions.access_control_list
+                    if permission.group_name == group_name and permission.permission_level == permission_level
+                ]
+            )
+            > 0
+        )
+
+    logger.info("Testing setting ownership on SQL Query.")
+    query = make_query()
+    ws_group, _ = make_ucx_group()
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+
+    state = group_manager.get_migration_state()
+    assert len(state) == 1
+
+    group_info = state.groups[0]
+
+    # Setting a test case of a query with permissions
+    sup = RedashPermissionsSupport(ws=ws, listings=[], verify_timeout=timedelta(seconds=15))
+    acl = [sql.AccessControl(group_name=ws_group.display_name, permission_level=sql.PermissionLevel.CAN_VIEW)]
+    result = sup._safe_set_permissions(sql.ObjectTypePlural.QUERIES, query.id, acl)
+    assert result is not None
+
+    check_permission_in_sql_object(sup, group_info.name_in_workspace, query.id, sql.PermissionLevel.CAN_VIEW)
+
+    # Attempting Switching Access on Query object
+    redash_acl_listing = [
+        redash.Listing(ws.alerts.list, sql.ObjectTypePlural.ALERTS),
+        redash.Listing(ws.dashboards.list, sql.ObjectTypePlural.DASHBOARDS),
+        redash.Listing(ws.queries.list, sql.ObjectTypePlural.QUERIES),
+    ]
+    sql_support = redash.RedashPermissionsSupport(ws, redash_acl_listing)
+    permission_manager = PermissionManager(sql_backend, inventory_schema, [sql_support])
+    permission_manager.inventorize_permissions()
+
+    group_manager.rename_groups()
+
+    group_manager.reflect_account_groups_on_workspace()
+    permission_manager.apply_group_permissions(state)
+
+    logging.getLogger("databricks").setLevel("DEBUG")
+    permission_manager.apply_group_permissions(state)
+    check_permission_in_sql_object(sup, group_info.name_in_workspace, query.id, sql.PermissionLevel.CAN_VIEW)
+    check_permission_in_sql_object(sup, group_info.temporary_name, query.id, sql.PermissionLevel.CAN_VIEW, omit=True)
+    group_manager.delete_original_workspace_groups()
+    assert len(query.name) > 0

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -84,15 +84,30 @@ def test_external_locations():
         ),
         row_factory(
             [
-                "jdbc:MYSQL://",
+                "jdbc:/MYSQL",
                 "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+            ]
+        ),
+        row_factory(
+            [
+                "jdbc:providerknown:/",
+                "[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted), \
+            provider=providerknown]",
+            ]
+        ),
+        row_factory(
+            [
+                "jdbc:providerunknown:/",
+                "[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted)]",
             ]
         ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 5
+    assert len(result_set) == 7
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
     assert (
@@ -100,6 +115,8 @@ def test_external_locations():
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
     assert result_set[4].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    assert result_set[5].location == "jdbc:providerknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
+    assert result_set[6].location == "jdbc:providerunknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -85,10 +85,10 @@ def test_external_locations():
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 3
+    assert len(result_set) == 4
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[2].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert result_set[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -88,7 +88,7 @@ def test_external_locations():
                 "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
             ]
-        )
+        ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
@@ -99,10 +99,7 @@ def test_external_locations():
         result_set[3].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
-    assert (
-        result_set[4].location
-        == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
-    )
+    assert result_set[4].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -65,22 +65,30 @@ def test_spark_version_compatibility():
 
 def test_external_locations():
     crawler = ExternalLocationCrawler(Mock(), MockBackend(), "test")
-    row_factory = type("Row", (Row,), {"__columns__": ["location"]})
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "storage_properties"]})
     sample_locations = [
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table2"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/testloc/Table3"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/anotherloc/Table4"]),
-        row_factory(["dbfs:/mnt/ucx/database1/table1"]),
-        row_factory(["dbfs:/mnt/ucx/database2/table2"]),
-        row_factory(["DatabricksRootmntDatabricksRoot"]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table2", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/testloc/Table3", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/anotherloc/Table4", ""]),
+        row_factory(["dbfs:/mnt/ucx/database1/table1", ""]),
+        row_factory(["dbfs:/mnt/ucx/database2/table2", ""]),
+        row_factory(["DatabricksRootmntDatabricksRoot", ""]),
+        row_factory(
+            [
+                "jdbc:databricks://",
+                "[personalAccessToken=*********(redacted), \
+        httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com, \
+        dbtable=samples.nyctaxi.trips]",
+            ]
+        ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
     assert len(result_set) == 3
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[2].location == "s3://us-east-1-ucx-container/"
+    assert result_set[2].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -36,6 +36,7 @@ from databricks.labs.ucx.assessment.crawlers import (
     JobsCrawler,
     PipelineInfo,
     PipelinesCrawler,
+    spark_version_compatibility,
 )
 from databricks.labs.ucx.hive_metastore.data_objects import ExternalLocationCrawler
 from databricks.labs.ucx.hive_metastore.mounts import Mount
@@ -44,6 +45,22 @@ from tests.unit.framework.mocks import MockBackend
 
 _SECRET_PATTERN = r"{{(secrets.*?)}}"
 _SECRET_VALUE = b"SGVsbG8sIFdvcmxkIQ=="
+
+
+def test_spark_version_compatibility():
+    assert "unsupported" == spark_version_compatibility("custom:snapshot__14")
+    assert "unsupported" == spark_version_compatibility("custom:custom-local__13.x-snapshot-scala2.12__unknown__head__")
+    assert "dlt" == spark_version_compatibility("dlt:12.2-delta-pipelines-dlt-release")
+    assert "unsupported" == spark_version_compatibility("6.4.x-esr-scala2.11")
+    assert "unsupported" == spark_version_compatibility("9.3.x-cpu-ml-scala2.12")
+    assert "kinda works" == spark_version_compatibility("10.4.x-scala2.12")
+    assert "supported" == spark_version_compatibility("11.3.x-photon-scala2.12")
+    assert "unsupported" == spark_version_compatibility("12.2.1-scala2.12")
+    assert "supported" == spark_version_compatibility("14.1.x-photon-scala2.12")
+    assert "supported" == spark_version_compatibility("123.1.x-quantumscale")
+    assert "supported" == spark_version_compatibility("14.1.x-gpu-ml-scala2.12")
+    assert "supported" == spark_version_compatibility("14.1.x-cpu-ml-scala2.12")
+    assert "unsupported" == spark_version_compatibility("x14.1.x-photon-scala2.12")
 
 
 def test_external_locations():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -82,13 +82,27 @@ def test_external_locations():
         dbtable=samples.nyctaxi.trips]",
             ]
         ),
+        row_factory(
+            [
+                "jdbc:MYSQL://",
+                "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
+            port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+            ]
+        )
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 4
+    assert len(result_set) == 5
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert (
+        result_set[3].location
+        == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
+    )
+    assert (
+        result_set[4].location
+        == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    )
 
 
 def test_job_assessment():


### PR DESCRIPTION
The UCX tool fetches the 'location' from the table properties while for an external location with jdbc, the host information is stored in 'storage properties'.

Add a field for Table class and fetch Storage Properties from the table. Using the host field from Storage properties, create the full jdbc url