### PR TITLE
Renamed columns in assessment SQL queries to use actual names, not aliases

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/03_0_database_summary.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/03_0_database_summary.sql
@@ -18,7 +18,7 @@ WITH table_stats AS (
         WHEN STARTSWITH(location, "adl") THEN 1
         ELSE 0
     END AS is_unsupported,
-    IF(format = "DELTA", 1, 0) AS is_delta
+    IF(table_format = "DELTA", 1, 0) AS is_delta
    FROM $inventory.tables
 ), database_stats AS (
   SELECT `database`,

--- a/src/databricks/labs/ucx/queries/assessment/main/05_0_all_tables.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/05_0_all_tables.sql
@@ -14,7 +14,7 @@ SELECT CONCAT(tables.`database`, '.', tables.name) AS name,
            WHEN STARTSWITH(location, "adl") THEN "UNSUPPORTED"
            ELSE "EXTERNAL"
        END AS storage,
-       IF(format = "DELTA", "Yes", "No") AS is_delta,
+       IF(table_format = "DELTA", "Yes", "No") AS is_delta,
        location,
        CASE
             WHEN size_in_bytes IS null THEN "Non DBFS Root"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Aliases are usually not allowed in projections (as they are replaced later in the query execution phases). While the DBSQL was smart enough to handle the references via aliases, for some setups this results in an error. Changing column references to use actual names fixes this.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #980

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
