### PR TITLE
Added CLI Command `databricks labs ucx save-uc-compatible-roles`

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -118,3 +118,11 @@ commands:
     flags:
       - name: aws-profile
         description: AWS Profile to use for authentication
+
+  - name: save-uc-compatible-roles
+    description: | 
+      Scan all the AWS roles that are set for UC access and produce a mapping to the S3 resources.
+      Requires a working setup of AWS CLI.
+    flags:
+      - name: aws-profile
+        description: AWS Profile to use for authentication

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -1,6 +1,3 @@
-import csv
-import dataclasses
-import io
 import json
 import logging
 import re
@@ -11,10 +8,10 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import lru_cache, partial
 
+from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.parallel import Threads
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import Privilege
-from databricks.sdk.service.workspace import ImportFormat
 
 logger = logging.getLogger(__name__)
 
@@ -219,26 +216,25 @@ class AWSResources:
 
 
 class AWSResourcePermissions:
-    def __init__(
-        self,
-        ws: WorkspaceClient,
-        aws_resources: AWSResources,
-        folder: str | None = None,
-    ):
-        if not folder:
-            folder = f"/Users/{ws.current_user.me().user_name}/.ucx"
-        self._folder = folder
+    def __init__(self, installation: Installation, ws: WorkspaceClient, aws_resources: AWSResources):
+        self._installation = installation
         self._aws_resources = aws_resources
         self._ws = ws
-        self._field_names = [_.name for _ in dataclasses.fields(AWSRoleAction)]
+
+    @classmethod
+    def for_cli(cls, ws: WorkspaceClient, aws_profile, product='ucx'):
+        installation = Installation.current(ws, product)
+        aws = AWSResources(aws_profile)
+        if not aws.validate_connection():
+            raise ResourceWarning("AWS CLI is not configured properly.")
+        return cls(installation, ws, aws)
 
     def save_uc_compatible_roles(self):
         uc_role_access = list(self._get_role_access())
         if len(uc_role_access) == 0:
             logger.warning("No Mapping Was Generated.")
             return None
-        path = f"{self._folder}/uc_roles_access.csv"
-        return self._save(uc_role_access, path)
+        return self._installation.save(uc_role_access, filename='uc_roles_access.csv')
 
     def _get_instance_profiles(self) -> Iterable[AWSInstanceProfile]:
         instance_profiles = self._ws.instance_profiles.list()
@@ -301,18 +297,4 @@ class AWSResourcePermissions:
         if len(instance_profile_access) == 0:
             logger.warning("No Mapping Was Generated.")
             return None
-        path = f"{self._folder}/aws_instance_profile_info.csv"
-        return self._save(instance_profile_access, path)
-
-    def _overwrite_mapping(self, buffer, path) -> str:
-        self._ws.workspace.upload(path, buffer, overwrite=True, format=ImportFormat.AUTO)
-        return path
-
-    def _save(self, instance_profile_actions: list[AWSRoleAction], path) -> str:
-        buffer = io.StringIO()
-        writer = csv.DictWriter(buffer, self._field_names)
-        writer.writeheader()
-        for instance_profile_action in instance_profile_actions:
-            writer.writerow(dataclasses.asdict(instance_profile_action))
-        buffer.seek(0)
-        return self._overwrite_mapping(buffer, path)
+        return self._installation.save(instance_profile_access, filename='aws_instance_profile_info.csv')

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -119,14 +119,16 @@ class AWSResources:
             if not policy_document:
                 continue
             for statement in policy_document["Statement"]:
-                try:
-                    if statement["Effect"] != "Allow":
-                        continue
-                    if statement["Action"] != "sts:AssumeRole":
-                        continue
-                    principal = statement["Principal"].get("AWS")
-                except KeyError:
+                effect = statement.get("Effect")
+                action = statement.get("Action")
+                principal = statement.get("Principal")
+                if not (effect and action and principal):
                     continue
+                if effect != "Allow":
+                    continue
+                if action != "sts:AssumeRole":
+                    continue
+                principal = principal.get("AWS")
                 if not principal:
                     continue
                 if isinstance(principal, list):

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -72,6 +72,10 @@ class AWSResources:
     S3_ACTIONS: typing.ClassVar[set[str]] = {"s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:PutObjectAcl"}
     S3_READONLY: typing.ClassVar[str] = "s3:GetObject"
     S3_REGEX: typing.ClassVar[str] = r"arn:aws:s3:::([a-zA-Z0-9+=,.@_-]*)\/\*$"
+    UC_MASTER_ROLES_ARN: typing.ClassVar[list[str]] = [
+        "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL",
+        "arn:aws:iam::707343435239:role/unity-catalog-dev-UCMasterRole-G3MMN8SP21FO"
+    ]
 
     def __init__(self, profile: str, command_runner: Callable[[str], tuple[int, str, str]] = run_command):
         self._profile = profile

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -227,7 +227,7 @@ class AWSResourcePermissions:
         self._ws = ws
         self._field_names = [_.name for _ in dataclasses.fields(AWSRoleAction)]
 
-    def save_ucx_compatible_roles(self):
+    def save_uc_compatible_roles(self):
         uc_role_access = list(self._get_role_access())
         if len(uc_role_access) == 0:
             logger.warning("No Mapping Was Generated.")

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -111,10 +111,13 @@ class AWSResources:
         return attached_policies
 
     def list_all_uc_roles(self):
-        list_roles_cmd = f"iam list-roles --profile {self._profile}"
-        roles = self._run_json_command(list_roles_cmd)
+        roles = self._run_json_command(f"iam list-roles --profile {self._profile}")
         uc_roles = []
-        for role in roles["Roles"]:
+        roles = roles.get("Roles")
+        if not roles:
+            logger.warning("list-roles couldn't find any roles")
+            return uc_roles
+        for role in roles:
             policy_document = role.get("AssumeRolePolicyDocument")
             if not policy_document:
                 continue

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -182,6 +182,9 @@ class AWSResourcePermissions:
             raise ResourceWarning("AWS CLI is not configured properly.")
         return cls(installation, ws, aws)
 
+    def save_ucx_compatible_roles(self):
+        pass
+
     def _get_instance_profiles(self) -> Iterable[AWSInstanceProfile]:
         instance_profiles = self._ws.instance_profiles.list()
         result_instance_profiles = []

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -274,7 +274,7 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
 
 
 @ucx.command
-def uc_comaptible_roles(w: WorkspaceClient, *,aws_profile: str | None = None):
+def save_uc_compatible_roles(w: WorkspaceClient, *, aws_profile: str | None = None):
     """identifies all Instance Profiles and map their access to S3 buckets.
     Requires a working setup of AWS CLI.
     https://aws.amazon.com/cli/

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -273,14 +273,10 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     return None
 
 
-if __name__ == "__main__":
-    ucx()
-
-
-
 @ucx.command
 def save_uc_compatible_roles(w: WorkspaceClient, *, aws_profile: str | None = None):
-    """identifies all Instance Profiles and map their access to S3 buckets.
+    """extracts all the iam roles with trust relationships to the UC master role.
+     Map these roles to the S3 buckets they have access to.
     Requires a working setup of AWS CLI.
     https://aws.amazon.com/cli/
     The command saves a CSV to the UCX installation folder with the mapping.
@@ -300,26 +296,8 @@ def save_uc_compatible_roles(w: WorkspaceClient, *, aws_profile: str | None = No
             "or use the '--aws-profile=[profile-name]' parameter."
         )
         return None
-    aws = AWSResources(aws_profile)
-    if not aws.validate_connection():
-        logger.error("AWS CLI is not configured properly.")
-        return None
-
-    installation_manager = InstallationManager(w)
-    installation = installation_manager.for_user(w.current_user.me())
-    if not installation:
-        logger.error(CANT_FIND_UCX_MSG)
-        return None
-
-    if not w.config.is_aws:
-        logger.error("Workspace is not on AWS, please run this command on AWS databricks workspaces.")
-        return None
-
-    aws_pm = AWSResourcePermissions(
-        w,
-        aws,
-    )
-    aws_pm.save_uc_compatible_roles()
+    aws_permissions = AWSResourcePermissions.for_cli(w, aws_profile)
+    aws_permissions.save_uc_compatible_roles()
     return None
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -5,6 +5,7 @@ import webbrowser
 
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
+from databricks.labs.blueprint.installation import Installation, SerdeError
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
@@ -270,6 +271,11 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     aws_permissions = AWSResourcePermissions.for_cli(w, aws_profile)
     aws_permissions.save_instance_profile_permissions()
     return None
+
+
+if __name__ == "__main__":
+    ucx()
+
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -314,7 +314,7 @@ def save_uc_compatible_roles(w: WorkspaceClient, *, aws_profile: str | None = No
         w,
         aws,
     )
-    aws_pm.save_ucx_compatible_roles()
+    aws_pm.save_uc_compatible_roles()
     return None
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -273,5 +273,50 @@ def save_aws_iam_profiles(w: WorkspaceClient, aws_profile: str | None = None):
     return None
 
 
+@ucx.command
+def uc_comaptible_roles(w: WorkspaceClient, *,aws_profile: str | None = None):
+    """identifies all Instance Profiles and map their access to S3 buckets.
+    Requires a working setup of AWS CLI.
+    https://aws.amazon.com/cli/
+    The command saves a CSV to the UCX installation folder with the mapping.
+
+    The user has to be authenticated with AWS and the have the permissions to browse the resources and iam services.
+    More information can be found here:
+    https://docs.aws.amazon.com/IAM/latest/UserGuide/access_permissions-required.html
+    """
+    if not shutil.which("aws"):
+        logger.error("Couldn't find AWS CLI in path.Please obtain and install the CLI from https://aws.amazon.com/cli/")
+        return None
+    if not aws_profile:
+        aws_profile = os.getenv("AWS_DEFAULT_PROFILE")
+    if not aws_profile:
+        logger.error(
+            "AWS Profile is not specified. Use the environment variable [AWS_DEFAULT_PROFILE] "
+            "or use the '--aws-profile=[profile-name]' parameter."
+        )
+        return None
+    aws = AWSResources(aws_profile)
+    if not aws.validate_connection():
+        logger.error("AWS CLI is not configured properly.")
+        return None
+
+    installation_manager = InstallationManager(w)
+    installation = installation_manager.for_user(w.current_user.me())
+    if not installation:
+        logger.error(CANT_FIND_UCX_MSG)
+        return None
+
+    if not w.config.is_aws:
+        logger.error("Workspace is not on AWS, please run this command on AWS databricks workspaces.")
+        return None
+
+    aws_pm = AWSResourcePermissions(
+        w,
+        aws,
+    )
+    aws_pm.save_ucx_compatible_roles()
+    return None
+
+
 if __name__ == "__main__":
     ucx()

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -5,7 +5,6 @@ import webbrowser
 
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
-from databricks.labs.blueprint.installation import Installation, SerdeError
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -5,10 +5,3 @@ def test_aws_validate(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
     assert aws.validate_connection()
-
-
-def test_aws_list_uc_roles(env_or_skip):
-    profile = env_or_skip("AWS_DEFAULT_PROFILE")
-    aws = AWSResources(profile)
-    print(aws.list_all_uc_roles())
-    assert True

--- a/tests/integration/assessment/test_aws.py
+++ b/tests/integration/assessment/test_aws.py
@@ -5,3 +5,10 @@ def test_aws_validate(env_or_skip):
     profile = env_or_skip("AWS_DEFAULT_PROFILE")
     aws = AWSResources(profile)
     assert aws.validate_connection()
+
+
+def test_aws_list_uc_roles(env_or_skip):
+    profile = env_or_skip("AWS_DEFAULT_PROFILE")
+    aws = AWSResources(profile)
+    print(aws.list_all_uc_roles())
+    assert True

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -335,6 +335,93 @@ def test_get_uc_roles():
     ]
 
 
+def test_get_uc_roles_missing_keys():
+    list_roles_return = """
+    {
+        "Roles": [
+            {
+                "Path": "/",
+                "RoleName": "NON-UC-Role",
+                "RoleId": "12345",
+                "Arn": "arn:aws:iam::123456789:role/non-uc-role",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Defect": "Allow",
+                            "Principal": {
+                                "Service": "ec2.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "MaxSessionDuration": 3600
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-1",
+                "RoleId": "12345",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-1",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    "arn:aws:iam::123456789:role/uc-role",
+                                    "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"
+                                ]
+                            },
+                            "Non-Action": "sts:AssumeRole",
+                            "Condition": {
+                                "StringEquals": {
+                                    "sts:ExternalId": "1122334455"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-2",
+                "RoleId": "123456",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-2",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"
+                            },
+                            "Action": "sts:DontAssumeRole",
+                            "Condition": {
+                                "StringEquals": {
+                                    "sts:ExternalId": "1122334466"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    """
+
+    def command_call(cmd: str):
+        return 0, list_roles_return, ""
+
+    aws = AWSResources("Fake_Profile", command_call)
+    uc_roles = aws.list_all_uc_roles()
+    assert not uc_roles
+
+
 def test_save_instance_profile_permissions():
     ws = create_autospec(WorkspaceClient)
     ws.instance_profiles.list.return_value = [

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -1,5 +1,4 @@
 import logging
-from typing import BinaryIO
 from unittest.mock import create_autospec
 
 import pytest
@@ -7,7 +6,6 @@ from databricks.labs.blueprint.installation import MockInstallation
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 from databricks.sdk.service.compute import InstanceProfile
-from databricks.sdk.service.workspace import ImportFormat, Language
 
 from databricks.labs.ucx.assessment.aws import (
     AWSInstanceProfile,
@@ -609,15 +607,6 @@ def test_save_uc_compatible_roles():
     ws = create_autospec(WorkspaceClient)
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
 
-    expected_csv_entries = [
-        "arn:aws:iam::12345:role/uc-role1,s3,READ_FILES,s3://bucket1",
-        "arn:aws:iam::12345:role/uc-role1,s3,READ_FILES,s3://bucket2",
-        "arn:aws:iam::12345:role/uc-role1,s3,READ_FILES,s3://bucket3",
-        "arn:aws:iam::12345:role/uc-role1,s3,WRITE_FILES,s3://bucketA",
-        "arn:aws:iam::12345:role/uc-role1,s3,WRITE_FILES,s3://bucketB",
-        "arn:aws:iam::12345:role/uc-role1,s3,WRITE_FILES,s3://bucketC",
-    ]
-
     aws = create_autospec(AWSResources)
     aws.get_role_policy.side_effect = [
         [
@@ -672,30 +661,46 @@ def test_save_uc_compatible_roles():
     aws_resource_permissions = AWSResourcePermissions(installation, ws, aws)
     aws_resource_permissions.save_uc_compatible_roles()
     installation.assert_file_written(
-        'uc_roles_access.csv', [{'privilege': 'READ_FILES',
-                                  'resource_path': 's3://bucket1',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'},
-                                 {'privilege': 'READ_FILES',
-                                  'resource_path': 's3://bucket2',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'},
-                                 {'privilege': 'READ_FILES',
-                                  'resource_path': 's3://bucket3',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'},
-                                 {'privilege': 'WRITE_FILES',
-                                  'resource_path': 's3://bucketA',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'},
-                                 {'privilege': 'WRITE_FILES',
-                                  'resource_path': 's3://bucketB',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'},
-                                 {'privilege': 'WRITE_FILES',
-                                  'resource_path': 's3://bucketC',
-                                  'resource_type': 's3',
-                                  'role_arn': 'arn:aws:iam::12345:role/uc-role1'}])
+        'uc_roles_access.csv',
+        [
+            {
+                'privilege': 'READ_FILES',
+                'resource_path': 's3://bucket1',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+            {
+                'privilege': 'READ_FILES',
+                'resource_path': 's3://bucket2',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+            {
+                'privilege': 'READ_FILES',
+                'resource_path': 's3://bucket3',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+            {
+                'privilege': 'WRITE_FILES',
+                'resource_path': 's3://bucketA',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+            {
+                'privilege': 'WRITE_FILES',
+                'resource_path': 's3://bucketB',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+            {
+                'privilege': 'WRITE_FILES',
+                'resource_path': 's3://bucketC',
+                'resource_type': 's3',
+                'role_arn': 'arn:aws:iam::12345:role/uc-role1',
+            },
+        ],
+    )
 
 
 def test_role_mismatched(caplog):

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -409,6 +409,89 @@ def test_get_uc_roles_missing_keys():
                         }
                     ]
                 }
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-3",
+                "RoleId": "123456",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-3",
+                "CreateDate": "2024-01-01T00:00:00+00:00"
+
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-4",
+                "RoleId": "123456",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-4",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Effect": "Deny",
+                            "Principal": {
+                                "AWS": "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"
+                            },
+                            "Action": "sts:DontAssumeRole",
+                            "Condition": {
+                                "StringEquals": {
+                                    "sts:ExternalId": "1122334466"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-5",
+                "RoleId": "12345",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-5",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    "arn:aws:iam::123456789:role/uc-role-5",
+                                    "arn:aws:iam::123456789:role/another-role"
+                                ]
+                            },
+                            "Action": "sts:AssumeRole",
+                            "Condition": {
+                                "StringEquals": {
+                                    "sts:ExternalId": "1122334455"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "Path": "/",
+                "RoleName": "uc-role-6",
+                "RoleId": "12345",
+                "Arn": "arn:aws:iam::123456789:role/uc-role-6",
+                "CreateDate": "2024-01-01T00:00:00+00:00",
+                "AssumeRolePolicyDocument": {
+                    "Version": "2024-01-01",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "arn:aws:iam::123456789:role/uc-role-5"
+                            },
+                            "Action": "sts:AssumeRole",
+                            "Condition": {
+                                "StringEquals": {
+                                    "sts:ExternalId": "1122334455"
+                                }
+                            }
+                        }
+                    ]
+                }
             }
         ]
     }
@@ -598,7 +681,16 @@ def test_get_role_policy_missing_role(caplog):
     assert "No role name or attached role ARN specified." in caplog.messages[0]
 
 
-def test_empty_mapping(caplog):
+def test_instance_profiles_empty_mapping(caplog):
+    ws = create_autospec(WorkspaceClient)
+    ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
+    aws = create_autospec(AWSResources)
+    aws_resource_permissions = AWSResourcePermissions(ws, aws)
+    aws_resource_permissions.save_instance_profile_permissions()
+    assert "No Mapping" in caplog.messages[0]
+
+
+def test_uc_roles_empty_mapping(caplog):
     ws = create_autospec(WorkspaceClient)
     ws.instance_profiles.list.return_value = [
         InstanceProfile("arn:aws:iam::12345:instance-profile/role1", "arn:aws:iam::12345:role/role1")
@@ -606,7 +698,7 @@ def test_empty_mapping(caplog):
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(ws, aws)
-    aws_resource_permissions.save_instance_profile_permissions()
+    aws_resource_permissions.save_uc_compatible_roles()
     assert "No Mapping" in caplog.messages[0]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,11 +21,12 @@ from databricks.labs.ucx.cli import (
     revert_migrated_tables,
     save_aws_iam_profiles,
     save_azure_storage_accounts,
+    save_uc_compatible_roles,
     skip,
     sync_workspace_info,
     validate_external_locations,
     validate_groups_membership,
-    workflows, save_uc_compatible_roles,
+    workflows,
 )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -64,7 +64,7 @@ def ws():
 
 def test_workflow(ws, caplog):
     workflows(ws)
-    assert caplog.messages == ["Fetching deployed jobs..."]
+    assert "Fetching deployed jobs..." in caplog.messages
     ws.jobs.list_runs.assert_called_once()
 
 


### PR DESCRIPTION
## Changes
CLI command to scan roles that are set with trust relationships with the UC master roles and the S3 buckets they have access to.
Genererates a CSV file.

The CSV File has the following format:

```
iam_role_arn,resource_type,privilege,resource_path
arn:aws:iam::12345:rolerole1,s3,READ_FILES,s3://bucket1
arn:aws:iam::12345:role/role1,s3,READ_FILES,s3a://bucket1
arn:aws:iam::12345:role/role1,s3,READ_FILES,s3://bucket2
arn:aws:iam::12345:role/role1,s3,READ_FILES,s3a://bucket2

```

The command relies on AWS CLI Command and require the user to setup and configure it.
Requires a working setup of AWS CLI.
[AWS CLI](https://aws.amazon.com/cli/)
The command saves a CSV to the UCX installation folder with the mapping.

The user has to be authenticated with AWS and the have the permissions to browse the resources and iam services.
More information can be found here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/access_permissions-required.html





### Linked issues
closes #861 


### Functionality 

- [ ] added relevant user documentation
- [x] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
