### PR TITLE
Update groups permissions validation to use Table ACL cluster

### DIFF
--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -310,7 +310,7 @@ def apply_permissions_to_account_groups(cfg: WorkspaceConfig, ws: WorkspaceClien
     permission_manager.apply_group_permissions(migration_state)
 
 
-@task("validate-groups-permissions")
+@task("validate-groups-permissions", job_cluster="tacl")
 def validate_groups_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
     """Validate that all the crawled permissions are applied correctly to the destination groups."""
     logger.info("Running validation of permissions applied to destination groups.")


### PR DESCRIPTION
## Changes
The validation job should use Table ACL cluster otherwise it cannot validate the grants correctly.

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
