### PR TITLE
Fixing installer not opening config file during the installation

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -265,8 +265,9 @@ class WorkspaceInstaller:
             spark_conf=spark_conf_dict,
             policy_id=policy_id,
         )
-        ws_file_url = self._installation.save(config)
-        if self._prompts.confirm("Open config file in the browser and continue installing?"):
+        ws_file = self._installation.save(config)
+        ws_file_url = self._installation.workspace_link(ws_file.replace(self._installation.install_folder(), ""))
+        if self._prompts.confirm(f"Open config file in the browser and continue installing? {ws_file_url}"):
             webbrowser.open(ws_file_url)
         return config
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1217,3 +1217,21 @@ def test_latest_job_status_exception(ws, mock_installation_with_jobs, any_prompt
     ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
     status = workspace_installation.latest_job_status()
     assert len(status) == 0
+
+
+def test_open_config(ws, mocker, mock_installation):
+    webbrowser_open = mocker.patch("webbrowser.open")
+    prompts = MockPrompts(
+        {
+            r".*PRO or SERVERLESS SQL warehouse.*": "1",
+            r"Choose how to map the workspace groups.*": "2",
+            r".*workspace group names.*": "g1, g2, g99",
+            r"Open config file in.*": "yes",
+            r".*": "",
+        }
+    )
+
+    install = WorkspaceInstaller(prompts, mock_installation, ws)
+    install.configure()
+
+    webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/config.yml')


### PR DESCRIPTION
## Changes
`self._installation.save(config)` returns a local path from the workspace.
Changed the installer to build an URL that can be resolved by webbrowser.open()

### Linked issues
fixes https://github.com/databrickslabs/ucx/issues/944

### Functionality 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X ] manually tested
- [X ] added unit tests
