### PR TITLE
Fixed `databricks labs ucx workflows` command

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -900,7 +900,7 @@ class WorkspaceInstaller:
                     }
                 )
             except InvalidParameterValue as e:
-                logger.warning(f'skipping {step}: {e}')
+                logger.warning(f"skipping {step}: {e}")
                 continue
         return latest_status
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -890,14 +890,18 @@ class WorkspaceInstaller:
     def latest_job_status(self) -> list[dict]:
         latest_status = []
         for step, job_id in self._state.jobs.items():
-            job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
-            latest_status.append(
-                {
-                    "step": step,
-                    "state": "UNKNOWN" if not job_runs else str(job_runs[0].state.result_state),
-                    "started": "" if not job_runs else job_runs[0].start_time,
-                }
-            )
+            try:
+                job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
+                latest_status.append(
+                    {
+                        "step": step,
+                        "state": "UNKNOWN" if not job_runs else str(job_runs[0].state.result_state),
+                        "started": "<never run>" if not job_runs else job_runs[0].start_time,
+                    }
+                )
+            except InvalidParameterValue as e:
+                logger.warning(f'skipping {step}: {e}')
+                continue
         return latest_status
 
 


### PR DESCRIPTION
This PR skips jobs that are still in the `~/.ucx/state.json`, but don't exist in the workspace.

<img width="1009" alt="image" src="https://github.com/databrickslabs/ucx/assets/259697/11a50e2d-44b6-476a-9ca9-88a6a59b9949">
