### PR TITLE
Added debug_truncate_bytes parameter to the config and extend the log truncation limit

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -201,6 +201,9 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
     database_to_catalog_mapping: dict[str, str] | None = None
     default_catalog: str | None = "ucx_default"
     log_level: str | None = "INFO"
+    # Truncate JSON fields in HTTP requests and responses above this limit.
+    # If this occurs, the log message will include the text `... (XXX additional elements)`
+    debug_truncate_bytes: int | None = 250000
 
     # Starting path for notebooks and directories crawler
     workspace_start_path: str = "/"


### PR DESCRIPTION
By default, the UCX is truncating API requests and responses in the log files to 96 bytes. This makes it very hard to debug any issues. This PR adds the debug_truncate_bytes parameter in the config and increases the truncation limit. 