### PR TITLE
Changed cluster security mode from NONE to LEGACY_SINGLE_USER, as `crawl_tables` was failing when run on non-UC Workspace in No Isolation mode with unable to access the config file

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -735,7 +735,7 @@ class WorkspaceInstaller:
         spec = self._cluster_node_type(
             compute.ClusterSpec(
                 spark_version=self._ws.clusters.select_spark_version(latest=True),
-                data_security_mode=compute.DataSecurityMode.NONE,
+                data_security_mode=compute.DataSecurityMode.LEGACY_SINGLE_USER,
                 spark_conf=spark_conf,
                 custom_tags={"ResourceClass": "SingleNode"},
                 num_workers=0,

--- a/src/databricks/labs/ucx/uninstall.py
+++ b/src/databricks/labs/ucx/uninstall.py
@@ -5,7 +5,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.labs.ucx.__about__ import __version__
 from databricks.labs.ucx.install import WorkspaceInstaller
 
-logger = logging.getLogger("databricks.labs.ucx.uninstall")
+logger = logging.getLogger("databricks.labs.ucx.install")
 
 if __name__ == "__main__":
     logger.setLevel("INFO")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -210,8 +210,8 @@ def test_jobs_with_no_inventory_database(
             assert sort_dict(schema_a_grants) == sort_dict(src_schema_a_grants)
             assert sort_dict(schema_b_grants) == sort_dict(src_schema_b_grants)
             assert (
-                    sort_dict(schema_default_grants)[ws_group_c.display_name]
-                    == sort_dict(src_schema_default_grants)[ws_group_c.display_name]
+                sort_dict(schema_default_grants)[ws_group_c.display_name]
+                == sort_dict(src_schema_default_grants)[ws_group_c.display_name]
             )
             assert len(all_grants) >= 6
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -192,6 +192,10 @@ def test_jobs_with_no_inventory_database(
         @retried(on=[AssertionError], timeout=timedelta(minutes=2))
         def validate_tacl():
             logger.info("validating tacl")
+
+            def sort_dict(obj: dict):
+                return {k: sorted(v) for k, v in obj.items()}
+
             table_a_grants = grants_crawler.for_table_info(table_a)
             table_b_grants = grants_crawler.for_table_info(table_b)
             table_c_grants = grants_crawler.for_table_info(table_c)
@@ -200,12 +204,15 @@ def test_jobs_with_no_inventory_database(
             schema_default_grants = grants_crawler.for_schema_info(schema_default)
             all_grants = grants_crawler.snapshot()
 
-            assert table_a_grants == src_table_a_grants
-            assert table_b_grants == src_table_b_grants
-            assert table_c_grants == src_table_c_grants
-            assert schema_a_grants == src_schema_a_grants
-            assert schema_b_grants == src_schema_b_grants
-            assert schema_default_grants[ws_group_c.display_name] == src_schema_default_grants[ws_group_c.display_name]
+            assert sort_dict(table_a_grants) == sort_dict(src_table_a_grants)
+            assert sort_dict(table_b_grants) == sort_dict(src_table_b_grants)
+            assert sort_dict(table_c_grants) == sort_dict(src_table_c_grants)
+            assert sort_dict(schema_a_grants) == sort_dict(src_schema_a_grants)
+            assert sort_dict(schema_b_grants) == sort_dict(src_schema_b_grants)
+            assert (
+                    sort_dict(schema_default_grants)[ws_group_c.display_name]
+                    == sort_dict(src_schema_default_grants)[ws_group_c.display_name]
+            )
             assert len(all_grants) >= 6
 
             return True


### PR DESCRIPTION
This PR contains 3 changes:
1. updating logger name in uninstall.py to databricks.labs.ucx.install so that it installs the install logs when running ucx uninstall
2. made fix to the test_installation.py test_jobs_with_no_inventory_database. if there multiple grants for a principal, it might come in different order resulting in assert test falsly failing. added sort dict to sort the dict values before comparing.
3. changing the cluster security mode from DataSecurityMode.NONE to DataSecurityMode. LEGACY_SINGLE_USER. The scala code is failing when run on Non UC Workspace in No Isolation mode with unable to access the config file. Changing the SecurityMode fixes it.