### PR TITLE
Fixed `crawl_cluster` failure over custom runtimes

### DIFF
--- a/src/databricks/labs/ucx/assessment/crawlers.py
+++ b/src/databricks/labs/ucx/assessment/crawlers.py
@@ -125,13 +125,23 @@ def spark_version_compatibility(spark_version: str) -> str:
     first_comp_custom_x = 2
     dbr_version_components = spark_version.split("-")
     first_components = dbr_version_components[0].split(".")
+    if "custom" in spark_version:
+        # custom runtime
+        return "unsupported"
+    if "dlt" in spark_version:
+        # shouldn't hit this? Does show up in cluster list
+        return "dlt"
     if len(first_components) != first_comp_custom_rt:
         # custom runtime
         return "unsupported"
     if first_components[first_comp_custom_x] != "x":
         # custom runtime
         return "unsupported"
-    version = int(first_components[0]), int(first_components[1])
+
+    try:
+        version = int(first_components[0]), int(first_components[1])
+    except ValueError:
+        version = 0, 0
     if version < (10, 0):
         return "unsupported"
     if (10, 0) <= version < (11, 3):

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -36,6 +36,7 @@ from databricks.labs.ucx.assessment.crawlers import (
     JobsCrawler,
     PipelineInfo,
     PipelinesCrawler,
+    spark_version_compatibility,
 )
 from databricks.labs.ucx.hive_metastore.data_objects import ExternalLocationCrawler
 from databricks.labs.ucx.hive_metastore.mounts import Mount
@@ -44,6 +45,22 @@ from tests.unit.framework.mocks import MockBackend
 
 _SECRET_PATTERN = r"{{(secrets.*?)}}"
 _SECRET_VALUE = b"SGVsbG8sIFdvcmxkIQ=="
+
+
+def test_spark_version_compatibility():
+    assert "unsupported" == spark_version_compatibility("custom:snapshot__14")
+    assert "unsupported" == spark_version_compatibility("custom:custom-local__13.x-snapshot-scala2.12__unknown__head__")
+    assert "dlt" == spark_version_compatibility("dlt:12.2-delta-pipelines-dlt-release")
+    assert "unsupported" == spark_version_compatibility("6.4.x-esr-scala2.11")
+    assert "unsupported" == spark_version_compatibility("9.3.x-cpu-ml-scala2.12")
+    assert "kinda works" == spark_version_compatibility("10.4.x-scala2.12")
+    assert "supported" == spark_version_compatibility("11.3.x-photon-scala2.12")
+    assert "unsupported" == spark_version_compatibility("12.2.1-scala2.12")
+    assert "supported" == spark_version_compatibility("14.1.x-photon-scala2.12")
+    assert "supported" == spark_version_compatibility("123.1.x-quantumscale")
+    assert "supported" == spark_version_compatibility("14.1.x-gpu-ml-scala2.12")
+    assert "supported" == spark_version_compatibility("14.1.x-cpu-ml-scala2.12")
+    assert "unsupported" == spark_version_compatibility("x14.1.x-photon-scala2.12")
 
 
 def test_external_locations():


### PR DESCRIPTION
May fix https://github.com/databrickslabs/ucx/issues/601 
Test for `custom`, `dlt` and add exception handling around casting to int.
Add unit tests based on observation of internal workspaces.