### PR TITLE
Check if the `hatch` is already installed, and install only if it isn't installed yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clean:
 	rm -fr .venv clean htmlcov .mypy_cache .pytest_cache .ruff_cache .coverage coverage.xml
 
 .venv/bin/python:
-	pip install hatch
+	if ! command -v hatch &> /dev/null; then pip install hatch ; fi
 	hatch env create
 
 dev: .venv/bin/python


### PR DESCRIPTION
I have `hatch` already installed via homebrew, and don't want install an additional copy of it.