### PR TITLE
Fixing move table command to delete table/view regardless if permissions are present, skipping corrupted tables when crawling table size and making existing tests more stable

### DIFF
--- a/src/databricks/labs/ucx/framework/dashboards.py
+++ b/src/databricks/labs/ucx/framework/dashboards.py
@@ -47,7 +47,7 @@ class SimpleQuery:
 class VizColumn:
     name: str
     title: str
-    type: str = "string"  # noqa: A003
+    type: str = "string"
     imageUrlTemplate: str = "{{ @ }}"  # noqa: N815
     imageTitleTemplate: str = "{{ @ }}"  # noqa: N815
     linkUrlTemplate: str = "{{ @ }}"  # noqa: N815

--- a/src/databricks/labs/ucx/framework/dashboards.py
+++ b/src/databricks/labs/ucx/framework/dashboards.py
@@ -47,7 +47,7 @@ class SimpleQuery:
 class VizColumn:
     name: str
     title: str
-    type: str = "string"
+    type: str = "string"  # noqa: A003
     imageUrlTemplate: str = "{{ @ }}"  # noqa: N815
     imageTitleTemplate: str = "{{ @ }}"  # noqa: N815
     linkUrlTemplate: str = "{{ @ }}"  # noqa: N815

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -74,6 +74,6 @@ class TableSizeCrawler(CrawlerBase):
                 logger.warning(f"Failed to evaluate {table_full_name} table size. Table not found.")
                 return None
             if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
-                logger.warning(f"Delta table {table_full_name} is missing transaction log.")
+                logger.warning(f"Delta table {table_full_name} is corrupted: missing transaction log.")
                 return None
             raise RuntimeError(str(e)) from e

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -44,7 +44,7 @@ class TableSizeCrawler(CrawlerBase):
                 continue
             size_in_bytes = self._safe_get_table_size(table.key)
             if size_in_bytes is None:
-                continue  # table does not exist anymore
+                continue  # table does not exist anymore or is corrupted
 
             yield TableSize(
                 catalog=table.catalog, database=table.database, name=table.name, size_in_bytes=size_in_bytes
@@ -72,5 +72,8 @@ class TableSizeCrawler(CrawlerBase):
         except Exception as e:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(e):
                 logger.warning(f"Failed to evaluate {table_full_name} table size. Table not found.")
+                return None
+            if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
+                logger.warning(f"Delta table {table_full_name} is missing transaction log.")
                 return None
             raise RuntimeError(str(e)) from e

--- a/tests/integration/hive_metastore/test_table_move.py
+++ b/tests/integration/hive_metastore/test_table_move.py
@@ -49,8 +49,10 @@ def test_move_tables(ws, sql_backend, make_catalog, make_schema, make_table, mak
     sql_backend.execute(f"GRANT SELECT,MODIFY ON TABLE {from_table_2.full_name} TO `{group_b.display_name}`")
     sql_backend.execute(f"GRANT SELECT ON VIEW {from_view_1.full_name} TO `{group_b.display_name}`")
     sql_backend.execute(f"GRANT SELECT ON TABLE {to_table_3.full_name} TO `{group_a.display_name}`")
+
     tm.move_tables(from_catalog.name, from_schema.name, "*", to_catalog.name, to_schema.name, False)
-    tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema.name)
+
+    to_tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema.name)
     table_1_grant = ws.grants.get(
         securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_1.name}"
     )
@@ -63,14 +65,16 @@ def test_move_tables(ws, sql_backend, make_catalog, make_schema, make_table, mak
     view_1_grant = ws.grants.get(
         securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_view_1.name}"
     )
-    for t in tables:
+    for t in to_tables:
         assert t.name in [from_table_1.name, from_table_2.name, from_table_3.name, from_view_1.name]
+
     expected_table_1_grant = [PrivilegeAssignment(group_a.display_name, [Privilege.SELECT])]
     expected_table_2_grant = [
         PrivilegeAssignment(group_b.display_name, [Privilege.MODIFY, Privilege.SELECT]),
     ]
     expected_table_3_grant = [PrivilegeAssignment(group_a.display_name, [Privilege.SELECT])]
     expected_view_1_grant = [PrivilegeAssignment(group_b.display_name, [Privilege.SELECT])]
+
     assert table_1_grant.privilege_assignments == expected_table_1_grant
     assert table_2_grant.privilege_assignments == expected_table_2_grant
     assert table_3_grant.privilege_assignments == expected_table_3_grant
@@ -82,15 +86,53 @@ def test_move_tables_no_to_schema(ws, sql_backend, make_catalog, make_schema, ma
     tm = TableMove(ws, sql_backend)
     from_catalog = make_catalog()
     from_schema = make_schema(catalog_name=from_catalog.name)
-    from_table_1 = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
-    from_table_2 = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
-    from_table_3 = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
+    from_table_to_migrate = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
+    from_table_not_to_migrate = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
     to_catalog = make_catalog()
     to_schema = make_random(4)
-    tm.move_tables(from_catalog.name, from_schema.name, from_table_1.name, to_catalog.name, to_schema, True)
-    tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema)
-    dropped_tables = ws.tables.list(catalog_name=from_catalog.name, schema_name=from_schema.name)
-    for t in tables:
-        assert t.name in [from_table_1.name, from_table_2.name, from_table_3.name]
-    for t in dropped_tables:
-        assert t.name in [from_table_1.name, from_table_2.name, from_table_3.name]
+
+    # migrate first table
+    tm.move_tables(from_catalog.name, from_schema.name, from_table_to_migrate.name, to_catalog.name, to_schema, True)
+
+    to_tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema)
+    from_tables = ws.tables.list(catalog_name=from_catalog.name, schema_name=from_schema.name)
+
+    for t in to_tables:
+        assert t.name == from_table_to_migrate.name
+
+    for t in from_tables:
+        assert t.name == from_table_not_to_migrate.name
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=2))
+def test_move_views(ws, sql_backend, make_catalog, make_schema, make_table, make_random):
+    tm = TableMove(ws, sql_backend)
+    from_catalog = make_catalog()
+    from_schema = make_schema(catalog_name=from_catalog.name)
+    from_table = make_table(catalog_name=from_catalog.name, schema_name=from_schema.name)
+    from_view_to_migrate = make_table(
+        catalog_name=from_catalog.name,
+        schema_name=from_schema.name,
+        view=True,
+        ctas=f"select * from {from_table.full_name}",
+    )
+    from_view_not_to_migrate = make_table(
+        catalog_name=from_catalog.name,
+        schema_name=from_schema.name,
+        view=True,
+        ctas=f"select * from {from_table.full_name}",
+    )
+    to_catalog = make_catalog()
+    to_schema = make_random(4)
+
+    # migrate first table
+    tm.move_tables(from_catalog.name, from_schema.name, from_view_to_migrate.name, to_catalog.name, to_schema, True)
+
+    to_views = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema)
+    from_views = ws.tables.list(catalog_name=from_catalog.name, schema_name=from_schema.name)
+
+    for t in to_views:
+        assert t.name == from_view_to_migrate.name
+
+    for t in from_views:
+        assert t.name in [from_view_not_to_migrate.name, from_table.name]

--- a/tests/unit/hive_metastore/test_table_move.py
+++ b/tests/unit/hive_metastore/test_table_move.py
@@ -42,18 +42,100 @@ def test_move_tables_invalid_to_schema(caplog):
     assert len([rec.message for rec in caplog.records if "schema TgtS not found in TgtC" in rec.message]) == 1
 
 
-def test_move_tables(caplog):
+def test_move_tables_not_found_table_error(mocker, caplog):
+    client = create_autospec(WorkspaceClient)
+    client.schemas.get.side_effect = [SchemaInfo(), NotFound()]
+    backend = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
+    backend.execute.side_effect = NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
+
+    client.tables.list.return_value = [
+        TableInfo(
+            catalog_name="SrcC",
+            schema_name="SrcS",
+            name="table1",
+            full_name="SrcC.SrcS.table1",
+            table_type=TableType.EXTERNAL,
+        ),
+    ]
+    client.tables.get.side_effect = [NotFound()]
+
+    tm = TableMove(client, backend)
+    tm.move_tables("SrcC", "SrcS", "table1", "TgtC", "TgtS", False)
+    assert len([rec.message for rec in caplog.records if "Could not find table SrcC.SrcS.table1" in rec.message]) == 1
+
+
+def test_move_tables_not_found_table_unknown_error(mocker, caplog):
+    client = create_autospec(WorkspaceClient)
+    client.schemas.get.side_effect = [SchemaInfo(), NotFound()]
+    backend = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
+    backend.execute.side_effect = NotFound("unknown error")
+
+    client.tables.list.return_value = [
+        TableInfo(
+            catalog_name="SrcC",
+            schema_name="SrcS",
+            name="table1",
+            full_name="SrcC.SrcS.table1",
+            table_type=TableType.EXTERNAL,
+        ),
+    ]
+    client.tables.get.side_effect = [NotFound()]
+
+    tm = TableMove(client, backend)
+    tm.move_tables("SrcC", "SrcS", "table1", "TgtC", "TgtS", False)
+    assert len([rec.message for rec in caplog.records if "unknown error" in rec.message]) == 1
+
+
+def test_move_tables_not_found_view_error(mocker, caplog):
+    client = create_autospec(WorkspaceClient)
+    client.schemas.get.side_effect = [SchemaInfo(), NotFound()]
+    backend = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
+    backend.execute.side_effect = NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
+
+    client.tables.list.return_value = [
+        TableInfo(
+            catalog_name="SrcC",
+            schema_name="SrcS",
+            name="view1",
+            full_name="SrcC.SrcS.view1",
+            table_type=TableType.VIEW,
+            view_definition="SELECT * FROM SrcC.SrcS.table1",
+        ),
+    ]
+    client.tables.get.side_effect = [NotFound()]
+
+    tm = TableMove(client, backend)
+    tm.move_tables("SrcC", "SrcS", "view1", "TgtC", "TgtS", False)
+    assert len([rec.message for rec in caplog.records if "Could not find view SrcC.SrcS.view1" in rec.message]) == 1
+
+
+def test_move_tables_not_found_view_unknown_error(mocker, caplog):
+    client = create_autospec(WorkspaceClient)
+    client.schemas.get.side_effect = [SchemaInfo(), NotFound()]
+    backend = mocker.patch("databricks.labs.ucx.framework.crawlers.StatementExecutionBackend.__init__")
+    backend.execute.side_effect = NotFound("unknown error")
+
+    client.tables.list.return_value = [
+        TableInfo(
+            catalog_name="SrcC",
+            schema_name="SrcS",
+            name="view1",
+            full_name="SrcC.SrcS.view1",
+            table_type=TableType.VIEW,
+            view_definition="SELECT * FROM SrcC.SrcS.table1",
+        ),
+    ]
+    client.tables.get.side_effect = [NotFound()]
+
+    tm = TableMove(client, backend)
+    tm.move_tables("SrcC", "SrcS", "view1", "TgtC", "TgtS", False)
+    assert len([rec.message for rec in caplog.records if "unknown error" in rec.message]) == 1
+
+
+def test_move_all_tables(caplog):
     caplog.set_level(logging.INFO)
     client = create_autospec(WorkspaceClient)
-    errors = {}
-    rows = {
-        "SHOW CREATE TABLE SrcC.SrcS.table1": [
-            ("CREATE TABLE SrcC.SrcS.table1 (name string)"),
-        ],
-        "SHOW CREATE TABLE SrcC.SrcS.table3": [
-            ("CREATE TABLE SrcC.SrcS.table3 (name string)"),
-        ],
-    }
+
     client.tables.list.return_value = [
         TableInfo(
             catalog_name="SrcC",
@@ -74,7 +156,7 @@ def test_move_tables(caplog):
             schema_name="SrcS",
             name="table3",
             full_name="SrcC.SrcS.table3",
-            table_type=TableType.EXTERNAL,
+            table_type=TableType.MANAGED,
         ),
         TableInfo(
             catalog_name="SrcC",
@@ -92,23 +174,72 @@ def test_move_tables(caplog):
             table_type=TableType.VIEW,
             view_definition="SELECT * FROM SrcC.SrcS.table1",
         ),
+        TableInfo(
+            catalog_name="SrcC",
+            schema_name="SrcS",
+            name="view3",
+            full_name="SrcC.SrcS.view3",
+            table_type=TableType.VIEW,
+            view_definition="SELECT * FROM SrcC.SrcS.table1",
+        ),
     ]
+
     perm_list = PermissionsList([PrivilegeAssignment("foo", [Privilege.SELECT])])
     perm_none = PermissionsList(None)
-    client.grants.get.side_effect = [perm_list, perm_none, perm_none, perm_list, perm_none]
+
+    grants_mapping = {
+        "SrcC.SrcS.table1": perm_list,
+        "SrcC.SrcS.table2": perm_none,
+        "SrcC.SrcS.table3": perm_none,
+        "SrcC.SrcS.view1": perm_list,
+        "SrcC.SrcS.view2": perm_none,
+        "SrcC.SrcS.view3": perm_none,
+    }
+
+    def target_tables_mapping(full_name):
+        to_migrate = ["TgtC.TgtS.table1", "TgtC.TgtS.table2", "TgtC.TgtS.view1", "TgtC.TgtS.view2"]
+        if full_name in to_migrate:
+            raise NotFound()
+
+        not_to_migrate = ["TgtC.TgtS.table3", "TgtC.TgtS.view3"]
+        if full_name in not_to_migrate:
+            return TableInfo()
+
+    rows = {
+        "SHOW CREATE TABLE SrcC.SrcS.table1": [
+            ["CREATE TABLE SrcC.SrcS.table1 (name string)"],
+        ],
+        "SHOW CREATE TABLE SrcC.SrcS.table2": [
+            ["CREATE TABLE SrcC.SrcS.table1 (name string)"],
+        ],
+    }
+
+    client.grants.get.side_effect = lambda _, full_name: grants_mapping[full_name]
     client.schemas.get.side_effect = [SchemaInfo(), SchemaInfo()]
-    client.tables.get.side_effect = [NotFound(), TableInfo(), NotFound(), NotFound(), NotFound()]
-    backend = MockBackend(fails_on_first=errors, rows=rows)
+    client.tables.get.side_effect = target_tables_mapping
+    backend = MockBackend(rows=rows)
     tm = TableMove(client, backend)
     tm.move_tables("SrcC", "SrcS", "*", "TgtC", "TgtS", True)
-    log_cnt = 0
-    for rec in caplog.records:
-        if rec.message in [
-            "moved 2 tables to the new schema TgtS.",
-            "moved 2 views to the new schema TgtS.",
-            "dropping source table SrcC.SrcS.table1",
-            "dropping source view SrcC.SrcS.view2",
-        ]:
-            log_cnt += 1
 
-    assert log_cnt == 4
+    expected_messages = [
+        "Moved 2 tables to the new schema TgtS.",
+        "Moved 2 views to the new schema TgtS.",
+        "Creating table TgtC.TgtS.table1",
+        "Applying grants on table TgtC.TgtS.table1",
+        "Dropping source table SrcC.SrcS.table1",
+        "Creating table TgtC.TgtS.table2",
+        "Dropping source table SrcC.SrcS.table2",
+        "Creating view TgtC.TgtS.view1",
+        "Applying grants on view TgtC.TgtS.view1",
+        "Dropping source view SrcC.SrcS.view1",
+        "Creating view TgtC.TgtS.view2",
+        "Dropping source view SrcC.SrcS.view2",
+    ]
+
+    log_count = 0
+    for rec in caplog.records:
+        print(rec)
+        if rec.message in expected_messages:
+            log_count += 1
+
+    assert log_count == len(expected_messages)

--- a/tests/unit/hive_metastore/test_table_size.py
+++ b/tests/unit/hive_metastore/test_table_size.py
@@ -79,3 +79,26 @@ def test_table_size_table_or_view_not_found(mocker):
     results = tsc.snapshot()
 
     assert len(results) == 0
+
+
+def test_table_size_when_table_corrupted(mocker):
+    errors = {}
+    rows = {
+        "table_size": [],
+        "hive_metastore.inventory_database.tables": [
+            ("hive_metastore", "db1", "table1", "MANAGED", "DELTA", "dbfs:/location/table", None),
+        ],
+        "SHOW DATABASES": [("db1",)],
+    }
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    pyspark_sql_session = mocker.Mock()
+    sys.modules["pyspark.sql.session"] = pyspark_sql_session
+    tsc = TableSizeCrawler(backend, "inventory_database")
+
+    tsc._spark._jsparkSession.table().queryExecution().analyzed().stats().sizeInBytes.side_effect = Exception(
+        "[DELTA_MISSING_TRANSACTION_LOG]"
+    )
+
+    results = tsc.snapshot()
+
+    assert len(results) == 0


### PR DESCRIPTION
* bug fixed: table/view not deleted if no permissions present
* bug fixed: some unit tests for move command failing occasionally
* added more unit and integration tests for move command
* bug fixed: skip crawling table size for corrupted delta tables