### PR TITLE
Extend error handling of delta issues in crawlers and hive metastore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-mock>=3.0.0,<4.0.0",
     "pytest-timeout",
+    "py4j",
     "black>=23.1.0",
     "ruff>=0.0.243",
     "isort>=2.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "pytest-cov>=4.0.0,<5.0.0",
     "pytest-mock>=3.0.0,<4.0.0",
     "pytest-timeout",
-    "py4j",
     "black>=23.1.0",
     "ruff>=0.0.243",
     "isort>=2.5.0",

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -277,7 +277,7 @@ class CrawlerBase(Generic[Result]):
 
         Exceptions:
         - If a runtime error occurs during fetching (other than "TABLE_OR_VIEW_NOT_FOUND"), the original error is
-        re-raised.
+          re-raised.
 
         Returns:
         list[any]: A list of data records, either fetched or loaded.

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -8,7 +8,13 @@ from types import UnionType
 from typing import Any, ClassVar, Generic, Protocol, TypeVar
 
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import BadRequest, NotFound, PermissionDenied, Unknown
+from databricks.sdk.errors import (
+    BadRequest,
+    DataLoss,
+    NotFound,
+    PermissionDenied,
+    Unknown,
+)
 
 from databricks.labs.ucx.mixins.sql import Row, StatementExecutionExt
 
@@ -183,6 +189,10 @@ class RuntimeBackend(SqlBackend):
             raise NotFound(error_message) from None
         elif "TABLE_OR_VIEW_NOT_FOUND" in error_message:
             raise NotFound(error_message) from None
+        elif "DELTA_TABLE_NOT_FOUND" in error_message:
+            raise NotFound(error_message) from None
+        elif "DELTA_MISSING_TRANSACTION_LOG" in error_message:
+            raise DataLoss(error_message) from None
         elif "PARSE_SYNTAX_ERROR" in error_message:
             raise BadRequest(error_message) from None
         elif "Operation not allowed" in error_message:
@@ -267,7 +277,7 @@ class CrawlerBase(Generic[Result]):
 
         Exceptions:
         - If a runtime error occurs during fetching (other than "TABLE_OR_VIEW_NOT_FOUND"), the original error is
-          re-raised.
+        re-raised.
 
         Returns:
         list[any]: A list of data records, either fetched or loaded.

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -102,8 +102,10 @@ class TableMapping:
                 f"ALTER TABLE `{schema}`.`{table}` SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
             )
         except NotFound as nf:
-            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(nf):
+            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(nf) or "[DELTA_TABLE_NOT_FOUND]" in str(nf):
                 logger.error(f"Failed to apply skip marker for Table {schema}.{table}. Table not found.")
+            elif "[DELTA_MISSING_TRANSACTION_LOG]" in str(nf):
+                logger.error(f"Delta table {schema}.{table} is corrupted: missing transaction log.")
             else:
                 logger.error(nf)
         except BadRequest as br:

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -105,9 +105,9 @@ class TableMapping:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(nf) or "[DELTA_TABLE_NOT_FOUND]" in str(nf):
                 logger.error(f"Failed to apply skip marker for Table {schema}.{table}. Table not found.")
             else:
-                logger.error(nf)
+                logger.error(f"Failed to apply skip marker for Table {schema}.{table}: {nf!s}", exc_info=True)
         except BadRequest as br:
-            logger.error(br)
+            logger.error(f"Failed to apply skip marker for Table {schema}.{table}: {br!s}", exc_info=True)
 
     def skip_schema(self, schema: str):
         # Marks a schema to be skipped in the migration process by applying a table property

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -104,8 +104,6 @@ class TableMapping:
         except NotFound as nf:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(nf) or "[DELTA_TABLE_NOT_FOUND]" in str(nf):
                 logger.error(f"Failed to apply skip marker for Table {schema}.{table}. Table not found.")
-            elif "[DELTA_MISSING_TRANSACTION_LOG]" in str(nf):
-                logger.error(f"Delta table {schema}.{table} is corrupted: missing transaction log.")
             else:
                 logger.error(nf)
         except BadRequest as br:

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -281,8 +281,6 @@ class TableMove:
         except NotFound as err:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):
                 logger.error(f"Could not find table {from_table_name}. Table not found.")
-            elif "[DELTA_MISSING_TRANSACTION_LOG]" in str(err):
-                logger.error(f"Delta table {from_table_name} is corrupted: missing transaction log.")
             else:
                 logger.error(err)
         return False

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -279,8 +279,10 @@ class TableMove:
 
             return True
         except NotFound as err:
-            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err):
+            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):
                 logger.error(f"Could not find table {from_table_name}. Table not found.")
+            elif "[DELTA_MISSING_TRANSACTION_LOG]" in str(err):
+                logger.error(f"Delta table {from_table_name} is corrupted: missing transaction log.")
             else:
                 logger.error(err)
         return False

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -282,7 +282,7 @@ class TableMove:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):
                 logger.error(f"Could not find table {from_table_name}. Table not found.")
             else:
-                logger.error(err)
+                logger.error(f"Failed to move table {from_table_name}: {err!s}", exc_info=True)
         return False
 
     def _move_view(
@@ -320,5 +320,5 @@ class TableMove:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err):
                 logger.error(f"Could not find view {from_view_name}. View not found.")
             else:
-                logger.error(err)
+                logger.error(f"Failed to move view {from_view_name}: {err!s}", exc_info=True)
         return False

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -76,5 +76,7 @@ class TableSizeCrawler(CrawlerBase):
             if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
                 logger.warning(f"Delta table {table_full_name} is corrupted: missing transaction log.")
                 return None
-            logger.error(f"Failed to evaluate {table_full_name} table size: {e!s}", exc_info=True)
-            return None
+        except:  # noqa: E722
+            logger.error(f"Failed to evaluate {table_full_name} table size: ", exc_info=True)
+
+        return None

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -76,5 +76,5 @@ class TableSizeCrawler(CrawlerBase):
             if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
                 logger.warning(f"Delta table {table_full_name} is corrupted: missing transaction log.")
                 return None
-            logger.error(e)
+            logger.error(f"Failed to evaluate {table_full_name} table size: {e!s}", exc_info=True)
             return None

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -70,10 +70,11 @@ class TableSizeCrawler(CrawlerBase):
         try:
             return self._spark._jsparkSession.table(table_full_name).queryExecution().analyzed().stats().sizeInBytes()
         except Exception as e:
-            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(e):
+            if "[TABLE_OR_VIEW_NOT_FOUND]" in str(e) or "[DELTA_TABLE_NOT_FOUND]" in str(e):
                 logger.warning(f"Failed to evaluate {table_full_name} table size. Table not found.")
                 return None
             if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
                 logger.warning(f"Delta table {table_full_name} is corrupted: missing transaction log.")
                 return None
-            raise RuntimeError(str(e)) from e
+            logger.error(e)
+            return None

--- a/src/databricks/labs/ucx/mixins/sql.py
+++ b/src/databricks/labs/ucx/mixins/sql.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import Any
 
 from databricks.sdk import errors
-from databricks.sdk.errors import NotFound
+from databricks.sdk.errors import DataLoss, NotFound
 from databricks.sdk.service.sql import (
     ColumnInfoTypeName,
     Disposition,
@@ -106,6 +106,10 @@ class StatementExecutionExt(StatementExecutionAPI):
             raise NotFound(error_message)
         if "TABLE_OR_VIEW_NOT_FOUND" in error_message:
             raise NotFound(error_message)
+        if "DELTA_TABLE_NOT_FOUND" in error_message:
+            raise NotFound(error_message)
+        if "DELTA_MISSING_TRANSACTION_LOG" in error_message:
+            raise DataLoss(error_message)
         mapping = {
             ServiceErrorCode.ABORTED: errors.Aborted,
             ServiceErrorCode.ALREADY_EXISTS: errors.AlreadyExists,

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -314,6 +314,13 @@ def test_execute(mocker):
             rb.execute(sql_query)
 
         pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
+            "Unexpected exception"
+        )
+
+        with pytest.raises(Exception):  # noqa: B017
+            rb.execute(sql_query)
+
+        pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(
             "DELTA_MISSING_TRANSACTION_LOG"
         )
         with pytest.raises(DataLoss):

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -317,7 +317,7 @@ def test_execute(mocker):
             "Unexpected exception"
         )
 
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(BaseException):  # noqa: B017
             rb.execute(sql_query)
 
         pyspark_sql_session.SparkSession.builder.getOrCreate.return_value.sql.side_effect = Exception(

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -4,7 +4,13 @@ from dataclasses import dataclass
 from unittest import mock
 
 import pytest
-from databricks.sdk.errors import BadRequest, NotFound, PermissionDenied, Unknown, DataLoss
+from databricks.sdk.errors import (
+    BadRequest,
+    DataLoss,
+    NotFound,
+    PermissionDenied,
+    Unknown,
+)
 from databricks.sdk.service import sql
 
 from databricks.labs.ucx.framework.crawlers import (


### PR DESCRIPTION
## Changes
Extend error handling of delta issues in crawlers and hive metastore by catching: `DELTA_TABLE_NOT_FOUND` and `DELTA_MISSING_TRANSACTION_LOG`

### Linked issues

Resolves [#778](https://github.com/databrickslabs/ucx/issues/778)

### Functionality 

- [x] extend error handling

### Tests
- [x] added unit tests

