### PR TITLE
Added `databricks labs ucx repair-run --step ...` CLI command for repair run of any failed workflows, like `assessment`, `migrate-groups` etc.

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -49,3 +49,9 @@ commands:
 
   - name: validate-external-locations
     description: validates and provides mapping to external table to external location and shared generation tf scripts
+
+  - name: repair-run
+      description: Repair Run the Failed Job
+      flags:
+        - name: step
+          description: name of the step

--- a/labs.yml
+++ b/labs.yml
@@ -51,7 +51,7 @@ commands:
     description: validates and provides mapping to external table to external location and shared generation tf scripts
 
   - name: repair-run
-      description: Repair Run the Failed Job
-      flags:
-        - name: step
-          description: name of the step
+    description: Repair Run the Failed Job
+    flags:
+      - name: step
+        description: name of the step

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -113,6 +113,15 @@ def ensure_assessment_run():
         workspace_installer.validate_and_run("assessment")
 
 
+def repair_run(step):
+    if not step:
+        raise KeyError("You did not specify --step")
+    ws = WorkspaceClient()
+    installer = WorkspaceInstaller(ws)
+    logger.info("Repair Running  Job...")
+    installer.repair_run(step)
+
+
 MAPPING = {
     "open-remote-config": open_remote_config,
     "installations": list_installations,

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -118,7 +118,7 @@ def repair_run(step):
         raise KeyError("You did not specify --step")
     ws = WorkspaceClient()
     installer = WorkspaceInstaller(ws)
-    logger.info("Repair Running  Job...")
+    logger.info(f"Repair Running {step} Job")
     installer.repair_run(step)
 
 
@@ -132,6 +132,7 @@ MAPPING = {
     "validate-external-locations": validate_external_locations,
     "ensure-assessment-run": ensure_assessment_run,
     "skip": skip,
+    "repair-run": repair_run,
 }
 
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -807,6 +807,15 @@ class WorkspaceInstaller:
                 continue
         return latest_status
 
+    def repair_run(self, workflow) -> list[dict]:
+        try:
+            job_id = [job_id for step, job_id in self._state.jobs.items() if workflow == step]
+            job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
+            run_id = job_runs[0].run_id
+            self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+        except Exception as e:
+            logger.warning(f"skipping {workflow}: {e}")
+
     def uninstall(self):
         if self._prompts and not self._prompts.confirm(
             "Do you want to uninstall ucx from the workspace too, this would "

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -833,8 +833,6 @@ class WorkspaceInstaller:
             logger.debug(f"Repair Running {workflow} job: {job_url}")
             self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
             webbrowser.open(job_url)
-
-
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -809,14 +809,19 @@ class WorkspaceInstaller:
 
     def repair_run(self, workflow):
         try:
-            job_id = [job_id for step, job_id in self._state.jobs.items() if workflow == step]
-            job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
-            state = job_runs[0].state
-            if job_runs and state.result_state.value != "SUCCESS":
-                run_id = job_runs[0].run_id
-                self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+            job_id_list = [job_id for step, job_id in self._state.jobs.items() if workflow == step]
+            if job_id_list:
+                job_id = job_id_list[0]
+                job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
+                state = job_runs[0].state
+                if job_runs and state.result_state.value != "SUCCESS":
+                    run_id = job_runs[0].run_id
+                    self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+                    logger.info("Exception")
+                else:
+                    logger.info(f"{workflow} job is not in FAILED state hence skipping Repair Run")
             else:
-                logger.info(f"{workflow} job is not in FAILED state hence skipping Repair Run")
+                logger.warning(f"{workflow} job does not exists hence skipping Repair Run")
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -827,8 +827,10 @@ class WorkspaceInstaller:
             state = latest_job_run.state
             if state.result_state.value != "SUCCESS":
                 run_id = latest_job_run.run_id
-                job_run_waiter = self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
-                job_run_waiter.result()
+                job_url = f"{self._ws.config.host}#job/{job_id}"
+                logger.debug(f"Repair Running {workflow} job: {job_url}")
+                self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+                webbrowser.open(job_url)
             else:
                 logger.warning(f"{workflow} job is not in FAILED state hence skipping Repair Run")
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -827,7 +827,7 @@ class WorkspaceInstaller:
             state = latest_job_run.state
             if state.result_state.value != "SUCCESS":
                 run_id = latest_job_run.run_id
-                job_url = f"{self._ws.config.host}#job/{job_id}"
+                job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
                 logger.debug(f"Repair Running {workflow} job: {job_url}")
                 self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
                 webbrowser.open(job_url)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -825,14 +825,15 @@ class WorkspaceInstaller:
                 return
             latest_job_run = job_runs[0]
             state = latest_job_run.state
-            if state.result_state.value != "SUCCESS":
-                run_id = latest_job_run.run_id
-                job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
-                logger.debug(f"Repair Running {workflow} job: {job_url}")
-                self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
-                webbrowser.open(job_url)
-            else:
+            if state.result_state.value != "FAILED":
                 logger.warning(f"{workflow} job is not in FAILED state hence skipping Repair Run")
+                return
+            run_id = latest_job_run.run_id
+            job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
+            logger.debug(f"Repair Running {workflow} job: {job_url}")
+            self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+            webbrowser.open(job_url)
+
 
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -809,19 +809,21 @@ class WorkspaceInstaller:
 
     def repair_run(self, workflow):
         try:
-            job_id_list = [job_id for step, job_id in self._state.jobs.items() if workflow == step]
-            if job_id_list:
-                job_id = job_id_list[0]
-                job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
-                state = job_runs[0].state
-                if job_runs and state.result_state.value != "SUCCESS":
-                    run_id = job_runs[0].run_id
-                    self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
-                    logger.info("Exception")
-                else:
-                    logger.info(f"{workflow} job is not in FAILED state hence skipping Repair Run")
-            else:
+            job_id = self._state.jobs.get(workflow)
+            if not job_id:
                 logger.warning(f"{workflow} job does not exists hence skipping Repair Run")
+            else:
+                job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
+                if not job_runs:
+                    logger.warning(f"{workflow} job is not initialized yet. Can't trigger repair run now")
+                else:
+                    latest_job_run = job_runs[0]
+                    state = latest_job_run.state
+                    if state.result_state.value != "SUCCESS":
+                        run_id = latest_job_run.run_id
+                        self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True)
+                    else:
+                        logger.warning(f"{workflow} job is not in FAILED state hence skipping Repair Run")
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -150,10 +150,7 @@ def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation
 
 
 @retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=5))
-def test_repair_run_assessment_job(
-    ws, new_installation, caplog
-):
-
+def test_repair_run_assessment_job(ws, new_installation, caplog):
     install = new_installation()
     install.run_workflow("assessment")
     install.repair_run("assessment")
@@ -172,6 +169,3 @@ def test_uninstallation(ws, sql_backend, new_installation):
         ws.jobs.get(job_id=assessment_job_id)
     with pytest.raises(NotFound):
         sql_backend.execute(f"show tables from hive_metastore.{install.current_config.inventory_database}")
-
-
-

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -149,7 +149,7 @@ def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation
         ws.groups.get(ws_group_a.id)
 
 
-@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=5))
+@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=10))
 def test_repair_run_assessment_job(ws, new_installation, caplog):
     install = new_installation()
     install.run_workflow("assessment")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -139,6 +139,17 @@ def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation
         ws.groups.get(ws_group_a.id)
 
 
+@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=5))
+def test_repair_run_assessment_job(
+    ws, new_installation, caplog
+):
+
+    install = new_installation()
+    install.run_workflow("assessment")
+    install.repair_run("assessment")
+    assert "job is not in FAILED state" in caplog.text
+
+
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_uninstallation(ws, sql_backend, new_installation):
     install = new_installation()
@@ -151,3 +162,6 @@ def test_uninstallation(ws, sql_backend, new_installation):
         ws.jobs.get(job_id=assessment_job_id)
     with pytest.raises(NotFound):
         sql_backend.execute(f"show tables from hive_metastore.{install.current_config.inventory_database}")
+
+
+

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -150,7 +150,7 @@ def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation
 
 
 @retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=10))
-def test_repair_run_assessment_job(ws, new_installation, sql_backend):
+def test_repair_run_workflow_job(ws, new_installation, sql_backend):
     install = new_installation()
     sql_backend.execute(f"DROP SCHEMA {install.current_config.inventory_database} CASCADE")
     with pytest.raises(OperationFailed):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,7 +5,7 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, User
 
-from databricks.labs.ucx.cli import skip
+from databricks.labs.ucx.cli import repair_run, skip
 
 
 @pytest.fixture
@@ -33,3 +33,21 @@ def test_skip_no_ucx(caplog, mocker):
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=None)
     skip(schema="schema", table="table")
     assert [rec.message for rec in caplog.records if "UCX configuration" in rec.message]
+
+
+def test_repair_run(mocker, caplog):
+    mocker.patch("databricks.sdk.WorkspaceClient.__init__", return_value=None)
+    mocker.patch("databricks.labs.ucx.install.WorkspaceInstaller.__init__", return_value=None)
+    mocker.patch("databricks.labs.ucx.install.WorkspaceInstaller.repair_run", return_value=None)
+    repair_run("assessment")
+    assert caplog.messages == []
+
+
+def test_no_step_in_repair_run(mocker, caplog):
+    mocker.patch("databricks.sdk.WorkspaceClient.__init__", return_value=None)
+    mocker.patch("databricks.labs.ucx.install.WorkspaceInstaller.__init__", return_value=None)
+    mocker.patch("databricks.labs.ucx.install.WorkspaceInstaller.repair_run", return_value=None)
+    try:
+        repair_run("")
+    except KeyError as e:
+        assert e.args[0] == "You did not specify --step"

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1024,7 +1024,7 @@ def test_repair_run(ws):
     install.repair_run("assessment")
 
 
-def test_repair_run_success(ws):
+def test_repair_run_success(ws,caplog):
     base = [
         BaseRun(
             job_clusters=None,
@@ -1041,6 +1041,8 @@ def test_repair_run_success(ws):
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None
     install.repair_run("assessment")
+    assert "job is not in FAILED state" in caplog.text
+    # install.repair_run("assessment")
 
 
 def test_repair_run_no_job_id(ws):
@@ -1060,6 +1062,25 @@ def test_repair_run_no_job_id(ws):
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None
     install.repair_run("workflow")
+
+
+def test_repair_run_no_job_run(ws):
+    base = [
+        BaseRun(
+            job_clusters=None,
+            job_id=677268692725050,
+            job_parameters=None,
+            number_in_job=725118654200173,
+            run_id=725118654200173,
+            run_name="[UCX] assessment",
+            state=RunState(result_state=RunResultState.SUCCESS),
+        )
+    ]
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": "677268692725050"}
+    ws.jobs.list_runs.return_value = ""
+    ws.jobs.list_runs.repair_run = None
+    install.repair_run("assessment")
 
 
 def test_repair_run_exception(ws):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -17,6 +17,7 @@ from databricks.sdk.service.compute import (
     GlobalInitScriptDetailsWithContent,
     Policy,
 )
+from databricks.sdk.service.jobs import BaseRun, RunResultState, RunState
 from databricks.sdk.service.sql import (
     Dashboard,
     DataSource,
@@ -1002,3 +1003,33 @@ def test_uninstall_no_config_file(ws, mocker):
     ws.workspace.download = lambda _: io.BytesIO(config_bytes)
     ws.workspace.get_status.side_effect = NotFound(...)
     install.uninstall()
+
+
+def test_repair_run(ws, mocker):
+    base = [
+        BaseRun(
+            attempt_number=None,
+            cleanup_duration=0,
+            cluster_instance=None,
+            cluster_spec=None,
+            creator_user_name="abc",
+            end_time=1703146375271,
+            execution_duration=0,
+            git_source=None,
+            job_clusters=None,
+            job_id=677268692725050,
+            job_parameters=None,
+            number_in_job=725118654200173,
+            original_attempt_run_id=725118654200173,
+            overriding_parameters=None,
+            run_duration=566445,
+            run_id=725118654200173,
+            run_name="[UCX] assessment",
+            state=RunState(result_state=RunResultState.FAILED),
+        )
+    ]
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": "test1"}
+    ws.jobs.list_runs.return_value = base
+    ws.jobs.list_runs.repair_run = None
+    install.repair_run("assessment")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1005,7 +1005,7 @@ def test_uninstall_no_config_file(ws, mocker):
     install.uninstall()
 
 
-def test_repair_run(ws):
+def test_repair_run(ws, mocker):
     base = [
         BaseRun(
             job_clusters=None,
@@ -1017,7 +1017,8 @@ def test_repair_run(ws):
             state=RunState(result_state=RunResultState.FAILED),
         )
     ]
-    install = WorkspaceInstaller(ws)
+    install = WorkspaceInstaller(ws, promtps=MockPrompts({".*": ""}))
+    mocker.patch("webbrowser.open")
     install._state.jobs = {"assessment": "123"}
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1005,31 +1005,65 @@ def test_uninstall_no_config_file(ws, mocker):
     install.uninstall()
 
 
-def test_repair_run(ws, mocker):
+def test_repair_run(ws):
     base = [
         BaseRun(
-            attempt_number=None,
-            cleanup_duration=0,
-            cluster_instance=None,
-            cluster_spec=None,
-            creator_user_name="abc",
-            end_time=1703146375271,
-            execution_duration=0,
-            git_source=None,
             job_clusters=None,
             job_id=677268692725050,
             job_parameters=None,
             number_in_job=725118654200173,
-            original_attempt_run_id=725118654200173,
-            overriding_parameters=None,
-            run_duration=566445,
             run_id=725118654200173,
             run_name="[UCX] assessment",
             state=RunState(result_state=RunResultState.FAILED),
         )
     ]
     install = WorkspaceInstaller(ws)
-    install._state.jobs = {"assessment": "test1"}
+    install._state.jobs = {"assessment": "123"}
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None
+    install.repair_run("assessment")
+
+
+def test_repair_run_success(ws):
+    base = [
+        BaseRun(
+            job_clusters=None,
+            job_id=677268692725050,
+            job_parameters=None,
+            number_in_job=725118654200173,
+            run_id=725118654200173,
+            run_name="[UCX] assessment",
+            state=RunState(result_state=RunResultState.SUCCESS),
+        )
+    ]
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": "123"}
+    ws.jobs.list_runs.return_value = base
+    ws.jobs.list_runs.repair_run = None
+    install.repair_run("assessment")
+
+
+def test_repair_run_no_job_id(ws):
+    base = [
+        BaseRun(
+            job_clusters=None,
+            job_id=677268692725050,
+            job_parameters=None,
+            number_in_job=725118654200173,
+            run_id=725118654200173,
+            run_name="[UCX] assessment",
+            state=RunState(result_state=RunResultState.SUCCESS),
+        )
+    ]
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": ""}
+    ws.jobs.list_runs.return_value = base
+    ws.jobs.list_runs.repair_run = None
+    install.repair_run("workflow")
+
+
+def test_repair_run_exception(ws):
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": "123"}
+    ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
     install.repair_run("assessment")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1042,7 +1042,6 @@ def test_repair_run_success(ws, caplog):
     ws.jobs.list_runs.repair_run = None
     install.repair_run("assessment")
     assert "job is not in FAILED state" in caplog.text
-    # install.repair_run("assessment")
 
 
 def test_repair_run_no_job_id(ws):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1024,7 +1024,7 @@ def test_repair_run(ws):
     install.repair_run("assessment")
 
 
-def test_repair_run_success(ws,caplog):
+def test_repair_run_success(ws, caplog):
     base = [
         BaseRun(
             job_clusters=None,
@@ -1065,17 +1065,6 @@ def test_repair_run_no_job_id(ws):
 
 
 def test_repair_run_no_job_run(ws):
-    base = [
-        BaseRun(
-            job_clusters=None,
-            job_id=677268692725050,
-            job_parameters=None,
-            number_in_job=725118654200173,
-            run_id=725118654200173,
-            run_name="[UCX] assessment",
-            state=RunState(result_state=RunResultState.SUCCESS),
-        )
-    ]
     install = WorkspaceInstaller(ws)
     install._state.jobs = {"assessment": "677268692725050"}
     ws.jobs.list_runs.return_value = ""


### PR DESCRIPTION
This may close #658