### PR TITLE
Introduce `StaticTablesCrawler` for integration tests

### DIFF
--- a/src/databricks/labs/ucx/framework/logger.py
+++ b/src/databricks/labs/ucx/framework/logger.py
@@ -32,7 +32,7 @@ class NiceFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord):  # noqa: A003
         if not self.colors:
             return super().format(record)
-        ts = self.formatTime(record, datefmt="%H:%M")
+        ts = self.formatTime(record, datefmt="%H:%M:%S")
         level = self._levels[record.levelno]
         # databricks.labs.ucx.foo.bar -> d.l.u.foo.bar
         module_split = record.name.split(".")
@@ -53,7 +53,10 @@ class NiceFormatter(logging.Formatter):
             color_marker = self.BOLD
         elif record.levelno in (logging.ERROR, logging.FATAL):
             color_marker = self.RED + self.BOLD
-        return f"{self.GRAY}{ts}{self.RESET} {level} {color_marker}[{name}] {msg}{self.RESET}"
+        thread_name = ""
+        if record.threadName != "MainThread":
+            thread_name = f"[{record.threadName}]"
+        return f"{self.GRAY}{ts}{self.RESET} {level} {color_marker}[{name}]{thread_name} {msg}{self.RESET}"
 
 
 def _install(level="DEBUG"):

--- a/src/databricks/labs/ucx/framework/parallel.py
+++ b/src/databricks/labs/ucx/framework/parallel.py
@@ -3,6 +3,7 @@ import datetime as dt
 import functools
 import logging
 import os
+import re
 import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -73,7 +74,8 @@ class Threads(Generic[Result]):
             logger.info(f"Finished '{self._name}' tasks: {stats}")
 
     def _execute(self):
-        with ThreadPoolExecutor(self._num_threads) as pool:
+        thread_name_prefix = re.sub(r"\W+", "_", self._name)
+        with ThreadPoolExecutor(self._num_threads, thread_name_prefix) as pool:
             futures = []
             for task in self._tasks:
                 if task is None:

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -749,7 +749,7 @@ def make_catalog(ws, sql_backend, make_random) -> Callable[..., CatalogInfo]:
 def make_schema(ws, sql_backend, make_random) -> Callable[..., SchemaInfo]:
     def create(*, catalog_name: str = "hive_metastore", name: str | None = None) -> SchemaInfo:
         if name is None:
-            name = f"ucx_S{make_random(4)}"
+            name = f"ucx_S{make_random(4)}".lower()
         full_name = f"{catalog_name}.{name}".lower()
         sql_backend.execute(f"CREATE SCHEMA {full_name}")
         schema_info = SchemaInfo(catalog_name=catalog_name, name=name, full_name=full_name)
@@ -784,7 +784,7 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Callable[..., Table
             catalog_name = schema.catalog_name
             schema_name = schema.name
         if name is None:
-            name = f"ucx_T{make_random(4)}"
+            name = f"ucx_T{make_random(4)}".lower()
         full_name = f"{catalog_name}.{schema_name}.{name}".lower()
         ddl = f'CREATE {"VIEW" if view else "TABLE"} {full_name}'
         if ctas is not None:

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -159,7 +159,7 @@ class PermissionManager(CrawlerBase):
 
     def load_all_for(self, object_type: str, object_id: str, klass: type) -> any:
         for perm in self.load_all():
-            if object_type == perm.object_type and object_id == perm.object_id:
+            if object_type == perm.object_type and object_id.lower() == perm.object_id.lower():
                 raw = json.loads(perm.raw)
                 yield klass(**raw)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,11 @@ from databricks.sdk import AccountClient
 from databricks.sdk.core import Config
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
+from databricks.sdk.service.catalog import TableInfo
 
+from databricks.labs.ucx.framework.crawlers import SqlBackend
+from databricks.labs.ucx.hive_metastore import TablesCrawler
+from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.mixins.fixtures import *  # noqa: F403
 
 logging.getLogger("tests").setLevel("DEBUG")
@@ -104,3 +108,23 @@ def make_ucx_group(make_random, make_group, make_acc_group, user_pool):
         return ws_group, acc_group
 
     return inner
+
+
+class StaticTablesCrawler(TablesCrawler):
+    def __init__(self, sql_backend: SqlBackend, schema: str, tables: list[TableInfo]):
+        super().__init__(sql_backend, schema)
+        self._tables = [
+            Table(
+                catalog=_.catalog_name,
+                database=_.schema_name,
+                name=_.name,
+                object_type="TABLE" if not _.view_definition else "VIEW",
+                view_text=_.view_definition,
+                location=_.storage_location,
+                table_format=f"{_.data_source_format}",
+            )
+            for _ in tables
+        ]
+
+    def snapshot(self) -> list[Table]:
+        return self._tables

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -143,7 +143,6 @@ def test_replace_workspace_groups_with_account_groups(
     dummy_table = make_table()
     sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
 
-    # tables = TablesCrawler(sql_backend, inventory_schema)
     tables = StaticTablesCrawler(sql_backend, inventory_schema, [dummy_table])
     grants = GrantsCrawler(tables)
 

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -7,7 +7,7 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.iam import PermissionLevel, ResourceMeta
 
-from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
+from databricks.labs.ucx.hive_metastore import GrantsCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
@@ -16,6 +16,8 @@ from databricks.labs.ucx.workspace_access.generic import (
 from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+
+from ..conftest import StaticTablesCrawler
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +120,8 @@ def test_delete_ws_groups_should_not_delete_non_reflected_acc_groups(ws, make_uc
     assert ws.groups.get(ws_group.id).display_name == "ucx-temp-" + ws_group.display_name
 
 
-@retried(on=[NotFound, TimeoutError, AssertionError], timeout=timedelta(minutes=20))
+# average runtime is 100 seconds
+@retried(on=[NotFound, TimeoutError, AssertionError], timeout=timedelta(minutes=15))
 def test_replace_workspace_groups_with_account_groups(
     ws,
     sql_backend,
@@ -137,13 +140,19 @@ def test_replace_workspace_groups_with_account_groups(
     )
     logger.info(f"Cluster policy: {ws.config.host}#setting/clusters/cluster-policies/view/{cluster_policy.policy_id}")
 
-    tables = TablesCrawler(sql_backend, inventory_schema)
-    grants = GrantsCrawler(tables)
-
     dummy_table = make_table()
     sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
-    res = grants.for_table_info(dummy_table)
-    assert len(res[ws_group.display_name]) == 2
+
+    # tables = TablesCrawler(sql_backend, inventory_schema)
+    tables = StaticTablesCrawler(sql_backend, inventory_schema, [dummy_table])
+    grants = GrantsCrawler(tables)
+
+    @retried(on=[AssertionError], timeout=timedelta(seconds=30))
+    def assert_table_has_two_grants():
+        res = grants.for_table_info(dummy_table)
+        assert len(res[ws_group.display_name]) == 2
+
+    assert_table_has_two_grants()
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
 
@@ -156,8 +165,12 @@ def test_replace_workspace_groups_with_account_groups(
 
     permission_manager.inventorize_permissions()
 
-    dummy_grants = list(permission_manager.load_all_for("TABLE", dummy_table.full_name, Grant))
-    assert 2 == len(dummy_grants)
+    @retried(on=[AssertionError], timeout=timedelta(seconds=30))
+    def assert_table_has_two_permissions():
+        dummy_grants = list(permission_manager.load_all_for("TABLE", dummy_table.full_name, Grant))
+        assert 2 == len(dummy_grants)
+
+    assert_table_has_two_permissions()
 
     table_permissions = grants.for_table_info(dummy_table)
     assert ws_group.display_name in table_permissions

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -1,8 +1,10 @@
 import logging
 
-from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
+from databricks.labs.ucx.hive_metastore import GrantsCrawler
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+
+from ..conftest import StaticTablesCrawler
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +20,7 @@ def test_owner_permissions_for_tables_and_schemas(sql_backend, inventory_schema,
     sql_backend.execute(f"ALTER TABLE {table_info.full_name} OWNER TO `{group_a.display_name}`")
     sql_backend.execute(f"ALTER DATABASE {schema_info.full_name} OWNER TO `{group_b.display_name}`")
 
-    tables = TablesCrawler(sql_backend, inventory_schema)
+    tables = StaticTablesCrawler(sql_backend, inventory_schema, [table_info])
     grants = GrantsCrawler(tables)
 
     original_table_grants = grants.for_table_info(table_info)

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -1,19 +1,7 @@
-import json
 import logging
-from datetime import timedelta
-
-from databricks.sdk.errors import NotFound
-from databricks.sdk.retries import retried
-from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
-from databricks.labs.ucx.hive_metastore.grants import Grant
-from databricks.labs.ucx.workspace_access.generic import (
-    GenericPermissionsSupport,
-    Listing,
-)
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
-from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
@@ -62,75 +50,3 @@ def test_owner_permissions_for_tables_and_schemas(sql_backend, inventory_schema,
     schema_grants = grants.for_schema_info(schema_info)
     assert group_b.display_name not in schema_grants
     assert "OWN" in schema_grants[group_d.display_name]
-
-
-@retried(on=[NotFound, TimeoutError], timeout=timedelta(minutes=15))
-def test_recover_permissions_from_grants(
-    ws,
-    sql_backend,
-    inventory_schema,
-    make_ucx_group,
-    make_cluster_policy,
-    make_cluster_policy_permissions,
-    make_table,
-):
-    ws_group, _ = make_ucx_group()
-    cluster_policy = make_cluster_policy()
-    make_cluster_policy_permissions(
-        object_id=cluster_policy.policy_id,
-        permission_level=PermissionLevel.CAN_USE,
-        group_name=ws_group.display_name,
-    )
-
-    dummy_table = make_table()
-    sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
-
-    generic_permissions = GenericPermissionsSupport(
-        ws, [Listing(ws.cluster_policies.list, "policy_id", "cluster-policies")]
-    )
-    tables = TablesCrawler(sql_backend, inventory_schema)
-    grants = GrantsCrawler(tables)
-    tacl = TableAclSupport(grants, sql_backend)
-
-    # simulate: Table ACLs were not part of $inventory.permissions
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [generic_permissions])
-    permission_manager.inventorize_permissions()
-
-    object_types = set()
-    for perm in permission_manager.load_all():
-        object_types.add(perm.object_type)
-    assert {"cluster-policies"} == object_types
-
-    # simulate: recovery of Table ACLs as part of $inventory.permissions
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [tacl])
-    permission_manager.inventorize_permissions()
-
-    # simulate: normal flow
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [generic_permissions, tacl])
-    object_types = set()
-    permissions_list = permission_manager.load_all()
-    for perm in permissions_list:
-        object_types.add(perm.object_type)
-
-    assert "TABLE" in object_types
-    assert "DATABASE" in object_types
-    assert "cluster-policies" in object_types
-
-    actual_raw_permissions = next(
-        obj.raw
-        for obj in permissions_list
-        if obj.object_id == dummy_table.full_name
-        and obj.object_type == "TABLE"
-        and json.loads(obj.raw)["principal"] == ws_group.display_name
-    )
-
-    assert Grant(
-        principal=ws_group.display_name,
-        action_type="MODIFY, SELECT",
-        catalog=dummy_table.catalog_name.lower(),
-        database=dummy_table.schema_name.lower(),
-        table=dummy_table.name.lower(),
-        view=None,
-        any_file=False,
-        anonymous_function=False,
-    ) == Grant(**json.loads(actual_raw_permissions))


### PR DESCRIPTION
Reduces removes 20 second of runtime on average from the integration tests involving `TablesCrawler`.

Fix #617