### PR TITLE
Added get_tables_to_migrate functionality in the mapping module

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -163,9 +163,8 @@ class TableMapping:
 
     def _validate_source_database(self, database: str) -> str | None:
         describe = {}
-        for key, value in self._backend.fetch(f"DESCRIBE SCHEMA EXTENDED {database}"):
-            describe[key] = value
-            logger.info(f"{key} --- {value}")
+        for value in self._backend.fetch(f"DESCRIBE SCHEMA EXTENDED {database}"):
+            describe[value["database_description_item"]] = value["database_description_value"]
         if self.UCX_SKIP_PROPERTY in TablesCrawler.parse_database_props(describe.get("Properties", "").lower()):
             logger.info(f"Database {database} is marked to be skipped")
             return None

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from functools import partial
 
+from databricks.labs.blueprint.parallel import Threads
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import BadRequest, NotFound
 from databricks.sdk.service.catalog import TableInfo
@@ -13,7 +14,6 @@ from databricks.sdk.service.workspace import ImportFormat
 
 from databricks.labs.ucx.account import WorkspaceInfo
 from databricks.labs.ucx.framework.crawlers import SqlBackend
-from databricks.labs.ucx.framework.parallel import Threads
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.tables import Table
 

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -173,7 +173,7 @@ class TableMapping:
             if rule.as_hms_table_key not in crawled_tables_keys:
                 logger.info(f"Table {rule.as_hms_table_key} in the mapping doesn't show up in assessment")
                 continue
-            if rule.as_uc_table_key in upgraded_tables:
+            if rule.as_hms_table_key in upgraded_tables:
                 logger.info(f"Table {rule.as_hms_table_key} was migrated to {rule.as_uc_table_key} and will be skipped")
                 continue
             if rule.src_schema not in databases_in_scope:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -140,6 +140,13 @@ class TablesCrawler(CrawlerBase):
         # Convert key-value pairs to dictionary
         return dict(key_value_pairs)
 
+    @staticmethod
+    def parse_database_props(tbl_props: str) -> dict:
+        pattern = r"([^,^\(^\)\[\]]+),([^,^\(^\)\[\]]+)"
+        key_value_pairs = re.findall(pattern, tbl_props)
+        # Convert key-value pairs to dictionary
+        return dict(key_value_pairs)
+
     def _try_load(self) -> Iterable[Table]:
         """Tries to load table information from the database or throws TABLE_OR_VIEW_NOT_FOUND error"""
         for row in self._fetch(f"SELECT * FROM {self._full_name}"):

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -36,7 +36,7 @@ def test_migrate_managed_tables(ws, sql_backend, inventory_schema, make_catalog,
             src_managed_table.name,
         ),
     ]
-    table_mapping = StaticTableMapping(rules=rules)
+    table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     table_migrate = TablesMigrate(table_crawler, ws, sql_backend, table_mapping)
 
     table_migrate.migrate_tables()
@@ -91,7 +91,7 @@ def test_migrate_tables_with_cache_should_not_create_table(
             dst_managed_table.name,
         ),
     ]
-    table_mapping = StaticTableMapping(rules=rules)
+    table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     table_migrate = TablesMigrate(table_crawler, ws, sql_backend, table_mapping)
 
     # FIXME: flaky: databricks.sdk.errors.mapping.NotFound: Catalog 'ucx_cjazg' does not exist.
@@ -129,7 +129,7 @@ def test_migrate_external_table(ws, sql_backend, inventory_schema, make_catalog,
             src_external_table.name,
         ),
     ]
-    table_mapping = StaticTableMapping(rules=rules)
+    table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     table_migrate = TablesMigrate(table_crawler, ws, sql_backend, table_mapping)
 
     table_migrate.migrate_tables()
@@ -170,7 +170,7 @@ def test_revert_migrated_table(ws, sql_backend, inventory_schema, make_schema, m
             table_to_not_revert.name,
         ),
     ]
-    table_mapping = StaticTableMapping(rules=rules)
+    table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     table_migrate = TablesMigrate(table_crawler, ws, sql_backend, table_mapping)
     table_migrate.migrate_tables()
 
@@ -191,3 +191,49 @@ def test_revert_migrated_table(ws, sql_backend, inventory_schema, make_schema, m
     assert len(target_tables_schema2) == 1
     assert target_tables_schema2[0]["database"] == dst_schema2.name
     assert target_tables_schema2[0]["tableName"] == table_to_not_revert.name
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
+def test_mapping_skips_tables_databases(ws, sql_backend, inventory_schema, make_schema, make_table, make_catalog):
+    src_schema1 = make_schema(catalog_name="hive_metastore")
+    src_schema2 = make_schema(catalog_name="hive_metastore")
+    table_to_migrate = make_table(schema_name=src_schema1.name)
+    table_to_skip = make_table(schema_name=src_schema1.name)
+    table_in_skipped_database = make_table(schema_name=src_schema2.name)
+    all_tables = [table_to_migrate, table_to_skip, table_in_skipped_database]
+
+    dst_catalog = make_catalog()
+    dst_schema1 = make_schema(catalog_name=dst_catalog.name, name=src_schema1.name)
+    dst_schema2 = make_schema(catalog_name=dst_catalog.name, name=src_schema2.name)
+
+    table_crawler = StaticTablesCrawler(sql_backend, inventory_schema, all_tables)
+    rules = [
+        Rule(
+            "workspace",
+            dst_catalog.name,
+            src_schema1.name,
+            dst_schema1.name,
+            table_to_migrate.name,
+            table_to_migrate.name,
+        ),
+        Rule(
+            "workspace",
+            dst_catalog.name,
+            src_schema1.name,
+            dst_schema1.name,
+            table_to_skip.name,
+            table_to_skip.name,
+        ),
+        Rule(
+            "workspace",
+            dst_catalog.name,
+            src_schema2.name,
+            dst_schema2.name,
+            table_in_skipped_database.name,
+            table_in_skipped_database.name,
+        ),
+    ]
+    table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
+    table_mapping.skip_table(src_schema1.name, table_to_skip.name)
+    table_mapping.skip_schema(src_schema2.name)
+    assert len(table_mapping.get_tables_to_migrate(table_crawler)) == 1

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -239,7 +239,7 @@ def test_mapping_skips_tables_databases(ws, sql_backend, inventory_schema, make_
     assert len(table_mapping.get_tables_to_migrate(table_crawler)) == 1
 
 
-# @retried(on=[NotFound], timeout=timedelta(minutes=5))
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_mapping_reverts_table(ws, sql_backend, inventory_schema, make_schema, make_table, make_catalog):
     src_schema = make_schema(catalog_name="hive_metastore")
     table_to_revert = make_table(schema_name=src_schema.name)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -50,7 +50,7 @@ def test_migrate_managed_tables(ws, sql_backend, inventory_schema, make_catalog,
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_migrate_tables_with_cache_should_not_create_table(
-        ws, sql_backend, inventory_schema, make_random, make_catalog, make_schema, make_table
+    ws, sql_backend, inventory_schema, make_random, make_catalog, make_schema, make_table
 ):
     if not ws.config.is_azure:
         pytest.skip("temporary: only works in azure test env")
@@ -244,7 +244,10 @@ def test_mapping_reverts_table(ws, sql_backend, inventory_schema, make_schema, m
     src_schema = make_schema(catalog_name="hive_metastore")
     table_to_revert = make_table(schema_name=src_schema.name)
     table_to_skip = make_table(schema_name=src_schema.name)
-    all_tables = [table_to_revert, table_to_skip, ]
+    all_tables = [
+        table_to_revert,
+        table_to_skip,
+    ]
 
     dst_catalog = make_catalog()
     dst_schema = make_schema(catalog_name=dst_catalog.name, name=src_schema.name)
@@ -267,13 +270,14 @@ def test_mapping_reverts_table(ws, sql_backend, inventory_schema, make_schema, m
     target_table_properties = ws.tables.get(f"{dst_schema.full_name}.{table_to_skip.name}").properties
     assert target_table_properties["upgraded_from"] == table_to_skip.full_name
 
-    sql_backend.execute(f"ALTER TABLE {table_to_revert.full_name} SET "
-                        f"TBLPROPERTIES('upgraded_to' = 'fake_catalog.fake_schema.fake_table');")
+    sql_backend.execute(
+        f"ALTER TABLE {table_to_revert.full_name} SET "
+        f"TBLPROPERTIES('upgraded_to' = 'fake_catalog.fake_schema.fake_table');"
+    )
 
-    results = {_["key"]: _["value"] for _ in
-               list(sql_backend.fetch(f"SHOW TBLPROPERTIES {table_to_revert.full_name}"))}
+    results = {_["key"]: _["value"] for _ in list(sql_backend.fetch(f"SHOW TBLPROPERTIES {table_to_revert.full_name}"))}
     assert "upgraded_to" in results
-    assert results["upgraded_to"] == f"fake_catalog.fake_schema.fake_table"
+    assert results["upgraded_to"] == "fake_catalog.fake_schema.fake_table"
 
     rules2 = [
         Rule(
@@ -306,6 +310,7 @@ def test_mapping_reverts_table(ws, sql_backend, inventory_schema, make_schema, m
         table_to_revert.name,
         table_to_revert.name,
     )
-    results2 = {_["key"]: _["value"] for _ in
-                list(sql_backend.fetch(f"SHOW TBLPROPERTIES {table_to_revert.full_name}"))}
+    results2 = {
+        _["key"]: _["value"] for _ in list(sql_backend.fetch(f"SHOW TBLPROPERTIES {table_to_revert.full_name}"))
+    }
     assert "upgraded_to" not in results2

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -334,6 +334,23 @@ def test_skipping_rules_existing_targets():
     assert ["DESCRIBE SCHEMA EXTENDED schema1"] == backend.queries
 
 
+def test_table_not_in_crawled_tables():
+    client = create_autospec(WorkspaceClient)
+    client.workspace.download.return_value = io.StringIO(
+        "workspace_name,catalog_name,src_schema,dst_schema,src_table,dst_table\r\n"
+        "fake_ws,cat1,schema1,schema1,table1,dest1\r\n"
+    )
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(client, backend)
+    tables_crawler = create_autospec(TablesCrawler)
+    tables_crawler.snapshot.return_value = []
+    table_mapping.get_tables_to_migrate(tables_crawler)
+
+    assert ["DESCRIBE SCHEMA EXTENDED schema1"] == backend.queries
+
+
 def test_skipping_rules_database_skipped():
     client = MagicMock()
     client.workspace.download.return_value = io.StringIO(

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -179,6 +179,9 @@ def test_skip_tables_marked_for_skipping_or_upgraded():
         "SHOW TBLPROPERTIES `test_schema1`.`test_view1`": [
             {"key": "databricks.labs.ucx.skip", "value": "true"},
         ],
+        "SHOW TBLPROPERTIES `test_schema1`.`test_table2`": [
+            {"key": "upgraded_to", "value": "fake_dest"},
+        ],
         "DESCRIBE SCHEMA EXTENDED test_schema1": [],
         "DESCRIBE SCHEMA EXTENDED test_schema2": [],
         "DESCRIBE SCHEMA EXTENDED test_schema3": [
@@ -263,7 +266,7 @@ def test_skip_tables_marked_for_skipping_or_upgraded():
     table_mapping = TableMapping(client, backend)
 
     tables_to_migrate = table_mapping.get_tables_to_migrate(table_crawler)
-    assert len(tables_to_migrate) == 3
+    assert len(tables_to_migrate) == 2
     tables = (table_to_migrate.src for table_to_migrate in tables_to_migrate)
     assert (
         Table(

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -2,16 +2,22 @@ import io
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
+from databricks.sdk.service.catalog import CatalogInfo, SchemaInfo, TableInfo
 
 from databricks.labs.ucx.account import WorkspaceInfo
 from databricks.labs.ucx.hive_metastore.mapping import Rule, TableMapping
 from databricks.labs.ucx.hive_metastore.tables import Table, TablesCrawler
+from tests.unit.framework.mocks import MockBackend
 
 
 def test_current_tables_empty_fails():
     ws = MagicMock()
-    table_mapping = TableMapping(ws, "~/.ucx")
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(ws, backend, "~/.ucx")
 
     tables_crawler = create_autospec(TablesCrawler)
     tables_crawler.snapshot.return_value = []
@@ -22,7 +28,10 @@ def test_current_tables_empty_fails():
 
 def test_current_tables_some_rules():
     ws = MagicMock()
-    table_mapping = TableMapping(ws, "~/.ucx")
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(ws, backend, "~/.ucx")
 
     tables_crawler = create_autospec(TablesCrawler)
     tables_crawler.snapshot.return_value = [
@@ -46,7 +55,10 @@ def test_current_tables_some_rules():
 
 def test_save_mapping():
     ws = MagicMock()
-    table_mapping = TableMapping(ws, "~/.ucx")
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(ws, backend, "~/.ucx")
 
     tables_crawler = create_autospec(TablesCrawler)
     tables_crawler.snapshot.return_value = [
@@ -75,7 +87,10 @@ def test_save_mapping():
 def test_load_mapping_not_found():
     ws = MagicMock()
     ws.workspace.download.side_effect = NotFound(...)
-    table_mapping = TableMapping(ws, "~/.ucx")
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(ws, backend, "~/.ucx")
 
     with pytest.raises(ValueError):
         table_mapping.load()
@@ -87,7 +102,10 @@ def test_load_mapping():
         "workspace_name,catalog_name,src_schema,dst_schema,src_table,dst_table\r\n"
         "foo-bar,foo_bar,foo,foo,bar,bar\r\n"
     )
-    table_mapping = TableMapping(ws, "~/.ucx")
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_mapping = TableMapping(ws, backend, "~/.ucx")
 
     rules = table_mapping.load()
 
@@ -106,13 +124,13 @@ def test_load_mapping():
 def test_skip_happy_path(mocker, caplog):
     ws = mocker.patch("databricks.sdk.WorkspaceClient.__init__")
     sbe = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
-    mapping = TableMapping(ws)
-    mapping.skip_table(sbe, schema="schema", table="table")
+    mapping = TableMapping(ws, sbe)
+    mapping.skip_table(schema="schema", table="table")
     sbe.execute.assert_called_with(
         f"ALTER TABLE `schema`.`table` SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)"
     )
     assert len(caplog.records) == 0
-    mapping.skip_schema(sbe, schema="schema")
+    mapping.skip_schema(schema="schema")
     sbe.execute.assert_called_with(f"ALTER SCHEMA `schema` SET DBPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)")
     assert len(caplog.records) == 0
 
@@ -121,8 +139,8 @@ def test_skip_missing_schema(mocker, caplog):
     ws = mocker.patch("databricks.sdk.WorkspaceClient.__init__")
     sbe = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
     sbe.execute.side_effect = NotFound("[SCHEMA_NOT_FOUND]")
-    mapping = TableMapping(ws)
-    mapping.skip_schema(sbe, schema="schema")
+    mapping = TableMapping(ws, sbe)
+    mapping.skip_schema(schema="schema")
     assert [rec.message for rec in caplog.records if "schema not found" in rec.message.lower()]
 
 
@@ -130,6 +148,103 @@ def test_skip_missing_table(mocker, caplog):
     ws = mocker.patch("databricks.sdk.WorkspaceClient.__init__")
     sbe = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
     sbe.execute.side_effect = NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
-    mapping = TableMapping(ws)
-    mapping.skip_table(sbe, schema="schema", table="table")
+    mapping = TableMapping(ws, sbe)
+    mapping.skip_table(sbe, table="table")
     assert [rec.message for rec in caplog.records if "table not found" in rec.message.lower()]
+
+
+def test_skip_tables_marked_for_skipping_or_upgraded():
+    errors = {}
+    rows = {
+        "SHOW DATABASES": [
+            ["test_schema1"],
+            ["test_schema2"],
+            ["test_schema3"],
+        ],
+        "SHOW TBLPROPERTIES `test_schema1`.`test_table1`": [
+            {"key": "upgraded_to", "value": "fake_dest"},
+        ],
+        "SHOW TBLPROPERTIES `test_schema1`.`test_table2`": [
+            {"key": "another_key", "value": "fake_value"},
+        ],
+        "DESCRIBE SCHEMA EXTENDED test_schema1": [],
+        "DESCRIBE SCHEMA EXTENDED test_schema2": [],
+        "DESCRIBE SCHEMA EXTENDED test_schema3": [
+            {"key": "properties", "value": "((databricks.labs.ucx.skip,true))"},
+        ],
+    }
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_crawler = create_autospec(TablesCrawler)
+    client = create_autospec(WorkspaceClient)
+    client.catalogs.list.return_value = [CatalogInfo(name="cat1")]
+    client.schemas.list.return_value = [
+        SchemaInfo(catalog_name="cat1", name="test_schema1"),
+        SchemaInfo(catalog_name="cat1", name="test_schema2"),
+    ]
+    client.tables.list.side_effect = [
+        [
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="dest1",
+                full_name="cat1.schema1.test_table1",
+                properties={"upgraded_from": "hive_metastore.test_schema1.test_table1"},
+            ),
+        ],
+        [],
+        [],
+    ]
+
+    test_tables = [
+        Table(
+            object_type="EXTERNAL",
+            table_format="DELTA",
+            catalog="hive_metastore",
+            database="test_schema1",
+            name="test_table1",
+            upgraded_to="cat1.schema1.dest1",
+        ),
+        Table(
+            object_type="VIEW",
+            table_format="VIEW",
+            catalog="hive_metastore",
+            database="test_schema1",
+            name="test_view1",
+            view_text="SELECT * FROM SOMETHING",
+            upgraded_to="cat1.schema1.dest_view1",
+        ),
+        Table(
+            object_type="MANAGED",
+            table_format="DELTA",
+            catalog="hive_metastore",
+            database="test_schema1",
+            name="test_table2",
+        ),
+        Table(
+            object_type="EXTERNAL",
+            table_format="DELTA",
+            catalog="hive_metastore",
+            database="test_schema2",
+            name="test_table3",
+        ),
+        Table(
+            object_type="EXTERNAL",
+            table_format="DELTA",
+            catalog="hive_metastore",
+            database="test_schema3",
+            name="test_table4",
+        ),
+    ]
+    client.workspace.download.return_value = io.StringIO(
+        "workspace_name,catalog_name,src_schema,dst_schema,src_table,dst_table\r\n"
+        "foo-bar,cat1,test_schema1,schema1,test_table1,test_table1\r\n"
+        "foo-bar,cat1,test_schema1,schema1,test_view1,test_view1\r\n"
+        "foo-bar,cat1,test_schema1,schema1,test_table2,test_table2\r\n"
+        "foo-bar,cat1,test_schema2,schema2,test_table3,test_table3\r\n"
+        "foo-bar,cat1,test_schema3,schema3,test_table4,test_table4\r\n"
+    )
+    table_crawler.snapshot.return_value = test_tables
+    table_mapping = TableMapping(client, backend)
+
+    tables_to_migrate = table_mapping.get_tables_to_migrate(table_crawler)
+    assert len(tables_to_migrate) == 4


### PR DESCRIPTION
closes #754 
Added functionality to the mapping module to compile a list of tables to migrate along with the rules/mappings.
We take into account the skip property and whether the table was migrated before.