### PR TITLE
Changed default UCX installation folder to `/Applications/ucx` from `/Users/<me>/.ucx` to allow multiple users users utilising the same installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
 * [Installation](#installation)
   * [Authenticate Databricks CLI](#authenticate-databricks-cli)
   * [Install UCX](#install-ucx)
+  * [[ADVANCED] Force install over existing UCX](#advanced-force-install-over-existing-ucx)
   * [Upgrading UCX for newer versions](#upgrading-ucx-for-newer-versions)
   * [Uninstall UCX](#uninstall-ucx)
 * [Migration process](#migration-process)
@@ -143,8 +144,6 @@ databricks labs install ucx
 ```
 
 [[back to top](#databricks-labs-ucx)]
-
-
 
 ## Upgrading UCX for newer versions
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,20 @@ If there is an existing global installation of UCX, you can force a user install
 
 At this moment there is no global override over a user installation of UCX. As this requires migration and can break existing installations.
 
-Example:
-```commandline
-export UCX_FORCE_INSTALL="user"
-databricks labs install ucx 
-```
+
+| global | user | expected install location | install_folder | mode |
+| --- | --- | --- | --- |--- |
+| no | no | default | `/Applications/ucx` | install |
+| yes | no | default | `/Applications/ucx` | upgrade |
+| no | yes | default | `/Users/X/.ucx` | upgrade (existing installations must not break) |
+| yes | yes | default | `/Users/X/.ucx` | upgrade |
+| yes | no | **USER** | `/Users/X/.ucx` | install (show prompt) |
+| no | yes | **GLOBAL** | ...  | migrate |
+
+
+* `UCX_FORCE_INSTALL=user databricks labs install ucx` - will force the installation to be for user only
+* `UCX_FORCE_INSTALL=global databricks labs install ucx` - will force the installation to be for root only
+
 
 [[back to top](#databricks-labs-ucx)]
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ You can also install a specific version by specifying it like `@v0.13.2` - `data
 
 [[back to top](#databricks-labs-ucx)]
 
+## [ADVANCED] Force install over existing UCX
+Using an environment variable `UCX_FORCE_INSTALL` you can force the installation of UCX over an existing installation.
+The values for the environment variable are 'global' and 'user'.
+
+Global Install: When UCX is installed at '/Applications/ucx'
+User Install: When UCX is installed at '/Users/<user>/.ucx'
+
+If there is an existing global installation of UCX, you can force a user installation of UCX over the existing installation by setting the environment variable `UCX_FORCE_INSTALL` to 'global'.
+
+At this moment there is no global override over a user installation of UCX. As this requires migration and can break existing installations.
+
+Example:
+```commandline
+export UCX_FORCE_INSTALL="user"
+databricks labs install ucx 
+```
+
+[[back to top](#databricks-labs-ucx)]
+
+
+
 ## Upgrading UCX for newer versions
 
 Verify that UCX is installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = ["databricks-sdk~=0.21.0",
-                "databricks-labs-blueprint~=0.3.1",
+                "databricks-labs-blueprint~=0.4.0",
                 "PyYAML>=6.0.0,<7.0.0"]
 
 [project.entry-points.databricks]

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -187,7 +187,6 @@ class WorkspaceInstaller:
         wheel_builder_factory: Callable[[], WheelsV2] | None = None,
     ):
         logger.info(f"Installing UCX v{PRODUCT_INFO.version()}")
-        self._get_existing_database_names()
         config = self.configure()
         if not sql_backend_factory:
             sql_backend_factory = self._new_sql_backend
@@ -244,6 +243,8 @@ class WorkspaceInstaller:
         if inventory_database in self._existing_database_names:
             raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
 
+        if self._check_inventory_database_exists(inventory_database):
+            raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
 
         # If there is a previous installation, return corresponding WorkspaceConfig
         # Else configure will create WorkspaceConfig for a fresh install

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -171,7 +171,13 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
 
 
 class WorkspaceInstaller:
-    def __init__(self, prompts: Prompts, installation: Installation, ws: WorkspaceClient):
+    def __init__(
+        self,
+        prompts: Prompts,
+        installation: Installation,
+        ws: WorkspaceClient,
+        product_info: str = PRODUCT_INFO.product_name(),
+    ):
         if "DATABRICKS_RUNTIME_VERSION" in os.environ:
             msg = "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"
             raise SystemExit(msg)
@@ -328,6 +334,7 @@ class WorkspaceInstallation:
         ws: WorkspaceClient,
         prompts: Prompts,
         verify_timeout: timedelta,
+        product_info: str = PRODUCT_INFO.product_name(),
     ):
         self._config = config
         self._installation = installation
@@ -338,6 +345,7 @@ class WorkspaceInstallation:
         self._verify_timeout = verify_timeout
         self._state = InstallState.from_installation(installation)
         self._this_file = Path(__file__)
+        self._product_info = product_info
 
     @classmethod
     def current(cls, ws: WorkspaceClient):
@@ -347,7 +355,8 @@ class WorkspaceInstallation:
         wheels = WheelsV2(installation, PRODUCT_INFO)
         prompts = Prompts()
         timeout = timedelta(minutes=2)
-        return WorkspaceInstallation(config, installation, sql_backend, wheels, ws, prompts, timeout)
+        product_info = ProductInfo(__file__).product_name()
+        return WorkspaceInstallation(config, installation, sql_backend, wheels, ws, prompts, timeout, product_info)
 
     @property
     def config(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -390,6 +390,7 @@ class WorkspaceInstallation:
         )
         dash.create_dashboards()
 
+
     def run_workflow(self, step: str):
         job_id = int(self._state.jobs[step])
         logger.debug(f"starting {step} job: {self._ws.config.host}#job/{job_id}")
@@ -955,6 +956,18 @@ class WorkspaceInstallation:
     def validate_and_run(self, step: str):
         if not self.validate_step(step):
             self.run_workflow(step)
+
+    def check_installation_conflicts(self, inventory_database) -> bool:
+        logger.info("Checking current installations....")
+        installation_manager = InstallationManager(self._ws)
+        logger.info("Fetching installations...")
+        all_users = [_.as_summary() for _ in installation_manager.user_installations()]
+
+        for user in all_users:
+            if inventory_database == user['database']:
+                return True
+
+        return False
 
 
 if __name__ == "__main__":

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -957,18 +957,6 @@ class WorkspaceInstallation:
         if not self.validate_step(step):
             self.run_workflow(step)
 
-    def check_installation_conflicts(self, inventory_database) -> bool:
-        logger.info("Checking current installations....")
-        installation_manager = InstallationManager(self._ws)
-        logger.info("Fetching installations...")
-        all_users = [_.as_summary() for _ in installation_manager.user_installations()]
-
-        for user in all_users:
-            if inventory_database == user['database']:
-                return True
-
-        return False
-
 
 if __name__ == "__main__":
     logger = get_logger(__file__)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -994,6 +994,6 @@ if __name__ == "__main__":
     logger.setLevel("INFO")
     app = ProductInfo.from_class(WorkspaceConfig)
     workspace_client = WorkspaceClient(product="ucx", product_version=__version__)
-    current = app.current_installation(workspace_client)
+    current = Installation.assume_global(workspace_client, app.product_name())
     installer = WorkspaceInstaller(Prompts(), current, workspace_client, app)
     installer.run()

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -390,7 +390,6 @@ class WorkspaceInstallation:
         )
         dash.create_dashboards()
 
-
     def run_workflow(self, step: str):
         job_id = int(self._state.jobs[step])
         logger.debug(f"starting {step} job: {self._ws.config.host}#job/{job_id}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from databricks.labs.blueprint.entrypoint import get_logger
-from databricks.labs.blueprint.installation import Installation
+from databricks.labs.blueprint.installation import Installation, NotInstalled
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.parallel import ManyError, Threads
 from databricks.labs.blueprint.tui import Prompts
@@ -187,6 +187,7 @@ class WorkspaceInstaller:
         wheel_builder_factory: Callable[[], WheelsV2] | None = None,
     ):
         logger.info(f"Installing UCX v{PRODUCT_INFO.version()}")
+        self._get_existing_database_names()
         config = self.configure()
         if not sql_backend_factory:
             sql_backend_factory = self._new_sql_backend
@@ -266,7 +267,6 @@ class WorkspaceInstaller:
             is_terraform_used=is_terraform_used,
             include_databases=self._select_databases(),
         )
-        self._installation = Installation(self._ws, PRODUCT_INFO.product_name(), install_folder=self._install_location)
         self._installation.save(config)
         ws_file_url = self._installation.workspace_link(config.__file__)
         if self._prompts.confirm(f"Open config file in the browser and continue installing? {ws_file_url}"):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -261,15 +261,12 @@ class WorkspaceInstaller:
     def _configure_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
         HiveMetastoreLineageEnabler(self._ws).apply(self._prompts)
-
         inventory_database = self._prompts.question(
             "Inventory Database stored in hive_metastore", default="ucx", valid_regex=r"^\w+$"
         )
-
         warehouse_id = self._configure_warehouse()
         configure_groups = ConfigureGroups(self._prompts)
         configure_groups.run()
-
         log_level = self._prompts.question("Log level", default="INFO").upper()
         num_threads = int(self._prompts.question("Number of threads", default="8", valid_number=True))
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import databricks.sdk.errors
 from databricks.labs.blueprint.entrypoint import get_logger
-from databricks.labs.blueprint.installation import Installation, NotInstalled
+from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.parallel import ManyError, Threads
 from databricks.labs.blueprint.tui import Prompts

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -235,22 +235,29 @@ class WorkspaceInstaller:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
         HiveMetastoreLineageEnabler(self._ws).apply(self._prompts)
 
+        # TODO adjust this to the new installation logic
+        # # If there is a previous installation, return corresponding WorkspaceConfig
+        # # Else configure will create WorkspaceConfig for a fresh install
+        # type_of_installation = "new"
+        #
+        # if self._is_global() or self._is_user():
+        #     # no global or user installation then default install location is global
+        #     self._installation, type_of_installation = self._get_existing_installation()
+        #
+        # if type_of_installation != "new":
+        #     return self._installation.load(WorkspaceConfig)
+
         inventory_database = self._prompts.question(
             "Inventory Database stored in hive_metastore", default="ucx", valid_regex=r"^\w+$"
         )
+        #
+        # if self._check_inventory_database_exists(inventory_database):
+        #     raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
 
         warehouse_id = self._configure_warehouse()
-        if inventory_database in self._existing_database_names:
-            raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
 
-        if self._check_inventory_database_exists(inventory_database):
-            raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
-
-        # If there is a previous installation, return corresponding WorkspaceConfig
-        # Else configure will create WorkspaceConfig for a fresh install
-        if self._is_global() or self._is_user():
-            # no global or user installation then default install location is global
-            return self._get_existing_installation()
+        logger.info("Please answer a couple of questions to configure Unity Catalog migration")
+        HiveMetastoreLineageEnabler(self._ws).apply(self._prompts)
 
         def warehouse_type(_):
             return _.warehouse_type.value if not _.enable_serverless_compute else "SERVERLESS"

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -266,6 +266,7 @@ class WorkspaceInstaller:
             is_terraform_used=is_terraform_used,
             include_databases=self._select_databases(),
         )
+        self._installation = Installation(self._ws, PRODUCT_INFO.product_name(), install_folder=self._install_location)
         self._installation.save(config)
         ws_file_url = self._installation.workspace_link(config.__file__)
         if self._prompts.confirm(f"Open config file in the browser and continue installing? {ws_file_url}"):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -188,6 +188,7 @@ class WorkspaceInstaller:
         self._prompts = prompts
         self._policy_installer = ClusterPolicyInstaller(installation, ws, prompts)
         self._product_info = product_info
+        self._force_install = environ.get("UCX_FORCE_INSTALL")
 
     def run(
         self,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -235,8 +235,6 @@ class WorkspaceInstaller:
     def _configure_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
         HiveMetastoreLineageEnabler(self._ws).apply(self._prompts)
-        me = self._ws.current_user.me()
-        product = PRODUCT_INFO.product_name()
 
         inventory_database = self._prompts.question(
             "Inventory Database stored in hive_metastore", default="ucx", valid_regex=r"^\w+$"
@@ -245,6 +243,13 @@ class WorkspaceInstaller:
         warehouse_id = self._configure_warehouse()
         if inventory_database in self._existing_database_names:
             raise RuntimeWarning(f"Inventory database with name {inventory_database} already exists")
+
+
+        # If there is a previous installation, return corresponding WorkspaceConfig
+        # Else configure will create WorkspaceConfig for a fresh install
+        if self._is_global() or self._is_user():
+            # no global or user installation then default install location is global
+            return self._get_existing_installation()
 
         def warehouse_type(_):
             return _.warehouse_type.value if not _.enable_serverless_compute else "SERVERLESS"
@@ -990,6 +995,6 @@ if __name__ == "__main__":
     logger.setLevel("INFO")
 
     workspace_client = WorkspaceClient(product="ucx", product_version=__version__)
-    current = Installation(workspace_client, PRODUCT_INFO.product_name())
+    current = Installation(workspace_client, PRODUCT_INFO.product_name(), install_folder='/Applications/ucx')
     installer = WorkspaceInstaller(Prompts(), current, workspace_client)
     installer.run()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -322,3 +322,12 @@ def test_uninstallation(ws, sql_backend, new_installation):
         ws.jobs.get(job_id=assessment_job_id)
     with pytest.raises(NotFound):
         sql_backend.execute(f"show tables from hive_metastore.{install.config.inventory_database}")
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
+def test_single_user_installation(ws, sql_backend, new_installation):
+    install_single_user = new_installation(single_user_install=True)
+    install_single_user.uninstall()
+
+    install_workspace_root = new_installation(single_user_install=False)
+    install_workspace_root.uninstall()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -325,9 +325,12 @@ def test_uninstallation(ws, sql_backend, new_installation):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-def test_single_user_installation(ws, sql_backend, new_installation):
+def test_single_user_installation(new_installation):
     install_single_user = new_installation(single_user_install=True)
     install_single_user.uninstall()
 
+
+# @retried(on=[NotFound], timeout=timedelta(minutes=5))
+def test_workspace_root_installation(new_installation):
     install_workspace_root = new_installation(single_user_install=False)
     install_workspace_root.uninstall()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -61,7 +61,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
         if single_user_install:
             workspace_start_path = f"/Users/{ws.current_user.me().user_name}/.{prefix}"
         else:
-            workspace_start_path = f"/.{prefix}"
+            workspace_start_path = f"/Applications/.{prefix}"
         default_cluster_id = env_or_skip("TEST_DEFAULT_CLUSTER_ID")
         tacl_cluster_id = env_or_skip("TEST_LEGACY_TABLE_ACL_CLUSTER_ID")
         Threads.strict(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -46,6 +46,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
             single_user_install: bool = False,
             fresh_install: bool = True,
             existing_installation_prefix_as_product: str = '',
+            force_prompt_confirmation='no',
     ):
         prefix = make_random(4)
         PRODUCT_INFO.product_name = MagicMock()
@@ -57,7 +58,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
             ucx_install_path = f"/Applications/{prefix}"
             single_user_prompt_response = "no"
 
-        if not fresh_install:
+        if not fresh_install and force_prompt_confirmation == "no":
             PRODUCT_INFO.product_name.return_value = existing_installation_prefix_as_product
 
         renamed_group_prefix = f"rename-{prefix}-"
@@ -73,6 +74,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
                 r".*Inventory Database.*": inventory_schema,
                 r".*Backup prefix*": renamed_group_prefix,
                 r"Do you want to install for a single user?": single_user_prompt_response,
+                r".*UCX is already installed on this workspace.*": force_prompt_confirmation,
                 r".*": "",
             }
         )
@@ -91,7 +93,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
         installer = WorkspaceInstaller(prompts, installation, ws)
         workspace_config = installer.configure()
 
-        if not fresh_install:
+        if not fresh_install and force_prompt_confirmation == 'no':
             installation = Installation.current(ws, existing_installation_prefix_as_product)
 
         overrides = {"main": default_cluster_id, "tacl": tacl_cluster_id}
@@ -374,22 +376,63 @@ def test_global_installation_on_existing_global_install(ws, new_installation):
 
 
 def test_user_installation_on_existing_global_install(ws, new_installation):
-    # TODO: Finish up the initial install and then pass the prefix
+    # existing install at global level
     existing_global_installation = new_installation(single_user_install=False)
     mock_product_value = existing_global_installation.folder[-4:]
-    reinstall_user = new_installation(single_user_install=False,
-                                        fresh_install=False,
-                                        existing_installation_prefix_as_product=mock_product_value)
+
+    # reinstall at user level should update global install
+    reinstall_user = new_installation(single_user_install=True,
+                                      fresh_install=False,
+                                      existing_installation_prefix_as_product=mock_product_value)
+
+    # environment variable to force user install
+    os.environ['UCX_FORCE_INSTALL'] = "user"
+
+    # warning to be thrown by installer if override environment variable present but no confirmation
+    with pytest.raises(RuntimeWarning):
+        new_installation(single_user_install=True,
+                                                fresh_install=False,
+                                                existing_installation_prefix_as_product=mock_product_value,
+                                                )
+
+    # successful override with confirmation
+    reinstall_user_force = new_installation(single_user_install=True,
+                                            fresh_install=False,
+                                            existing_installation_prefix_as_product=mock_product_value,
+                                            force_prompt_confirmation='yes'
+                                            )
     reinstall_user.uninstall()
+    reinstall_user_force.uninstall()
     existing_global_installation.uninstall()
 
 
 def test_global_installation_on_existing_user_install(ws, new_installation):
-    # TODO: Finish up the initial install and then pass the prefix
-    existing_global_installation = new_installation(single_user_install=True)
-    mock_product_value = existing_global_installation.folder[-4:]
+    # existing installation at user level
+    existing_user_installation = new_installation(single_user_install=True)
+    mock_product_value = existing_user_installation.folder[-4:]
+
+    # reinstall at global level should update user install without override
     reinstall_global = new_installation(single_user_install=False,
-                                      fresh_install=False,
-                                      existing_installation_prefix_as_product=mock_product_value)
+                                        fresh_install=False,
+                                        existing_installation_prefix_as_product=mock_product_value)
+
+    # environment variable to force user install
+    os.environ['UCX_FORCE_INSTALL'] = "global"
+
+    # warning to be thrown by installer if override environment variable present but no confirmation
+    with pytest.raises(RuntimeWarning):
+        new_installation(single_user_install=False,
+                         fresh_install=False,
+                         existing_installation_prefix_as_product=mock_product_value,
+                         )
+
+    # successful override with confirmation
+    reinstall_global_force = new_installation(single_user_install=False,
+                                              fresh_install=False,
+                                              existing_installation_prefix_as_product=mock_product_value,
+                                              force_prompt_confirmation='yes',
+                                              )
     reinstall_global.uninstall()
+    reinstall_global_force.uninstall()
+    existing_user_installation.uninstall()
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -39,8 +39,9 @@ logger = logging.getLogger(__name__)
 def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random):
     cleanup = []
 
-    def factory(config_transform: Callable[[WorkspaceConfig], WorkspaceConfig] | None = None,
-                single_user_install: bool = True):
+    def factory(
+        config_transform: Callable[[WorkspaceConfig], WorkspaceConfig] | None = None, single_user_install: bool = True
+    ):
         prefix = make_random(4)
         renamed_group_prefix = f"rename-{prefix}-"
         prompts = MockPrompts(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -330,7 +330,7 @@ def test_single_user_installation(new_installation):
     install_single_user.uninstall()
 
 
-# @retried(on=[NotFound], timeout=timedelta(minutes=5))
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_workspace_root_installation(new_installation):
     install_workspace_root = new_installation(single_user_install=False)
     install_workspace_root.uninstall()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -59,9 +59,9 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
         )
         workspace_start_path = f"/Users/{ws.current_user.me().user_name}/.{prefix}"
         if single_user_install:
-            workspace_start_path = f"/Users/{ws.current_user.me().user_name}/.{prefix}"
+            ucx_install_path = f"/Users/{ws.current_user.me().user_name}/.{prefix}"
         else:
-            workspace_start_path = f"/Applications/.{prefix}"
+            ucx_install_path = f"/Applications/{prefix}"
         default_cluster_id = env_or_skip("TEST_DEFAULT_CLUSTER_ID")
         tacl_cluster_id = env_or_skip("TEST_LEGACY_TABLE_ACL_CLUSTER_ID")
         Threads.strict(
@@ -80,7 +80,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
         if config_transform:
             workspace_config = config_transform(workspace_config)
 
-        installation = Installation(ws, prefix, install_folder=workspace_start_path)
+        installation = Installation(ws, prefix, install_folder=ucx_install_path)
         installation.save(workspace_config)
 
         # TODO: see if we want to move building wheel as a context manager for yield factory,

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -360,7 +360,7 @@ def test_uninstallation(ws, sql_backend, new_installation):
         sql_backend.execute(f"show tables from hive_metastore.{install.config.inventory_database}")
 
 
-def test_fresh_global_installation(ws, new_installation):
+def test_fresh_global_installation(new_installation):
     global_installation = new_installation(single_user_install=False)
     global_installation.uninstall()
 
@@ -394,12 +394,13 @@ def test_user_installation_on_existing_global_install(new_installation):
     os.environ['UCX_FORCE_INSTALL'] = "user"
 
     # warning to be thrown by installer if override environment variable present but no confirmation
-    with pytest.raises(RuntimeWarning):
+    with pytest.raises(RuntimeWarning) as err:
         new_installation(
             single_user_install=True,
             fresh_install=False,
             existing_installation_prefix=mock_product_value,
         )
+    assert err.value.args[0] == "Existing global install and user installation override, but no confirmation"
 
     # successful override with confirmation
     reinstall_user_force = new_installation(
@@ -427,12 +428,13 @@ def test_global_installation_on_existing_user_install(new_installation):
     os.environ['UCX_FORCE_INSTALL'] = "global"
 
     # warning to be thrown by installer if override environment variable present but no confirmation
-    with pytest.raises(RuntimeWarning):
+    with pytest.raises(RuntimeWarning) as err:
         new_installation(
             single_user_install=False,
             fresh_install=False,
             existing_installation_prefix=mock_product_value,
         )
+    assert err.value.args[0] == "Existing user install and global installation override, but no confirmation"
 
     # successful override with confirmation
     reinstall_global_force = new_installation(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -5,7 +5,7 @@ import os.path
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import databricks.sdk.errors
 import pytest  # pylint: disable=wrong-import-order
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random):
     cleanup = []
+    ProductInfo = MagicMock()  # pylint: disable=invalid-name
 
     def factory(
         config_transform: Callable[[WorkspaceConfig], WorkspaceConfig] | None = None,
@@ -49,7 +50,7 @@ def new_installation(ws, sql_backend, env_or_skip, inventory_schema, make_random
         force_prompt_confirmation='no',
     ):
         product = make_random(4)
-
+        ProductInfo.product_name.return_value = product
         if not fresh_install:
             product = existing_installation_prefix
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import databricks.sdk.errors
-import pytest
+import pytest  # pylint: disable=wrong-import-order
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.parallel import Threads

--- a/tests/unit/assessment/test_dashboard.py
+++ b/tests/unit/assessment/test_dashboard.py
@@ -4,6 +4,7 @@ from databricks.labs.blueprint.entrypoint import find_project_root
 from databricks.labs.blueprint.installation import MockInstallation
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.tui import Prompts
+from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.sdk.service import iam
 from databricks.sdk.service.sql import (
     Dashboard,
@@ -13,6 +14,7 @@ from databricks.sdk.service.sql import (
     Widget,
 )
 
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.install import WorkspaceInstaller
 
@@ -51,7 +53,7 @@ def test_dashboard(mocker):
     ws.dashboard_widgets.create.return_value = Widget(id="abc")
     ws.warehouses.list.return_value = []
     prompts = create_autospec(Prompts)
-    WorkspaceInstaller(prompts, installation, ws)
+    WorkspaceInstaller(prompts, installation, ws, ProductInfo.from_class(WorkspaceConfig))
     local_query_files = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     dash = DashboardFromFiles(
         ws,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -46,6 +46,7 @@ from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
 
+
 from ..unit.framework.mocks import MockBackend
 
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -46,7 +46,6 @@ from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
 
-
 from ..unit.framework.mocks import MockBackend
 
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -142,6 +142,11 @@ def any_prompt():
     return MockPrompts({".*": ""})
 
 
+def not_found(_):
+    msg = "save_config"
+    raise NotFound(msg)
+
+
 def test_create_database(ws, caplog, mock_installation, any_prompt):
     sql_backend = MockBackend(
         fails_on_first={'CREATE TABLE': '[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable is incorrect'}
@@ -399,10 +404,6 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, any_prompt, mock_in
 
 
 def test_save_config(ws, mock_installation):
-    def not_found(_):
-        msg = "save_config"
-        raise NotFound(msg)
-
     ws.workspace.get_status = not_found
     ws.warehouses.list = lambda **_: [
         EndpointInfo(name="abc", id="abc", warehouse_type=EndpointInfoWarehouseType.PRO, state=State.RUNNING)
@@ -446,6 +447,7 @@ def test_save_config_strip_group_names(ws, mock_installation):
             r".*": "",
         }
     )
+    ws.workspace.get_status = not_found
 
     install = WorkspaceInstaller(prompts, mock_installation, ws)
     install.configure()
@@ -469,7 +471,6 @@ def test_save_config_strip_group_names(ws, mock_installation):
 
 
 def test_create_cluster_policy(ws, mock_installation):
-
     ws.cluster_policies.list.return_value = [
         Policy(
             policy_id="foo1",
@@ -1036,6 +1037,7 @@ def test_open_config(ws, mocker, mock_installation):
             r".*": "",
         }
     )
+    ws.workspace.get_status = not_found
 
     install = WorkspaceInstaller(prompts, mock_installation, ws)
     install.configure()
@@ -1121,3 +1123,4 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
     )
 
     existing_installation.assert_file_uploaded('logs/README.md')
+

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1220,12 +1220,13 @@ def test_get_existing_installation_global(ws, mock_installation):
     workspace_config = install.configure()
     assert workspace_config.inventory_database == 'ucx_global'
 
+    environ = {'UCX_FORCE_INSTALL': 'user'}
+
     # test for force user install variable without prompts
-    with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'user'}):
-        install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO)
-        with pytest.raises(RuntimeWarning) as err:
-            install.configure()
-        assert err.value.args[0] == 'UCX is already installed, but no confirmation'
+    install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO, environ)
+    with pytest.raises(RuntimeWarning) as err:
+        install.configure()
+    assert err.value.args[0] == 'UCX is already installed, but no confirmation'
 
     # test for force user install variable with prompts
     prompts = MockPrompts(
@@ -1239,10 +1240,9 @@ def test_get_existing_installation_global(ws, mock_installation):
             r".*": "",
         }
     )
-    with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'user'}):
-        install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO)
-        workspace_config = install.configure()
-        assert workspace_config.inventory_database == 'ucx_user'
+    install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO, environ)
+    workspace_config = install.configure()
+    assert workspace_config.inventory_database == 'ucx_user'
 
 
 def test_existing_installation_user(ws, mock_installation):
@@ -1286,11 +1286,12 @@ def test_existing_installation_user(ws, mock_installation):
             r".*": "",
         }
     )
-    with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'global'}):
-        install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO)
-        with pytest.raises(RuntimeWarning) as err:
-            install.configure()
-        assert err.value.args[0] == 'UCX is already installed, but no confirmation'
+
+    environ = {'UCX_FORCE_INSTALL': 'global'}
+    install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO, environ)
+    with pytest.raises(RuntimeWarning) as err:
+        install.configure()
+    assert err.value.args[0] == 'UCX is already installed, but no confirmation'
 
     # test for force global install variable with prompts
     prompts = MockPrompts(
@@ -1305,11 +1306,10 @@ def test_existing_installation_user(ws, mock_installation):
         }
     )
 
-    with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'global'}):
-        install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO)
-        with pytest.raises(NotImplemented) as err:
-            install.configure()
-        assert err.value.args[0] == "Migration needed. Not implemented yet."
+    install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO, environ)
+    with pytest.raises(NotImplemented) as err:
+        install.configure()
+    assert err.value.args[0] == "Migration needed. Not implemented yet."
 
 
 def test_databricks_runtime_version_set(ws, mock_installation):
@@ -1319,8 +1319,8 @@ def test_databricks_runtime_version_set(ws, mock_installation):
         }
     )
     product_info = "mock"
+    environ = {'DATABRICKS_RUNTIME_VERSION': "13.3"}
 
-    with patch.dict('os.environ', {'DATABRICKS_RUNTIME_VERSION': "13.3"}):
-        with pytest.raises(SystemExit) as err:
-            WorkspaceInstaller(prompts, mock_installation, ws, product_info)
-        assert err.value.args[0] == "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"
+    with pytest.raises(SystemExit) as err:
+        WorkspaceInstaller(prompts, mock_installation, ws, product_info, environ)
+    assert err.value.args[0] == "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1275,3 +1275,17 @@ def test_existing_installation_user(ws, mock_installation):
         with pytest.raises(NotImplemented) as err:
             install.configure()
         assert err.value.args[0] == "Migration needed. Not implemented yet."
+
+
+def test_databricks_runtime_version_set(ws, mock_installation):
+    prompts = MockPrompts(
+        {
+            r".*": "",
+        }
+    )
+    product_info = "mock"
+
+    with patch.dict('os.environ', {'DATABRICKS_RUNTIME_VERSION': "13.3"}):
+        with pytest.raises(SystemExit) as err:
+            WorkspaceInstaller(prompts, mock_installation, ws, product_info)
+        assert err.value.args[0] == "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1189,6 +1189,7 @@ def test_get_existing_installation_global(ws, mock_installation):
 
     # test for force user install variable without prompts
     with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'user'}):
+        install = WorkspaceInstaller(prompts, installation, ws)
         with pytest.raises(RuntimeWarning) as err:
             install.configure()
         assert err.value.args[0] == 'UCX is already installed, but no confirmation'
@@ -1205,8 +1206,8 @@ def test_get_existing_installation_global(ws, mock_installation):
             r".*": "",
         }
     )
-    install = WorkspaceInstaller(prompts, installation, ws)
     with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'user'}):
+        install = WorkspaceInstaller(prompts, installation, ws)
         workspace_config = install.configure()
         assert workspace_config.inventory_database == 'ucx_user'
 
@@ -1252,8 +1253,8 @@ def test_existing_installation_user(ws, mock_installation):
             r".*": "",
         }
     )
-    install = WorkspaceInstaller(prompts, installation, ws)
     with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'global'}):
+        install = WorkspaceInstaller(prompts, installation, ws)
         with pytest.raises(RuntimeWarning) as err:
             install.configure()
         assert err.value.args[0] == 'UCX is already installed, but no confirmation'
@@ -1270,8 +1271,9 @@ def test_existing_installation_user(ws, mock_installation):
             r".*": "",
         }
     )
-    install = WorkspaceInstaller(prompts, installation, ws)
+
     with patch.dict('os.environ', {'UCX_FORCE_INSTALL': 'global'}):
+        install = WorkspaceInstaller(prompts, installation, ws)
         with pytest.raises(NotImplemented) as err:
             install.configure()
         assert err.value.args[0] == "Migration needed. Not implemented yet."


### PR DESCRIPTION
## [ADVANCED] Force install over existing UCX

Using an environment variable `UCX_FORCE_INSTALL` you can force the installation of UCX over an existing installation.
The values for the environment variable are 'global' and 'user'.

Global Install: When UCX is installed at '/Applications/ucx'
User Install: When UCX is installed at '/Users/<user>/.ucx'

If there is an existing global installation of UCX, you can force a user installation of UCX over the existing installation by setting the environment variable `UCX_FORCE_INSTALL` to 'global'.

At this moment there is no global override over a user installation of UCX. As this requires migration and can break existing installations.


| global | user | expected install location | install_folder | mode |
| --- | --- | --- | --- |--- |
| no | no | default | `/Applications/ucx` | install |
| yes | no | default | `/Applications/ucx` | upgrade |
| no | yes | default | `/Users/X/.ucx` | upgrade (existing installations must not break) |
| yes | yes | default | `/Users/X/.ucx` | upgrade |
| yes | no | **USER** | `/Users/X/.ucx` | install (show prompt) |
| no | yes | **GLOBAL** | ...  | migrate |


* `UCX_FORCE_INSTALL=user databricks labs install ucx` - will force the installation to be for user only
* `UCX_FORCE_INSTALL=global databricks labs install ucx` - will force the installation to be for root only

Related to #803  
