### PR TITLE
Improve error message inference from failed workflow runs

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 import pytest
 from databricks.labs.blueprint.parallel import Threads
-from databricks.sdk.errors import InvalidParameterValue, NotFound, OperationFailed
+from databricks.sdk.errors import InvalidParameterValue, NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.iam import PermissionLevel
 
@@ -67,7 +67,7 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
 
     sql_backend.execute(f"DROP SCHEMA {install.current_config.inventory_database} CASCADE")
 
-    with pytest.raises(OperationFailed) as failure:
+    with pytest.raises(NotFound) as failure:
         install.run_workflow("099-destroy-schema")
 
     assert "cannot be found" in str(failure.value)
@@ -76,7 +76,7 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
     assert len(workflow_run_logs) == 1
 
 
-@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=10))
+@retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=6))
 def test_running_real_assessment_job(
     ws, new_installation, make_ucx_group, make_cluster_policy, make_cluster_policy_permissions
 ):
@@ -130,7 +130,7 @@ def test_running_real_migrate_groups_job(
     assert found[f"{install.current_config.renamed_group_prefix}{ws_group_a.display_name}"] == PermissionLevel.CAN_USE
 
 
-@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=5))
+@retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
 def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation, make_ucx_group):
     ws_group_a, acc_group_a = make_ucx_group()
 
@@ -149,12 +149,12 @@ def test_running_real_remove_backup_groups_job(ws, sql_backend, new_installation
         ws.groups.get(ws_group_a.id)
 
 
-@retried(on=[NotFound, InvalidParameterValue, OperationFailed], timeout=timedelta(minutes=10))
+@retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=10))
 def test_repair_run_workflow_job(ws, mocker, new_installation, sql_backend):
     install = new_installation()
     mocker.patch("webbrowser.open")
     sql_backend.execute(f"DROP SCHEMA {install.current_config.inventory_database} CASCADE")
-    with pytest.raises(OperationFailed):
+    with pytest.raises(NotFound):
         install.run_workflow("099-destroy-schema")
 
     sql_backend.execute(f"CREATE SCHEMA IF NOT EXISTS {install.current_config.inventory_database}")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, create_autospec, patch
 import pytest
 import yaml
 from databricks.labs.blueprint.installer import InstallState
+from databricks.labs.blueprint.parallel import ManyError
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.blueprint.wheels import Wheels, find_project_root
 from databricks.sdk.errors import (
@@ -13,6 +14,7 @@ from databricks.sdk.errors import (
     NotFound,
     OperationFailed,
     PermissionDenied,
+    Unknown,
 )
 from databricks.sdk.service import iam, jobs, sql
 from databricks.sdk.service.compute import (
@@ -248,10 +250,92 @@ def test_run_workflow_creates_proper_failure(ws, mocker):
     ws.jobs.get_run_output.return_value = jobs.RunOutput(error="does not compute", error_trace="# goes to stderr")
     installer = WorkspaceInstaller(ws)
     installer._state.jobs = {"foo": "111"}
-    with pytest.raises(OperationFailed) as failure:
+    with pytest.raises(Unknown) as failure:
         installer.run_workflow("foo")
 
-    assert "Stuff happens: stuff: does not compute" == str(failure.value)
+    assert "stuff: does not compute" == str(failure.value)
+
+
+def test_run_workflow_creates_failure_from_mapping(ws, mocker):
+    def run_now(job_id):
+        assert "bar" == job_id
+
+        def result():
+            raise OperationFailed(...)
+
+        waiter = mocker.Mock()
+        waiter.result = result
+        waiter.run_id = "qux"
+        return waiter
+
+    ws.jobs.run_now = run_now
+    ws.jobs.get_run.return_value = jobs.Run(
+        state=jobs.RunState(state_message="Stuff happens."),
+        tasks=[
+            jobs.RunTask(
+                task_key="stuff",
+                state=jobs.RunState(result_state=jobs.RunResultState.FAILED),
+                run_id=123,
+            )
+        ],
+    )
+    ws.jobs.get_run_output.return_value = jobs.RunOutput(
+        error="something: PermissionDenied: does not compute", error_trace="# goes to stderr"
+    )
+    installer = WorkspaceInstaller(ws)
+    installer._state.jobs = {"foo": "bar"}
+    with pytest.raises(PermissionDenied) as failure:
+        installer.run_workflow("foo")
+
+    assert str(failure.value) == "does not compute"
+
+
+def test_run_workflow_creates_failure_many_error(ws, mocker):
+    def run_now(job_id):
+        assert "bar" == job_id
+
+        def result():
+            raise OperationFailed(...)
+
+        waiter = mocker.Mock()
+        waiter.result = result
+        waiter.run_id = "qux"
+        return waiter
+
+    ws.jobs.run_now = run_now
+    ws.jobs.get_run.return_value = jobs.Run(
+        state=jobs.RunState(state_message="Stuff happens."),
+        tasks=[
+            jobs.RunTask(
+                task_key="stuff",
+                state=jobs.RunState(result_state=jobs.RunResultState.FAILED),
+                run_id=123,
+            ),
+            jobs.RunTask(
+                task_key="things",
+                state=jobs.RunState(result_state=jobs.RunResultState.TIMEDOUT),
+                run_id=124,
+            ),
+            jobs.RunTask(
+                task_key="some",
+                state=jobs.RunState(result_state=jobs.RunResultState.FAILED),
+                run_id=125,
+            ),
+        ],
+    )
+    ws.jobs.get_run_output.return_value = jobs.RunOutput(
+        error="something: DataLoss: does not compute", error_trace="# goes to stderr"
+    )
+    installer = WorkspaceInstaller(ws)
+    installer._state.jobs = {"foo": "bar"}
+    with pytest.raises(ManyError) as failure:
+        installer.run_workflow("foo")
+
+    assert str(failure.value) == (
+        "Detected 3 failures: "
+        "DataLoss: does not compute, "
+        "DeadlineExceeded: things: The run was stopped after reaching the timeout"
+    )
 
 
 def test_save_config(ws):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -258,7 +258,7 @@ def test_run_workflow_creates_proper_failure(ws, mocker):
 
 def test_run_workflow_creates_failure_from_mapping(ws, mocker):
     def run_now(job_id):
-        assert "bar" == job_id
+        assert 111 == job_id
 
         def result():
             raise OperationFailed(...)
@@ -283,7 +283,7 @@ def test_run_workflow_creates_failure_from_mapping(ws, mocker):
         error="something: PermissionDenied: does not compute", error_trace="# goes to stderr"
     )
     installer = WorkspaceInstaller(ws)
-    installer._state.jobs = {"foo": "bar"}
+    installer._state.jobs = {"foo": "111"}
     with pytest.raises(PermissionDenied) as failure:
         installer.run_workflow("foo")
 
@@ -292,7 +292,7 @@ def test_run_workflow_creates_failure_from_mapping(ws, mocker):
 
 def test_run_workflow_creates_failure_many_error(ws, mocker):
     def run_now(job_id):
-        assert "bar" == job_id
+        assert 111 == job_id
 
         def result():
             raise OperationFailed(...)
@@ -327,7 +327,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker):
         error="something: DataLoss: does not compute", error_trace="# goes to stderr"
     )
     installer = WorkspaceInstaller(ws)
-    installer._state.jobs = {"foo": "bar"}
+    installer._state.jobs = {"foo": "111"}
     with pytest.raises(ManyError) as failure:
         installer.run_workflow("foo")
 


### PR DESCRIPTION
This PR adds heuristics to determine the actual remote error type based on message content. This improves integration test flakiness for those that call `run_workflow`.