### PR TITLE
Fixed `config.yml` upgrade from very old versions

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -41,15 +41,11 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def v1_migrate(cls, raw: dict) -> dict:
-        stored_version = raw.pop("version", None)
-        if stored_version == cls.__version__:
-            return raw
-        if stored_version == 1:
-            raw["include_group_names"] = (
-                raw.get("groups", {"selected": []})["selected"] if "selected" in raw["groups"] else None
-            )
-            raw["renamed_group_prefix"] = raw.get("groups", {"backup_group_prefix": "db-temp-"})["backup_group_prefix"]
-            raw.pop("groups", None)
-            return raw
-        msg = f"Unknown config version: {stored_version}"
-        raise ValueError(msg)
+        # See https://github.com/databrickslabs/ucx/blob/v0.5.0/src/databricks/labs/ucx/config.py#L16-L32
+        groups = raw.pop("groups", {})
+        selected_groups = groups.get("selected", [])
+        if selected_groups:
+            raw["include_group_names"] = selected_groups
+        raw["renamed_group_prefix"] = groups.get("backup_group_prefix", "db-temp-")
+        raw["version"] = 2
+        return raw

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,30 @@
+from databricks.labs.blueprint.installation import MockInstallation
+
+from databricks.labs.ucx.config import WorkspaceConfig
+
+
+def test_v1_migrate_zeroconf():
+    installation = MockInstallation(
+        {'config.yml': {'inventory_database': 'x', 'groups': {}, 'connect': {'host': 'a', 'token': 'b'}}}
+    )
+
+    workspace_config = installation.load(WorkspaceConfig)
+
+    assert workspace_config.renamed_group_prefix == 'db-temp-'
+
+
+def test_v1_migrate_some_conf():
+    installation = MockInstallation(
+        {
+            'config.yml': {
+                'inventory_database': 'x',
+                'groups': {'selected': ['foo', 'bar'], 'backup_group_prefix': 'some-'},
+                'connect': {'host': 'a', 'token': 'b'},
+            }
+        }
+    )
+
+    workspace_config = installation.load(WorkspaceConfig)
+
+    assert workspace_config.renamed_group_prefix == 'some-'
+    assert workspace_config.include_group_names == ['foo', 'bar']


### PR DESCRIPTION
Fixed `WorkspaceConfig.v1_migrate()` method to work with the Installation infrastructure.

Fixes #982

