### PR TITLE
Reduce runtime of `test_set_owner_permission` from 15 minutes to 44 seconds

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -76,7 +76,7 @@ class Grant:
         object_type, object_key = self.this_type_and_key()
         # See https://docs.databricks.com/en/sql/language-manual/security-grant.html
         if self.action_type.upper() == "OWN":
-            return f"ALTER {object_key} OWNER TO `{self.principal}`"
+            return f"ALTER {object_type} {object_key} OWNER TO `{self.principal}`"
         else:
             return f"GRANT {self.action_type} ON {object_type} {object_key} TO `{self.principal}`"
 

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -27,6 +27,17 @@ class MigratedGroup:
     external_id: str = None
     roles: str = None
 
+    @classmethod
+    def partial_info(cls, workspace: iam.Group, account: iam.Group):
+        """This method is only intended for use in tests"""
+        return cls(
+            id_in_workspace=workspace.id,
+            name_in_workspace=workspace.display_name,
+            name_in_account=account.display_name,
+            temporary_name=f"tmp-{workspace.display_name}",
+            external_id=workspace.external_id,
+        )
+
 
 class MigrationState:
     """Holds migration state of workspace-to-account groups"""

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -5,19 +5,16 @@ from datetime import timedelta
 import pytest
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
-from databricks.sdk.service import sql
 from databricks.sdk.service.iam import PermissionLevel, ResourceMeta
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
-from databricks.labs.ucx.workspace_access import redash
 from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
 )
 from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
-from databricks.labs.ucx.workspace_access.redash import RedashPermissionsSupport
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
@@ -242,155 +239,3 @@ def test_replace_workspace_groups_with_account_groups(
         assert "SELECT" in table_permissions[group_info.name_in_account]
 
     check_table_permissions_after_backup_delete()
-
-
-@retried(on=[NotFound, TimeoutError, AssertionError], timeout=timedelta(minutes=15))
-def test_set_owner_permission(ws, sql_backend, inventory_schema, make_ucx_group, make_table):
-    ws_group, _ = make_ucx_group()
-
-    logger.info("Testing setting ownership on table.")
-    dummy_table = make_table()
-    logger.info(f"Table name {dummy_table.full_name} group name {ws_group.display_name}")
-    sql_backend.execute(f"GRANT SELECT, MODIFY ON TABLE {dummy_table.full_name} TO `{ws_group.display_name}`")
-    sql_backend.execute(f"ALTER {dummy_table.full_name} OWNER TO `{ws_group.display_name}`")
-
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
-
-    tables = TablesCrawler(sql_backend, inventory_schema)
-    grants = GrantsCrawler(tables)
-    tacl = TableAclSupport(grants, sql_backend)
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [tacl])
-
-    permission_manager.inventorize_permissions()
-
-    dummy_grants = list(permission_manager.load_all_for("TABLE", dummy_table.full_name, Grant))
-    assert 2 == len(dummy_grants)
-
-    table_permissions = grants.for_table_info(dummy_table)
-    assert ws_group.display_name in table_permissions
-    assert "MODIFY" in table_permissions[ws_group.display_name]
-    assert "SELECT" in table_permissions[ws_group.display_name]
-    assert "OWN" in table_permissions[ws_group.display_name]
-
-    state = group_manager.get_migration_state()
-    assert len(state.groups) == 1
-
-    group_manager.rename_groups()
-
-    group_info = state.groups[0]
-
-    @retried(on=[AssertionError], timeout=timedelta(seconds=30))
-    def check_permissions_for_backup_group():
-        logger.info("check_permissions_for_backup_group()")
-
-        table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.name_in_workspace not in table_permissions
-        assert "MODIFY" in table_permissions[group_info.temporary_name]
-        assert "SELECT" in table_permissions[group_info.temporary_name]
-        assert "OWN" in table_permissions[group_info.temporary_name]
-
-    check_permissions_for_backup_group()
-
-    group_manager.reflect_account_groups_on_workspace()
-
-    @retried(on=[AssertionError], timeout=timedelta(minutes=1))
-    def check_permissions_after_replace():
-        logger.info("check_permissions_after_replace()")
-
-        table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.name_in_account not in table_permissions
-        assert "MODIFY" in table_permissions[group_info.temporary_name]
-        assert "SELECT" in table_permissions[group_info.temporary_name]
-        assert "OWN" in table_permissions[group_info.temporary_name]
-
-    check_permissions_after_replace()
-
-    permission_manager.apply_group_permissions(state)
-
-    @retried(on=[AssertionError], timeout=timedelta(seconds=30))
-    def check_permissions_for_account_group():
-        logger.info("check_permissions_for_account_group()")
-
-        table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.name_in_account in table_permissions
-        assert group_info.temporary_name in table_permissions
-        assert "MODIFY" in table_permissions[group_info.temporary_name]
-        assert "SELECT" in table_permissions[group_info.temporary_name]
-        assert "MODIFY" in table_permissions[group_info.name_in_account]
-        assert "SELECT" in table_permissions[group_info.name_in_account]
-        assert "OWN" in table_permissions[group_info.name_in_account]
-
-    check_permissions_for_account_group()
-
-    group_manager.delete_original_workspace_groups()
-
-    @retried(on=[AssertionError], timeout=timedelta(minutes=1))
-    def check_table_permissions_after_backup_delete():
-        logger.info("check_table_permissions_after_backup_delete()")
-
-        table_permissions = grants.for_table_info(dummy_table)
-        assert group_info.name_in_account in table_permissions
-        assert group_info.temporary_name not in table_permissions
-        assert "MODIFY" in table_permissions[group_info.name_in_account]
-        assert "SELECT" in table_permissions[group_info.name_in_account]
-        assert "OWN" in table_permissions[group_info.name_in_account]
-
-    check_table_permissions_after_backup_delete()
-
-
-def test_query_permission(ws, sql_backend, inventory_schema, make_table, make_query, make_ucx_group, make_group):
-    @retried(on=[AssertionError], timeout=timedelta(seconds=60))
-    def check_permission_in_sql_object(
-        sup: RedashPermissionsSupport, group_name: str, obj_id: str, permission_level, *, omit: bool = False
-    ):
-        permissions = sup._safe_get_dbsql_permissions(sql.ObjectTypePlural.QUERIES, obj_id)
-        assert (not omit) == (
-            len(
-                [
-                    permission
-                    for permission in permissions.access_control_list
-                    if permission.group_name == group_name and permission.permission_level == permission_level
-                ]
-            )
-            > 0
-        )
-
-    logger.info("Testing setting ownership on SQL Query.")
-    query = make_query()
-    ws_group, _ = make_ucx_group()
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
-
-    state = group_manager.get_migration_state()
-    assert len(state) == 1
-
-    group_info = state.groups[0]
-
-    # Setting a test case of a query with permissions
-    sup = RedashPermissionsSupport(ws=ws, listings=[], verify_timeout=timedelta(seconds=15))
-    acl = [sql.AccessControl(group_name=ws_group.display_name, permission_level=sql.PermissionLevel.CAN_VIEW)]
-    result = sup._safe_set_permissions(sql.ObjectTypePlural.QUERIES, query.id, acl)
-    assert result is not None
-
-    check_permission_in_sql_object(sup, group_info.name_in_workspace, query.id, sql.PermissionLevel.CAN_VIEW)
-
-    # Attempting Switching Access on Query object
-    redash_acl_listing = [
-        redash.Listing(ws.alerts.list, sql.ObjectTypePlural.ALERTS),
-        redash.Listing(ws.dashboards.list, sql.ObjectTypePlural.DASHBOARDS),
-        redash.Listing(ws.queries.list, sql.ObjectTypePlural.QUERIES),
-    ]
-    sql_support = redash.RedashPermissionsSupport(ws, redash_acl_listing)
-    permission_manager = PermissionManager(sql_backend, inventory_schema, [sql_support])
-    permission_manager.inventorize_permissions()
-
-    group_manager.rename_groups()
-
-    group_manager.reflect_account_groups_on_workspace()
-    permission_manager.apply_group_permissions(state)
-
-    logging.getLogger("databricks").setLevel("DEBUG")
-    permission_manager.apply_group_permissions(state)
-    check_permission_in_sql_object(sup, group_info.name_in_workspace, query.id, sql.PermissionLevel.CAN_VIEW)
-    check_permission_in_sql_object(sup, group_info.temporary_name, query.id, sql.PermissionLevel.CAN_VIEW, omit=True)
-    group_manager.delete_original_workspace_groups()
-    assert len(query.name) > 0

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -12,10 +12,56 @@ from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
 )
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
+
+
+def test_owner_permissions_for_tables_and_schemas(sql_backend, inventory_schema, make_schema, make_table, make_group):
+    group_a = make_group()
+    group_b = make_group()
+    group_c = make_group()
+    group_d = make_group()
+
+    schema_info = make_schema()
+    table_info = make_table(schema_name=schema_info.name)
+    sql_backend.execute(f"ALTER TABLE {table_info.full_name} OWNER TO `{group_a.display_name}`")
+    sql_backend.execute(f"ALTER DATABASE {schema_info.full_name} OWNER TO `{group_b.display_name}`")
+
+    tables = TablesCrawler(sql_backend, inventory_schema)
+    grants = GrantsCrawler(tables)
+
+    original_table_grants = grants.for_table_info(table_info)
+    assert "OWN" in original_table_grants[group_a.display_name]
+
+    original_schema_grants = grants.for_schema_info(schema_info)
+    assert "OWN" in original_schema_grants[group_b.display_name]
+
+    tacl_support = TableAclSupport(grants, sql_backend)
+
+    migration_state = MigrationState(
+        [
+            MigratedGroup.partial_info(group_a, group_c),
+            MigratedGroup.partial_info(group_b, group_d),
+        ]
+    )
+
+    for crawler_task in tacl_support.get_crawler_tasks():
+        permission = crawler_task()
+        apply_task = tacl_support.get_apply_task(permission, migration_state)
+        if not apply_task:
+            continue
+        apply_task()
+
+    table_grants = grants.for_table_info(table_info)
+    assert group_a.display_name not in table_grants
+    assert "OWN" in table_grants[group_c.display_name]
+
+    schema_grants = grants.for_schema_info(schema_info)
+    assert group_b.display_name not in schema_grants
+    assert "OWN" in schema_grants[group_d.display_name]
 
 
 @retried(on=[NotFound, TimeoutError], timeout=timedelta(minutes=15))

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -77,9 +77,14 @@ def test_hive_sql():
     assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM `user`"
 
 
-def test_hive_own_sql():
+def test_hive_table_own_sql():
     grant = Grant(principal="user", action_type="OWN", catalog="hive_metastore", database="mydb", table="mytable")
-    assert grant.hive_grant_sql() == "ALTER hive_metastore.mydb.mytable OWNER TO `user`"
+    assert grant.hive_grant_sql() == "ALTER TABLE hive_metastore.mydb.mytable OWNER TO `user`"
+
+
+def test_hive_database_own_sql():
+    grant = Grant(principal="user", action_type="OWN", catalog="hive_metastore", database="mydb")
+    assert grant.hive_grant_sql() == "ALTER DATABASE hive_metastore.mydb OWNER TO `user`"
 
 
 def test_hive_revoke_sql():


### PR DESCRIPTION
This PR fixes the bug, where ownership transfer permissions were not applied on the database level, resulting in cryptic exceptions like

```
ALTER hive_metastore.ucx_sjvoa OWNER TO `ucx_O000`

...

[TABLE_OR_VIEW_NOT_FOUND] The table or view `spark_catalog`.`hive_metastore`.`ucx_sjvoa` cannot be found. Verify the spelling and correctness of the schema and catalog.
If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
To tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.;
```

Fix #616