### PR TITLE
Installation checks if either configs ("enableProjectTypeInWorkspace", "enableWorkspaceFilesystem") are 'false' and makes them 'true' for valid installation

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -368,6 +368,7 @@ class WorkspaceInstallation:
 
     def run(self):
         logger.info(f"Installing UCX v{PRODUCT_INFO.version()}")
+        self._enable_files_in_repos()
         Threads.strict(
             "installing components",
             [
@@ -962,7 +963,7 @@ class WorkspaceInstallation:
         if not self.validate_step(step):
             self.run_workflow(step)
 
-    def enable_files_in_repos(self):
+    def _enable_files_in_repos(self):
         # check if "enableProjectTypeInWorkspace" and "enableWorkspaceFilesystem" are set to false
         project_type = self._ws.workspace_conf.get_status("enableProjectTypeInWorkspace")
         workspace_file_system = self._ws.workspace_conf.get_status("enableWorkspaceFilesystem")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -975,7 +975,7 @@ class WorkspaceInstallation:
 
         if workspace_file_system["enableWorkspaceFilesystem"] == "false":
             logger.debug("enableWorkspaceFilesystem is False, enabling the config")
-            self._ws.workspace_conf.set_status("enableWorkspaceFileSystem")
+            self._ws.workspace_conf.set_status("enableWorkspaceFilesystem")
 
 
 if __name__ == "__main__":

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -962,6 +962,21 @@ class WorkspaceInstallation:
         if not self.validate_step(step):
             self.run_workflow(step)
 
+    def enable_files_in_repos(self):
+        # check if "enableProjectTypeInWorkspace" and "enableWorkspaceFilesystem" are set to false
+        project_type = self._ws.workspace_conf.get_status("enableProjectTypeInWorkspace")
+        workspace_file_system = self._ws.workspace_conf.get_status("enableWorkspaceFilesystem")
+
+        logger.debug("Checking Files In Repos configuration")
+
+        if project_type["enableProjectTypeInWorkspace"] == "false":
+            logger.debug("enableProjectTypeInWorkspace is False, enabling the config")
+            self._ws.workspace_conf.set_status("enableProjectTypeInWorkspace")
+
+        if workspace_file_system["enableWorkspaceFilesystem"] == "false":
+            logger.debug("enableWorkspaceFilesystem is False, enabling the config")
+            self._ws.workspace_conf.set_status("enableWorkspaceFileSystem")
+
 
 if __name__ == "__main__":
     logger = get_logger(__file__)

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -310,3 +310,12 @@ def test_uninstallation(ws, sql_backend, new_installation):
         ws.jobs.get(job_id=assessment_job_id)
     with pytest.raises(NotFound):
         sql_backend.execute(f"show tables from hive_metastore.{install.config.inventory_database}")
+
+
+def test_files_in_repos_enablement(new_installation):
+    try:
+        install = new_installation()
+        install.uninstall()
+    except NotFound as e:
+        raise AssertionError() from e
+    assert True

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1076,5 +1076,5 @@ def test_enable_files_in_repos(ws, mock_installation, any_prompt, mocker):
         timedelta(seconds=1),
     )
 
-    workspace_installation.enable_files_in_repos()
+    workspace_installation._enable_files_in_repos()
     assert True


### PR DESCRIPTION
## Changes
Installation fails if either of the configs ("enableProjectTypeInWorkspace", "enableWorkspaceFilesystem") are 'false'. Checks the two configs via API and sets them to "true" if they are "false". 

### Linked issues

Resolves #576

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)


Using SDK for getting and setting conf values blocked by https://github.com/databricks/databricks-sdk-py/issues/500