### PR TITLE
Added functionality to determine migration method based on DBFS Root

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -134,6 +134,9 @@ class TableMapping:
             if rule.src_schema not in databases_in_scope:
                 logger.info(f"Table {rule.as_hms_table_key} is in a database that was marked to be skipped")
                 continue
+            if crawled_tables_keys[rule.as_hms_table_key].is_db_dataset:
+                logger.info(f"Table {rule.as_hms_table_key} is a db demo dataset and will not be upgraded")
+                continue
             tasks.append(
                 partial(self._get_table_in_scope_task, TableToMigrate(crawled_tables_keys[rule.as_hms_table_key], rule))
             )

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -134,7 +134,7 @@ class TableMapping:
             if rule.src_schema not in databases_in_scope:
                 logger.info(f"Table {rule.as_hms_table_key} is in a database that was marked to be skipped")
                 continue
-            if crawled_tables_keys[rule.as_hms_table_key].is_db_dataset:
+            if crawled_tables_keys[rule.as_hms_table_key].is_databricks_dataset:
                 logger.info(f"Table {rule.as_hms_table_key} is a db demo dataset and will not be upgraded")
                 continue
             tasks.append(

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -39,12 +39,13 @@ class TablesMigrate:
         if self._table_already_upgraded(rule.as_uc_table_key):
             logger.info(f"Table {src_table.key} already upgraded to {rule.as_uc_table_key}")
             return True
-        if src_table.kind == "TABLE" and src_table.is_dbfs_root:
+        if src_table.kind == "TABLE" and src_table.table_format == "DELTA" and src_table.is_dbfs_root:
             return self._migrate_dbfs_root_table(src_table, rule)
-        if src_table.kind == "TABLE":
+        if src_table.kind == "TABLE" and src_table.is_format_supported_for_sync:
             return self._migrate_external_table(src_table, rule)
         if src_table.kind == "VIEW":
             return self._migrate_view(src_table, rule)
+        logger.info(f"Table {src_table.key} is not supported for migration")
         return True
 
     def _migrate_external_table(self, src_table: Table, rule: Rule):

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -40,7 +40,7 @@ class TableSizeCrawler(CrawlerBase):
         for table in self._tables_crawler.snapshot():
             if not table.kind == "TABLE":
                 continue
-            if not table.is_dbfs_root():
+            if not table.is_dbfs_root:
                 continue
             size_in_bytes = self.get_table_size(table.key)
             yield TableSize(

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -37,7 +37,7 @@ class Table:
         "dbfs:/mnt",
     ]
 
-    DBFS_DB_DATASETS_PREFIXES: typing.ClassVar[list[str]] = [
+    DBFS_DATABRICKS_DATASETS_PREFIXES: typing.ClassVar[list[str]] = [
         "/dbfs/databricks-datasets",
         "dbfs:/databricks-datasets",
     ]
@@ -74,7 +74,7 @@ class Table:
                 for exception in self.DBFS_ROOT_PREFIX_EXCEPTIONS:
                     if self.location.startswith(exception):
                         return False
-                for db_datasets in self.DBFS_DB_DATASETS_PREFIXES:
+                for db_datasets in self.DBFS_DATABRICKS_DATASETS_PREFIXES:
                     if self.location.startswith(db_datasets):
                         return False
                 return True
@@ -87,10 +87,10 @@ class Table:
         return self.table_format.upper() in ("DELTA", "PARQUET", "CSV", "JSON", "ORC", "TEXT")
 
     @property
-    def is_db_dataset(self) -> bool:
+    def is_databricks_dataset(self) -> bool:
         if not self.location:
             return False
-        for db_datasets in self.DBFS_DB_DATASETS_PREFIXES:
+        for db_datasets in self.DBFS_DATABRICKS_DATASETS_PREFIXES:
             if self.location.startswith(db_datasets):
                 return True
         return False

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -81,6 +81,12 @@ class Table:
         return False
 
     @property
+    def is_format_supported_for_sync(self) -> bool:
+        if self.table_format is None:
+            return False
+        return self.table_format.upper() in ("DELTA", "PARQUET", "CSV", "JSON", "ORC", "TEXT")
+
+    @property
     def is_db_dataset(self) -> bool:
         if not self.location:
             return False

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -198,6 +198,9 @@ def test_mapping_skips_tables_databases(ws, sql_backend, inventory_schema, make_
     src_schema1 = make_schema(catalog_name="hive_metastore")
     src_schema2 = make_schema(catalog_name="hive_metastore")
     table_to_migrate = make_table(schema_name=src_schema1.name)
+    table_databricks_dataset = make_table(
+        schema_name=src_schema1.name, external_csv="dbfs:/databricks-datasets/adult/adult.data"
+    )
     table_to_skip = make_table(schema_name=src_schema1.name)
     table_in_skipped_database = make_table(schema_name=src_schema2.name)
     all_tables = [table_to_migrate, table_to_skip, table_in_skipped_database]
@@ -223,6 +226,14 @@ def test_mapping_skips_tables_databases(ws, sql_backend, inventory_schema, make_
             dst_schema1.name,
             table_to_skip.name,
             table_to_skip.name,
+        ),
+        Rule(
+            "workspace",
+            dst_catalog.name,
+            src_schema1.name,
+            dst_schema1.name,
+            table_databricks_dataset.name,
+            table_databricks_dataset.name,
         ),
         Rule(
             "workspace",

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -23,7 +23,7 @@ from ..framework.mocks import MockBackend
 logger = logging.getLogger(__name__)
 
 
-def test_migrate_managed_tables_should_produce_proper_queries():
+def test_migrate_dbfs_root_tables_should_produce_proper_queries():
     errors = {}
     rows = {}
     backend = MockBackend(fails_on_first=errors, rows=rows)
@@ -32,20 +32,38 @@ def test_migrate_managed_tables_should_produce_proper_queries():
     table_mapping = create_autospec(TableMapping)
     table_mapping.get_tables_to_migrate.return_value = [
         TableToMigrate(
-            Table("hive_metastore", "db1_src", "managed_src", "MANAGED", "DELTA"),
-            Rule("workspace", "ucx_default", "db1_src", "db1_dst", "managed_src", "managed_dst"),
-        )
+            Table("hive_metastore", "db1_src", "managed_dbfs", "MANAGED", "DELTA", "dbfs:/some_location"),
+            Rule("workspace", "ucx_default", "db1_src", "db1_dst", "managed_dbfs", "managed_dbfs"),
+        ),
+        TableToMigrate(
+            Table("hive_metastore", "db1_src", "managed_mnt", "MANAGED", "DELTA", "s3:/mnt/location"),
+            Rule("workspace", "ucx_default", "db1_src", "db1_dst", "managed_mnt", "managed_mnt"),
+        ),
+        TableToMigrate(
+            Table("hive_metastore", "db1_src", "managed_other", "MANAGED", "DELTA", "s3:/location"),
+            Rule("workspace", "ucx_default", "db1_src", "db1_dst", "managed_other", "managed_other"),
+        ),
     ]
     table_migrate = TablesMigrate(table_crawler, client, backend, table_mapping)
     table_migrate.migrate_tables()
 
-    assert (list(backend.queries)) == [
-        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dst DEEP CLONE hive_metastore.db1_src.managed_src;",
-        "ALTER TABLE hive_metastore.db1_src.managed_src "
-        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dst');",
-        "ALTER TABLE ucx_default.db1_dst.managed_dst "
-        "SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_src');",
-    ]
+    assert (
+        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
+    ) in list(backend.queries)
+    assert "SYNC TABLE ucx_default.db1_dst.managed_mnt FROM hive_metastore.db1_src.managed_mnt;" in list(
+        backend.queries
+    )
+    assert (
+        "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+    ) in list(backend.queries)
+    assert (
+        "ALTER TABLE ucx_default.db1_dst.managed_dbfs "
+        "SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs');"
+    ) in list(backend.queries)
+    assert "SYNC TABLE ucx_default.db1_dst.managed_other FROM hive_metastore.db1_src.managed_other;" in list(
+        backend.queries
+    )
 
 
 def test_migrate_external_tables_should_produce_proper_queries():

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -103,13 +103,15 @@ def test_migrate_view_should_produce_proper_queries():
     table_migrate = TablesMigrate(table_crawler, client, backend, table_mapping)
     table_migrate.migrate_tables()
 
-    assert (list(backend.queries)) == [
-        "CREATE VIEW IF NOT EXISTS ucx_default.db1_dst.view_dst AS SELECT * FROM table;",
+    assert "CREATE VIEW IF NOT EXISTS ucx_default.db1_dst.view_dst AS SELECT * FROM table;" in list(backend.queries)
+    assert (
         "ALTER VIEW hive_metastore.db1_src.view_src "
-        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.view_dst');",
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.view_dst');"
+    ) in list(backend.queries)
+    assert (
         "ALTER VIEW ucx_default.db1_dst.view_dst "
-        "SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.view_src');",
-    ]
+        "SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.view_src');"
+    ) in list(backend.queries)
 
 
 def get_table_migrate(backend: SqlBackend) -> TablesMigrate:

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -152,18 +152,22 @@ def test_is_dbfs_root():
 
 
 def test_is_db_dataset():
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="dbfs:/somelocation/tablename").is_db_dataset
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="/dbfs/somelocation/tablename").is_db_dataset
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="dbfs:/mnt/somelocation/tablename").is_db_dataset
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="/dbfs/mnt/somelocation/tablename").is_db_dataset
+    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="dbfs:/somelocation/tablename").is_databricks_dataset
+    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="/dbfs/somelocation/tablename").is_databricks_dataset
+    assert not Table(
+        "a", "b", "c", "MANAGED", "DELTA", location="dbfs:/mnt/somelocation/tablename"
+    ).is_databricks_dataset
+    assert not Table(
+        "a", "b", "c", "MANAGED", "DELTA", location="/dbfs/mnt/somelocation/tablename"
+    ).is_databricks_dataset
     assert Table(
         "a", "b", "c", "MANAGED", "DELTA", location="dbfs:/databricks-datasets/somelocation/tablename"
-    ).is_db_dataset
+    ).is_databricks_dataset
     assert Table(
         "a", "b", "c", "MANAGED", "DELTA", location="/dbfs/databricks-datasets/somelocation/tablename"
-    ).is_db_dataset
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="s3:/somelocation/tablename").is_db_dataset
-    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="adls:/somelocation/tablename").is_db_dataset
+    ).is_databricks_dataset
+    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="s3:/somelocation/tablename").is_databricks_dataset
+    assert not Table("a", "b", "c", "MANAGED", "DELTA", location="adls:/somelocation/tablename").is_databricks_dataset
 
 
 def test_is_supported_for_sync():

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -164,3 +164,20 @@ def test_is_db_dataset():
     ).is_db_dataset
     assert not Table("a", "b", "c", "MANAGED", "DELTA", location="s3:/somelocation/tablename").is_db_dataset
     assert not Table("a", "b", "c", "MANAGED", "DELTA", location="adls:/somelocation/tablename").is_db_dataset
+
+
+def test_is_supported_for_sync():
+    assert Table(
+        "a", "b", "c", "EXTERNAL", "DELTA", location="dbfs:/somelocation/tablename"
+    ).is_format_supported_for_sync
+    assert Table("a", "b", "c", "EXTERNAL", "CSV", location="dbfs:/somelocation/tablename").is_format_supported_for_sync
+    assert Table(
+        "a", "b", "c", "EXTERNAL", "TEXT", location="dbfs:/somelocation/tablename"
+    ).is_format_supported_for_sync
+    assert Table("a", "b", "c", "EXTERNAL", "ORC", location="dbfs:/somelocation/tablename").is_format_supported_for_sync
+    assert Table(
+        "a", "b", "c", "EXTERNAL", "JSON", location="dbfs:/somelocation/tablename"
+    ).is_format_supported_for_sync
+    assert not (
+        Table("a", "b", "c", "EXTERNAL", "AVRO", location="dbfs:/somelocation/tablename").is_format_supported_for_sync
+    )


### PR DESCRIPTION
closes #334 
Change migration functionality to base migration type on whether the table is on DBFS root or not.
- If the table location on a mount, sync the table to an external UC table
- If the table points to a databrick's dataset skip it
- If the table location is on a dbfs root location (dbfs location that is not a mount or a databricks dataset) deep clone the table to a managed UC table.
- Otherwise sync the table to an external UC table 