### PR TITLE
Reuse existing UCX Cluster policy if present

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -559,7 +559,7 @@ class WorkspaceInstallation:
             if self.config.policy_id is None:
                 msg = "Cluster policy not present, please uninstall and reinstall ucx completely."
                 raise InvalidParameterValue(msg)
-            policy_definition = self._ws.cluster_policies.get(policy_id=self.config.policy_id).definition
+            policy = self._ws.cluster_policies.get(policy_id=self.config.policy_id)
         except NotFound as err:
             msg = f"UCX Policy {self.config.policy_id} not found, please reinstall UCX"
             logger.error(msg)
@@ -567,8 +567,8 @@ class WorkspaceInstallation:
 
         self._ws.cluster_policies.edit(
             policy_id=self.config.policy_id,
-            name=f"Unity Catalog Migration ({self.config.inventory_database})",
-            definition=policy_definition,
+            name=policy.name,
+            definition=policy.definition,
             libraries=[compute.Library(whl=f"dbfs:{remote_wheel}")],
         )
         desired_steps = {t.workflow for t in _TASKS.values() if t.cloud_compatible(self._ws.config)}

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -116,10 +116,11 @@ def test_job_failure_propagates_correct_error_message_and_logs(ws, sql_backend, 
 @retried(on=[NotFound, Unknown, InvalidParameterValue], timeout=timedelta(minutes=18))
 def test_job_cluster_policy(ws, new_installation):
     install = new_installation(lambda wc: replace(wc, override_clusters=None))
+    user_name = ws.current_user.me().user_name
     cluster_policy = ws.cluster_policies.get(policy_id=install.config.policy_id)
     policy_definition = json.loads(cluster_policy.definition)
 
-    assert cluster_policy.name == f"Unity Catalog Migration ({install.config.inventory_database})"
+    assert cluster_policy.name == f"Unity Catalog Migration ({install.config.inventory_database}) ({user_name})"
 
     assert policy_definition["spark_version"]["value"] == ws.clusters.select_spark_version(latest=True)
     assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -653,10 +653,12 @@ def test_install_edit_policy_with_library(ws, mock_installation, any_prompt):
         timedelta(seconds=1),
     )
     wheels.upload_to_wsfs.return_value = "path1"
-    ws.cluster_policies.get.return_value = Policy(policy_id="foo")
+    ws.cluster_policies.get.return_value = Policy(
+        policy_id="foo", name="Unity Catalog Migration (ucx) (me@example.com)"
+    )
     workspace_installation.create_jobs()
     ws.cluster_policies.edit.assert_called_with(
-        name="Unity Catalog Migration (ucx)",
+        name="Unity Catalog Migration (ucx) (me@example.com)",
         policy_id="foo",
         definition=None,
         libraries=[compute.Library(whl="dbfs:path1")],


### PR DESCRIPTION
## Changes
This change fixes two bugs related to cluster policy setup during ucx installation
 - If a user is rerunning installation (due to some issue previously but some steps completed like policy creation), if a UCX cluster policy is found, it reuses that instead of creating one
 - If the user is upgrading UCX where the initial installation steps are skipped, but the policy ID is not found in the config.yaml (due to manually deleting or upgrading from an older version), then raise an InvalidParameterValue with a custom msg saying policy id not found and request the user to uninstall and reinstall ucx completely.

### #963 


### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests

- [X] manually tested
- [X] added unit tests
- [X] added integration tests
- [ ] verified on staging environment (screenshot attached)
