### PR TITLE
Added `databricks labs ucx save-aws-iam-profiles` command to scan instance profiles identify S3 access and save a CSV with permissions

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -95,7 +95,7 @@ commands:
       {{end}}
 
   - name: save-aws-iam-profiles
-    description: Identifies all storage account used by tables, identify spn and its permission on each storage accounts
+    description: Identifies all instance profiles associated with the workspace and lists all the S3 buckets they have access to.
     flags:
       - name: aws-profile
         description: AWS Profile to use for authentication

--- a/labs.yml
+++ b/labs.yml
@@ -50,6 +50,9 @@ commands:
   - name: validate-external-locations
     description: validates and provides mapping to external table to external location and shared generation tf scripts
 
+  - name: aws-iam-profiles
+    description: validates and provides mapping to external table to external location and shared generation tf scripts
+
   - name: repair-run
     description: Repair Run the Failed Job
     flags:

--- a/labs.yml
+++ b/labs.yml
@@ -95,7 +95,9 @@ commands:
       {{end}}
 
   - name: save-aws-iam-profiles
-    description: Identifies all instance profiles associated with the workspace and lists all the S3 buckets they have access to.
+    description: '
+    Identifies all Instance Profiles and map their access to S3 buckets.
+    Requires a working setup of AWS CLI.'
     flags:
       - name: aws-profile
         description: AWS Profile to use for authentication

--- a/labs.yml
+++ b/labs.yml
@@ -96,3 +96,9 @@ commands:
       Workflow Group Name\tAccount Group Name
       {{range .}}{{.name_in_workspace}}\t{{.name_in_group}}
       {{end}}
+
+  - name: save-aws-iam-profiles
+    description: Identifies all storage account used by tables, identify spn and its permission on each storage accounts
+    flags:
+      - name: aws-profile
+        description: AWS Profile to use for authentication

--- a/labs.yml
+++ b/labs.yml
@@ -95,9 +95,9 @@ commands:
       {{end}}
 
   - name: save-aws-iam-profiles
-    description: '
-    Identifies all Instance Profiles and map their access to S3 buckets.
-    Requires a working setup of AWS CLI.'
+    description: | 
+      Identifies all Instance Profiles and map their access to S3 buckets.
+      Requires a working setup of AWS CLI.
     flags:
       - name: aws-profile
         description: AWS Profile to use for authentication

--- a/labs.yml
+++ b/labs.yml
@@ -50,9 +50,6 @@ commands:
   - name: validate-external-locations
     description: validates and provides mapping to external table to external location and shared generation tf scripts
 
-  - name: aws-iam-profiles
-    description: validates and provides mapping to external table to external location and shared generation tf scripts
-
   - name: repair-run
     description: Repair Run the Failed Job
     flags:

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -204,7 +204,7 @@ class AWSResourcePermissions:
         tasks = []
         for instance_profile in instance_profiles:
             tasks.append(partial(self._get_instance_profile_access_task, instance_profile))
-
+# Aggregating the outputs from all the tasks
         return sum(Threads.strict("Scanning Instance Profiles", tasks), [])
 
     def _get_instance_profile_access_task(self, instance_profile: AWSInstanceProfile):

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -1,13 +1,14 @@
+import subprocess
+import json
+
+
+def run_command(command):
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    output, error = process.communicate()
+    return process.returncode, output.decode("utf-8"), error.decode("utf-8")
+
 
 def iam_profiles():
-    import subprocess
-    import json
-
-    def run_command(command):
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        output, error = process.communicate()
-        return process.returncode, output.decode("utf-8"), error.decode("utf-8")
-
     # List all IAM roles
     roles_command = "aws iam list-roles"
     code, roles_output, roles_error = run_command(roles_command)

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -65,7 +65,7 @@ class AWSInstanceProfile:
 @lru_cache(maxsize=1024)
 def run_command(command):
     logger.info(f"Invoking Command {command}")
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  # noqa: S602
     output, error = process.communicate()
     return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -232,7 +232,7 @@ class AWSResourcePermissions:
     def save_instance_profile_permissions(self) -> str | None:
         instance_profile_access = list(self._get_instance_profiles_access())
         if len(instance_profile_access) == 0:
-            logger.warning("No Mapping Was Generated. Please check if assessment job is run")
+            logger.warning("No Mapping Was Generated.")
             return None
         return self._save(instance_profile_access)
 

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import re
+import shutil
 import subprocess
 import typing
 from collections.abc import Callable, Iterable
@@ -65,7 +66,7 @@ class AWSInstanceProfile:
 @lru_cache(maxsize=1024)
 def run_command(command):
     logger.info(f"Invoking Command {command}")
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  # noqa: S602
+    process = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = process.communicate()
     return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 
@@ -162,7 +163,8 @@ class AWSResources:
         return policy_actions
 
     def _run_json_command(self, command: str):
-        code, output, error = self._command_runner(f"aws {command} --output json --no-paginate")
+        aws_cmd = shutil.which("aws")
+        code, output, error = self._command_runner(f"{aws_cmd} {command} --output json --no-paginate")
         if code != 0:
             logger.error(error)
             return None

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -59,16 +59,15 @@ class AWSInstanceProfile:
         if not role_match:
             logger.error(f"Role ARN is mismatched {self.iam_role_arn}")
             return None
-        else:
-            return role_match.group(1)
+        return role_match.group(1)
 
 
 @lru_cache(maxsize=1024)
 def run_command(command):
     logger.info(f"Invoking Command {command}")
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)  # noqa: S602
-    output, error = process.communicate()
-    return process.returncode, output.decode("utf-8"), error.decode("utf-8")
+    with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True) as process:  # noqa: S602
+        output, error = process.communicate()
+        return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 
 
 class AWSResources:

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -204,7 +204,7 @@ class AWSResourcePermissions:
         tasks = []
         for instance_profile in instance_profiles:
             tasks.append(partial(self._get_instance_profile_access_task, instance_profile))
-# Aggregating the outputs from all the tasks
+        # Aggregating the outputs from all the tasks
         return sum(Threads.strict("Scanning Instance Profiles", tasks), [])
 
     def _get_instance_profile_access_task(self, instance_profile: AWSInstanceProfile):

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -67,7 +67,7 @@ class AWSInstanceProfile:
 @lru_cache(maxsize=1024)
 def run_command(command):
     logger.info(f"Invoking Command {command}")
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     output, error = process.communicate()
     return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -1,0 +1,71 @@
+
+def iam_profiles():
+    import subprocess
+    import json
+
+    def run_command(command):
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        output, error = process.communicate()
+        return process.returncode, output.decode("utf-8"), error.decode("utf-8")
+
+    # List all IAM roles
+    roles_command = "aws iam list-roles"
+    code, roles_output, roles_error = run_command(roles_command)
+
+    if code == 0:
+        roles_data = json.loads(roles_output)
+        roles = roles_data.get("Roles", [])
+
+        for role in roles:
+            role_name = role["RoleName"]
+            print(f"IAM Role: {role_name}")
+
+            # List attached policies
+            attached_policies_command = f"aws iam list-attached-role-policies --role-name {role_name}"
+            code, attached_policies_output, attached_policies_error = run_command(attached_policies_command)
+
+            if code == 0:
+                attached_policies_data = json.loads(attached_policies_output)
+                attached_policies = attached_policies_data.get("AttachedPolicies", [])
+                for policy in attached_policies:
+                    policy_name = policy["PolicyName"]
+                    print(f"  Attached Policy: {policy_name}")
+
+            # List inline policies
+            inline_policies_command = f"aws iam list-role-policies --role-name {role_name}"
+            code, inline_policies_output, inline_policies_error = run_command(inline_policies_command)
+
+            if code == 0:
+                inline_policies_data = json.loads(inline_policies_output)
+                inline_policies = inline_policies_data.get("PolicyNames", [])
+                for inline_policy in inline_policies:
+                    print(f"  Inline Policy: {inline_policy}")
+
+            # List S3 bucket permissions for the role
+            s3_permissions_command = f"aws s3api list-buckets"
+            code, s3_permissions_output, s3_permissions_error = run_command(s3_permissions_command)
+
+            if code == 0:
+                s3_buckets_data = json.loads(s3_permissions_output)
+                s3_buckets = s3_buckets_data.get("Buckets", [])
+                for bucket in s3_buckets:
+                    bucket_name = bucket["Name"]
+                    print(f"    S3 Bucket: {bucket_name}")
+
+                    # Check if the role has access to the bucket
+                    check_access_command = f"aws s3api get-bucket-policy-status --bucket {bucket_name}"
+                    code, access_output, access_error = run_command(check_access_command)
+
+                    if code == 0:
+                        access_data = json.loads(access_output)
+                        if access_data.get("IsPublic"):
+                            print("      Access: Public")
+                        else:
+                            print("      Access: Restricted")
+                    else:
+                        print("      Access: Unknown (Error checking access)")
+
+            print("\n")
+    else:
+        print("Error listing IAM roles.")
+        print(roles_error)

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -1,7 +1,14 @@
 import logging
+import re
 import subprocess
 import json
 from dataclasses import dataclass
+from typing import Callable, Iterable, List
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.compute import InstanceProfile
+
+from databricks.labs.ucx.framework.crawlers import CrawlerBase, SqlBackend
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +19,27 @@ class AWSRole:
     role_name: str
     role_id: str
     arn: str
+
+
+@dataclass
+class AWSPolicyAction:
+    resource_type: str
+    Action: set[str]
+    resource_path: str
+
+
+@dataclass
+class AWSInstanceProfileAccess:
+    instance_profile_arn: str
+    iam_role_arn: str
+
+
+@dataclass
+class AWSInstanceProfile:
+    instance_profile: str
+    resource_type: str
+    resource_path: str
+    actions: str
 
 
 def iam_profiles():
@@ -84,58 +112,116 @@ def run_command(command):
     return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 
 
-class AwsResources:
-    def __init__(self):
-        pass
+class AWSResources:
+
+    S3_ACTIONS = {
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:PutObjectAcl"
+    }
+    S3_REGEX = "arn:aws:s3:::([a-zA-Z0-9+=,.@_-]*)\/\*"
+
+    def __init__(self, profile: str, command_runner: Callable[[str],str] = run_command):
+        self._profile = profile
+        self._command_runner = command_runner
+
+    def validate_connection(self):
+        validate_command = f"aws sts get-caller-identity --profile {self._profile}"
+        code, output, error = run_command(validate_command)
+        if code == 0:
+            logger.info(output)
+            return True
+        logger.error(error)
+        return False
+
+    def get_roles_in_instance_profile(self, instance_profile_name: str):
+        get_instance_profile_cmd = f"aws iam get-instance-profile --profile {self._profile} --instance-profile-name {instance_profile_name}"
+        code, output, error = run_command(get_instance_profile_cmd)
+        if code == 0:
+            ip_details = json.loads(output)
+            try:
+                for role in ip_details["InstanceProfile"]["Roles"]:
+                    yield AWSRole(
+                        path=role["Path"],
+                        role_name=role["RoleName"],
+                        role_id=role["RoleId"],
+                        arn=role["Arn"]
+                    )
+            except KeyError:
+                logger.error(f"Malformed response from AWS CLI {ip_details}")
+        logger.error(error)
+
+    def list_policies_in_role(self, role_name: str):
+        list_policies_cmd = f"aws iam list-role-policies --profile {self._profile} --role-name {role_name} --no-paginate"
+        code, output, error = run_command(list_policies_cmd)
+        if code == 0:
+            policies = json.loads(output)
+            for policy in policies.get("PolicyNames", []):
+                yield policy
+        logger.error(error)
+
+    def list_attached_policies_in_role(self, role_name: str):
+        list_attached_policies_cmd = f"aws iam list-attached-role-policies --profile {self._profile} --role-name {role_name}"
+        code, output, error = run_command(list_attached_policies_cmd)
+        if code == 0:
+            policies = json.loads(output)
+            for policy in policies.get("AttachedPolicies", []):
+                yield policy.get("PolicyName")
+        logger.error(error)
+
+    def get_role_policy(self, role_name, policy_name: str):
+        get_policy = f"aws iam get-role-policy --profile {self._profile} --role-name {role_name} --policy-name {policy_name}"
+        code, output, error = run_command(get_policy)
+        if code == 0:
+            policy = json.loads(output)
+            for action in policy["PolicyDocument"].get("Statement", []):
+                actions = action["Action"]
+                s3_action = False
+                if isinstance(actions, List):
+                    for single_action in actions:
+                        if single_action in self.S3_ACTIONS:
+                            s3_action = True
+                            continue
+                else:
+                    if actions in self.S3_ACTIONS:
+                        s3_action = True
+
+                if not s3_action:
+                    continue
+                for resource in action.get("Resource", []):
+                    match = re.match(self.S3_REGEX, resource)
+                    if match:
+                        yield AWSPolicyAction("s3", set(actions,), match.group(1))
+        logger.error(error)
+
+
+class AWSInstanceProfileCrawler(CrawlerBase[InstanceProfile]):
+    def __init__(self, ws: WorkspaceClient, sbe: SqlBackend, schema):
+        super().__init__(sbe, "hive_metastore", schema, "aws_instance_profile", InstanceProfile)
+        self._ws = ws
+        self._schema = schema
+
+    def _crawl(self) -> Iterable[InstanceProfile]:
+        return list(self._ws.instance_profiles.list())
+
+    def snapshot(self) -> Iterable[InstanceProfile]:
+        return self._snapshot(self._try_fetch, self._crawl)
+
+    def _try_fetch(self) -> Iterable[InstanceProfile]:
+        for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
+            yield InstanceProfile(*row)
+
+class AWSResourcePermissions:
+    def __init__(self, ws: WorkspaceClient, awsrm: AWSResources,
+                 instance_profile_crawler: AWSInstanceProfileCrawler,
+                 folder: str | None = None):
+        self._folder = folder
+        self._awsrm = awsrm
+        self._ws = ws
+
+    def _get_instance_profiles(self) -> list[str]:
+        instance_profiles = self._awsrm.snapshot()
 
 
 
-
-
-
-def validate_connection(profile: str):
-    validate_command = f"aws sts get-caller-identity --profile {profile}"
-    code, output, error = run_command(validate_command)
-    if code == 0:
-        logger.info(output)
-        return True
-    logger.error(error)
-    return False
-
-
-def get_roles_in_instance_profile(instance_profile_name: str):
-    get_instance_profile_cmd = f"aws iam get-instance-profile --instance-profile-name {instance_profile_name}"
-    code, output, error = run_command(get_instance_profile_cmd)
-    if code == 0:
-        ip_details = json.loads(output)
-        try:
-            for role in ip_details["InstanceProfile"]["Roles"]:
-                yield AWSRole(
-                    path=role["Path"],
-                    role_name=role["RoleName"],
-                    role_id=role["RoleId"],
-                    arn=role["Arn"]
-                )
-        except KeyError:
-            logger.error(f"Malformed response from AWS CLI {ip_details}")
-    logger.error(error)
-
-
-def get_policies_in_role(role_name: str):
-    get_policies_in_role_cmd = f"aws iam list-role-policies --role-name {role_name}"
-    code, output, error = run_command(get_policies_in_role_cmd)
-    if code == 0:
-        policies = json.loads(output)
-        for policy in policies.get("PolicyNames", []):
-            yield policy
-    logger.error(error)
-
-
-def get_attached_policies_in_role(role_name: str):
-    get_policies_in_role_cmd = f"aws iam list-attached-role-policies --role-name {role_name}"
-    code, output, error = run_command(get_policies_in_role_cmd)
-    if code == 0:
-        policies = json.loads(output)
-        for policy in policies.get("AttachedPolicies", []):
-            yield policy.get("PolicyName")
-    logger.error(error)

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -157,10 +157,8 @@ class AWSResources:
             for resource in action.get("Resource", []):
                 match = re.match(self.S3_REGEX, resource)
                 if match:
-                    s3_resource_path = f"s3://{match.group(1)}"
-                    policy_actions.append(AWSPolicyAction("s3", privilege, s3_resource_path))
-                    s3a_resource_path = f"s3a://{match.group(1)}"
-                    policy_actions.append(AWSPolicyAction("s3", privilege, s3a_resource_path))
+                    policy_actions.append(AWSPolicyAction("s3", privilege, f"s3://{match.group(1)}"))
+                    policy_actions.append(AWSPolicyAction("s3", privilege, f"s3a://{match.group(1)}"))
         return policy_actions
 
     def _run_json_command(self, command: str):

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -66,9 +66,9 @@ class AWSInstanceProfile:
 @lru_cache(maxsize=1024)
 def run_command(command):
     logger.info(f"Invoking Command {command}")
-    process = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, error = process.communicate()
-    return process.returncode, output.decode("utf-8"), error.decode("utf-8")
+    with subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+        output, error = process.communicate()
+        return process.returncode, output.decode("utf-8"), error.decode("utf-8")
 
 
 class AWSResources:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -281,7 +281,7 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     if not aws_profile:
         logger.error(
             "AWS Profile is not specified. Use the environment variable [AWS_DEFAULT_PROFILE] "
-            "or use the aws-profile parameter."
+            "or use the '--aws-profile=[profile-name]' parameter."
         )
         return None
     aws = AWSResources(aws_profile)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -304,6 +304,7 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
         aws,
     )
     aws_pm.save_instance_profile_permissions()
+    return None
 
 
 if __name__ == "__main__":

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -276,6 +276,7 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     """
     if not shutil.which("aws"):
         logger.error("Couldn't find AWS CLI in path.Please obtain and install the CLI from https://aws.amazon.com/cli/")
+        return
     if not aws_profile:
         aws_profile = os.getenv("AWS_DEFAULT_PROFILE")
     if not aws_profile:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -276,7 +276,7 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     """
     if not shutil.which("aws"):
         logger.error("Couldn't find AWS CLI in path.Please obtain and install the CLI from https://aws.amazon.com/cli/")
-        return
+        return None
     if not aws_profile:
         aws_profile = os.getenv("AWS_DEFAULT_PROFILE")
     if not aws_profile:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -1,4 +1,6 @@
 import json
+import os
+import shutil
 import webbrowser
 
 from databricks.labs.blueprint.cli import App
@@ -7,6 +9,7 @@ from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import AccountClient, WorkspaceClient
 
 from databricks.labs.ucx.account import AccountWorkspaces, WorkspaceInfo
+from databricks.labs.ucx.assessment.aws import AWSResourcePermissions, AWSResources
 from databricks.labs.ucx.assessment.azure import (
     AzureResourcePermissions,
     AzureResources,
@@ -258,6 +261,49 @@ def save_azure_storage_accounts(w: WorkspaceClient, subscription_id: str):
     azure_resource_permissions = AzureResourcePermissions(w, AzureResources(w), location)
     logger.info("Generating azure storage accounts and service principal permission info")
     azure_resource_permissions.save_spn_permissions()
+
+
+@ucx.command
+def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
+    """identifies all Instance Profiles and map their access to S3 buckets.
+    Requires a working setup of AWS CLI.
+    https://aws.amazon.com/cli/
+    The command saves a CSV to the UCX installation folder with the mapping.
+
+    The user has to be authenticated with AWS and the have the permissions to browse the resources and iam services.
+    More information can be found here:
+    https://docs.aws.amazon.com/IAM/latest/UserGuide/access_permissions-required.html
+    """
+    if not shutil.which("aws"):
+        logger.error("Couldn't find AWS CLI in path.Please obtain and install the CLI from https://aws.amazon.com/cli/")
+    if not aws_profile:
+        aws_profile = os.getenv("AWS_DEFAULT_PROFILE")
+    if not aws_profile:
+        logger.error(
+            "AWS Profile is not specified. Use the environment variable [AWS_DEFAULT_PROFILE] "
+            "or use the aws-profile parameter."
+        )
+        return None
+    aws = AWSResources(aws_profile)
+    if not aws.validate_connection():
+        logger.error("AWS CLI is not configured properly.")
+        return None
+
+    installation_manager = InstallationManager(w)
+    installation = installation_manager.for_user(w.current_user.me())
+    if not installation:
+        logger.error(CANT_FIND_UCX_MSG)
+        return None
+
+    if not w.config.is_aws:
+        logger.error("Workspace is not on AWS, please run this command on AWS databricks workspaces.")
+        return None
+
+    aws_pm = AWSResourcePermissions(
+        w,
+        aws,
+    )
+    aws_pm.save_instance_profile_permissions()
 
 
 if __name__ == "__main__":

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -1,8 +1,4 @@
-from databricks.labs.ucx.assessment.aws import (
-    AWSInstanceProfileCrawler,
-    AWSResourcePermissions,
-    AWSResources,
-)
+from databricks.labs.ucx.assessment.aws import AWSResourcePermissions, AWSResources
 
 
 def test_aws_validate(env_or_skip):
@@ -19,24 +15,14 @@ def test_role_policy(env_or_skip):
     assert len(role_policy_actions) == 15
 
 
-def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema):
-    instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
-    instance_profiles = instance_profile_crawler.snapshot()
-    assert instance_profiles
-
-
 def test_creating_instance_profile_csv(
     env_or_skip,
     ws,
-    sql_backend,
-    inventory_schema,
 ):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
     aws = AWSResources(profile)
     aws_pm = AWSResourcePermissions(
         ws,
         aws,
-        instance_profile_crawler,
     )
     aws_pm.save_instance_profile_permissions()

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -1,4 +1,4 @@
-from databricks.labs.ucx.assessment.aws import AWSResourcePermissions, AWSResources
+from databricks.labs.ucx.assessment.aws import AWSResources
 
 
 def test_aws_validate(env_or_skip):
@@ -6,23 +6,3 @@ def test_aws_validate(env_or_skip):
     aws = AWSResources(profile)
     assert aws.validate_connection()
 
-
-def test_role_policy(env_or_skip):
-    profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    aws = AWSResources(profile)
-    role_policy_actions = aws.get_role_policy("databricks-s3-access", "databricks-s3-access")
-    print(role_policy_actions)
-    assert len(role_policy_actions) == 15
-
-
-def test_creating_instance_profile_csv(
-    env_or_skip,
-    ws,
-):
-    profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    aws = AWSResources(profile)
-    aws_pm = AWSResourcePermissions(
-        ws,
-        aws,
-    )
-    aws_pm.save_instance_profile_permissions()

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -2,14 +2,13 @@ import logging
 
 import pytest
 
-from databricks.labs.ucx.assessment.aws import validate_connection, get_roles_in_instance_profile, get_policies_in_role, \
-    get_attached_policies_in_role
+from databricks.labs.ucx.assessment.aws import AWSResources
 
 
 def test_aws_validate(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    assert validate_connection(profile)
-
+    aws = AWSResources(profile)
+    assert aws.validate_connection()
 
 def test_get_roles_in_ip():
     roles = list(get_roles_in_instance_profile("databricks-s3-access"))
@@ -27,5 +26,15 @@ def test_get_attached_policies():
     policies = list(get_attached_policies_in_role("databricks-s3-access"))
     print(policies)
     assert len(policies)==5
+
+
+def test_role_policy(env_or_skip):
+    profile = env_or_skip("AWS_DEFAULT_PROFILE")
+    aws = AWSResources(profile)
+    role_policy_actions = list(aws.get_role_policy("databricks-s3-access","databricks-s3-access"))
+    print(role_policy_actions)
+    assert len(role_policy_actions) == 15
+
+
 
 

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from databricks.labs.ucx.assessment.aws import AWSResources
+from databricks.labs.ucx.assessment.aws import AWSResources, AWSInstanceProfileCrawler
 
 
 def test_aws_validate(env_or_skip):
@@ -34,6 +34,16 @@ def test_role_policy(env_or_skip):
     role_policy_actions = list(aws.get_role_policy("databricks-s3-access","databricks-s3-access"))
     print(role_policy_actions)
     assert len(role_policy_actions) == 15
+
+
+def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema):
+    profile = env_or_skip("AWS_DEFAULT_PROFILE")
+    instance_profile_crawler = AWSInstanceProfileCrawler(ws,sql_backend,inventory_schema)
+    instance_profiles = instance_profile_crawler.snapshot()
+    print(instance_profiles)
+    assert instance_profiles
+
+
 
 
 

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -5,4 +5,3 @@ def test_aws_validate(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
     assert aws.validate_connection()
-

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -10,7 +10,7 @@ def test_aws_validate(env_or_skip):
 def test_role_policy(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
-    role_policy_actions = list(aws.get_role_policy("databricks-s3-access", "databricks-s3-access"))
+    role_policy_actions = aws.get_role_policy("databricks-s3-access", "databricks-s3-access")
     print(role_policy_actions)
     assert len(role_policy_actions) == 15
 

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from databricks.labs.ucx.assessment.aws import AWSResources, AWSInstanceProfileCrawler
+from databricks.labs.ucx.assessment.aws import AWSResources, AWSInstanceProfileCrawler, AWSResourcePermissions
 
 
 def test_aws_validate(env_or_skip):
@@ -10,41 +10,27 @@ def test_aws_validate(env_or_skip):
     aws = AWSResources(profile)
     assert aws.validate_connection()
 
-def test_get_roles_in_ip():
-    roles = list(get_roles_in_instance_profile("databricks-s3-access"))
-    print(roles)
-    assert len(roles)==1
-
-
-def test_get_policies():
-    policies = list(get_policies_in_role("databricks-s3-access"))
-    print(policies)
-    assert len(policies)==6
-
-
-def test_get_attached_policies():
-    policies = list(get_attached_policies_in_role("databricks-s3-access"))
-    print(policies)
-    assert len(policies)==5
 
 
 def test_role_policy(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
-    role_policy_actions = list(aws.get_role_policy("databricks-s3-access","databricks-s3-access"))
+    role_policy_actions = list(aws.get_role_policy("databricks-s3-access", "databricks-s3-access"))
     print(role_policy_actions)
     assert len(role_policy_actions) == 15
 
 
 def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    instance_profile_crawler = AWSInstanceProfileCrawler(ws,sql_backend,inventory_schema)
+    instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
     instance_profiles = instance_profile_crawler.snapshot()
     print(instance_profiles)
     assert instance_profiles
 
 
-
-
-
-
+def test_creating_instance_profile_csv(env_or_skip, ws, sql_backend, inventory_schema, ):
+    profile = env_or_skip("AWS_DEFAULT_PROFILE")
+    instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
+    aws = AWSResources(profile)
+    aws_pm = AWSResourcePermissions(ws, aws, instance_profile_crawler,)
+    aws_pm.save_instance_profile_permissions()

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -1,15 +1,16 @@
-import logging
 
-import pytest
 
-from databricks.labs.ucx.assessment.aws import AWSResources, AWSInstanceProfileCrawler, AWSResourcePermissions
+from databricks.labs.ucx.assessment.aws import (
+    AWSInstanceProfileCrawler,
+    AWSResourcePermissions,
+    AWSResources,
+)
 
 
 def test_aws_validate(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
     assert aws.validate_connection()
-
 
 
 def test_role_policy(env_or_skip):
@@ -27,9 +28,18 @@ def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema
     assert instance_profiles
 
 
-def test_creating_instance_profile_csv(env_or_skip, ws, sql_backend, inventory_schema, ):
+def test_creating_instance_profile_csv(
+    env_or_skip,
+    ws,
+    sql_backend,
+    inventory_schema,
+):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
     aws = AWSResources(profile)
-    aws_pm = AWSResourcePermissions(ws, aws, instance_profile_crawler,)
+    aws_pm = AWSResourcePermissions(
+        ws,
+        aws,
+        instance_profile_crawler,
+    )
     aws_pm.save_instance_profile_permissions()

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -1,5 +1,3 @@
-
-
 from databricks.labs.ucx.assessment.aws import (
     AWSInstanceProfileCrawler,
     AWSResourcePermissions,
@@ -22,7 +20,6 @@ def test_role_policy(env_or_skip):
 
 
 def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema):
-    profile = env_or_skip("AWS_DEFAULT_PROFILE")
     instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
     instance_profiles = instance_profile_crawler.snapshot()
     assert instance_profiles

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -1,0 +1,31 @@
+import logging
+
+import pytest
+
+from databricks.labs.ucx.assessment.aws import validate_connection, get_roles_in_instance_profile, get_policies_in_role, \
+    get_attached_policies_in_role
+
+
+def test_aws_validate(env_or_skip):
+    profile = env_or_skip("AWS_DEFAULT_PROFILE")
+    assert validate_connection(profile)
+
+
+def test_get_roles_in_ip():
+    roles = list(get_roles_in_instance_profile("databricks-s3-access"))
+    print(roles)
+    assert len(roles)==1
+
+
+def test_get_policies():
+    policies = list(get_policies_in_role("databricks-s3-access"))
+    print(policies)
+    assert len(policies)==6
+
+
+def test_get_attached_policies():
+    policies = list(get_attached_policies_in_role("databricks-s3-access"))
+    print(policies)
+    assert len(policies)==5
+
+

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -24,7 +24,6 @@ def test_instance_profile_crawler(env_or_skip, ws, sql_backend, inventory_schema
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     instance_profile_crawler = AWSInstanceProfileCrawler(ws, sql_backend, inventory_schema)
     instance_profiles = instance_profile_crawler.snapshot()
-    print(instance_profiles)
     assert instance_profiles
 
 

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -216,34 +216,3 @@ def test_get_role_policy():
     ]
 
 
-def test_aws_instance_profile_crawler():
-    errors = {}
-    rows = {
-        "SELECT": [
-            ("arn:aws:iam::12345:instance-profile/Role1", "arn:aws:iam::12345:role/Role1"),
-            ("arn:aws:iam::12345:instance-profile/Role2", "arn:aws:iam::12345:role/Role2"),
-        ],
-    }
-    backend = MockBackend(fails_on_first=errors, rows=rows)
-    ws = create_autospec(WorkspaceClient)
-    instance_profile_crawler = AWSInstanceProfileCrawler(ws, backend, "ucx")
-    results = instance_profile_crawler.snapshot()
-    assert len(results) == 2
-    assert AWSInstanceProfile("arn:aws:iam::12345:instance-profile/Role1", "arn:aws:iam::12345:role/Role1") in results
-    assert AWSInstanceProfile("arn:aws:iam::12345:instance-profile/Role2", "arn:aws:iam::12345:role/Role2") in results
-
-    errors = {}
-    rows = {
-        "SELECT": [],
-    }
-    backend = MockBackend(fails_on_first=errors, rows=rows)
-    ws = create_autospec(WorkspaceClient)
-    ws.instance_profiles.list.return_value = [
-        InstanceProfile("arn:aws:iam::12345:instance-profile/Role1", "arn:aws:iam::12345:role/Role1"),
-        InstanceProfile("arn:aws:iam::12345:instance-profile/Role2", "arn:aws:iam::12345:role/Role2"),
-    ]
-    instance_profile_crawler = AWSInstanceProfileCrawler(ws, backend, "ucx")
-    results = instance_profile_crawler.snapshot()
-    assert len(results) == 2
-    assert AWSInstanceProfile("arn:aws:iam::12345:instance-profile/Role1", "arn:aws:iam::12345:role/Role1") in results
-    assert AWSInstanceProfile("arn:aws:iam::12345:instance-profile/Role2", "arn:aws:iam::12345:role/Role2") in results

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -148,7 +148,7 @@ def test_get_role_policy():
                 }
             ]
         },
-        "VersionId": "v3",
+        "VersionId": "v1",
         "IsDefaultVersion": true,
         "CreateDate": "2024-01-01T00:00:00+00:00"
     }
@@ -158,7 +158,7 @@ def test_get_role_policy():
     def command_call(cmd: str):
         if cmd.startswith("aws iam get-role-policy"):
             return 0, get_role_policy_return, ""
-        elif cmd.startswith("aws iam get-policy"):
+        elif cmd.startswith("aws iam get-policy "):
             return 0, get_policy_return, ""
         elif cmd.startswith("aws iam get-policy-version"):
             return 0, get_policy_version_return, ""

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -369,3 +369,4 @@ def test_command(caplog):
     assert return_code == 0
     with pytest.raises(FileNotFoundError) as exception:
         run_command("no_way_this_command_would_work")
+        print(exception)

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -178,17 +178,32 @@ def test_get_role_policy():
         AWSPolicyAction(
             resource_type="s3",
             privilege="READ_FILES",
-            resource_path="bucket1",
+            resource_path="s3://bucket1",
         ),
         AWSPolicyAction(
             resource_type="s3",
             privilege="READ_FILES",
-            resource_path="bucket2",
+            resource_path="s3a://bucket1",
         ),
         AWSPolicyAction(
             resource_type="s3",
             privilege="READ_FILES",
-            resource_path="bucket3",
+            resource_path="s3://bucket2",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="READ_FILES",
+            resource_path="s3a://bucket2",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="READ_FILES",
+            resource_path="s3://bucket3",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="READ_FILES",
+            resource_path="s3a://bucket3",
         ),
     ]
 
@@ -197,17 +212,32 @@ def test_get_role_policy():
         AWSPolicyAction(
             resource_type="s3",
             privilege="WRITE_FILES",
-            resource_path="bucketA",
+            resource_path="s3://bucketA",
         ),
         AWSPolicyAction(
             resource_type="s3",
             privilege="WRITE_FILES",
-            resource_path="bucketB",
+            resource_path="s3a://bucketA",
         ),
         AWSPolicyAction(
             resource_type="s3",
             privilege="WRITE_FILES",
-            resource_path="bucketC",
+            resource_path="s3://bucketB",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="WRITE_FILES",
+            resource_path="s3a://bucketB",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="WRITE_FILES",
+            resource_path="s3://bucketC",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            privilege="WRITE_FILES",
+            resource_path="s3a://bucketC",
         ),
     ]
 
@@ -222,22 +252,22 @@ def test_save_instance_profile_permissions():
     expected_csv_entries = [
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "READ_FILES",
-        "bucket1,arn:aws:iam::12345:role/role1",
+        "s3://bucket1,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "READ_FILES",
-        "bucket2,arn:aws:iam::12345:role/role1",
+        "s3://bucket2,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "READ_FILES",
-        "bucket3,arn:aws:iam::12345:role/role1",
+        "s3://bucket3,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "WRITE_FILES",
-        "bucketA,arn:aws:iam::12345:role/role1",
+        "s3://bucketA,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "WRITE_FILES",
-        "bucketB,arn:aws:iam::12345:role/role1",
+        "s3://bucketB,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
         "WRITE_FILES",
-        "bucketC,arn:aws:iam::12345:role/role1",
+        "s3://bucketC,arn:aws:iam::12345:role/role1",
     ]
 
     def upload(
@@ -259,17 +289,17 @@ def test_save_instance_profile_permissions():
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="READ_FILES",
-                resource_path="bucket1",
+                resource_path="s3://bucket1",
             ),
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="READ_FILES",
-                resource_path="bucket2",
+                resource_path="s3://bucket2",
             ),
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="READ_FILES",
-                resource_path="bucket3",
+                resource_path="s3://bucket3",
             ),
         ],
         [],
@@ -278,17 +308,17 @@ def test_save_instance_profile_permissions():
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="WRITE_FILES",
-                resource_path="bucketA",
+                resource_path="s3://bucketA",
             ),
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="WRITE_FILES",
-                resource_path="bucketB",
+                resource_path="s3://bucketB",
             ),
             AWSPolicyAction(
                 resource_type="s3",
                 privilege="WRITE_FILES",
-                resource_path="bucketC",
+                resource_path="s3://bucketC",
             ),
         ],
         [],

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -242,7 +242,7 @@ def test_save_instance_profile_permissions():
         path: str,
         content: BinaryIO,
         *,
-        format: ImportFormat | None = None,
+        format: ImportFormat | None = None,  # noqa: A002
         language: Language | None = None,
         overwrite: bool | None = False,
     ) -> None:

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -11,7 +11,7 @@ from databricks.sdk.service.workspace import ImportFormat, Language
 from databricks.labs.ucx.assessment.aws import (
     AWSPolicyAction,
     AWSResourcePermissions,
-    AWSResources, run_command,
+    AWSResources, run_command, AWSInstanceProfile,
 )
 
 logger = logging.getLogger(__name__)
@@ -301,3 +301,19 @@ def test_save_instance_profile_permissions():
 
     aws_resource_permissions = AWSResourcePermissions(ws, aws)
     aws_resource_permissions.save_instance_profile_permissions()
+
+def test_role_mismatched(caplog):
+    instance_profile = AWSInstanceProfile("test","fake")
+    role_name = instance_profile.role_name
+    assert "Role ARN is mismatched" in caplog.messages[0]
+
+def test_get_role_policy_missing_role(caplog):
+    def command_call(cmd: str):
+        return 0, "", ""
+
+    aws = AWSResources("Fake_Profile", command_call)
+
+    role_policies = aws.get_role_policy("fake_role")
+    assert "No role name or attached role ARN specified." in caplog.messages[0]
+
+

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -97,12 +97,7 @@ def test_get_role_policy():
                 {
                     "Effect": "Allow",
                     "Action": [
-                        "s3:PutObject",
-                        "s3:GetObject",
-                        "s3:DeleteObject",
-                        "s3:PutObjectAcl",
-                        "s3:GetBucketNotification",
-                        "s3:PutBucketNotification"
+                        "s3:GetObject"
                     ],
                     "Resource": [
                         "arn:aws:s3:::bucket1/*",
@@ -182,17 +177,17 @@ def test_get_role_policy():
     assert role_policy == [
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="READ_FILES",
             resource_path="bucket1",
         ),
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="READ_FILES",
             resource_path="bucket2",
         ),
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="READ_FILES",
             resource_path="bucket3",
         ),
     ]
@@ -201,17 +196,17 @@ def test_get_role_policy():
     assert role_policy == [
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="WRITE_FILES",
             resource_path="bucketA",
         ),
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="WRITE_FILES",
             resource_path="bucketB",
         ),
         AWSPolicyAction(
             resource_type="s3",
-            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            privilege="WRITE_FILES",
             resource_path="bucketC",
         ),
     ]
@@ -226,16 +221,22 @@ def test_save_instance_profile_permissions():
 
     expected_csv_entries = [
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "READ_FILES",
         "bucket1,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "READ_FILES",
         "bucket2,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "READ_FILES",
         "bucket3,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "WRITE_FILES",
         "bucketA,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "WRITE_FILES",
         "bucketB,arn:aws:iam::12345:role/role1",
         "arn:aws:iam::12345:instance-profile/role1,s3",
+        "WRITE_FILES",
         "bucketC,arn:aws:iam::12345:role/role1",
     ]
 
@@ -257,17 +258,17 @@ def test_save_instance_profile_permissions():
         [
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="READ_FILES",
                 resource_path="bucket1",
             ),
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="READ_FILES",
                 resource_path="bucket2",
             ),
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="READ_FILES",
                 resource_path="bucket3",
             ),
         ],
@@ -276,17 +277,17 @@ def test_save_instance_profile_permissions():
         [
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="WRITE_FILES",
                 resource_path="bucketA",
             ),
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="WRITE_FILES",
                 resource_path="bucketB",
             ),
             AWSPolicyAction(
                 resource_type="s3",
-                action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+                privilege="WRITE_FILES",
                 resource_path="bucketC",
             ),
         ],

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -1,0 +1,206 @@
+import logging
+
+
+from databricks.labs.ucx.assessment.aws import AWSPolicyAction, AWSResources
+
+logger = logging.getLogger(__name__)
+
+
+def test_aws_validate():
+    successful_return = """
+    {
+        "UserId": "uu@mail.com",
+        "Account": "1234",
+        "Arn": "arn:aws:sts::1234:assumed-role/AWSVIEW/uu@mail.com"
+    }
+    """
+
+    def successful_call(cmd: str):
+        return 0, successful_return, ""
+
+    aws = AWSResources("Fake_Profile", successful_call)
+    assert aws.validate_connection()
+
+    def failed_call(cmd: str):
+        return -1, "", "Can't connect"
+
+    aws = AWSResources("Fake_Profile", failed_call)
+    assert not aws.validate_connection()
+
+
+def test_list_role_policies():
+    command_return = """
+{
+    "PolicyNames": [
+        "Policy1",
+        "Policy2",
+        "Policy3"
+    ],
+    "IsTruncated": false
+}
+
+    """
+
+    def command_call(cmd: str):
+        return 0, command_return, ""
+
+    aws = AWSResources("Fake_Profile", command_call)
+    role_policies = list(aws.list_role_policies("fake_role"))
+    assert role_policies == ["Policy1", "Policy2", "Policy3"]
+
+
+def test_list_attached_policies_in_role():
+    command_return = """
+{
+    "AttachedPolicies": [
+        {
+            "PolicyName": "Policy1",
+            "PolicyArn": "arn:aws:iam::aws:policy/Policy1"
+        },
+        {
+            "PolicyName": "Policy2",
+            "PolicyArn": "arn:aws:iam::aws:policy/Policy2"
+        }
+    ],
+    "IsTruncated": false
+}
+
+    """
+
+    def command_call(cmd: str):
+        return 0, command_return, ""
+
+    aws = AWSResources("Fake_Profile", command_call)
+    role_policies = list(aws.list_attached_policies_in_role("fake_role"))
+    assert role_policies == ["arn:aws:iam::aws:policy/Policy1", "arn:aws:iam::aws:policy/Policy2"]
+
+
+def test_get_role_policy():
+    get_role_policy_return = """
+{
+    "RoleName": "Role",
+    "PolicyName": "Policy",
+    "PolicyDocument": {
+        "Version": "2024-01-01",
+        "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:GetObject",
+                        "s3:DeleteObject",
+                        "s3:PutObjectAcl",
+                        "s3:GetBucketNotification",
+                        "s3:PutBucketNotification"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::bucket1/*",
+                        "arn:aws:s3:::bucket2/*",
+                        "arn:aws:s3:::bucket3/*"
+                    ]
+                }
+        ]
+    }
+}
+
+    """
+
+    get_policy_return = """
+{
+    "Policy": {
+        "PolicyName": "policy",
+        "PolicyId": "1234",
+        "Arn": "arn:aws:iam::12345:policy/policy",
+        "Path": "/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 1,
+        "PermissionsBoundaryUsageCount": 0,
+        "IsAttachable": true,
+        "Description": "Policy Description",
+        "CreateDate": "2024-01-01T00:00:00+00:00",
+        "UpdateDate": "2024-01-01T00:00:00+00:00",
+        "Tags": []
+    }
+}
+    """
+
+    get_policy_version_return = """
+{
+    "PolicyVersion": {
+        "Document": {
+            "Version": "V1",
+            "Statement": [
+                {
+                    "Sid": "Permit",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:GetObject",
+                        "s3:DeleteObject",
+                        "s3:PutObjectAcl",
+                        "s3:GetBucketNotification",
+                        "s3:PutBucketNotification"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::bucketA/*",
+                        "arn:aws:s3:::bucketB/*",
+                        "arn:aws:s3:::bucketC/*"
+                    ]
+                }
+            ]
+        },
+        "VersionId": "v3",
+        "IsDefaultVersion": true,
+        "CreateDate": "2024-01-01T00:00:00+00:00"
+    }
+}
+    """
+
+    def command_call(cmd: str):
+        if cmd.startswith("aws iam get-role-policy"):
+            return 0, get_role_policy_return, ""
+        elif cmd.startswith("aws iam get-policy"):
+            return 0, get_policy_return, ""
+        elif cmd.startswith("aws iam get-policy-version"):
+            return 0, get_policy_version_return, ""
+        else:
+            return -1, "", "Error"
+
+    aws = AWSResources("Fake_Profile", command_call)
+    role_policy = list(aws.get_role_policy("fake_role", policy_name="fake_policy"))
+    assert role_policy == [
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucket1",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucket2",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucket3",
+        ),
+    ]
+
+    role_policy = list(aws.get_role_policy("fake_role", attached_policy_arn="arn:aws:iam::12345:policy/policy"))
+    assert role_policy == [
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucketA",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucketB",
+        ),
+        AWSPolicyAction(
+            resource_type="s3",
+            action={"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:PutObjectAcl"},
+            resource_path="bucketC",
+        ),
+    ]

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -1,17 +1,6 @@
 import logging
-from unittest.mock import create_autospec
 
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.compute import InstanceProfile
-
-from databricks.labs.ucx.assessment.aws import (
-    AWSInstanceProfile,
-    AWSInstanceProfileCrawler,
-    AWSPolicyAction,
-    AWSResources,
-)
-
-from ..framework.mocks import MockBackend
+from databricks.labs.ucx.assessment.aws import AWSPolicyAction, AWSResources
 
 logger = logging.getLogger(__name__)
 
@@ -214,5 +203,3 @@ def test_get_role_policy():
             resource_path="bucketC",
         ),
     ]
-
-

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -2,6 +2,7 @@ import logging
 from typing import BinaryIO
 from unittest.mock import create_autospec
 
+import pytest
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 from databricks.sdk.service.compute import InstanceProfile
@@ -12,6 +13,7 @@ from databricks.labs.ucx.assessment.aws import (
     AWSPolicyAction,
     AWSResourcePermissions,
     AWSResources,
+    run_command,
 )
 
 logger = logging.getLogger(__name__)
@@ -360,3 +362,10 @@ def test_empty_mapping(caplog):
     aws_resource_permissions = AWSResourcePermissions(ws, aws)
     aws_resource_permissions.save_instance_profile_permissions()
     assert "No Mapping" in caplog.messages[0]
+
+
+def test_command(caplog):
+    return_code, output, error = run_command("echo success")
+    assert return_code == 0
+    with pytest.raises(FileNotFoundError) as exception:
+        run_command("no_way_this_command_would_work")

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 from typing import BinaryIO
 from unittest.mock import create_autospec
 
@@ -10,7 +11,7 @@ from databricks.sdk.service.workspace import ImportFormat, Language
 from databricks.labs.ucx.assessment.aws import (
     AWSPolicyAction,
     AWSResourcePermissions,
-    AWSResources,
+    AWSResources, run_command,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -163,11 +163,11 @@ def test_get_role_policy():
     """
 
     def command_call(cmd: str):
-        if cmd.startswith("aws iam get-role-policy"):
+        if "iam get-role-policy" in cmd:
             return 0, get_role_policy_return, ""
-        elif cmd.startswith("aws iam get-policy "):
+        elif "iam get-policy " in cmd:
             return 0, get_policy_return, ""
-        elif cmd.startswith("aws iam get-policy-version"):
+        elif "iam get-policy-version" in cmd:
             return 0, get_policy_version_return, ""
         else:
             return -1, "", "Error"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -31,7 +31,7 @@ from databricks.labs.ucx.installer import Installation
 def test_workflow(caplog):
     w = create_autospec(WorkspaceClient)
     with patch(
-        "databricks.labs.ucx.install.WorkspaceInstaller.latest_job_status", return_value=[{"key": "dummy"}]
+            "databricks.labs.ucx.install.WorkspaceInstaller.latest_job_status", return_value=[{"key": "dummy"}]
     ) as latest_job_status:
         workflows(w)
         assert caplog.messages == ["Fetching deployed jobs..."]
@@ -99,7 +99,7 @@ def test_skip_no_ucx(caplog, mocker):
 
 def test_sync_workspace_info():
     with patch("databricks.labs.ucx.account.AccountWorkspaces.sync_workspace_info", return_value=None) as s, patch(
-        "databricks.labs.ucx.account.AccountWorkspaces.__init__", return_value=None
+            "databricks.labs.ucx.account.AccountWorkspaces.__init__", return_value=None
     ):
         sync_workspace_info(create_autospec(AccountClient))
         s.assert_called_once()
@@ -126,8 +126,8 @@ def test_validate_external_locations(mocker):
     # test save_as_terraform_definitions_on_workspace is called
     # also test if the saving tf scripts returns None
     with patch(
-        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-        return_value=None,
+            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+            return_value=None,
     ) as s, patch("webbrowser.open") as w:
         validate_external_locations(w)
         s.assert_called_once()
@@ -135,16 +135,16 @@ def test_validate_external_locations(mocker):
     # test when tf scripts is written and user confirmed to open it over browser
     path = "dummy/external_locations.tf"
     with patch(
-        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-        return_value=path,
+            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+            return_value=path,
     ) as s, patch("webbrowser.open") as w, patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True):
         validate_external_locations(w)
         s.assert_called_once()
         w.assert_called_with(f"{w.config.host}/#workspace{path}")
     # test when tf scripts is written but user did not confirm to open it over browser
     with patch(
-        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-        return_value=path,
+            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+            return_value=path,
     ) as s, patch("webbrowser.open") as w, patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=False):
         validate_external_locations(w)
         s.assert_called_once()
@@ -158,7 +158,7 @@ def test_ensure_assessment_run(mocker, caplog):
         assert caplog.messages == [CANT_FIND_UCX_MSG]
 
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-        "databricks.labs.ucx.install.WorkspaceInstaller.validate_and_run", return_value=MagicMock()
+            "databricks.labs.ucx.install.WorkspaceInstaller.validate_and_run", return_value=MagicMock()
     ) as v:
         ensure_assessment_run(w)
         v.assert_called_with("assessment")
@@ -186,12 +186,12 @@ def test_revert_migrated_tables(mocker, caplog):
     w = create_autospec(WorkspaceClient)
     # test with no schema and no table, user confirm to not retry
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-        "databricks.labs.blueprint.tui.Prompts.confirm", return_value=False
+            "databricks.labs.blueprint.tui.Prompts.confirm", return_value=False
     ):
         assert revert_migrated_tables(w, schema=None, table=None) is None
     # test with no schema and no table, user confirm to retry, but no ucx installation found
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=None), patch(
-        "databricks.labs.blueprint.tui.Prompts.confirm", return_value=True
+            "databricks.labs.blueprint.tui.Prompts.confirm", return_value=True
     ):
         assert revert_migrated_tables(w, schema=None, table=None) is None
         assert caplog.messages[0] == CANT_FIND_UCX_MSG
@@ -205,7 +205,7 @@ def test_revert_migrated_tables(mocker, caplog):
         assert caplog.messages[3] == CANT_FIND_UCX_MSG
     # test revert_migrated_tables is executed when revert report print successfully and user confirm
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
+            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -213,7 +213,7 @@ def test_revert_migrated_tables(mocker, caplog):
         r.assert_called_once()
     # test revert_migrated_tables is not executed when revert report print failed
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=False
+            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=False
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -221,7 +221,7 @@ def test_revert_migrated_tables(mocker, caplog):
         r.assert_not_called()
     # test revert_migrated_tables is not executed when revert report print successfully but user does not confirm
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
+            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=False), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -243,7 +243,8 @@ def test_move_no_catalog(mocker, caplog):
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=w.current_user)
     move(w, "", "", "", "", "")
     assert (
-        len([rec.message for rec in caplog.records if "Please enter from_catalog and to_catalog" in rec.message]) == 1
+            len([rec.message for rec in caplog.records if
+                 "Please enter from_catalog and to_catalog" in rec.message]) == 1
     )
 
 
@@ -321,7 +322,7 @@ def test_save_azure_storage_accounts(mocker, caplog):
     w.current_user.me = lambda: iam.User(user_name="foo", groups=[iam.ComplexValue(display="admins")])
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=w.current_user)
     with patch(
-        "databricks.labs.ucx.assessment.azure.AzureResourcePermissions.save_spn_permissions", return_value=None
+            "databricks.labs.ucx.assessment.azure.AzureResourcePermissions.save_spn_permissions", return_value=None
     ) as m:
         save_azure_storage_accounts(w, "test")
         m.assert_called_once()
@@ -375,16 +376,14 @@ def test_save_aws_iam_profiles_no_profile(mocker, caplog):
     assert "AWS Profile is not specified." in caplog.messages[0]
 
 
-def test_save_aws_iam_profiles_no_connection(mocker, caplog):
+def test_save_aws_iam_profiles_no_connection(caplog, mocker):
     w = create_autospec(WorkspaceClient)
     w.current_user.me = lambda: iam.User(user_name="test_user", groups=[iam.ComplexValue(display="admins")])
     mocker.patch("shutil.which", return_value="/path/aws")
-
     pop = create_autospec(subprocess.Popen)
-    pop.communicate.return_value = bytes("message", "utf-8"), bytes("error", "utf-8")
-    pop.returncode = 127
     mocker.patch("subprocess.Popen", return_value=pop)
-
+    pop.communicate.return_value = (bytes("message", "utf-8"), bytes("error", "utf-8"))
+    pop.returncode = 127
     save_aws_iam_profiles(w, aws_profile="profile")
     assert "AWS CLI is not configured properly." in caplog.messages[len(caplog.messages) - 1]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -31,7 +31,7 @@ from databricks.labs.ucx.installer import Installation
 def test_workflow(caplog):
     w = create_autospec(WorkspaceClient)
     with patch(
-            "databricks.labs.ucx.install.WorkspaceInstaller.latest_job_status", return_value=[{"key": "dummy"}]
+        "databricks.labs.ucx.install.WorkspaceInstaller.latest_job_status", return_value=[{"key": "dummy"}]
     ) as latest_job_status:
         workflows(w)
         assert caplog.messages == ["Fetching deployed jobs..."]
@@ -99,7 +99,7 @@ def test_skip_no_ucx(caplog, mocker):
 
 def test_sync_workspace_info():
     with patch("databricks.labs.ucx.account.AccountWorkspaces.sync_workspace_info", return_value=None) as s, patch(
-            "databricks.labs.ucx.account.AccountWorkspaces.__init__", return_value=None
+        "databricks.labs.ucx.account.AccountWorkspaces.__init__", return_value=None
     ):
         sync_workspace_info(create_autospec(AccountClient))
         s.assert_called_once()
@@ -126,8 +126,8 @@ def test_validate_external_locations(mocker):
     # test save_as_terraform_definitions_on_workspace is called
     # also test if the saving tf scripts returns None
     with patch(
-            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-            return_value=None,
+        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+        return_value=None,
     ) as s, patch("webbrowser.open") as w:
         validate_external_locations(w)
         s.assert_called_once()
@@ -135,16 +135,16 @@ def test_validate_external_locations(mocker):
     # test when tf scripts is written and user confirmed to open it over browser
     path = "dummy/external_locations.tf"
     with patch(
-            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-            return_value=path,
+        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+        return_value=path,
     ) as s, patch("webbrowser.open") as w, patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True):
         validate_external_locations(w)
         s.assert_called_once()
         w.assert_called_with(f"{w.config.host}/#workspace{path}")
     # test when tf scripts is written but user did not confirm to open it over browser
     with patch(
-            "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
-            return_value=path,
+        "databricks.labs.ucx.hive_metastore.locations.ExternalLocations.save_as_terraform_definitions_on_workspace",
+        return_value=path,
     ) as s, patch("webbrowser.open") as w, patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=False):
         validate_external_locations(w)
         s.assert_called_once()
@@ -158,7 +158,7 @@ def test_ensure_assessment_run(mocker, caplog):
         assert caplog.messages == [CANT_FIND_UCX_MSG]
 
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-            "databricks.labs.ucx.install.WorkspaceInstaller.validate_and_run", return_value=MagicMock()
+        "databricks.labs.ucx.install.WorkspaceInstaller.validate_and_run", return_value=MagicMock()
     ) as v:
         ensure_assessment_run(w)
         v.assert_called_with("assessment")
@@ -186,12 +186,12 @@ def test_revert_migrated_tables(mocker, caplog):
     w = create_autospec(WorkspaceClient)
     # test with no schema and no table, user confirm to not retry
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-            "databricks.labs.blueprint.tui.Prompts.confirm", return_value=False
+        "databricks.labs.blueprint.tui.Prompts.confirm", return_value=False
     ):
         assert revert_migrated_tables(w, schema=None, table=None) is None
     # test with no schema and no table, user confirm to retry, but no ucx installation found
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=None), patch(
-            "databricks.labs.blueprint.tui.Prompts.confirm", return_value=True
+        "databricks.labs.blueprint.tui.Prompts.confirm", return_value=True
     ):
         assert revert_migrated_tables(w, schema=None, table=None) is None
         assert caplog.messages[0] == CANT_FIND_UCX_MSG
@@ -205,7 +205,7 @@ def test_revert_migrated_tables(mocker, caplog):
         assert caplog.messages[3] == CANT_FIND_UCX_MSG
     # test revert_migrated_tables is executed when revert report print successfully and user confirm
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
+        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -213,7 +213,7 @@ def test_revert_migrated_tables(mocker, caplog):
         r.assert_called_once()
     # test revert_migrated_tables is not executed when revert report print failed
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=False
+        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=False
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=True), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -221,7 +221,7 @@ def test_revert_migrated_tables(mocker, caplog):
         r.assert_not_called()
     # test revert_migrated_tables is not executed when revert report print successfully but user does not confirm
     with patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=MagicMock()), patch(
-            "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
+        "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.print_revert_report", return_value=True
     ), patch("databricks.labs.blueprint.tui.Prompts.confirm", return_value=False), patch(
         "databricks.labs.ucx.hive_metastore.table_migrate.TablesMigrate.revert_migrated_tables", return_value=None
     ) as r:
@@ -243,8 +243,7 @@ def test_move_no_catalog(mocker, caplog):
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=w.current_user)
     move(w, "", "", "", "", "")
     assert (
-            len([rec.message for rec in caplog.records if
-                 "Please enter from_catalog and to_catalog" in rec.message]) == 1
+        len([rec.message for rec in caplog.records if "Please enter from_catalog and to_catalog" in rec.message]) == 1
     )
 
 
@@ -322,7 +321,7 @@ def test_save_azure_storage_accounts(mocker, caplog):
     w.current_user.me = lambda: iam.User(user_name="foo", groups=[iam.ComplexValue(display="admins")])
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=w.current_user)
     with patch(
-            "databricks.labs.ucx.assessment.azure.AzureResourcePermissions.save_spn_permissions", return_value=None
+        "databricks.labs.ucx.assessment.azure.AzureResourcePermissions.save_spn_permissions", return_value=None
     ) as m:
         save_azure_storage_accounts(w, "test")
         m.assert_called_once()
@@ -381,9 +380,12 @@ def test_save_aws_iam_profiles_no_connection(caplog, mocker):
     w.current_user.me = lambda: iam.User(user_name="test_user", groups=[iam.ComplexValue(display="admins")])
     mocker.patch("shutil.which", return_value="/path/aws")
     pop = create_autospec(subprocess.Popen)
-    mocker.patch("subprocess.Popen", return_value=pop)
+
     pop.communicate.return_value = (bytes("message", "utf-8"), bytes("error", "utf-8"))
     pop.returncode = 127
+    mocker.patch("subprocess.Popen.__init__", return_value=None)
+    mocker.patch("subprocess.Popen.__enter__", return_value=pop)
+    mocker.patch("subprocess.Popen.__exit__", return_value=None)
     save_aws_iam_profiles(w, aws_profile="profile")
     assert "AWS CLI is not configured properly." in caplog.messages[len(caplog.messages) - 1]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from unittest.mock import MagicMock, create_autospec, patch
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -381,10 +381,10 @@ def test_save_aws_iam_profiles_no_connection(mocker, caplog):
     mocker.patch("shutil.which", return_value="/path/aws")
 
     pop = create_autospec(subprocess.Popen)
-    pop.communicate.return_value = (bytes("message", "utf-8"), bytes("error", "utf-8"))
+    pop.communicate.return_value = bytes("message", "utf-8"), bytes("error", "utf-8")
     pop.returncode = 127
-    mocker.patch("subprocess.Popen.__init__", return_value=None)
     mocker.patch("subprocess.Popen", return_value=pop)
+
     save_aws_iam_profiles(w, aws_profile="profile")
     assert "AWS CLI is not configured properly." in caplog.messages[len(caplog.messages) - 1]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -379,10 +379,11 @@ def test_save_aws_iam_profiles_no_connection(mocker, caplog):
     w = create_autospec(WorkspaceClient)
     w.current_user.me = lambda: iam.User(user_name="test_user", groups=[iam.ComplexValue(display="admins")])
     mocker.patch("shutil.which", return_value="/path/aws")
-    mocker.patch("subprocess.Popen.__init__", return_value=None)
+
     pop = create_autospec(subprocess.Popen)
     pop.communicate.return_value = (bytes("message", "utf-8"), bytes("error", "utf-8"))
     pop.returncode = 127
+    mocker.patch("subprocess.Popen.__init__", return_value=None)
     mocker.patch("subprocess.Popen", return_value=pop)
     save_aws_iam_profiles(w, aws_profile="profile")
     assert "AWS CLI is not configured properly." in caplog.messages[len(caplog.messages) - 1]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -369,8 +369,9 @@ def test_validate_group_no_ucx(mocker, caplog):
 def test_save_aws_iam_profiles_no_profile(mocker, caplog):
     w = create_autospec(WorkspaceClient)
     w.current_user.me = lambda: iam.User(user_name="test_user", groups=[iam.ComplexValue(display="admins")])
+    mocker.patch("shutil.which", return_value="/path/aws")
     mocker.patch("databricks.labs.ucx.installer.InstallationManager.for_user", return_value=None)
-    os.environ["AWS_DEFAULT_PROFILE"] = ""
+    mocker.patch("os.getenv", return_value=None)
     save_aws_iam_profiles(w)
     assert "AWS Profile is not specified." in caplog.messages[0]
 


### PR DESCRIPTION
## Changes
CLI command to scan service principals and link to all the S3 buckets they have access to.
Genererates a CSV file.

The CSV File has the following format:

```
instance_profile_arn,resource_type,privilege,resource_path,iam_role_arn
arn:aws:iam::12345:instance-profile/role1,s3,READ_FILES,s3://bucket1,arn:aws:iam::12345:role/role1
arn:aws:iam::12345:instance-profile/role1,s3,READ_FILES,s3a://bucket1,arn:aws:iam::12345:role/role1
arn:aws:iam::12345:instance-profile/role1,s3,READ_FILES,s3://bucket2,arn:aws:iam::12345:role/role1
arn:aws:iam::12345:instance-profile/role1,s3,READ_FILES,s3a://bucket2,arn:aws:iam::12345:role/role1

```

The command relies on AWS CLI Command and require the user to setup and configure it.
Requires a working setup of AWS CLI.
[AWS CLI](https://aws.amazon.com/cli/)
The command saves a CSV to the UCX installation folder with the mapping.

The user has to be authenticated with AWS and the have the permissions to browse the resources and iam services.
More information can be found here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/access_permissions-required.html





### Linked issues
closes #338 


### Functionality 

- [ ] added relevant user documentation
- [x] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
