### PR TITLE
Fix ruff config for ruff==2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,8 @@ skip-string-normalization = true
 cache-dir = ".venv/ruff-cache"
 target-version = "py310"
 line-length = 120
+
+[tool.ruff.lint]
 ignore = [
     # Allow boolean positional values in function calls, like `dict.get(... True)`
     "FBT003",
@@ -112,13 +114,13 @@ ignore = [
     "EM102",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["databricks.labs.ucx"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 
 "src/databricks/labs/ucx/mixins/*" = ["S311"]
 


### PR DESCRIPTION
## Changes
Removes warning from ruff when running `make fmt`

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'flake8-tidy-imports' -> 'lint.flake8-tidy-imports'
  - 'isort' -> 'lint.isort'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```