### PR TITLE
Convert to SDK exceptions for RuntimeBackend query executions

### DIFF
--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -153,7 +153,6 @@ class RuntimeBackend(SqlBackend):
         logger.debug(f"[spark][execute] {sql}")
         try:
             immediate_response = self._spark.sql(sql)
-            # status = immediate_response.status
         except Exception as e:
             error_message = str(e)
             self._raise_spark_sql_exceptions(error_message)

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -157,13 +157,7 @@ class RuntimeBackend(SqlBackend):
         except Exception as e:
             error_message = str(e)
             self._raise_spark_sql_exceptions(error_message)
-
-        # if status is None:
-        #     status = StatementStatus(state=StatementState.FAILED)
-        # if status.state == StatementState.SUCCEEDED:
         return immediate_response
-
-        # self._raise_if_needed(status)
 
     def fetch(self, sql) -> Iterator[Row]:
         logger.debug(f"[spark][fetch] {sql}")
@@ -196,46 +190,6 @@ class RuntimeBackend(SqlBackend):
             raise PermissionDenied(error_message) from None
         else:
             raise Unknown(error_message) from None
-
-    # @staticmethod
-    # def _raise_if_needed(status: StatementStatus):
-    #     if status.state not in [StatementState.FAILED, StatementState.CANCELED, StatementState.CLOSED]:
-    #         return
-    #     status_error = status.error
-    #     if status_error is None:
-    #         status_error = ServiceError(message="unknown", error_code=ServiceErrorCode.UNKNOWN)
-    #     error_message = status_error.message
-    #     if error_message is None:
-    #         error_message = ""
-    #     if "SCHEMA_NOT_FOUND" in error_message:
-    #         raise NotFound(error_message)
-    #     if "TABLE_OR_VIEW_NOT_FOUND" in error_message:
-    #         raise NotFound(error_message)
-    #     if "PARSE_SYNTAX_ERROR" in error_message:
-    #         raise BadRequest(error_message)
-    #     if "Operation not allowed" in error_message:
-    #         raise PermissionDenied(error_message)
-    #     mapping = {
-    #         ServiceErrorCode.ABORTED: errors.Aborted,
-    #         ServiceErrorCode.ALREADY_EXISTS: errors.AlreadyExists,
-    #         ServiceErrorCode.BAD_REQUEST: errors.BadRequest,
-    #         ServiceErrorCode.CANCELLED: errors.Cancelled,
-    #         ServiceErrorCode.DEADLINE_EXCEEDED: errors.DeadlineExceeded,
-    #         ServiceErrorCode.INTERNAL_ERROR: errors.InternalError,
-    #         ServiceErrorCode.IO_ERROR: errors.InternalError,
-    #         ServiceErrorCode.NOT_FOUND: errors.NotFound,
-    #         ServiceErrorCode.RESOURCE_EXHAUSTED: errors.ResourceExhausted,
-    #         ServiceErrorCode.SERVICE_UNDER_MAINTENANCE: errors.TemporarilyUnavailable,
-    #         ServiceErrorCode.TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
-    #         ServiceErrorCode.UNAUTHENTICATED: errors.Unauthenticated,
-    #         ServiceErrorCode.UNKNOWN: errors.Unknown,
-    #         ServiceErrorCode.WORKSPACE_TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
-    #     }
-    #     error_code = status_error.error_code
-    #     if error_code is None:
-    #         error_code = ServiceErrorCode.UNKNOWN
-    #     error_class = mapping.get(error_code, errors.Unknown)
-    #     raise error_class(error_message)
 
 
 class CrawlerBase(Generic[Result]):

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -7,14 +7,8 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from types import UnionType
 from typing import Any, ClassVar, Generic, Protocol, TypeVar
 
-from databricks.sdk import WorkspaceClient, errors
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import BadRequest, NotFound, PermissionDenied, Unknown
-from databricks.sdk.service.sql import (
-    ServiceError,
-    ServiceErrorCode,
-    StatementState,
-    StatementStatus,
-)
 
 from databricks.labs.ucx.mixins.sql import Row, StatementExecutionExt
 
@@ -159,17 +153,17 @@ class RuntimeBackend(SqlBackend):
         logger.debug(f"[spark][execute] {sql}")
         try:
             immediate_response = self._spark.sql(sql)
-            status = immediate_response.status
+            # status = immediate_response.status
         except Exception as e:
             error_message = str(e)
             self._raise_spark_sql_exceptions(error_message)
 
-        if status is None:
-            status = StatementStatus(state=StatementState.FAILED)
-        if status.state == StatementState.SUCCEEDED:
-            return immediate_response
+        # if status is None:
+        #     status = StatementStatus(state=StatementState.FAILED)
+        # if status.state == StatementState.SUCCEEDED:
+        return immediate_response
 
-        self._raise_if_needed(status)
+        # self._raise_if_needed(status)
 
     def fetch(self, sql) -> Iterator[Row]:
         logger.debug(f"[spark][fetch] {sql}")
@@ -203,45 +197,45 @@ class RuntimeBackend(SqlBackend):
         else:
             raise Unknown(error_message) from None
 
-    @staticmethod
-    def _raise_if_needed(status: StatementStatus):
-        if status.state not in [StatementState.FAILED, StatementState.CANCELED, StatementState.CLOSED]:
-            return
-        status_error = status.error
-        if status_error is None:
-            status_error = ServiceError(message="unknown", error_code=ServiceErrorCode.UNKNOWN)
-        error_message = status_error.message
-        if error_message is None:
-            error_message = ""
-        if "SCHEMA_NOT_FOUND" in error_message:
-            raise NotFound(error_message)
-        if "TABLE_OR_VIEW_NOT_FOUND" in error_message:
-            raise NotFound(error_message)
-        if "PARSE_SYNTAX_ERROR" in error_message:
-            raise BadRequest(error_message)
-        if "Operation not allowed" in error_message:
-            raise PermissionDenied(error_message)
-        mapping = {
-            ServiceErrorCode.ABORTED: errors.Aborted,
-            ServiceErrorCode.ALREADY_EXISTS: errors.AlreadyExists,
-            ServiceErrorCode.BAD_REQUEST: errors.BadRequest,
-            ServiceErrorCode.CANCELLED: errors.Cancelled,
-            ServiceErrorCode.DEADLINE_EXCEEDED: errors.DeadlineExceeded,
-            ServiceErrorCode.INTERNAL_ERROR: errors.InternalError,
-            ServiceErrorCode.IO_ERROR: errors.InternalError,
-            ServiceErrorCode.NOT_FOUND: errors.NotFound,
-            ServiceErrorCode.RESOURCE_EXHAUSTED: errors.ResourceExhausted,
-            ServiceErrorCode.SERVICE_UNDER_MAINTENANCE: errors.TemporarilyUnavailable,
-            ServiceErrorCode.TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
-            ServiceErrorCode.UNAUTHENTICATED: errors.Unauthenticated,
-            ServiceErrorCode.UNKNOWN: errors.Unknown,
-            ServiceErrorCode.WORKSPACE_TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
-        }
-        error_code = status_error.error_code
-        if error_code is None:
-            error_code = ServiceErrorCode.UNKNOWN
-        error_class = mapping.get(error_code, errors.Unknown)
-        raise error_class(error_message)
+    # @staticmethod
+    # def _raise_if_needed(status: StatementStatus):
+    #     if status.state not in [StatementState.FAILED, StatementState.CANCELED, StatementState.CLOSED]:
+    #         return
+    #     status_error = status.error
+    #     if status_error is None:
+    #         status_error = ServiceError(message="unknown", error_code=ServiceErrorCode.UNKNOWN)
+    #     error_message = status_error.message
+    #     if error_message is None:
+    #         error_message = ""
+    #     if "SCHEMA_NOT_FOUND" in error_message:
+    #         raise NotFound(error_message)
+    #     if "TABLE_OR_VIEW_NOT_FOUND" in error_message:
+    #         raise NotFound(error_message)
+    #     if "PARSE_SYNTAX_ERROR" in error_message:
+    #         raise BadRequest(error_message)
+    #     if "Operation not allowed" in error_message:
+    #         raise PermissionDenied(error_message)
+    #     mapping = {
+    #         ServiceErrorCode.ABORTED: errors.Aborted,
+    #         ServiceErrorCode.ALREADY_EXISTS: errors.AlreadyExists,
+    #         ServiceErrorCode.BAD_REQUEST: errors.BadRequest,
+    #         ServiceErrorCode.CANCELLED: errors.Cancelled,
+    #         ServiceErrorCode.DEADLINE_EXCEEDED: errors.DeadlineExceeded,
+    #         ServiceErrorCode.INTERNAL_ERROR: errors.InternalError,
+    #         ServiceErrorCode.IO_ERROR: errors.InternalError,
+    #         ServiceErrorCode.NOT_FOUND: errors.NotFound,
+    #         ServiceErrorCode.RESOURCE_EXHAUSTED: errors.ResourceExhausted,
+    #         ServiceErrorCode.SERVICE_UNDER_MAINTENANCE: errors.TemporarilyUnavailable,
+    #         ServiceErrorCode.TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
+    #         ServiceErrorCode.UNAUTHENTICATED: errors.Unauthenticated,
+    #         ServiceErrorCode.UNKNOWN: errors.Unknown,
+    #         ServiceErrorCode.WORKSPACE_TEMPORARILY_UNAVAILABLE: errors.TemporarilyUnavailable,
+    #     }
+    #     error_code = status_error.error_code
+    #     if error_code is None:
+    #         error_code = ServiceErrorCode.UNKNOWN
+    #     error_class = mapping.get(error_code, errors.Unknown)
+    #     raise error_class(error_message)
 
 
 class CrawlerBase(Generic[Result]):

--- a/tests/integration/framework/test_crawlers.py
+++ b/tests/integration/framework/test_crawlers.py
@@ -13,44 +13,72 @@ def test_deploys_database(sql_backend, inventory_schema):
     deployer.deploy_view("grant_detail", "queries/views/grant_detail.sql")
 
 
-def test_runtime_backend_incorrect_schema_and_table_handled(ws, wsfs_wheel):
+def test_runtime_backend_incorrect_schema_and_table_handled(ws, wsfs_wheel, make_random):
     commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
 
     commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
-    query_response_incorrect_schema = commands.run(
-        """
+    query_response_incorrect_schema_execute = commands.run(
+        f"""
         from databricks.labs.ucx.framework.crawlers import RuntimeBackend
         from databricks.sdk.errors import NotFound
         backend = RuntimeBackend()
         try:
-            backend.execute("USE ABCDEF")
+            backend.execute("USE {make_random()}")
             return "FAILED"
         except NotFound as e:
             return "PASSED"
         """
     )
-    assert query_response_incorrect_schema == "PASSED"
+    assert query_response_incorrect_schema_execute == "PASSED"
 
-    query_response_incorrect_table = commands.run(
-        """
+    query_response_incorrect_table_execute = commands.run(
+        f"""
         from databricks.labs.ucx.framework.crawlers import RuntimeBackend
         from databricks.sdk.errors import NotFound
         backend = RuntimeBackend()
         try:
-            backend.execute("SELECT * FROM default.ABCDEF")
+            backend.execute("SELECT * FROM default.{make_random()}")
             return "FAILED"
         except NotFound as e:
             return "PASSED"
         """
     )
-    assert query_response_incorrect_table == "PASSED"
+    assert query_response_incorrect_table_execute == "PASSED"
+
+    query_response_incorrect_schema_fetch = commands.run(
+        f"""
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import NotFound
+        backend = RuntimeBackend()
+        try:
+            query_response = backend.fetch("DESCRIBE {make_random()}")
+            return "FAILED"
+        except NotFound as e:
+            return "PASSED"
+        """
+    )
+    assert query_response_incorrect_schema_fetch == "PASSED"
+
+    query_response_incorrect_table_fetch = commands.run(
+        f"""
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import NotFound
+        backend = RuntimeBackend()
+        try:
+            query_response = backend.fetch("SELECT * FROM default.{make_random()}")
+            return "FAILED"
+        except NotFound as e:
+            return "PASSED"
+        """
+    )
+    assert query_response_incorrect_table_fetch == "PASSED"
 
 
 def test_runtime_backend_incorrect_syntax_handled(ws, wsfs_wheel):
     commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
 
     commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
-    query_response_incorrect_syntax = commands.run(
+    query_response_incorrect_syntax_execute = commands.run(
         """
         from databricks.labs.ucx.framework.crawlers import RuntimeBackend
         from databricks.sdk.errors import BadRequest
@@ -62,27 +90,87 @@ def test_runtime_backend_incorrect_syntax_handled(ws, wsfs_wheel):
             return "PASSED"
         """
     )
-    assert query_response_incorrect_syntax == "PASSED"
+    assert query_response_incorrect_syntax_execute == "PASSED"
 
-
-def test_runtime_backend_permission_denied_handled(
-    ws,
-    wsfs_wheel,
-):
-    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
-
-    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
-    query_response_permission_denied = commands.run(
+    query_response_incorrect_syntax_fetch = commands.run(
         """
         from databricks.labs.ucx.framework.crawlers import RuntimeBackend
-        from databricks.sdk.errors import PermissionDenied, BadRequest
+        from databricks.sdk.errors import BadRequest
         backend = RuntimeBackend()
         try:
-            current_user = backend.fetch("SELECT current_user()")
-            backend.execute(f"GRANT CREATE EXTERNAL LOCATION ON METASTORE TO {current_user}")
-            #return "FAILED"
+            query_response = backend.fetch("SHWO DTABASES")
+            return "FAILED"
         except BadRequest:
             return "PASSED"
         """
     )
-    assert query_response_permission_denied == "PASSED"
+    assert query_response_incorrect_syntax_fetch == "PASSED"
+
+
+def test_runtime_backend_permission_denied_handled(ws, wsfs_wheel):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+
+    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
+    query_response_permission_denied_execute = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import PermissionDenied
+        backend = RuntimeBackend()
+        try:
+            current_user = backend.fetch("SELECT current_user()")
+            backend.execute(f"GRANT CREATE EXTERNAL LOCATION ON METASTORE TO {current_user}")
+            return "FAILED"
+        except PermissionDenied:
+            return "PASSED"
+        """
+    )
+    assert query_response_permission_denied_execute == "PASSED"
+
+    query_response_permission_denied_fetch = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import PermissionDenied
+        backend = RuntimeBackend()
+        try:
+            current_user = backend.fetch(f"SELECT current_user()")
+            grants = backend.fetch(f"GRANT CREATE EXTERNAL LOCATION ON METASTORE TO {current_user}")
+            return "FAILED"
+        except PermissionDenied:
+            return "PASSED"
+        """
+    )
+    assert query_response_permission_denied_fetch == "PASSED"
+
+
+def test_runtime_backend_unknown_error_handled(ws, wsfs_wheel):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+
+    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
+
+    query_response_unknown_execute = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import Unknown
+        backend = RuntimeBackend()
+        try:
+            backend.execute("SHOW GRANTS ON METASTORE")
+            return "FAILED"
+        except Unknown:
+            return "PASSED"
+        """
+    )
+    assert query_response_unknown_execute == "PASSED"
+
+    query_response_unknown_fetch = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import Unknown
+        backend = RuntimeBackend()
+        try:
+            grants = backend.fetch("SHOW GRANTS ON METASTORE")
+            return "FAILED"
+        except Unknown:
+            return "PASSED"
+        """
+    )
+    assert query_response_unknown_fetch == "PASSED"

--- a/tests/integration/framework/test_crawlers.py
+++ b/tests/integration/framework/test_crawlers.py
@@ -1,3 +1,5 @@
+from databricks.labs.blueprint.commands import CommandExecutor
+
 from databricks.labs.ucx.framework.crawlers import SchemaDeployer
 from databricks.labs.ucx.hive_metastore.grants import Grant
 
@@ -9,3 +11,78 @@ def test_deploys_database(sql_backend, inventory_schema):
     deployer.deploy_schema()
     deployer.deploy_table("grants", Grant)
     deployer.deploy_view("grant_detail", "queries/views/grant_detail.sql")
+
+
+def test_runtime_backend_incorrect_schema_and_table_handled(ws, wsfs_wheel):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+
+    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
+    query_response_incorrect_schema = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import NotFound
+        backend = RuntimeBackend()
+        try:
+            backend.execute("USE ABCDEF")
+            return "FAILED"
+        except NotFound as e:
+            return "PASSED"
+        """
+    )
+    assert query_response_incorrect_schema == "PASSED"
+
+    query_response_incorrect_table = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import NotFound
+        backend = RuntimeBackend()
+        try:
+            backend.execute("SELECT * FROM default.ABCDEF")
+            return "FAILED"
+        except NotFound as e:
+            return "PASSED"
+        """
+    )
+    assert query_response_incorrect_table == "PASSED"
+
+
+def test_runtime_backend_incorrect_syntax_handled(ws, wsfs_wheel):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+
+    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
+    query_response_incorrect_syntax = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import BadRequest
+        backend = RuntimeBackend()
+        try:
+            backend.execute("SHWO DTABASES")
+            return "FAILED"
+        except BadRequest:
+            return "PASSED"
+        """
+    )
+    assert query_response_incorrect_syntax == "PASSED"
+
+
+def test_runtime_backend_permission_denied_handled(
+    ws,
+    wsfs_wheel,
+):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+
+    commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
+    query_response_permission_denied = commands.run(
+        """
+        from databricks.labs.ucx.framework.crawlers import RuntimeBackend
+        from databricks.sdk.errors import PermissionDenied, BadRequest
+        backend = RuntimeBackend()
+        try:
+            current_user = backend.fetch("SELECT current_user()")
+            backend.execute(f"GRANT CREATE EXTERNAL LOCATION ON METASTORE TO {current_user}")
+            #return "FAILED"
+        except BadRequest:
+            return "PASSED"
+        """
+    )
+    assert query_response_permission_denied == "PASSED"

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -279,3 +279,108 @@ def test_raise_if_needed(mocker):
         status_unknown_error = StatementStatus(state=StatementState.FAILED, error=None)
         with pytest.raises(Unknown):
             RuntimeBackend._raise_if_needed(status_unknown_error)
+
+
+def test_raise_spark_sql_exceptions(mocker):
+    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
+        pyspark_sql_session = mocker.Mock()
+        sys.modules["pyspark.sql.session"] = pyspark_sql_session
+
+        rb = RuntimeBackend
+        error_message_invalid_schema = "SCHEMA_NOT_FOUND foo schema does not exist"
+        with pytest.raises(NotFound):
+            rb._raise_spark_sql_exceptions(error_message_invalid_schema)
+
+        error_message_invalid_table = "TABLE_OR_VIEW_NOT_FOUND foo table does not exist"
+        with pytest.raises(NotFound):
+            rb._raise_spark_sql_exceptions(error_message_invalid_table)
+
+        error_message_invalid_syntax = "PARSE_SYNTAX_ERROR foo"
+        with pytest.raises(BadRequest):
+            rb._raise_spark_sql_exceptions(error_message_invalid_syntax)
+
+        error_message_permission_denied = "foo Operation not allowed"
+        with pytest.raises(PermissionDenied):
+            rb._raise_spark_sql_exceptions(error_message_permission_denied)
+
+        error_message_invalid_schema = "foo error failure"
+        with pytest.raises(Unknown):
+            rb._raise_spark_sql_exceptions(error_message_invalid_schema)
+
+
+def test_execute(mocker):
+    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
+        pyspark_sql_session = mocker.Mock()
+        sys.modules["pyspark.sql.session"] = pyspark_sql_session
+        rb = RuntimeBackend()
+
+        sql_query = "SELECT * from bar"
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "SCHEMA_NOT_FOUND"
+        )
+        with pytest.raises(NotFound):
+            rb.execute(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "TABLE_OR_VIEW_NOT_FOUND"
+        )
+        with pytest.raises(NotFound):
+            rb.execute(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "PARSE_SYNTAX_ERROR"
+        )
+        with pytest.raises(BadRequest):
+            rb.execute(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "Operation not allowed"
+        )
+        with pytest.raises(PermissionDenied):
+            rb.execute(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "foo error occurred"
+        )
+        with pytest.raises(Unknown):
+            rb.execute(sql_query)
+
+
+def test_fetch(mocker):
+    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
+        pyspark_sql_session = mocker.Mock()
+        sys.modules["pyspark.sql.session"] = pyspark_sql_session
+        rb = RuntimeBackend()
+
+        sql_query = "SELECT * from bar"
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "SCHEMA_NOT_FOUND"
+        )
+        with pytest.raises(NotFound):
+            rb.fetch(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "TABLE_OR_VIEW_NOT_FOUND"
+        )
+        with pytest.raises(NotFound):
+            rb.fetch(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "PARSE_SYNTAX_ERROR"
+        )
+        with pytest.raises(BadRequest):
+            rb.fetch(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "Operation not allowed"
+        )
+        with pytest.raises(PermissionDenied):
+            rb.fetch(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "foo error occurred"
+        )
+        with pytest.raises(Unknown):
+            rb.fetch(sql_query)

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -246,40 +246,6 @@ def test_save_table_with_not_null_constraint_violated(mocker):
         )
 
 
-# def test_raise_if_needed(mocker):
-#     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
-#         pyspark_sql_session = mocker.Mock()
-#         sys.modules["pyspark.sql.session"] = pyspark_sql_session
-#
-#         status_invalid_schema = StatementStatus(
-#             state=StatementState.FAILED, error=ServiceError(message="SCHEMA_NOT_FOUND")
-#         )
-#         with pytest.raises(NotFound):
-#             RuntimeBackend._raise_if_needed(status_invalid_schema)
-#
-#         status_invalid_table = StatementStatus(
-#             state=StatementState.FAILED, error=ServiceError(message="TABLE_OR_VIEW_NOT_FOUND")
-#         )
-#         with pytest.raises(NotFound):
-#             RuntimeBackend._raise_if_needed(status_invalid_table)
-#
-#         status_syntax_error = StatementStatus(
-#             state=StatementState.FAILED, error=ServiceError(message="PARSE_SYNTAX_ERROR")
-#         )
-#         with pytest.raises(BadRequest):
-#             RuntimeBackend._raise_if_needed(status_syntax_error)
-#
-#         status_permission_denied = StatementStatus(
-#             state=StatementState.FAILED, error=ServiceError(message="Operation not allowed")
-#         )
-#         with pytest.raises(PermissionDenied):
-#             RuntimeBackend._raise_if_needed(status_permission_denied)
-#
-#         status_unknown_error = StatementStatus(state=StatementState.FAILED, error=None)
-#         with pytest.raises(Unknown):
-#             RuntimeBackend._raise_if_needed(status_unknown_error)
-
-
 def test_raise_spark_sql_exceptions(mocker):
     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
         pyspark_sql_session = mocker.Mock()

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 from databricks.sdk.errors import BadRequest, NotFound, PermissionDenied, Unknown
 from databricks.sdk.service import sql
-from databricks.sdk.service.sql import ServiceError, StatementState, StatementStatus
 
 from databricks.labs.ucx.framework.crawlers import (
     CrawlerBase,
@@ -247,38 +246,38 @@ def test_save_table_with_not_null_constraint_violated(mocker):
         )
 
 
-def test_raise_if_needed(mocker):
-    with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
-        pyspark_sql_session = mocker.Mock()
-        sys.modules["pyspark.sql.session"] = pyspark_sql_session
-
-        status_invalid_schema = StatementStatus(
-            state=StatementState.FAILED, error=ServiceError(message="SCHEMA_NOT_FOUND")
-        )
-        with pytest.raises(NotFound):
-            RuntimeBackend._raise_if_needed(status_invalid_schema)
-
-        status_invalid_table = StatementStatus(
-            state=StatementState.FAILED, error=ServiceError(message="TABLE_OR_VIEW_NOT_FOUND")
-        )
-        with pytest.raises(NotFound):
-            RuntimeBackend._raise_if_needed(status_invalid_table)
-
-        status_syntax_error = StatementStatus(
-            state=StatementState.FAILED, error=ServiceError(message="PARSE_SYNTAX_ERROR")
-        )
-        with pytest.raises(BadRequest):
-            RuntimeBackend._raise_if_needed(status_syntax_error)
-
-        status_permission_denied = StatementStatus(
-            state=StatementState.FAILED, error=ServiceError(message="Operation not allowed")
-        )
-        with pytest.raises(PermissionDenied):
-            RuntimeBackend._raise_if_needed(status_permission_denied)
-
-        status_unknown_error = StatementStatus(state=StatementState.FAILED, error=None)
-        with pytest.raises(Unknown):
-            RuntimeBackend._raise_if_needed(status_unknown_error)
+# def test_raise_if_needed(mocker):
+#     with mock.patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
+#         pyspark_sql_session = mocker.Mock()
+#         sys.modules["pyspark.sql.session"] = pyspark_sql_session
+#
+#         status_invalid_schema = StatementStatus(
+#             state=StatementState.FAILED, error=ServiceError(message="SCHEMA_NOT_FOUND")
+#         )
+#         with pytest.raises(NotFound):
+#             RuntimeBackend._raise_if_needed(status_invalid_schema)
+#
+#         status_invalid_table = StatementStatus(
+#             state=StatementState.FAILED, error=ServiceError(message="TABLE_OR_VIEW_NOT_FOUND")
+#         )
+#         with pytest.raises(NotFound):
+#             RuntimeBackend._raise_if_needed(status_invalid_table)
+#
+#         status_syntax_error = StatementStatus(
+#             state=StatementState.FAILED, error=ServiceError(message="PARSE_SYNTAX_ERROR")
+#         )
+#         with pytest.raises(BadRequest):
+#             RuntimeBackend._raise_if_needed(status_syntax_error)
+#
+#         status_permission_denied = StatementStatus(
+#             state=StatementState.FAILED, error=ServiceError(message="Operation not allowed")
+#         )
+#         with pytest.raises(PermissionDenied):
+#             RuntimeBackend._raise_if_needed(status_permission_denied)
+#
+#         status_unknown_error = StatementStatus(state=StatementState.FAILED, error=None)
+#         with pytest.raises(Unknown):
+#             RuntimeBackend._raise_if_needed(status_unknown_error)
 
 
 def test_raise_spark_sql_exceptions(mocker):


### PR DESCRIPTION
Convert the query execution exceptions to SDK exceptions like NotFound, PermissionDenied and SyntaxError (currently used BadRequest to map syntax errors).

Integration and unit tests added.

Fixes #726 