### PR TITLE
Fixing installer not being able to migrate from V1 to V2

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -206,8 +206,11 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
         if stored_version == _CONFIG_VERSION:
             return raw
         if stored_version == 1:
-            raw["include_group_names"] = raw.get("groups", {"selected": []})["selected"]
+            raw["include_group_names"] = (
+                raw.get("groups", {"selected": []})["selected"] if "selected" in raw["groups"] else ""
+            )
             raw["renamed_group_prefix"] = raw.get("groups", {"backup_group_prefix": "db-temp-"})["backup_group_prefix"]
+            raw.pop("groups", None)
             return raw
         msg = f"Unknown config version: {stored_version}"
         raise ValueError(msg)

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -207,7 +207,7 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
             return raw
         if stored_version == 1:
             raw["include_group_names"] = (
-                raw.get("groups", {"selected": []})["selected"] if "selected" in raw["groups"] else ""
+                raw.get("groups", {"selected": []})["selected"] if "selected" in raw["groups"] else None
             )
             raw["renamed_group_prefix"] = raw.get("groups", {"backup_group_prefix": "db-temp-"})["backup_group_prefix"]
             raw.pop("groups", None)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -16,7 +16,7 @@ from typing import Any
 import yaml
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.core import DatabricksError
-from databricks.sdk.errors import OperationFailed
+from databricks.sdk.errors import NotFound, OperationFailed
 from databricks.sdk.mixins.compute import SemVer
 from databricks.sdk.service import compute, jobs
 from databricks.sdk.service.sql import EndpointInfoWarehouseType, SpotInstancePolicy
@@ -342,17 +342,17 @@ class WorkspaceInstaller:
     def _configure(self):
         ws_file_url = self.notebook_link(self.config_file)
         try:
-            ws_file_url = self.notebook_link(self.config_file)
             if "version: 1" in self._raw_previous_config():
                 logger.info("old version detected, attempting to migrate to new config")
                 self._config = self._current_config
                 self._write_config(overwrite=True)
+                return
             elif "version: 2" in self._raw_previous_config():
                 logger.info(f"UCX is already configured. See {ws_file_url}")
                 return
-        except DatabricksError as err:
+        except NotFound as err:
             if err.error_code != "RESOURCE_DOES_NOT_EXIST":
-                    raise err
+                raise err
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
         inventory_database = self._configure_inventory_database()
 


### PR DESCRIPTION
- [x] Needs to verify if "backup_group_prefix" is properly migrated
- [x] Needs to verify if "selected_groups" is properly migrated
- [x] Needs to verify if "auto:True" is properly migrated
- [ ] Needs to verify if previous config and jobs are overriden by V2 config
- [x] Needs to work on a fresh installation
- [x] Needs to work when being re-run