### PR TITLE
Fixed `databricks labs ucx repair-run` command to execute correctly

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -916,9 +916,7 @@ class WorkspaceInstaller:
             latest_repair_run_id = run_details.repair_history[-1].id
             job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
             logger.debug(f"Repair Running {workflow} job: {job_url}")
-            repair_run = self._ws.jobs.repair_run(
-                run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id
-            )
+            self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id)
             webbrowser.open(job_url)
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -906,6 +906,7 @@ class WorkspaceInstaller:
             if not job_runs:
                 logger.warning(f"{workflow} job is not initialized yet. Can't trigger repair run now")
                 return
+
             latest_job_run = job_runs[0]
             retry_on_attribute_error = retried(on=[AttributeError], timeout=self._verify_timeout)
             retried_check = retry_on_attribute_error(self._get_result_state)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -7,8 +7,7 @@ import sys
 import time
 import webbrowser
 from dataclasses import replace
-from datetime import timedelta
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -925,8 +925,8 @@ class WorkspaceInstaller:
             webbrowser.open(job_url)
         except InvalidParameterValue as e:
             logger.warning(f"skipping {workflow}: {e}")
-        except TimeoutError as e:
-            logger.warning(f"Skipping the {workflow} due to time out: {e}. Please try after sometime")
+        except TimeoutError:
+            logger.warning(f"Skipping the {workflow} due to time out. Please try after sometime")
 
     def uninstall(self):
         if self._prompts and not self._prompts.confirm(

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -891,8 +891,7 @@ class WorkspaceInstaller:
         job_runs = list(self._ws.jobs.list_runs(job_id=job_id, limit=1))
         latest_job_run = job_runs[0]
         if not latest_job_run.state.result_state:
-            logger.info("Waiting for the result_state to update the state")
-            time.sleep(10)
+            raise AttributeError("no result state in job run")
         job_state = latest_job_run.state.result_state.value
         return job_state
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -905,7 +905,6 @@ class WorkspaceInstaller:
             if not job_runs:
                 logger.warning(f"{workflow} job is not initialized yet. Can't trigger repair run now")
                 return
-
             latest_job_run = job_runs[0]
             retry_on_attribute_error = retried(on=[AttributeError], timeout=self._verify_timeout)
             retried_check = retry_on_attribute_error(self._get_result_state)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1179,3 +1179,22 @@ def test_repair_run_exception(ws):
     install._state.jobs = {"assessment": "123"}
     ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
     install.repair_run("assessment")
+
+
+def test_repair_run_result_state(ws, caplog):
+    base = [
+        BaseRun(
+            job_clusters=None,
+            job_id=677268692725050,
+            job_parameters=None,
+            number_in_job=725118654200173,
+            run_id=725118654200173,
+            run_name="[UCX] assessment",
+            state=RunState(result_state=None),
+        )
+    ]
+    install = WorkspaceInstaller(ws)
+    install._state.jobs = {"assessment": "123"}
+    ws.jobs.list_runs.return_value = base
+    ws.jobs.list_runs.repair_run = None
+    install.repair_run("assessment")

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1199,4 +1199,4 @@ def test_repair_run_result_state(ws, caplog):
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None
     install.repair_run("assessment")
-    assert "Please try after some time" in caplog.text
+    assert "Please try after sometime" in caplog.text

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,4 +1,5 @@
 import io
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -1193,8 +1194,9 @@ def test_repair_run_result_state(ws, caplog):
             state=RunState(result_state=None),
         )
     ]
-    install = WorkspaceInstaller(ws)
+    install = WorkspaceInstaller(ws, verify_timeout=timedelta(seconds=5))
     install._state.jobs = {"assessment": "123"}
     ws.jobs.list_runs.return_value = base
     ws.jobs.list_runs.repair_run = None
     install.repair_run("assessment")
+    assert "Please try after some time" in caplog.text


### PR DESCRIPTION
## Changes
Fixing the issue for repair run CLI `databricks labs ucx repair-run` . When a CLI  tries to repair run a job before if updates its response json to either FAILED or SUCCESS it was failing with NoneType exception.

Added a check in `repair_run` inside `install.py` to check the status of the response and wait for 20 seconds to get it updated .

Enhanced the code to repair run already repaired job.  

### Linked issues
closes #787 

Resolves #787 

### Functionality 

- modified the cli command `databricks labs ucx repair-run` which was failing in regression testing

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- This has been manually tested
- added unit tests `test_repair_run_result_state` in `test_install.py`
- This was tested using integration test
- <img width="1394" alt="Screenshot 2024-01-17 at 11 08 42 AM" src="https://github.com/databrickslabs/ucx/assets/127273819/0f54b711-55c2-4845-b23d-4ef96b2968ba">
