### PR TITLE
Added `allow-no-subscriptions` to `azure/login` action

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Run integration tests
         run: hatch run integration


### PR DESCRIPTION
Some of the integration tests fail because of it and we don't need a subscription id anywhere
