### PR TITLE
Writing log readme in multiprocess safe way

### DIFF
--- a/src/databricks/labs/ucx/assessment/azure.py
+++ b/src/databricks/labs/ucx/assessment/azure.py
@@ -118,21 +118,23 @@ class AzureServicePrincipalCrawler(CrawlerBase[AzureServicePrincipalInfo]):
 
     def _get_cluster_configs_from_all_jobs(self, all_jobs, all_clusters_by_id):
         for j in all_jobs:
-            if j.settings.job_clusters is not None:
-                for jc in j.settings.job_clusters:
-                    if jc.new_cluster is None:
-                        continue
-                    yield j, jc.new_cluster
+            if j.settings is not None:
+                if j.settings.job_clusters is not None:
+                    for jc in j.settings.job_clusters:
+                        if jc.new_cluster is None:
+                            continue
+                        yield j, jc.new_cluster
 
-            for t in j.settings.tasks:
-                if t.existing_cluster_id is not None:
-                    interactive_cluster = all_clusters_by_id.get(t.existing_cluster_id, None)
-                    if interactive_cluster is None:
-                        continue
-                    yield j, interactive_cluster
+                if j.settings.tasks is not None:
+                    for t in j.settings.tasks:
+                        if t.existing_cluster_id is not None:
+                            interactive_cluster = all_clusters_by_id.get(t.existing_cluster_id, None)
+                            if interactive_cluster is None:
+                                continue
+                            yield j, interactive_cluster
 
-                elif t.new_cluster is not None:
-                    yield j, t.new_cluster
+                        elif t.new_cluster is not None:
+                            yield j, t.new_cluster
 
     def _get_relevant_service_principals(self) -> list:
         relevant_service_principals = []

--- a/tests/integration/workspace_access/test_redash.py
+++ b/tests/integration/workspace_access/test_redash.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from unittest import skip
 
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
@@ -60,6 +61,7 @@ def test_permissions_for_redash(
 # Redash group permissions are cached for up to 10 mins. If a group is renamed, redash permissions api returns
 # the old name for some time. Therefore, we need to allow at least 10 mins in the timeout for checking the permissions
 # after group rename.
+@skip  # skipping as it takes 5-10 mins to execute
 @retried(on=[NotFound], timeout=timedelta(minutes=13))
 def test_permissions_for_redash_after_group_is_renamed(
     ws,


### PR DESCRIPTION
## Changes

1. Changed writing of the readme log in a multiprocess safe way. Without this the assessment tasks are occasionally failing with error: `FileExistsError: [Errno 17] File exists: '/Workspace/Users/jni4fe@xxx.com/.ucx/logs/assessment/run-340934288146817/README.md'`
2. Skip long running integration test for Redash
3. Check if job settings and tasks are present while crawling

### Tests
- [x] manually tested