### PR TITLE
Create instructions to install UCX v0.9.0 and greater from a Databricks cluster web terminal

### DIFF
--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -11,7 +11,7 @@ apt install python3.10-venv
 unset DATABRICKS_RUNTIME_VERSION
 ```
 
-Download and install databricks cli
+Download and install Databricks cli
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
@@ -23,14 +23,14 @@ Set PATH variable to point to new install
 export PATH=/usr/local/bin:$PATH
 ```
 
-Verify databricks cli
+Verify Databricks cli
 
 ```shell
 which databricks
 databricks --version
 ```
 
-Configure databricks cli to authenticate to correct workspace, add host name and PAT token
+Configure Databricks cli to authenticate to correct workspace, add host name and PAT token
 ```shell
 databricks configure
 ```

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -1,9 +1,8 @@
-
 # Setup UCX from Databricks web terminal
 
 - Start an *Unassigned* interactive cluster
 - Create a new notebook to attach to the cluster
-- Open a web terminal, expand to full page for better readability
+- Open the web terminal, expand to full page for better readability
 
 Install / setup needed UCX dependencies
 
@@ -40,7 +39,7 @@ Add account level config
 ```shell
 vi ~/.databrickcfg
 ```
-and based on your cloud provider, add
+and based on your cloud provider, add these config sections to `~/.databrickscfg` with your Databricks account_id
 ```ini
 [AZUCX]
 host       = https://accounts.azuredatabricks.net
@@ -53,14 +52,14 @@ host = https://accounts.cloud.databricks.com
 account_id = beefdead-beef-dead-beef-beefdeadbeef
 ```
 
-Verify configuration and databricks labs
+Verify configuration, connection and Databricks labs
 ```shell
 databricks auth env
 databricks clusters list
 databricks labs list
 ```
 
-Install UCX, do not select options to open config or README
+Install UCX, do not select options to open config.yml or README.py in a browser
 ```shell
 databricks labs install ucx
 ```

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -1,0 +1,46 @@
+
+# Setup UCX from Databricks web terminal
+
+- Start an *Unassigned* interactive cluster
+- Create a new notebook to attch to the cluster
+- Open a web terminal, expand to full page for better readability
+
+- Install / setup needed UCX dependencies
+`apt install python3.10-venv`
+`unset DATABRICKS_RUNTIME_VERSION`
+
+- Download and install databricks cli
+`curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+
+- Set PATH variable to point to new install
+`export PATH=/usr/local/bin:$PATH`
+
+- Verify databricks cli
+`which databricks`
+`databricks --version`
+
+- Configure databricks cli to authenticate to correct workspace, add host name and PAT token
+`databricks configure`
+
+- add account level config
+`vi ~/.databrickcfg`
+and depending on your cloud, add
+```
+[AZUCX]
+host       = https://accounts.azuredatabricks.net
+account_id = beefdead-beef-dead-9999-beefdeadbeef
+```
+or
+```
+[AWSUCX]
+host = https://accounts.cloud.databricks.com
+account_id = beefdead-beef-dead-beef-beefdeadbeef
+```
+
+- Verify configuration and databricks labs
+`databricks auth env`
+`databricks clusters list`
+`databricks labs list`
+
+- Install UCX, do not select options to open config or README
+`databricks labs install ucx`

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -5,38 +5,38 @@
 - Create a new notebook to attach to the cluster
 - Open a web terminal, expand to full page for better readability
 
-- Install / setup needed UCX dependencies
+Install / setup needed UCX dependencies
 
 ```shell
 apt install python3.10-venv
 unset DATABRICKS_RUNTIME_VERSION
 ```
 
-- Download and install databricks cli
+Download and install databricks cli
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
 ```
 
-- Set PATH variable to point to new install
+Set PATH variable to point to new install
 
 ```shell
 export PATH=/usr/local/bin:$PATH
 ```
 
-- Verify databricks cli
+Verify databricks cli
 
 ```shell
 which databricks
 databricks --version
 ```
 
-- Configure databricks cli to authenticate to correct workspace, add host name and PAT token
+Configure databricks cli to authenticate to correct workspace, add host name and PAT token
 ```shell
 databricks configure
 ```
 
-- add account level config
+Add account level config
 ```shell
 vi ~/.databrickcfg
 ```
@@ -53,14 +53,14 @@ host = https://accounts.cloud.databricks.com
 account_id = beefdead-beef-dead-beef-beefdeadbeef
 ```
 
-- Verify configuration and databricks labs
+Verify configuration and databricks labs
 ```shell
 databricks auth env
 databricks clusters list
 databricks labs list
 ```
 
-- Install UCX, do not select options to open config or README
+Install UCX, do not select options to open config or README
 ```shell
 databricks labs install ucx
 ```

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -6,41 +6,61 @@
 - Open a web terminal, expand to full page for better readability
 
 - Install / setup needed UCX dependencies
-`apt install python3.10-venv`
-`unset DATABRICKS_RUNTIME_VERSION`
+
+```shell
+apt install python3.10-venv
+unset DATABRICKS_RUNTIME_VERSION
+```
 
 - Download and install databricks cli
-`curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh`
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+```
 
 - Set PATH variable to point to new install
-`export PATH=/usr/local/bin:$PATH`
+
+```shell
+export PATH=/usr/local/bin:$PATH
+```
 
 - Verify databricks cli
-`which databricks`
-`databricks --version`
+
+```shell
+which databricks
+databricks --version
+```
 
 - Configure databricks cli to authenticate to correct workspace, add host name and PAT token
-`databricks configure`
+```shell
+databricks configure
+```
 
 - add account level config
-`vi ~/.databrickcfg`
-and depending on your cloud, add
+```shell
+vi ~/.databrickcfg
 ```
+and based on your cloud provider, add
+```ini
 [AZUCX]
 host       = https://accounts.azuredatabricks.net
 account_id = beefdead-beef-dead-9999-beefdeadbeef
 ```
 or
-```
+```ini
 [AWSUCX]
 host = https://accounts.cloud.databricks.com
 account_id = beefdead-beef-dead-beef-beefdeadbeef
 ```
 
 - Verify configuration and databricks labs
-`databricks auth env`
-`databricks clusters list`
-`databricks labs list`
+```shell
+databricks auth env
+databricks clusters list
+databricks labs list
+```
 
 - Install UCX, do not select options to open config or README
-`databricks labs install ucx`
+```shell
+databricks labs install ucx
+```

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -4,42 +4,42 @@
 - Create a new notebook to attach to the cluster
 - Open the web terminal, expand to full page for better readability
 
-Install / setup needed UCX dependencies
+Install and setup needed UCX dependencies:
 
 ```shell
 apt install python3.10-venv
 unset DATABRICKS_RUNTIME_VERSION
 ```
 
-Download and install Databricks cli
+Download and install Databricks cli:
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
 ```
 
-Set PATH variable to point to new install
+Set PATH variable to point to new install:
 
 ```shell
 export PATH=/usr/local/bin:$PATH
 ```
 
-Verify Databricks cli
+Verify Databricks cli:
 
 ```shell
 which databricks
 databricks --version
 ```
 
-Configure Databricks cli to authenticate to correct workspace, add host name and PAT token
+Configure Databricks cli to authenticate to correct workspace, add host name and PAT token:
 ```shell
 databricks configure
 ```
 
-Add account level config
+Add account level config:
 ```shell
 vi ~/.databrickcfg
 ```
-and based on your cloud provider, add these config sections to `~/.databrickscfg` with your Databricks account_id
+and based on your cloud provider, add these config sections to `~/.databrickscfg` with your Databricks `account_id`
 ```ini
 [AZUCX]
 host       = https://accounts.azuredatabricks.net
@@ -52,14 +52,14 @@ host = https://accounts.cloud.databricks.com
 account_id = beefdead-beef-dead-beef-beefdeadbeef
 ```
 
-Verify configuration, connection and Databricks labs
+Verify configuration, connection and Databricks labs:
 ```shell
 databricks auth env
 databricks clusters list
 databricks labs list
 ```
 
-Install UCX, do not select options to open config.yml or README.py in a browser
+Install UCX, do not select options to open config.yml or README.py in a browser:
 ```shell
 databricks labs install ucx
 ```

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -32,7 +32,8 @@ databricks --version
 
 Configure Databricks cli to authenticate to correct workspace, add host name and PAT token:
 ```shell
-databricks configure
+EXPORT DATABRICKS_TOKEN=<PAT TOKEN>
+EXPORT DATABRICKS_HOST=<host url https://....com>
 ```
 
 Add account level config:

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -2,7 +2,7 @@
 # Setup UCX from Databricks web terminal
 
 - Start an *Unassigned* interactive cluster
-- Create a new notebook to attch to the cluster
+- Create a new notebook to attach to the cluster
 - Open a web terminal, expand to full page for better readability
 
 - Install / setup needed UCX dependencies

--- a/docs/cluster_install.md
+++ b/docs/cluster_install.md
@@ -1,6 +1,6 @@
 # Setup UCX from Databricks web terminal
-
-- Start an *Unassigned* interactive cluster
+For cases when your desktop or laptop will not support the `databricks labs install ucx` technical requirements such as Python 3.10, administrative access, python package access or network access but your Databricks cluster will have the internet access requirements same as described in the main README.md document.
+- Start an *Unassigned* interactive cluster 
 - Create a new notebook to attach to the cluster
 - Open the web terminal, expand to full page for better readability
 


### PR DESCRIPTION
Stumbled upon how to install UCX from a web terminal. This will be useful for when the user does not have desktop access to install dependencies etc.

<img width="1302" alt="image" src="https://github.com/databrickslabs/ucx/assets/1122251/5e1b4f8f-bb83-4b4d-9dfe-52da15989270">
