### PR TITLE
Release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Version changelog
 
+## 0.13.2
+
+* Fixed `AnalysisException` in `crawl_tables` task by ignoring the database that is not found ([#970](https://github.com/databrickslabs/ucx/pull/970)).
+* Fixed `Unknown: org.apache.hadoop.hive.ql.metadata.HiveException: NoSuchObjectException` in `crawl_grants` task by ignoring the database that is not found ([#967](https://github.com/databrickslabs/ucx/pull/967)).
+* Fixed ruff config for ruff==2.0 ([#969](https://github.com/databrickslabs/ucx/pull/969)).
+* Made groups integration tests less flaky ([#965](https://github.com/databrickslabs/ucx/pull/965)).
+
+
 ## 0.13.1
 
 * Added secret detection logic to Azure service principal crawler ([#950](https://github.com/databrickslabs/ucx/pull/950)).

--- a/src/databricks/labs/ucx/__about__.py
+++ b/src/databricks/labs/ucx/__about__.py
@@ -1,2 +1,2 @@
 # DO NOT MODIFY THIS FILE
-__version__ = "0.13.1"
+__version__ = "0.13.2"


### PR DESCRIPTION

* Fixed `AnalysisException` in `crawl_tables` task by ignoring the database that is not found ([#970](https://github.com/databrickslabs/ucx/pull/970)).
* Fixed `Unknown: org.apache.hadoop.hive.ql.metadata.HiveException: NoSuchObjectException` in `crawl_grants` task by ignoring the database that is not found ([#967](https://github.com/databrickslabs/ucx/pull/967)).
* Fixed ruff config for ruff==2.0 ([#969](https://github.com/databrickslabs/ucx/pull/969)).
* Made groups integration tests less flaky ([#965](https://github.com/databrickslabs/ucx/pull/965)).


