### PR TITLE
Temporarily remove SQL warehouse requirement from `labs.yml`

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -2,8 +2,6 @@
 name: ucx
 description: Unity Catalog Migration Toolkit (UCX)
 install:
-  warehouse_types:
-    - PRO
   script: src/databricks/labs/ucx/install.py
 entrypoint: src/databricks/labs/ucx/cli.py
 min_python: 3.10


### PR DESCRIPTION
At the moment the Databricks CLI installer has a bug, when a `DEFAULT` profile without `warehouse_id` is causing an installation error.