### PR TITLE
Fixec AzureResourcePermissions.load to call Installation.load

### DIFF
--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -87,7 +87,7 @@ class AzureResourcePermissions:
         return self._installation.save(storage_account_infos, filename=self._filename)
 
     def load(self):
-        return self._installation.save(list[StoragePermissionMapping], filename=self._filename)
+        return self._installation.load(list[StoragePermissionMapping], filename=self._filename)
 
     def _get_storage_accounts(self) -> list[str]:
         external_locations = self._locations.snapshot()


### PR DESCRIPTION
AzureResourcePermissions.load should call Installation.load instead of Installation.save

## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
