### PR TITLE
Fixed install check for git pre-release versions

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -776,7 +776,7 @@ class WorkspaceInstaller:
             dv = SemVer.parse(git_detached_version)
             datestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
             # new commits on main branch since the last tag
-            new_commits = dv.pre_release.split("-")[0]
+            new_commits = dv.pre_release.split("-")[0] if dv.pre_release else None
             # show that it's a version different from the released one in stats
             bump_patch = dv.patch + 1
             # create something that is both https://semver.org and https://peps.python.org/pep-0440/


### PR DESCRIPTION
May fix #599. Installer going down path of checking git, and splitting a variable that wasn't tested for 'None`. Added guard, which fixed 3 broken unit tests.