### PR TITLE
Changed revert report to report on all "what" types rather than managed/external tables

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -176,23 +176,36 @@ class TablesMigrate:
             logger.info("No migrated tables were found.")
             return False
         print("The following is the count of migrated tables and views found in scope:")
-        table_header = "Database                      |"
+        table_header = "Database            |"
+        headers = 1
         for what in list(What):
-            table_header += f" {what.name:<16} |"
+            headers = max(headers, len(what.name.split("_")))
+            table_header += f" {what.name.split('_')[0]:<10} |"
         print(table_header)
-        print("=" * 88)
-        for count in migrated_count:
-            table_row = f"{count.database:<30}|"
+        # Split the header so _ separated what names are splitted into multiple lines
+        for header in range(1, headers):
+            table_sub_header = "                    |"
             for what in list(What):
-                table_row += f" {count.what_count.get(what,0):16} |"
+                if len(what.name.split("_")) - 1 < header:
+                    table_sub_header += f"{' '*12}|"
+                    continue
+                table_sub_header += f" {what.name.split('_')[header]:<10} |"
+            print(table_sub_header)
+        separator = "=" * (22 + 13 * len(What))
+        print(separator)
+        for count in migrated_count:
+            table_row = f"{count.database:<20}|"
+            for what in list(What):
+                table_row += f" {count.what_count.get(what, 0):10} |"
             print(table_row)
-        print("=" * 88)
-        print("Migrated External Tables and Views (targets) will be deleted")
+        print(separator)
+        print("The following actions will be performed")
+        print("- Migrated External Tables and Views (targets) will be deleted")
         if delete_managed:
-            print("Migrated DBFS Root Tables will be deleted")
+            print("- Migrated DBFS Root Tables will be deleted")
         else:
-            print("Migrated DBFS Root Tables will be left intact.")
-            print("To revert and delete Migrated Tables, add --delete_managed true flag to the command.")
+            print("- Migrated DBFS Root Tables will be left intact")
+            print("To revert and delete Migrated Tables, add --delete_managed true flag to the command")
         return True
 
 

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -153,16 +153,12 @@ class TablesMigrate:
 
         migration_list = []
         for cur_database, tables in table_by_database.items():
-            what_count: dict[str, int]={}
+            what_count: dict[What, int] = {}
             for current_table in tables:
                 if current_table.upgraded_to is not None:
                     count = what_count.get(current_table.what, 0)
-                    what_count[current_table.what] = count+1
-            migration_list.append(
-                MigrationCount(
-                    database=cur_database, what_count=what_count
-                )
-            )
+                    what_count[current_table.what] = count + 1
+            migration_list.append(MigrationCount(database=cur_database, what_count=what_count))
         return migration_list
 
     def is_upgraded(self, schema: str, table: str) -> bool:
@@ -180,15 +176,15 @@ class TablesMigrate:
             logger.info("No migrated tables were found.")
             return False
         print("The following is the count of migrated tables and views found in scope:")
-        table_header="Database                      |"
+        table_header = "Database                      |"
         for what in list(What):
             table_header += f" {what.name:<16} |"
         print(table_header)
         print("=" * 88)
         for count in migrated_count:
-            table_row=f"{count.database:<30}|"
+            table_row = f"{count.database:<30}|"
             for what in list(What):
-                table_row += f" {count.what_count.get(what.name,0):16} |"
+                table_row += f" {count.what_count.get(what,0):16} |"
             print(table_row)
         print("=" * 88)
         print("Migrated External Tables and Views (targets) will be deleted")

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -147,7 +147,8 @@ class TableError:
 @dataclass
 class MigrationCount:
     database: str
-    what_count: dict[str, int]
+    what_count: dict[What, int]
+
 
 class TablesCrawler(CrawlerBase):
     def __init__(self, backend: SqlBackend, schema):

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -147,10 +147,7 @@ class TableError:
 @dataclass
 class MigrationCount:
     database: str
-    managed_tables: int = 0
-    external_tables: int = 0
-    views: int = 0
-
+    what_count: dict[str, int]
 
 class TablesCrawler(CrawlerBase):
     def __init__(self, backend: SqlBackend, schema):

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -373,11 +373,11 @@ def test_revert_report(capsys):
     captured = capsys.readouterr()
     assert "test_schema1|1|0|1|0|1|0|0|" in captured.out.replace(" ", "")
     assert "test_schema2|1|0|0|0|0|0|0|" in captured.out.replace(" ", "")
-    assert "Migrated DBFS Root Tables will be deleted" in captured.out
+    assert "- Migrated DBFS Root Tables will be deleted" in captured.out
 
     table_migrate.print_revert_report(delete_managed=False)
     captured = capsys.readouterr()
-    assert "Migrated DBFS Root Tables will be left intact" in captured.out
+    assert "- Migrated DBFS Root Tables will be left intact" in captured.out
 
 
 def test_empty_revert_report(capsys):


### PR DESCRIPTION
## Changes
Changed the revert report to scan all table "What" types and report how many of these tables will be reverted.

### Linked issues
closes #857 

Resolves #..


### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [X] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
