### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Version changelog
 
+## 0.11.0
+
+* Added `databricks labs ucx alias` command to create a view of tables from one schema/catalog in another schema/catalog ([#837](https://github.com/databrickslabs/ucx/pull/837)).
+* Added `databricks labs ucx save-aws-iam-profiles` command to scan instance profiles identify AWS S3 access and save a CSV with permissions ([#817](https://github.com/databrickslabs/ucx/pull/817)).
+* Added total view counts in the assessment dashboard ([#834](https://github.com/databrickslabs/ucx/pull/834)).
+* Cleaned up `assess_jobs` and `assess_clusters` tasks in the `assessment` workflow to improve testing and reduce redundancy.([#825](https://github.com/databrickslabs/ucx/pull/825)).
+* Added documentation for the assessment report ([#806](https://github.com/databrickslabs/ucx/pull/806)).
+* Fixed escaping for SQL object names ([#836](https://github.com/databrickslabs/ucx/pull/836)).
+
+Dependency updates:
+
+ * Updated databricks-sdk requirement from ~=0.17.0 to ~=0.18.0 ([#832](https://github.com/databrickslabs/ucx/pull/832)).
+
 ## 0.10.0
 
 * Added `databricks labs ucx validate-groups-membership` command to validate groups to see if they have same membership across acount and workspace level ([#772](https://github.com/databrickslabs/ucx/pull/772)).

--- a/src/databricks/labs/ucx/__about__.py
+++ b/src/databricks/labs/ucx/__about__.py
@@ -1,2 +1,2 @@
 # DO NOT MODIFY THIS FILE
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION

* Added `databricks labs ucx alias` command to create a view of tables from one schema/catalog in another schema/catalog ([#837](https://github.com/databrickslabs/ucx/pull/837)).
* Added `databricks labs ucx save-aws-iam-profiles` command to scan instance profiles identify AWS S3 access and save a CSV with permissions ([#817](https://github.com/databrickslabs/ucx/pull/817)).
* Added total view counts in the assessment dashboard ([#834](https://github.com/databrickslabs/ucx/pull/834)).
* Cleaned up `assess_jobs` and `assess_clusters` tasks in the `assessment` workflow to improve testing and reduce redundancy.([#825](https://github.com/databrickslabs/ucx/pull/825)).
* Added documentation for the assessment report ([#806](https://github.com/databrickslabs/ucx/pull/806)).
* Fixed escaping for SQL object names ([#836](https://github.com/databrickslabs/ucx/pull/836)).

Dependency updates:

 * Updated databricks-sdk requirement from ~=0.17.0 to ~=0.18.0 ([#832](https://github.com/databrickslabs/ucx/pull/832)).

