### PR TITLE
Mount Point crawler lists /Volume with four variations which is confusing

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -207,7 +207,7 @@ class Mounts(CrawlerBase[Mount]):
         deduplicated_mounts = []
         volume_flag = 0
         for obj in mounts:
-            if 'volume' in obj.name.lower():
+            if "volume" in obj.name.lower():
                 volume_flag = 1
             obj_tuple = (obj.name, obj.source)
             if obj_tuple not in seen:

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -206,7 +206,7 @@ class Mounts(CrawlerBase[Mount]):
         seen = set()
         deduplicated_mounts = []
         for obj in mounts:
-            if "volume" in obj.name.lower():
+            if "dbfsreserved" in obj.source.lower():
                 obj_tuple = ("/Volume", obj.source)
             else:
                 obj_tuple = (obj.name, obj.source)

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -205,15 +205,14 @@ class Mounts(CrawlerBase[Mount]):
     def _deduplicate_mounts(self, mounts: list) -> list:
         seen = set()
         deduplicated_mounts = []
-        volume_flag = 0
         for obj in mounts:
             if "volume" in obj.name.lower():
-                volume_flag = 1
-            obj_tuple = (obj.name, obj.source)
+                obj_tuple = ("/Volume", obj.source)
+            else:
+                obj_tuple = (obj.name, obj.source)
             if obj_tuple not in seen:
-                if not volume_flag:
-                    seen.add(obj_tuple)
-                    deduplicated_mounts.append(obj)
+                seen.add(obj_tuple)
+                deduplicated_mounts.append(obj)
         return deduplicated_mounts
 
     def inventorize_mounts(self):

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -206,6 +206,8 @@ class Mounts(CrawlerBase[Mount]):
         seen = set()
         deduplicated_mounts = []
 
+        ### Deduplicate Volume variations.
+
         for obj in mounts:
             obj_tuple = (obj.name, obj.source)
             if obj_tuple not in seen:

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -205,14 +205,15 @@ class Mounts(CrawlerBase[Mount]):
     def _deduplicate_mounts(self, mounts: list) -> list:
         seen = set()
         deduplicated_mounts = []
-
-        ### Deduplicate Volume variations.
-
+        volume_flag = 0
         for obj in mounts:
+            if 'volume' in obj.name.lower():
+                volume_flag = 1
             obj_tuple = (obj.name, obj.source)
             if obj_tuple not in seen:
-                seen.add(obj_tuple)
-                deduplicated_mounts.append(obj)
+                if not volume_flag:
+                    seen.add(obj_tuple)
+                    deduplicated_mounts.append(obj)
         return deduplicated_mounts
 
     def inventorize_mounts(self):

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -46,6 +46,20 @@ def test_list_mounts_should_return_a_deduped_list_of_mount_without_encryption_ty
     assert expected == backend.rows_written_for("hive_metastore.test.mounts", "append")
 
 
+def test_list_mounts_should_return_a_deduped_list_of_mount_without_variable_volume_names():
+    mounts = [
+        Mount(name="/Volume", source="DbfsReserved"),
+        Mount(name="/Volumes", source="DbfsReserved"),
+        Mount(name="/volume", source="DbfsReserved"),
+        Mount(name="/volumes", source="DbfsReserved"),
+    ]
+    client = MagicMock()
+    backend = MockBackend()
+    mount_list = Mounts(backend, client, "test")._deduplicate_mounts(mounts)
+
+    assert mount_list == [Mount("/Volume", "DbfsReserved")]
+
+
 def test_external_locations():
     crawler = ExternalLocations(Mock(), MockBackend(), "test")
     row_factory = type("Row", (Row,), {"__columns__": ["location", "storage_properties"]})


### PR DESCRIPTION
This pull request includes changes to the `locations.py` file in the `databricks/labs/ucx/hive_metastore` directory and the addition of a new unit test in `test_locations.py`. The changes in `locations.py` involve modifying the `_deduplicate_mounts` method in the `Mounts` class. The method now checks if the name of the `Mount` object contains the word "volume", and if so, it standardizes the name to "/Volume". This is done to ensure that mounts with different casing for the word "volume" are treated as the same mount and not duplicated in the deduplicated list.

The new unit test in `test_locations.py` verifies that the `_deduplicate_mounts` method correctly deduplicates a list of `Mount` objects with different casing for the word "volume" in their names. The test creates a list of `Mount` objects with different casing for the word "volume" and passes it to the `_deduplicate_mounts` method. The test then asserts that the deduplicated list contains only one `Mount` object with the name "/Volume". This test ensures that the changes to the `_deduplicate_mounts` method work as intended and prevent duplication of mounts with different casing for the word "volume" in their names.

In summary, the changes in this pull request modify the `_deduplicate_mounts` method to standardize the name of mounts containing the word "volume" and add a unit test to ensure that the method correctly deduplicates a list of `Mount` objects with different casing for the word "volume" in their names.