### PR TITLE
Fix for secret scope apply task always raises ValueError

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -18,7 +18,7 @@ class SecretScopesSupport(AclSupport):
     def __init__(self, ws: WorkspaceClient, verify_timeout: timedelta | None = None):
         self._ws = ws
         if verify_timeout is None:
-            verify_timeout = timedelta(minutes=1)
+            verify_timeout = timedelta(minutes=2)
         self._verify_timeout = verify_timeout
 
     def get_crawler_tasks(self):
@@ -69,36 +69,30 @@ class SecretScopesSupport(AclSupport):
         return any(g in mentioned_groups for g in [info.name_in_workspace for info in migration_state.groups])
 
     def secret_scope_permission(self, scope_name: str, group_name: str) -> workspace.AclPermission | None:
-        try:
-            scope_acl = self._ws.secrets.get_acl(scope_name, group_name)
-            return scope_acl.permission
-        except:
-            return None
-
-        # for acl in self._ws.secrets.list_acls(scope=scope_name):
-        #     if acl.principal == group_name:
-        #         return acl.permission
-        # return None
+        for acl in self._ws.secrets.list_acls(scope=scope_name):
+            if acl.principal == group_name:
+                return acl.permission
+        return None
 
     def _inflight_check(self, scope_name: str, group_name: str, expected_permission: workspace.AclPermission):
         # in-flight check for the applied permissions
         # the api might be inconsistent, therefore we need to check that the permissions were applied
         applied_permission = self.secret_scope_permission(scope_name, group_name)
         if applied_permission != expected_permission:
-            msg = f"Applied permission {applied_permission} is not equal to expected permission {expected_permission} for {scope_name} and {group_name}!"
-            # raise ValueError(msg)
-            logger.warning(msg)
-            return False
+            # try to apply again if the permissions are not equal: sometimes the list_acls api is inconsistent
+            logger.info(f"Applying permissions again {expected_permission} to {group_name} for {scope_name}")
+            self._ws.secrets.put_acl(scope_name, group_name, expected_permission)
+            msg = (
+                f"Applied permission {applied_permission} is not equal to expected "
+                f"permission {expected_permission} for {scope_name} and {group_name}!"
+            )
+            raise ValueError(msg)
         logger.info(f"Permissions matched for {scope_name}, {group_name} and {expected_permission}!")
         return True
 
     @rate_limited(max_requests=1100, burst_period_seconds=60)
     def _rate_limited_put_acl(self, object_id: str, principal: str, permission: workspace.AclPermission):
         self._ws.secrets.put_acl(object_id, principal, permission)
-
-        while not self._inflight_check(object_id, principal, permission):
-            logger.info(f"Performing inflight check for {object_id}, {principal} and {permission}")
-            self._ws.secrets.put_acl(object_id, principal, permission)
         retry_on_value_error = retried(on=[ValueError], timeout=self._verify_timeout)
         retried_check = retry_on_value_error(self._inflight_check)
         retried_check(object_id, principal, permission)

--- a/src/databricks/labs/ucx/workspace_access/secrets.py
+++ b/src/databricks/labs/ucx/workspace_access/secrets.py
@@ -74,7 +74,7 @@ class SecretScopesSupport(AclSupport):
                 return acl.permission
         return None
 
-    def _inflight_check(self, scope_name: str, group_name: str, expected_permission: workspace.AclPermission):
+    def _reapply_on_failure(self, scope_name: str, group_name: str, expected_permission: workspace.AclPermission):
         # in-flight check for the applied permissions
         # the api might be inconsistent, therefore we need to check that the permissions were applied
         applied_permission = self.secret_scope_permission(scope_name, group_name)
@@ -94,5 +94,5 @@ class SecretScopesSupport(AclSupport):
     def _rate_limited_put_acl(self, object_id: str, principal: str, permission: workspace.AclPermission):
         self._ws.secrets.put_acl(object_id, principal, permission)
         retry_on_value_error = retried(on=[ValueError], timeout=self._verify_timeout)
-        retried_check = retry_on_value_error(self._inflight_check)
+        retried_check = retry_on_value_error(self._reapply_on_failure)
         retried_check(object_id, principal, permission)

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -11,6 +11,7 @@ from databricks.labs.ucx.workspace_access.secrets import SecretScopesSupport
 
 logger = logging.getLogger(__name__)
 
+
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_permissions_for_secrets(ws: WorkspaceClient, make_group, make_secret_scope, make_secret_scope_acl):
     group_a = make_group()

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -6,81 +6,37 @@ from databricks.sdk.errors.mapping import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.workspace import AclPermission
 
-from databricks.labs.ucx.workspace_access.groups import GroupManager
-from databricks.labs.ucx.workspace_access.manager import PermissionManager
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.secrets import SecretScopesSupport
 
 logger = logging.getLogger(__name__)
 
-
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
-def test_secrets(
-    ws: WorkspaceClient,
-    make_ucx_group,
-    sql_backend,
-    inventory_schema,
-    make_secret_scope,
-    make_secret_scope_acl,
-):
-    """
-    This test does the following:
-    * creates a ws group and secret scope
-    * assigns ACL permissions to the group on the secret
-    * run assessment
-    * migrate group
-    * verify that the migrated group has the same permissions on the scope
-    :return:
-    """
-
-    ws_group, acc_group = make_ucx_group()
+def test_permissions_for_secrets(ws: WorkspaceClient, make_group, make_secret_scope, make_secret_scope_acl):
+    group_a = make_group()
+    group_b = make_group()
 
     scope = make_secret_scope()
-    make_secret_scope_acl(scope=scope, principal=ws_group.display_name, permission=AclPermission.WRITE)
+    make_secret_scope_acl(scope=scope, principal=group_a.display_name, permission=AclPermission.WRITE)
 
-    scope_acl = ws.secrets.get_acl(scope, ws_group.display_name)
-    item = {
-        "ws_group": ws_group,
-        "acc_group": acc_group,
-        "scope": scope,
-        "scope_acl": scope_acl,
-    }
-    logger.debug(f"secret scope acls: {scope_acl}")
+    scope_acl = ws.secrets.get_acl(scope, group_a.display_name)
 
-    created_group_name = ws_group.display_name
-
-    # Task 1 - crawl_permissions
     secret_support = SecretScopesSupport(ws)
-    pi = PermissionManager(sql_backend, inventory_schema, [secret_support])
-    pi.cleanup()
-    pi.inventorize_permissions()
 
-    # Task 2 - crawl_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
-    group_manager.snapshot()
+    migration_state = MigrationState(
+        [
+            MigratedGroup.partial_info(group_a, group_b),
+        ]
+    )
 
-    # Task 2 - apply_permissions_to_backup_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
-    group_manager.rename_groups()
+    for crawler_task in secret_support.get_crawler_tasks():
+        permission = crawler_task()
+        apply_task = secret_support.get_apply_task(permission, migration_state)
+        if not apply_task:
+            continue
+        apply_task()
 
-    # Task 3 - reflect_account_groups_on_workspace
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
-    group_manager.reflect_account_groups_on_workspace()
+    reflected_scope_acls = ws.secrets.get_acl(scope, group_b.display_name)
 
-    # Task 4 - apply_permissions_to_account_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
-    migration_state = group_manager.get_migration_state()
-    permission_manager = PermissionManager.factory(ws, sql_backend, inventory_database=inventory_schema)
-    permission_manager.apply_group_permissions(migration_state)
-
-    ws_group = item["ws_group"]
-    acc_group = item["acc_group"]
-    scope = item["scope"]
-    old_scope_acl = item["scope_acl"]
-    old_group = ws.groups.get(ws_group.id)
-    reflected_group = ws.groups.get(acc_group.id)
-    reflected_scope_acls = ws.secrets.get_acl(scope, reflected_group.display_name)
-
-    assert reflected_group.display_name == ws_group.display_name
-    assert reflected_group.id == acc_group.id
-    assert old_scope_acl == reflected_scope_acls
-    assert len(reflected_group.members) == len(old_group.members)
+    assert reflected_scope_acls.principal == group_b.display_name
+    assert scope_acl.permission == reflected_scope_acls.permission

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -24,32 +24,29 @@ def test_secrets(
 ):
     """
     This test does the following:
-    * creates 2 ws groups and secret scopes
-    * assigns ACL permissions to the groups on the secrets
+    * creates a ws group and secret scope
+    * assigns ACL permissions to the group on the secret
     * run assessment
-    * migrate groups
-    * verify that the migrated groups has the same permissions on the scopes
+    * migrate group
+    * verify that the migrated group has the same permissions on the scope
     :return:
     """
 
-    created_items = []
-    for _ in range(2):
-        ws_group, acc_group = make_ucx_group()
+    ws_group, acc_group = make_ucx_group()
 
-        scope = make_secret_scope()
-        make_secret_scope_acl(scope=scope, principal=ws_group.display_name, permission=AclPermission.WRITE)
+    scope = make_secret_scope()
+    make_secret_scope_acl(scope=scope, principal=ws_group.display_name, permission=AclPermission.WRITE)
 
-        scope_acl = ws.secrets.get_acl(scope, ws_group.display_name)
-        item = {
-            "ws_group": ws_group,
-            "acc_group": acc_group,
-            "scope": scope,
-            "scope_acl": scope_acl,
-        }
-        created_items.append(item)
-        logger.debug(f"secret scope acls: {scope_acl}")
+    scope_acl = ws.secrets.get_acl(scope, ws_group.display_name)
+    item = {
+        "ws_group": ws_group,
+        "acc_group": acc_group,
+        "scope": scope,
+        "scope_acl": scope_acl,
+    }
+    logger.debug(f"secret scope acls: {scope_acl}")
 
-    created_groups_names = [i["ws_group"].display_name for i in created_items]
+    created_group_name = ws_group.display_name
 
     # Task 1 - crawl_permissions
     secret_support = SecretScopesSupport(ws)
@@ -58,33 +55,32 @@ def test_secrets(
     pi.inventorize_permissions()
 
     # Task 2 - crawl_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
     group_manager.snapshot()
 
     # Task 2 - apply_permissions_to_backup_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
     group_manager.rename_groups()
 
     # Task 3 - reflect_account_groups_on_workspace
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
     group_manager.reflect_account_groups_on_workspace()
 
     # Task 4 - apply_permissions_to_account_groups
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=[created_group_name])
     migration_state = group_manager.get_migration_state()
     permission_manager = PermissionManager.factory(ws, sql_backend, inventory_database=inventory_schema)
     permission_manager.apply_group_permissions(migration_state)
 
-    for item in created_items:
-        ws_group = item["ws_group"]
-        acc_group = item["acc_group"]
-        scope = item["scope"]
-        old_scope_acl = item["scope_acl"]
-        old_group = ws.groups.get(ws_group.id)
-        reflected_group = ws.groups.get(acc_group.id)
-        reflected_scope_acls = ws.secrets.get_acl(scope, reflected_group.display_name)
+    ws_group = item["ws_group"]
+    acc_group = item["acc_group"]
+    scope = item["scope"]
+    old_scope_acl = item["scope_acl"]
+    old_group = ws.groups.get(ws_group.id)
+    reflected_group = ws.groups.get(acc_group.id)
+    reflected_scope_acls = ws.secrets.get_acl(scope, reflected_group.display_name)
 
-        assert reflected_group.display_name == ws_group.display_name
-        assert reflected_group.id == acc_group.id
-        assert old_scope_acl == reflected_scope_acls
-        assert len(reflected_group.members) == len(old_group.members)
+    assert reflected_group.display_name == ws_group.display_name
+    assert reflected_group.id == acc_group.id
+    assert old_scope_acl == reflected_scope_acls
+    assert len(reflected_group.members) == len(old_group.members)

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -1,0 +1,87 @@
+import logging
+from datetime import timedelta
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.workspace import AclPermission
+
+from databricks.labs.ucx.workspace_access.groups import GroupManager
+from databricks.labs.ucx.workspace_access.manager import PermissionManager
+from databricks.labs.ucx.workspace_access.secrets import SecretScopesSupport
+
+logger = logging.getLogger(__name__)
+
+def test_secrets(
+    ws: WorkspaceClient,
+    make_ucx_group,
+    sql_backend,
+    inventory_schema,
+    make_random,
+    make_secret_scope,
+    make_secret_scope_acl,
+):
+    """
+    This test does the following:
+    * creates 10 ws groups and secret scopes  with permissions to
+    * assigns ACL permissions to the groups on the secrets
+    * run assessment
+    * migrate this group
+    * verify that the migrated group has the same permissions on the scopes
+    :return:
+    """
+
+    created_groups = []
+    created_secrets_scopes = []
+    created_items = []
+    for i in range(10):
+        ws_group, acc_group = make_ucx_group()
+        created_groups.append(ws_group)
+
+        scope = make_secret_scope()
+        created_secrets_scopes.append(scope)
+        created_items.append((ws_group, acc_group, scope))
+        make_secret_scope_acl(scope=scope, principal=ws_group.display_name, permission=AclPermission.WRITE)
+
+        scope_acls = ws.secrets.get_acl(scope, ws_group.display_name)
+        logger.debug(f"secret scope acls: {scope_acls}")
+
+    created_groups_names = [g.display_name for g in created_groups]
+
+    # Task 1 - crawl_permissions
+    secret_support = SecretScopesSupport(ws)
+    pi = PermissionManager(sql_backend, inventory_schema, [secret_support])
+    pi.cleanup()
+    pi.inventorize_permissions()
+
+    # Task 2 - crawl_groups
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager.snapshot()
+
+    # Task 2 - apply_permissions_to_backup_groups
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager.rename_groups()
+
+    # Task 3 - reflect_account_groups_on_workspace
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    group_manager.reflect_account_groups_on_workspace()
+
+    # Task 4 - apply_permissions_to_account_groups
+    group_manager = GroupManager(sql_backend, ws, inventory_schema, include_group_names=created_groups_names)
+    migration_state = group_manager.get_migration_state()
+    permission_manager = PermissionManager.factory(ws, sql_backend, inventory_database=inventory_schema)
+    permission_manager.apply_group_permissions(migration_state)
+
+    for item in created_items:
+        ws_group = item[0]
+        acc_group = item[1]
+        scope = item[2]
+        old_group = ws.groups.get(ws_group.id)
+        reflected_group = ws.groups.get(acc_group.id)
+        scope_acls = ws.secrets.get_acl(scope, reflected_group.display_name)
+        logger.debug(f"old_group: {old_group}")
+        logger.debug(f"reflected_group: {reflected_group}")
+        logger.debug(f"secret scope: {scope}")
+        logger.debug(f"secret scope acls: {scope_acls}")
+
+        assert reflected_group.display_name == ws_group.display_name
+        assert reflected_group.id == acc_group.id
+        assert len(reflected_group.members) == len(old_group.members)

--- a/tests/unit/workspace_access/test_secrets.py
+++ b/tests/unit/workspace_access/test_secrets.py
@@ -128,3 +128,38 @@ def test_secret_scopes_reapply():
 
     sup._rate_limited_put_acl("test", "db-temp-test", expected_permission)
     assert ws.secrets.put_acl.call_count == 2
+
+
+def test_secret_scopes_reapply_check_valueerror():
+    ws = MagicMock()
+    ws.secrets.list_acls.side_effect = [
+        [
+            workspace.AclItem(
+                principal="db-temp-test",
+                permission=workspace.AclPermission.READ,
+            )
+        ]
+    ]
+
+    sup = SecretScopesSupport(ws, timedelta(seconds=10))
+    expected_permission = workspace.AclPermission.MANAGE
+
+    with pytest.raises(ValueError):
+        sup._reapply_on_failure("test", "db-temp-test", expected_permission)
+
+
+def test_secret_scopes_reapply_check_exception_type():
+    ws = MagicMock()
+    ws.secrets.list_acls.return_value = [
+        workspace.AclItem(
+            principal="db-temp-test",
+            permission=workspace.AclPermission.READ,
+        )
+    ]
+
+    sup = SecretScopesSupport(ws, timedelta(seconds=1))
+    expected_permission = workspace.AclPermission.MANAGE
+    try:
+        sup._rate_limited_put_acl("test", "db-temp-test", expected_permission)
+    except Exception as e:
+        assert isinstance(e, TimeoutError)

--- a/tests/unit/workspace_access/test_secrets.py
+++ b/tests/unit/workspace_access/test_secrets.py
@@ -104,3 +104,27 @@ def test_secret_scopes_apply_incorrect():
     expected_permission = workspace.AclPermission.MANAGE
     with pytest.raises(TimeoutError):
         sup._rate_limited_put_acl("test", "db-temp-test", expected_permission)
+
+
+def test_secret_scopes_reapply():
+    ws = MagicMock()
+    ws.secrets.list_acls.side_effect = [
+        [
+            workspace.AclItem(
+                principal="db-temp-test",
+                permission=workspace.AclPermission.READ,
+            )
+        ],
+        [
+            workspace.AclItem(
+                principal="db-temp-test",
+                permission=workspace.AclPermission.MANAGE,
+            )
+        ],
+    ]
+
+    sup = SecretScopesSupport(ws, timedelta(seconds=10))
+    expected_permission = workspace.AclPermission.MANAGE
+
+    sup._rate_limited_put_acl("test", "db-temp-test", expected_permission)
+    assert ws.secrets.put_acl.call_count == 2


### PR DESCRIPTION
### Summary: 
Unfortunately, both the `list_acls` and `get_acl` methods seem to be very inconsistent for checking whether a permission is applied to a given secret scope. For this reason, this PR introduces a workaround where if the permissions don't match, the acl is being applied again. From my experience of trying multiple workarounds, this was the only one that proved to be consistent.

**Fixes #627** 

### Changes:
- Added extra safety checks for inflight permission check logic in secrets.py
- Added integration tests in test_secrets.py

### Tests:
Introduced integration tests for secrets which were missing before.