### PR TITLE
Fixed External Location widget to return hostname for `jdbc:` locations

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/data_objects.py
+++ b/src/databricks/labs/ucx/hive_metastore/data_objects.py
@@ -74,7 +74,7 @@ class ExternalLocationCrawler(CrawlerBase):
                     port = result_dict.get("port", "")
                     database = result_dict.get("database", "")
                     httppath = result_dict.get("httpPath", "")
-
+                    provider = result_dict.get("provider", "")
                     # dbtable = result_dict.get("dbtable", "")
 
                     # currently supporting databricks and mysql external tables
@@ -83,7 +83,12 @@ class ExternalLocationCrawler(CrawlerBase):
                         jdbc_location = f"jdbc:databricks://{host};httpPath={httppath}"
                     elif "mysql" in location.lower():
                         jdbc_location = f"jdbc:mysql://{host}:{port}/{database}"
+                    elif not provider == "":
+                        jdbc_location = f"jdbc:{provider.lower()}://{host}:{port}/{database}"
+                    else:
+                        jdbc_location = f"{location.lower()}/{host}:{port}/{database}"
                     external_locations.append(ExternalLocation(jdbc_location))
+
         return external_locations
 
     def _external_location_list(self):

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -26,6 +26,8 @@ class Table:
     view_text: str = None
     upgraded_to: str = None
 
+    storage_properties: str = None
+
     @property
     def is_delta(self) -> bool:
         if self.table_format is None:
@@ -162,6 +164,7 @@ class TablesCrawler(CrawlerBase):
                 location=describe.get("Location", None),
                 view_text=describe.get("View Text", None),
                 upgraded_to=self._parse_table_props(describe.get("Table Properties", "")).get("upgraded_to", None),
+                storage_properties=self._parse_table_props(describe.get("Storage Properties", "")),
             )
         except Exception as e:
             # TODO: https://github.com/databrickslabs/ucx/issues/406

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -44,6 +44,8 @@ def metadataForAllTables(databases: Seq[String], queue: ConcurrentLinkedQueue[Ta
             case (key, value) =>
               if (key == "personalAccessToken")
                 s"$key=$redactedKey(redacted)"
+              else if (key.equalsIgnoreCase("password"))
+                s"$key=$redactedKey(redacted)"
               else
                 s"$key=$value"
           }.mkString("[", ", ", "]")

--- a/src/databricks/labs/ucx/hive_metastore/tables.scala
+++ b/src/databricks/labs/ucx/hive_metastore/tables.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.DataFrame
 
 // must follow the same structure as databricks.labs.ucx.hive_metastore.tables.Table
 case class TableDetails(catalog: String, database: String, name: String, object_type: String,
-                        table_format: String, location: String, view_text: String, upgraded_to: String)
+                        table_format: String, location: String, view_text: String, upgraded_to: String, storage_properties: String)
 
 // recording error log in the database
 case class TableError(catalog: String, database: String, name: String, error: String)
@@ -37,10 +37,20 @@ def metadataForAllTables(databases: Seq[String], queue: ConcurrentLinkedQueue[Ta
           failures.add(TableError("hive_metastore", databaseName, tableName, s"result is null"))
           None
         } else {
-          val upgraded_to=table.properties.get("upgraded_to")
+          val upgraded_to = table.properties.get("upgraded_to")
+          val redactedKey = "*********"
+
+          val formattedString = table.storage.properties.map {
+            case (key, value) =>
+              if (key == "personalAccessToken")
+                s"$key=$redactedKey(redacted)"
+              else
+                s"$key=$value"
+          }.mkString("[", ", ", "]")
+
           Some(TableDetails("hive_metastore", databaseName, tableName, table.tableType.name, table.provider.orNull,
             table.storage.locationUri.map(_.toString).orNull, table.viewText.orNull,
-              upgraded_to match {case Some(target) => target case None => null}))
+            upgraded_to match { case Some(target) => target case None => null }, formattedString))
         }
       } catch {
         case err: Throwable =>

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -34,16 +34,39 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
             storage_properties="[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
         ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://providerknown/",
+            storage_properties="[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted), \
+            provider=providerknown]",
+        ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://providerunknown/",
+            storage_properties="[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted)]",
+        ),
     ]
     sql_backend.save_table(f"{inventory_schema}.tables", tables, Table)
     sql_backend.save_table(f"{inventory_schema}.mounts", [Mount("/mnt/foo", "s3://bar")], Mount)
 
     crawler = ExternalLocationCrawler(ws, sql_backend, inventory_schema)
     results = crawler.snapshot()
-    assert len(results) == 4
+    assert len(results) == 6
     assert results[1].location == "s3://bar/test3/"
     assert (
         results[2].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
     assert results[3].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    assert results[4].location == "jdbc:providerknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
+    assert results[5].location == "jdbc://providerunknown//somedb.us-east-1.rds.amazonaws.com:1234/test_db"

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -46,7 +46,4 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
         results[2].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
-    assert (
-            results[3].location
-            == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
-    )
+    assert results[3].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"

--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -24,6 +24,16 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
             httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com, \
             dbtable=samples.nyctaxi.trips]",
         ),
+        Table(
+            "hive_metastore",
+            "foo",
+            "bar",
+            "EXTERNAL",
+            "delta",
+            location="jdbc://MYSQL/",
+            storage_properties="[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
+            port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+        ),
     ]
     sql_backend.save_table(f"{inventory_schema}.tables", tables, Table)
     sql_backend.save_table(f"{inventory_schema}.mounts", [Mount("/mnt/foo", "s3://bar")], Mount)
@@ -32,4 +42,11 @@ def test_external_locations(ws, sql_backend, inventory_schema, env_or_skip):
     results = crawler.snapshot()
     assert len(results) == 4
     assert results[1].location == "s3://bar/test3/"
-    assert results[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert (
+        results[2].location
+        == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
+    )
+    assert (
+            results[3].location
+            == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    )

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -84,15 +84,30 @@ def test_external_locations():
         ),
         row_factory(
             [
-                "jdbc:MYSQL://",
+                "jdbc:/MYSQL",
                 "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+            ]
+        ),
+        row_factory(
+            [
+                "jdbc:providerknown:/",
+                "[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted), \
+            provider=providerknown]",
+            ]
+        ),
+        row_factory(
+            [
+                "jdbc:providerunknown:/",
+                "[database=test_db, host=somedb.us-east-1.rds.amazonaws.com, \
+            port=1234, dbtable=sometable, user=*********(redacted), password=*********(redacted)]",
             ]
         ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 5
+    assert len(result_set) == 7
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
     assert (
@@ -100,6 +115,8 @@ def test_external_locations():
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
     assert result_set[4].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    assert result_set[5].location == "jdbc:providerknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
+    assert result_set[6].location == "jdbc:providerunknown://somedb.us-east-1.rds.amazonaws.com:1234/test_db"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -85,10 +85,10 @@ def test_external_locations():
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 3
+    assert len(result_set) == 4
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[2].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert result_set[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -88,7 +88,7 @@ def test_external_locations():
                 "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
             port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
             ]
-        )
+        ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
@@ -99,10 +99,7 @@ def test_external_locations():
         result_set[3].location
         == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
     )
-    assert (
-        result_set[4].location
-        == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
-    )
+    assert result_set[4].location == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -65,22 +65,30 @@ def test_spark_version_compatibility():
 
 def test_external_locations():
     crawler = ExternalLocationCrawler(Mock(), MockBackend(), "test")
-    row_factory = type("Row", (Row,), {"__columns__": ["location"]})
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "storage_properties"]})
     sample_locations = [
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table2"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/testloc/Table3"]),
-        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/anotherloc/Table4"]),
-        row_factory(["dbfs:/mnt/ucx/database1/table1"]),
-        row_factory(["dbfs:/mnt/ucx/database2/table2"]),
-        row_factory(["DatabricksRootmntDatabricksRoot"]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/Table2", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/testloc/Table3", ""]),
+        row_factory(["s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/anotherloc/Table4", ""]),
+        row_factory(["dbfs:/mnt/ucx/database1/table1", ""]),
+        row_factory(["dbfs:/mnt/ucx/database2/table2", ""]),
+        row_factory(["DatabricksRootmntDatabricksRoot", ""]),
+        row_factory(
+            [
+                "jdbc:databricks://",
+                "[personalAccessToken=*********(redacted), \
+        httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com, \
+        dbtable=samples.nyctaxi.trips]",
+            ]
+        ),
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
     assert len(result_set) == 3
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[2].location == "s3://us-east-1-ucx-container/"
+    assert result_set[2].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
 
 
 def test_job_assessment():

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -82,13 +82,27 @@ def test_external_locations():
         dbtable=samples.nyctaxi.trips]",
             ]
         ),
+        row_factory(
+            [
+                "jdbc:MYSQL://",
+                "[database=test_db, host=somemysql.us-east-1.rds.amazonaws.com, \
+            port=3306, dbtable=movies, user=*********(redacted), password=*********(redacted)]",
+            ]
+        )
     ]
     sample_mounts = [Mount("/mnt/ucx", "s3://us-east-1-ucx-container")]
     result_set = crawler._external_locations(sample_locations, sample_mounts)
-    assert len(result_set) == 4
+    assert len(result_set) == 5
     assert result_set[0].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-1/Location/"
     assert result_set[1].location == "s3://us-east-1-dev-account-staging-uc-ext-loc-bucket-23/"
-    assert result_set[3].location == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com"
+    assert (
+        result_set[3].location
+        == "jdbc:databricks://dbc-test1-aa11.cloud.databricks.com;httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be"
+    )
+    assert (
+        result_set[4].location
+        == "jdbc:mysql://somemysql.us-east-1.rds.amazonaws.com:3306/test_db"
+    )
 
 
 def test_job_assessment():


### PR DESCRIPTION
The UCX tool fetches the 'location' from the table properties while for an external location with jdbc, the host information is stored in 'storage properties'.

Add a field for Table class and fetch Storage Properties from the table. Using the host field from Storage properties, create the full jdbc url

Older PR closed due to Git issues: https://github.com/databrickslabs/ucx/pull/582