### PR TITLE
Rename summary panel from Failure Summary to Assessment Summary

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/01_1_failure_summary.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/01_1_failure_summary.sql
@@ -1,5 +1,5 @@
--- viz type=table, name=Failure Summary, search_by=failure, columns=failure,count
--- widget title=Failure Summary, row=1, col=1, size_x=2, size_y=8
+-- viz type=table, name=Assessment Summary, search_by=failure, columns=failure,count
+-- widget title=Assessment Summary, row=1, col=1, size_x=2, size_y=8
 WITH raw AS (
   SELECT EXPLODE(FROM_JSON(failures, 'array<string>')) AS failure FROM $inventory.objects WHERE failures <> '[]'
 )


### PR DESCRIPTION
Failure Summary was mis-leading, where as "Assessment Summary" for the panel of found objects and assessment (e.g. DBR version) is more appropriate.