### PR TITLE
Create UC external locations in Azure based on migrated storage credentials

### DIFF
--- a/src/databricks/labs/ucx/azure/credentials.py
+++ b/src/databricks/labs/ucx/azure/credentials.py
@@ -246,6 +246,9 @@ class ServicePrincipalMigration(SecretsMixin):
     def save(self, migration_results: list[StorageCredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
+    def load(self):
+        return self._installation.load(list[StorageCredentialValidationResult], filename=self._output_file)
+
     def run(self, prompts: Prompts, include_names: set[str] | None = None) -> list[StorageCredentialValidationResult]:
 
         sp_list_with_secret = self._generate_migration_list(include_names)

--- a/src/databricks/labs/ucx/azure/credentials.py
+++ b/src/databricks/labs/ucx/azure/credentials.py
@@ -246,9 +246,6 @@ class ServicePrincipalMigration(SecretsMixin):
     def save(self, migration_results: list[StorageCredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
-    def load(self):
-        return self._installation.load(list[StorageCredentialValidationResult], filename=self._output_file)
-
     def run(self, prompts: Prompts, include_names: set[str] | None = None) -> list[StorageCredentialValidationResult]:
 
         sp_list_with_secret = self._generate_migration_list(include_names)

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -1,0 +1,151 @@
+import logging
+from urllib.parse import urlparse
+from databricks.sdk import WorkspaceClient
+
+from databricks.labs.blueprint.installation import Installation
+from databricks.labs.ucx.azure.access import AzureResourcePermissions
+from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.config import WorkspaceConfig
+from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
+from databricks.labs.ucx.hive_metastore import ExternalLocations
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalLocationsMigration:
+    def __init__(
+            self,
+            ws: WorkspaceClient,
+            hms_locations: ExternalLocations,
+            resource_permissions: AzureResourcePermissions,
+            azurerm: AzureResources
+    ):
+        self._ws = ws
+        self._hms_locations = hms_locations
+        self._resource_permissions = resource_permissions
+        self._azurerm = azurerm
+
+    @classmethod
+    def for_cli(cls, ws: WorkspaceClient, installation: Installation):
+        config = installation.load(WorkspaceConfig)
+        sql_backend = StatementExecutionBackend(ws, config.warehouse_id)
+        locations = ExternalLocations(ws, sql_backend, config.inventory_database)
+        azurerm = AzureResources(ws)
+        resource_permissions = AzureResourcePermissions(installation, ws, azurerm, locations)
+
+        return cls(installation, ws, locations, resource_permissions, azurerm)
+
+    def _app_id_credential_name_mapping(self) -> tuple[dict[str, str], dict[str, str]]:
+        # list all storage credentials.
+        # generate the managed identity/service principal application id to credential name mapping.
+        # return one mapping for all non read-only credentials and one mapping for all read-only credentials
+        # TODO: considering put this logic into the StorageCredentialManager
+        app_id_mapping_write = {}
+        app_id_mapping_read = {}
+        all_credentials = self._ws.storage_credentials.list(max_results=0)
+        for credential in all_credentials:
+            if credential.azure_service_principal:
+                if not credential.read_only:
+                    app_id_mapping_write[credential.azure_service_principal.application_id]=credential.name
+                    continue
+                if credential.read_only:
+                    app_id_mapping_read[credential.azure_service_principal.application_id]=credential.name
+            if credential.azure_managed_identity:
+                application_id = self._azurerm.access_connector_identity_client_id(credential.azure_managed_identity.access_connector_id)
+                if not application_id:
+                    continue
+                if not credential.read_only:
+                    app_id_mapping_write[application_id]=credential.name
+                    continue
+                if credential.read_only:
+                    app_id_mapping_read[application_id]=credential.name
+
+        return app_id_mapping_write, app_id_mapping_read
+
+    def _prefix_credential_name_mapping(self)-> tuple[dict[str, str], dict[str, str]]:
+        # get managed identity/service principal's application id to storage credential name mapping
+        # for all non read-only and read-only credentials
+        app_id_mapping_write, app_id_mapping_read = self._app_id_credential_name_mapping()
+
+        # use the application id to storage credential name mapping to create prefix to storage credential name mapping
+        prefix_mapping_write = {}
+        prefix_mapping_read = {}
+        for permission_mapping in self._resource_permissions.load():
+            if permission_mapping.client_id in app_id_mapping_write:
+                prefix_mapping_write[permission_mapping.prefix] = app_id_mapping_write[permission_mapping.client_id]
+                continue
+            if permission_mapping.client_id in app_id_mapping_read:
+                prefix_mapping_read[permission_mapping.prefix] = app_id_mapping_read[permission_mapping.client_id]
+        return prefix_mapping_write, prefix_mapping_read
+
+    def _create_location_name(self, location_url:str)-> str:
+        # generate the UC external location name
+        container_name = location_url[8 : location_url.index("@")]
+        res_name = (
+            location_url[location_url.index("@") + 1 :]
+            .replace(".dfs.core.windows.net", "")
+            .rstrip("/")
+            .replace("/", "_")
+        )
+        return f"{container_name}_{res_name}"
+
+    def _create_external_location(self, location_url: str, prefix_mapping_write: dict[str, str], prefix_mapping_read: dict[str, str])-> str | None:
+        location_name = self._create_location_name(location_url)
+
+        # get container url as the prefix
+        parsed_url = urlparse(location_url)
+        container_url = f"{parsed_url.scheme}://{parsed_url.netloc}/"
+
+        # try to create external location with write privilege first
+        if container_url in prefix_mapping_write:
+            self._ws.external_locations.create(
+                location_name,
+                location_url,
+                prefix_mapping_write[container_url],
+                comment=f"Created by UCX"
+            )
+            return location_url
+        # if no matched write privilege credential, try to create read-only external location
+        if container_url in prefix_mapping_read:
+            self._ws.external_locations.create(
+                location_name,
+                location_url,
+                prefix_mapping_read[container_url],
+                comment=f"Created by UCX",
+                read_only=True
+            )
+            return location_url
+        # if no credential found
+        return None
+
+    def run(self):
+        # list missing external locations in UC
+        missing_locs = [loc.location for loc in self._hms_locations.match_table_external_locations()[1]]
+
+        # get prefix to storage credential name mapping
+        prefix_mapping_write, prefix_mapping_read = self._prefix_credential_name_mapping()
+
+        # if missing external location is in prefix to storage credential name mapping
+        # create a UC external location with mapped storage credential name
+        migrated_locs = []
+        for location in missing_locs:
+            migrated_loc = self._create_external_location(location, prefix_mapping_write, prefix_mapping_read)
+            if migrated_loc:
+                migrated_locs.append(migrated_loc)
+
+        leftover_loc = [loc for loc in missing_locs if loc not in migrated_locs]
+        if leftover_loc:
+            logger.info("External locations below are not created in UC. You may check following cases and rerun this command:"
+                        "1. Please check the output of 'migrate_credentials' command for storage credentials migration failure."
+                        "2. If you use service principal in extra_config when create dbfs mount or use service principal "
+                        "in your code directly for storage access, UCX cannot automatically migrate them to storage credential."
+                        "Please manually create those storage credentials first.")
+            for loc_url in leftover_loc:
+                logger.info(f"Not created external location: {loc_url}")
+        else:
+            logger.info("All UC external location are created.")
+
+        return leftover_loc
+
+
+

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -234,3 +234,15 @@ class AzureResources:
                 return None
             self._role_definitions[role_definition_id] = role_name
         return self._role_definitions.get(role_definition_id)
+
+    def access_connector_identity_client_id(self, access_connector_id) -> str | None:
+        identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
+        if not identity:
+            return None
+        if identity.get("type") == "UserAssigned":
+            return identity.get("userAssignedIdentities").get("clientId")
+        if identity.get("type") == "SystemAssigned":
+            principal = self._get_principal(identity.get("principalId"))
+            if not principal:
+                return None
+            return principal.client_id

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -235,14 +235,18 @@ class AzureResources:
             self._role_definitions[role_definition_id] = role_name
         return self._role_definitions.get(role_definition_id)
 
-    def access_connector_identity_client_id(self, access_connector_id) -> str | None:
+    def managed_identity_client_id(self, access_connector_id) -> str | None:
+        # get te client_id/application_id of the managed identity used in the access connector
         identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
         if not identity:
             return None
         if identity.get("type") == "UserAssigned":
             return identity.get("userAssignedIdentities").get("clientId")
         if identity.get("type") == "SystemAssigned":
+            # SystemAssigned managed identity does not have client_id in get access connector response
+            # need to call graph api directoryObjects to fetch the client_id
             principal = self._get_principal(identity.get("principalId"))
             if not principal:
                 return None
             return principal.client_id
+        return None

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -160,7 +160,7 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
             cnt += 1
         return tf_script
 
-    def _match_table_external_locations(self) -> tuple[list[list], list[ExternalLocation]]:
+    def match_table_external_locations(self) -> tuple[list[list], list[ExternalLocation]]:
         external_locations = list(self._ws.external_locations.list())
         location_path = [_.url.lower() for _ in external_locations]
         table_locations = self.snapshot()
@@ -178,7 +178,7 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         return matching_locations, missing_locations
 
     def save_as_terraform_definitions_on_workspace(self, installation: Installation):
-        matching_locations, missing_locations = self._match_table_external_locations()
+        matching_locations, missing_locations = self.match_table_external_locations()
         if len(matching_locations) > 0:
             logger.info("following external locations are already configured.")
             logger.info("sharing details of # tables that can be migrated for each location")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Create UC external locations for missing locations reported by `ExternalLocations` in `hive_metastore/locations.py`.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Partially resolve #100 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
