### PR TITLE
Added task filtering by cloud

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -452,7 +452,8 @@ class WorkspaceInstaller:
                 self._state.jobs[step] = job_id
         logger.debug(f"Creating jobs from tasks in {main.__name__}")
         remote_wheel = self._upload_wheel()
-        desired_steps = {t.workflow for t in _TASKS.values()}
+        desired_steps = {t.workflow for t in _TASKS.values() if t.cloud_compatible(self._ws.config)}
+
         wheel_runner = None
 
         if self._override_clusters:

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -130,7 +130,7 @@ def assess_pipelines(cfg: WorkspaceConfig):
     crawler.snapshot()
 
 
-@task("assessment")
+@task("assessment", is_azure=True, is_aws=False, is_gcp=False)
 def assess_azure_service_principals(cfg: WorkspaceConfig):
     """This module scans through all the clusters configurations, cluster policies, job cluster configurations,
     Pipeline configurations, Warehouse configuration and identifies all the Azure Service Principals who has been

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -411,6 +411,8 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     ws.config.host = "https://foo"
     ws.config.is_aws = True
+    ws.config.is_azure = False
+    ws.config.is_gcp = False
     config_bytes = b"""default_catalog: ucx_default
 include_group_names:
 - '42'
@@ -425,7 +427,6 @@ version: 2
 warehouse_id: abc
 workspace_start_path: /
 """
-
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
     ws.workspace.get_status = lambda _: ObjectInfo(object_id=123)
     ws.data_sources.list = lambda: [DataSource(id="bcd", warehouse_id="abc")]
@@ -440,6 +441,22 @@ workspace_start_path: /
 
     webbrowser_open.assert_called_with("https://foo/#workspace/Users/me@example.com/.ucx/README.py")
     # ws.workspace.mkdirs.assert_called_with("/Users/me@example.com/.ucx")
+
+
+def test_cloud_match(ws, mocker):
+    from databricks.labs.ucx.framework.tasks import Task
+
+    tasks = [
+        Task(task_id=0, workflow="wl_1", name="n3", doc="d3", fn=lambda: None, is_aws=True),
+        Task(task_id=1, workflow="wl_2", name="n2", doc="d2", fn=lambda: None, is_azure=True),
+        Task(task_id=2, workflow="wl_1", name="n1", doc="d1", fn=lambda: None, is_gcp=True),
+    ]
+
+    with mocker.patch.object(WorkspaceInstaller, attribute="_sorted_tasks", return_value=tasks):
+        install = WorkspaceInstaller(ws)
+        steps = install._step_list()
+    assert len(steps) == 2
+    assert steps[0] == "wl_1" and steps[1] == "wl_2"
 
 
 def test_query_metadata(ws, mocker):


### PR DESCRIPTION
This will filter out Azure only tasks when on AWS cloud and similarly for all clouds and task types.
This will be useful for cloud specific assessment types such as AWS Instance profiles, Azure service principals etc.