### PR TITLE
Fix integration tests on AWS

### DIFF
--- a/tests/integration/framework/test_crawlers.py
+++ b/tests/integration/framework/test_crawlers.py
@@ -142,8 +142,8 @@ def test_runtime_backend_permission_denied_handled(ws, wsfs_wheel):
     assert permission_denied_fetch == "PASSED"
 
 
-def test_runtime_backend_unknown_error_handled(ws, wsfs_wheel):
-    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: ws.config.cluster_id)
+def test_runtime_backend_unknown_error_handled(ws, env_or_skip, wsfs_wheel):
+    commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: env_or_skip("TEST_DEFAULT_CLUSTER_ID"))
 
     commands.install_notebook_library(f"/Workspace{wsfs_wheel}")
 

--- a/tests/integration/framework/test_crawlers.py
+++ b/tests/integration/framework/test_crawlers.py
@@ -143,6 +143,7 @@ def test_runtime_backend_permission_denied_handled(ws, wsfs_wheel):
 
 
 def test_runtime_backend_unknown_error_handled(ws, env_or_skip, wsfs_wheel):
+    """We test this on the default cluster, i.e. without UC enabled. The command will throw an unknown error"""
     commands = CommandExecutor(ws.clusters, ws.command_execution, lambda: env_or_skip("TEST_DEFAULT_CLUSTER_ID"))
 
     commands.install_notebook_library(f"/Workspace{wsfs_wheel}")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -126,12 +126,11 @@ def test_job_cluster_policy(ws, new_installation):
     assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True)
     if ws.config.is_azure:
         assert (
-            policy_definition["azure_attributes.availability"]["value"] == compute.AzureAvailability.ON_DEMAND_AZURE.value
+            policy_definition["azure_attributes.availability"]["value"]
+            == compute.AzureAvailability.ON_DEMAND_AZURE.value
         )
     if ws.config.is_aws:
-        assert (
-            policy_definition["aws_attributes.availability"]["value"] == compute.AwsAvailability.ON_DEMAND.value
-        )
+        assert policy_definition["aws_attributes.availability"]["value"] == compute.AwsAvailability.ON_DEMAND.value
 
 
 @pytest.mark.skip

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -128,6 +128,10 @@ def test_job_cluster_policy(ws, new_installation):
         assert (
             policy_definition["azure_attributes.availability"]["value"] == compute.AzureAvailability.ON_DEMAND_AZURE.value
         )
+    if ws.config.is_aws:
+        assert (
+            policy_definition["aws_attributes.availability"]["value"] == compute.AwsAvailability.ON_DEMAND.value
+        )
 
 
 @pytest.mark.skip

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -124,9 +124,10 @@ def test_job_cluster_policy(ws, new_installation):
 
     assert policy_definition["spark_version"]["value"] == ws.clusters.select_spark_version(latest=True)
     assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True)
-    assert (
-        policy_definition["azure_attributes.availability"]["value"] == compute.AzureAvailability.ON_DEMAND_AZURE.value
-    )
+    if ws.config.is_azure:
+        assert (
+            policy_definition["azure_attributes.availability"]["value"] == compute.AzureAvailability.ON_DEMAND_AZURE.value
+        )
 
 
 @pytest.mark.skip


### PR DESCRIPTION
## Changes
Fix 2 tests that are failing on aws
- `test_job_cluster_policy` checks for `azure_attributes`
- `test_runtime_backend_unknown_error_handled` picks up a UC cluster in aws infra

- [x] manually tested