### PR TITLE
Improve error handling by not failing group rename step if a group was removed from account before reflecting it to workspace

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -18,7 +18,6 @@ from databricks.sdk.errors.mapping import (
     InternalError,
     NotFound,
     ResourceConflict,
-    ResourceDoesNotExist,
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -508,7 +508,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         except BadRequest:
             # already exists
             return True
-        except ResourceDoesNotExist:
+        except NotFound:
             # the given group has been removed from the account after getting the group and before running this method
             logger.warning("Group with ID: %s does not exist anymore in the Databricks account.", account_group_id)
             return True

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -509,7 +509,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
             # already exists
             return True
         except ResourceDoesNotExist:
-            # the given account group has been removed after getting the group and before running this method
+            # the given group has been removed from the account after getting the group and before running this method
             logger.warning("Group with ID: %s does not exist anymore in the Databricks account.", account_group_id)
             return True
 

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -18,6 +18,7 @@ from databricks.sdk.errors.mapping import (
     InternalError,
     NotFound,
     ResourceConflict,
+    ResourceDoesNotExist,
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam
@@ -506,6 +507,10 @@ class GroupManager(CrawlerBase[MigratedGroup]):
             return True
         except BadRequest:
             # already exists
+            return True
+        except ResourceDoesNotExist:
+            # the given account group has been removed after getting the group and before running this method
+            logger.warning("Group with ID: %s does not exist anymore in the Databricks account.", account_group_id)
             return True
 
     def _get_strategy(

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -398,6 +399,12 @@ def test_reflect_account_should_not_fail_if_group_not_in_the_account_anymore():
 
     wsclient.api_client.do.side_effect = reflect_account_side_effect
     GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace()
+
+    wsclient.api_client.do.assert_called_with(
+        'PUT',
+        f"/api/2.0/preview/permissionassignments/principals/{account_group1.id}",
+        data=json.dumps({"permissions": ["USER"]})
+    )
 
 
 def test_delete_original_workspace_groups_should_delete_relected_acc_groups_in_workspace():

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -4,7 +4,7 @@ import pytest
 from _pytest.outcomes import fail
 from databricks.labs.blueprint.parallel import ManyError
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.sdk.errors import DatabricksError
+from databricks.sdk.errors import DatabricksError, ResourceDoesNotExist
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta
 
@@ -378,6 +378,26 @@ def test_reflect_account_should_fail_if_error_is_thrown():
 
     with pytest.raises(ManyError):
         gm.reflect_account_groups_on_workspace()
+
+
+def test_reflect_account_should_not_fail_if_group_not_in_the_account_anymore():
+    backend = MockBackend(rows={"SELECT": [("1", "de", "de", "test-group-de", "", "", "", "")]})
+    wsclient = MagicMock()
+    account_group1 = Group(id="11", display_name="de")
+
+    def reflect_account_side_effect(method, *args, **kwargs):
+        if method == "GET":
+            return {
+                "Resources": [g.as_dict() for g in [account_group1]],
+            }
+        if method == "PUT":
+            raise ResourceDoesNotExist(
+                "The group has been removed from the Databricks account after getting the group "
+                "and before reflecting it to the workspace."
+            )
+
+    wsclient.api_client.do.side_effect = reflect_account_side_effect
+    GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace()
 
 
 def test_delete_original_workspace_groups_should_delete_relected_acc_groups_in_workspace():

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -401,9 +401,9 @@ def test_reflect_account_should_not_fail_if_group_not_in_the_account_anymore():
     GroupManager(backend, wsclient, inventory_database="inv").reflect_account_groups_on_workspace()
 
     wsclient.api_client.do.assert_called_with(
-        'PUT',
+        "PUT",
         f"/api/2.0/preview/permissionassignments/principals/{account_group1.id}",
-        data=json.dumps({"permissions": ["USER"]})
+        data=json.dumps({"permissions": ["USER"]}),
     )
 
 


### PR DESCRIPTION
- Fix isssue [761](https://github.com/databrickslabs/ucx/issues/761)

In rare cases, it can happen that a group is removed from the account before we manage to reflect it in the workspace. It's usually a couple of minutes between listing the groups and reflecting it. This PR will log such cases without failing the tool.