### PR TITLE
Added parallel fetching of registered model identifiers to speed-up assessment workflow

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -331,6 +331,8 @@ def models_listing(ws: WorkspaceClient, num_threads: int):
         for m in ws.model_registry.list_models():
             tasks.append(partial(ws.model_registry.get_model, name=m.name))
         models, errors = Threads.gather("listing model ids", tasks, num_threads)
+        if len(errors) > 0:
+            logger.error(f"Detected {len(errors)} errors while listing models")
         for model in models:
             yield model.registered_model_databricks
 

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -15,7 +15,7 @@ from databricks.sdk.service import iam, ml
 from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
-from databricks.labs.ucx.framework.parallel import Threads
+from databricks.labs.ucx.framework.parallel import ManyError, Threads
 from databricks.labs.ucx.mixins.hardening import rate_limited
 from databricks.labs.ucx.workspace_access.base import AclSupport, Permissions
 from databricks.labs.ucx.workspace_access.groups import MigrationState
@@ -333,6 +333,7 @@ def models_listing(ws: WorkspaceClient, num_threads: int):
         models, errors = Threads.gather("listing model ids", tasks, num_threads)
         if len(errors) > 0:
             logger.error(f"Detected {len(errors)} errors while listing models")
+            raise ManyError(errors)
         for model in models:
             yield model.registered_model_databricks
 

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -43,7 +43,7 @@ class PermissionManager(CrawlerBase):
             generic.Listing(ws.jobs.list, "job_id", "jobs"),
             generic.Listing(ws.pipelines.list_pipelines, "pipeline_id", "pipelines"),
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
-            generic.Listing(generic.models_listing(ws), "id", "registered-models"),
+            generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
             generic.WorkspaceListing(
                 ws,

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -213,7 +213,7 @@ def test_passwords_tokens_crawler(migration_state):
 
 def test_models_listing():
     ws = MagicMock()
-    ws.model_registry.list_models.return_value = [ml.Model(name="test")]
+    ws.model_registry.list_models.return_value = [ml.Model(name="test"), ml.Model(name="test2")]
     ws.model_registry.get_model.return_value = ml.GetModelResponse(
         registered_model_databricks=ml.ModelDatabricks(
             id="some-id",
@@ -221,9 +221,9 @@ def test_models_listing():
         )
     )
 
-    wrapped = Listing(models_listing(ws), id_attribute="id", object_type="registered-models")
+    wrapped = Listing(models_listing(ws, 2), id_attribute="id", object_type="registered-models")
     result = list(wrapped)
-    assert len(result) == 1
+    assert len(result) == 2
     assert result[0].object_id == "some-id"
     assert result[0].request_type == "registered-models"
 


### PR DESCRIPTION
**Change description:**
This PR makes changes to the model listing process. Currently the model listing is done serially which takes time in workspace with large number of registered models. This changes uses python threads to parallelize model listing to speed up the inventory process for models

**Changes details:**
Updates to generic.py.model_listing() to use Threads.gather to parallelize get_model function
It accepts num_threads from config.
Also updated the relevant test cases