### PR TITLE
Create UC external locations in Azure based on migrated storage credentials

### DIFF
--- a/src/databricks/labs/ucx/azure/credentials.py
+++ b/src/databricks/labs/ucx/azure/credentials.py
@@ -257,6 +257,9 @@ class ServicePrincipalMigration(SecretsMixin):
     def save(self, migration_results: list[StorageCredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
+    def load(self):
+        return self._installation.load(list[StorageCredentialValidationResult], filename=self._output_file)
+
     def run(self, prompts: Prompts, include_names: set[str] | None = None) -> list[StorageCredentialValidationResult]:
 
         sp_list_with_secret = self._generate_migration_list(include_names)

--- a/src/databricks/labs/ucx/azure/credentials.py
+++ b/src/databricks/labs/ucx/azure/credentials.py
@@ -257,9 +257,6 @@ class ServicePrincipalMigration(SecretsMixin):
     def save(self, migration_results: list[StorageCredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
-    def load(self):
-        return self._installation.load(list[StorageCredentialValidationResult], filename=self._output_file)
-
     def run(self, prompts: Prompts, include_names: set[str] | None = None) -> list[StorageCredentialValidationResult]:
 
         sp_list_with_secret = self._generate_migration_list(include_names)

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -167,7 +167,7 @@ class ExternalLocationsMigration:
             )
             for loc_url in leftover_loc:
                 logger.info(f"Not created external location: {loc_url}")
-        else:
-            logger.info("All UC external location are created.")
+            return leftover_loc
 
+        logger.info("All UC external location are created.")
         return leftover_loc

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -46,7 +46,7 @@ class ExternalLocationsMigration:
         app_id_mapping_read = {}
         all_credentials = self._ws.storage_credentials.list(max_results=0)
         for credential in all_credentials:
-            # cannot have none credential name, it required for external location
+            # cannot have none credential name, it's required for external location
             if not credential.name:
                 continue
             # if service principal based credential, use service principal's application_id directly
@@ -92,11 +92,7 @@ class ExternalLocationsMigration:
         # generate the UC external location name
         before_at, sep, after_at = location_url.partition('@')
         container_name = before_at.removeprefix("abfss://")
-        res_name = (
-            after_at.replace(".dfs.core.windows.net", "")
-            .rstrip("/")
-            .replace("/", "_")
-        )
+        res_name = after_at.replace(".dfs.core.windows.net", "").rstrip("/").replace("/", "_")
         return f"{container_name}_{res_name}"
 
     def _create_external_location(

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -90,7 +90,7 @@ class ExternalLocationsMigration:
 
     def _create_location_name(self, location_url: str) -> str:
         # generate the UC external location name
-        before_at, sep, after_at = location_url.partition('@')
+        before_at, _, after_at = location_url.partition('@')
         container_name = before_at.removeprefix("abfss://")
         res_name = after_at.replace(".dfs.core.windows.net", "").rstrip("/").replace("/", "_")
         return f"{container_name}_{res_name}"

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -1,0 +1,151 @@
+import logging
+from urllib.parse import urlparse
+from databricks.sdk import WorkspaceClient
+
+from databricks.labs.blueprint.installation import Installation
+from databricks.labs.ucx.azure.access import AzureResourcePermissions
+from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.config import WorkspaceConfig
+from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
+from databricks.labs.ucx.hive_metastore import ExternalLocations
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalLocationsMigration:
+    def __init__(
+            self,
+            ws: WorkspaceClient,
+            hms_locations: ExternalLocations,
+            resource_permissions: AzureResourcePermissions,
+            azurerm: AzureResources
+    ):
+        self._ws = ws
+        self._hms_locations = hms_locations
+        self._resource_permissions = resource_permissions
+        self._azurerm = azurerm
+
+    @classmethod
+    def for_cli(cls, ws: WorkspaceClient, installation: Installation):
+        config = installation.load(WorkspaceConfig)
+        sql_backend = StatementExecutionBackend(ws, config.warehouse_id)
+        locations = ExternalLocations(ws, sql_backend, config.inventory_database)
+        azurerm = AzureResources(ws)
+        resource_permissions = AzureResourcePermissions(installation, ws, azurerm, locations)
+
+        return cls(installation, ws, locations, resource_permissions, azurerm)
+
+    def _app_id_credential_name_mapping(self) -> tuple[dict[str, str], dict[str, str]]:
+        # list all storage credentials.
+        # generate the managed identity/service principal application id to credential name mapping.
+        # return one mapping for all non read-only credentials and one mapping for all read-only credentials
+        # TODO: considering put this logic into the StorageCredentialManager
+        app_id_mapping_write = {}
+        app_id_mapping_read = {}
+        all_credentials = self._ws.storage_credentials.list(max_results=0)
+        for credential in all_credentials:
+            if credential.azure_service_principal:
+                if not credential.read_only:
+                    app_id_mapping_write[credential.azure_service_principal.application_id]=credential.name
+                    continue
+                if credential.read_only:
+                    app_id_mapping_read[credential.azure_service_principal.application_id]=credential.name
+            if credential.azure_managed_identity:
+                application_id = self._azurerm.access_connector_identity_client_id(credential.azure_managed_identity.access_connector_id)
+                if not application_id:
+                    continue
+                if not credential.read_only:
+                    app_id_mapping_write[application_id]=credential.name
+                    continue
+                if credential.read_only:
+                    app_id_mapping_read[application_id]=credential.name
+
+        return app_id_mapping_write, app_id_mapping_read
+
+    def _prefix_credential_name_mapping(self)-> tuple[dict[str, str], dict[str, str]]:
+        # get managed identity/service principal's application id to storage credential name mapping
+        # for all non read-only and read-only credentials
+        app_id_mapping_write, app_id_mapping_read = self._app_id_credential_name_mapping()
+
+        # use the application id to storage credential name mapping to create prefix to storage credential name mapping
+        prefix_mapping_write = {}
+        prefix_mapping_read = {}
+        for permission_mapping in self._resource_permissions.load():
+            if permission_mapping.client_id in app_id_mapping_write:
+                prefix_mapping_write[permission_mapping.prefix] = app_id_mapping_write[permission_mapping.client_id]
+                continue
+            if permission_mapping.client_id in app_id_mapping_read:
+                prefix_mapping_read[permission_mapping.prefix] = app_id_mapping_read[permission_mapping.client_id]
+        return prefix_mapping_write, prefix_mapping_read
+
+    def _create_location_name(self, location_url:str)-> str:
+        # generate the UC external location name
+        container_name = location_url[8 : location_url.index("@")]
+        res_name = (
+            location_url[location_url.index("@") + 1 :]
+            .replace(".dfs.core.windows.net", "")
+            .rstrip("/")
+            .replace("/", "_")
+        )
+        return f"{container_name}_{res_name}"
+
+    def _create_external_location(self, location_url: str, prefix_mapping_write: dict[str, str], prefix_mapping_read: dict[str, str])-> str | None:
+        location_name = self._create_location_name(location_url)
+
+        # get container url as the prefix
+        parsed_url = urlparse(location_url)
+        container_url = f"{parsed_url.scheme}://{parsed_url.netloc}/"
+
+        # try to create external location with write privilege first
+        if container_url in prefix_mapping_write:
+            self._ws.external_locations.create(
+                location_name,
+                location_url,
+                prefix_mapping_write[container_url],
+                comment=f"Created by UCX"
+            )
+            return location_url
+        # if no matched write privilege credential, try to create read-only external location
+        if container_url in prefix_mapping_read:
+            self._ws.external_locations.create(
+                location_name,
+                location_url,
+                prefix_mapping_read[container_url],
+                comment=f"Created by UCX",
+                read_only=True
+            )
+            return location_url
+        # if no credential found
+        return None
+
+    def run(self):
+        # list missing external locations in UC
+        missing_locs = [loc.location for loc in self._hms_locations.match_table_external_locations()[1]]
+
+        # get prefix to storage credential name mapping
+        prefix_mapping_write, prefix_mapping_read = self._prefix_credential_name_mapping()
+
+        # if missing external location is in prefix to storage credential name mapping
+        # create a UC external location with mapped storage credential name
+        migrated_locs = []
+        for location in missing_locs:
+            migrated_loc = self._create_external_location(location, prefix_mapping_write, prefix_mapping_read)
+            if migrated_loc:
+                migrated_locs.append(migrated_loc)
+
+        leftover_loc = [loc for loc in missing_locs if loc not in migrated_locs]
+        if leftover_loc:
+            logger.info("External locations below are not created in UC. You may check following cases and rerun this command:"
+                        "1. Please check the output of 'migrate_credentials' command for storage credentials migration failure."
+                        "2. If you use service principal in extra_config when create dbfs mount or use service principal "
+                        "in your code directly for storage access, UCX cannot automatically migrate them to storage credential."
+                        "Please manually create those storage credentials first.")
+            for loc_url in leftover_loc:
+                logger.info(f"Not created external location: {loc_url}")
+        else:
+            logger.info("All UC external location are created.")
+
+        return leftover_loc
+
+
+

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -59,7 +59,7 @@ class ExternalLocationsMigration:
             if credential.azure_managed_identity:
                 application_id = self._azurerm.managed_identity_client_id(
                     credential.azure_managed_identity.access_connector_id,
-                    credential.azure_managed_identity.managed_identity_id
+                    credential.azure_managed_identity.managed_identity_id,
                 )
                 if not application_id:
                     continue

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -90,10 +90,10 @@ class ExternalLocationsMigration:
 
     def _create_location_name(self, location_url: str) -> str:
         # generate the UC external location name
-        container_name = location_url[8 : location_url.index("@")]
+        before_at, sep, after_at = location_url.partition('@')
+        container_name = before_at.removeprefix("abfss://")
         res_name = (
-            location_url[location_url.index("@") + 1 :]
-            .replace(".dfs.core.windows.net", "")
+            after_at.replace(".dfs.core.windows.net", "")
             .rstrip("/")
             .replace("/", "_")
         )

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -58,7 +58,8 @@ class ExternalLocationsMigration:
             # if managed identity based credential, fetch the application_id of the managed identity
             if credential.azure_managed_identity:
                 application_id = self._azurerm.managed_identity_client_id(
-                    credential.azure_managed_identity.access_connector_id
+                    credential.azure_managed_identity.access_connector_id,
+                    credential.azure_managed_identity.managed_identity_id
                 )
                 if not application_id:
                     continue

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -143,21 +143,23 @@ class ExternalLocationsMigration:
 
     def run(self):
         # list missing external locations in UC
-        missing_locs = [loc.location for loc in self._hms_locations.match_table_external_locations()[1]]
+        _, missing_locations = self._hms_locations.match_table_external_locations()
+        # Extract the location URLs from the missing locations
+        missing_loc_urls = [loc.location for loc in missing_locations]
 
         # get prefix to storage credential name mapping
         prefix_mapping_write, prefix_mapping_read = self._prefix_credential_name_mapping()
 
         # if missing external location is in prefix to storage credential name mapping
         # create a UC external location with mapped storage credential name
-        migrated_locs = []
-        for location in missing_locs:
-            migrated_loc = self._create_external_location(location, prefix_mapping_write, prefix_mapping_read)
-            if migrated_loc:
-                migrated_locs.append(migrated_loc)
+        migrated_loc_urls = []
+        for location_url in missing_loc_urls:
+            migrated_loc_url = self._create_external_location(location_url, prefix_mapping_write, prefix_mapping_read)
+            if migrated_loc_url:
+                migrated_loc_urls.append(migrated_loc_url)
 
-        leftover_loc = [loc for loc in missing_locs if loc not in migrated_locs]
-        if leftover_loc:
+        leftover_loc_urls = [url for url in missing_loc_urls if url not in migrated_loc_urls]
+        if leftover_loc_urls:
             logger.info(
                 "External locations below are not created in UC. You may check following cases and rerun this command:"
                 "1. Please check the output of 'migrate_credentials' command for storage credentials migration failure."
@@ -165,9 +167,9 @@ class ExternalLocationsMigration:
                 "in your code directly for storage access, UCX cannot automatically migrate them to storage credential."
                 "Please manually create those storage credentials first."
             )
-            for loc_url in leftover_loc:
+            for loc_url in leftover_loc_urls:
                 logger.info(f"Not created external location: {loc_url}")
-            return leftover_loc
+            return leftover_loc_urls
 
         logger.info("All UC external location are created.")
-        return leftover_loc
+        return leftover_loc_urls

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -351,9 +351,9 @@ class AzureResources:
         except NotFound:
             logger.warning(f"Access connector {access_connector_id} no longer exists")
             return None
-
         if not identity:
             return None
+
         if identity.get("type") == "UserAssigned":
             if not user_assigned_identity_id:
                 return None
@@ -361,11 +361,10 @@ class AzureResources:
             if user_assigned_identity_id in identities:
                 return identities.get(user_assigned_identity_id).get("clientId")
             # sometimes we see "resourceGroups" instead of "resourcegroups" in the response from Azure RM API
-            # but "resourcegroups" in response from storage credential's managed_identity_id
-            if user_assigned_identity_id.replace("resourcegroups", "resourceGroups") in identities:
-                return identities.get(user_assigned_identity_id.replace("resourcegroups", "resourceGroups")).get(
-                    "clientId"
-                )
+            # but "resourcegroups" is in response from storage credential's managed_identity_id
+            alternative_identity_id = user_assigned_identity_id.replace("resourcegroups", "resourceGroups")
+            if alternative_identity_id in identities:
+                return identities.get(alternative_identity_id).get("clientId")
             return None
         if identity.get("type") == "SystemAssigned":
             # SystemAssigned managed identity does not have client_id in get access connector response

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -342,7 +342,9 @@ class AzureResources:
             self._role_definitions[role_definition_id] = role_name
         return self._role_definitions.get(role_definition_id)
 
-    def managed_identity_client_id(self, access_connector_id: str, user_assigned_identity_id: str | None = None) -> str | None:
+    def managed_identity_client_id(
+        self, access_connector_id: str, user_assigned_identity_id: str | None = None
+    ) -> str | None:
         # get te client_id/application_id of the managed identity used in the access connector
         try:
             identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
@@ -353,11 +355,15 @@ class AzureResources:
         if not identity:
             return None
         if identity.get("type") == "UserAssigned":
+            if not user_assigned_identity_id:
+                return None
             identities = identity.get("userAssignedIdentities")
             if user_assigned_identity_id in identities:
                 return identities.get(user_assigned_identity_id).get("clientId")
-            if user_assigned_identity_id.replace("resourcegroups","resourceGroups") in identities:
-                return identities.get(user_assigned_identity_id.replace("resourcegroups","resourceGroups")).get("clientId")
+            if user_assigned_identity_id.replace("resourcegroups", "resourceGroups") in identities:
+                return identities.get(user_assigned_identity_id.replace("resourcegroups", "resourceGroups")).get(
+                    "clientId"
+                )
             return None
         if identity.get("type") == "SystemAssigned":
             # SystemAssigned managed identity does not have client_id in get access connector response

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -360,6 +360,7 @@ class AzureResources:
             identities = identity.get("userAssignedIdentities")
             if user_assigned_identity_id in identities:
                 return identities.get(user_assigned_identity_id).get("clientId")
+            # sometimes we see "resourceGroups" instead of "resourcegroups" in the response from the API
             if user_assigned_identity_id.replace("resourcegroups", "resourceGroups") in identities:
                 return identities.get(user_assigned_identity_id.replace("resourcegroups", "resourceGroups")).get(
                     "clientId"

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -341,3 +341,15 @@ class AzureResources:
                 return None
             self._role_definitions[role_definition_id] = role_name
         return self._role_definitions.get(role_definition_id)
+
+    def access_connector_identity_client_id(self, access_connector_id) -> str | None:
+        identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
+        if not identity:
+            return None
+        if identity.get("type") == "UserAssigned":
+            return identity.get("userAssignedIdentities").get("clientId")
+        if identity.get("type") == "SystemAssigned":
+            principal = self._get_principal(identity.get("principalId"))
+            if not principal:
+                return None
+            return principal.client_id

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -360,7 +360,8 @@ class AzureResources:
             identities = identity.get("userAssignedIdentities")
             if user_assigned_identity_id in identities:
                 return identities.get(user_assigned_identity_id).get("clientId")
-            # sometimes we see "resourceGroups" instead of "resourcegroups" in the response from the API
+            # sometimes we see "resourceGroups" instead of "resourcegroups" in the response from Azure RM API
+            # but "resourcegroups" in response from storage credential's managed_identity_id
             if user_assigned_identity_id.replace("resourcegroups", "resourceGroups") in identities:
                 return identities.get(user_assigned_identity_id.replace("resourcegroups", "resourceGroups")).get(
                     "clientId"

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -347,7 +347,7 @@ class AzureResources:
     ) -> str | None:
         # get te client_id/application_id of the managed identity used in the access connector
         try:
-            identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
+            identity = self._mgmt.get(access_connector_id, "2023-05-01").get("identity")
         except NotFound:
             logger.warning(f"Access connector {access_connector_id} no longer exists")
             return None

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -342,14 +342,18 @@ class AzureResources:
             self._role_definitions[role_definition_id] = role_name
         return self._role_definitions.get(role_definition_id)
 
-    def access_connector_identity_client_id(self, access_connector_id) -> str | None:
+    def managed_identity_client_id(self, access_connector_id) -> str | None:
+        # get te client_id/application_id of the managed identity used in the access connector
         identity = self._get_resource(access_connector_id, "2023-05-01").get("identity")
         if not identity:
             return None
         if identity.get("type") == "UserAssigned":
             return identity.get("userAssignedIdentities").get("clientId")
         if identity.get("type") == "SystemAssigned":
+            # SystemAssigned managed identity does not have client_id in get access connector response
+            # need to call graph api directoryObjects to fetch the client_id
             principal = self._get_principal(identity.get("principalId"))
             if not principal:
                 return None
             return principal.client_id
+        return None

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -160,7 +160,7 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
             cnt += 1
         return tf_script
 
-    def _match_table_external_locations(self) -> tuple[list[list], list[ExternalLocation]]:
+    def match_table_external_locations(self) -> tuple[list[list], list[ExternalLocation]]:
         external_locations = list(self._ws.external_locations.list())
         location_path = [_.url.lower() for _ in external_locations]
         table_locations = self.snapshot()
@@ -178,7 +178,7 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         return matching_locations, missing_locations
 
     def save_as_terraform_definitions_on_workspace(self, installation: Installation):
-        matching_locations, missing_locations = self._match_table_external_locations()
+        matching_locations, missing_locations = self.match_table_external_locations()
         if len(matching_locations) > 0:
             logger.info("following external locations are already configured.")
             logger.info("sharing details of # tables that can be migrated for each location")

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -4,7 +4,7 @@ from databricks.sdk.errors.platform import NotFound
 
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
-from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.hive_metastore import ExternalLocations
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 
@@ -49,7 +49,13 @@ def test_run(caplog, ws, sql_backend, inventory_schema):
             ]
         }
     )
-    azurerm = AzureResources(ws)
+
+    azure_mgmt_client = AzureAPIClient(
+        ws.config.arm_environment.resource_manager_endpoint,
+        ws.config.arm_environment.service_management_endpoint,
+    )
+    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
+    azurerm = AzureResources(azure_mgmt_client, graph_client)
 
     location_migration = ExternalLocationsMigration(
         ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
@@ -85,7 +91,13 @@ def test_read_only_location(caplog, ws, sql_backend, inventory_schema):
             ]
         }
     )
-    azurerm = AzureResources(ws)
+
+    azure_mgmt_client = AzureAPIClient(
+        ws.config.arm_environment.resource_manager_endpoint,
+        ws.config.arm_environment.service_management_endpoint,
+    )
+    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
+    azurerm = AzureResources(azure_mgmt_client, graph_client)
 
     location_migration = ExternalLocationsMigration(
         ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
@@ -120,7 +132,13 @@ def test_missing_credential(caplog, ws, sql_backend, inventory_schema):
             ]
         }
     )
-    azurerm = AzureResources(ws)
+
+    azure_mgmt_client = AzureAPIClient(
+        ws.config.arm_environment.resource_manager_endpoint,
+        ws.config.arm_environment.service_management_endpoint,
+    )
+    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
+    azurerm = AzureResources(azure_mgmt_client, graph_client)
 
     location_migration = ExternalLocationsMigration(
         ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
@@ -158,7 +176,13 @@ def test_overlapping_location(caplog, ws, sql_backend, inventory_schema):
             ]
         }
     )
-    azurerm = AzureResources(ws)
+
+    azure_mgmt_client = AzureAPIClient(
+        ws.config.arm_environment.resource_manager_endpoint,
+        ws.config.arm_environment.service_management_endpoint,
+    )
+    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
+    azurerm = AzureResources(azure_mgmt_client, graph_client)
 
     location_migration = ExternalLocationsMigration(
         ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -1,4 +1,6 @@
+import pytest
 from databricks.labs.blueprint.installation import MockInstallation
+from databricks.sdk.errors.platform import NotFound
 
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
@@ -7,12 +9,22 @@ from databricks.labs.ucx.hive_metastore import ExternalLocations
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 
 
-def test_run(caplog, ws, sql_backend, inventory_schema):
-    azurerm = AzureResources(ws)
+def save_delete_location(ws, name):
+    try:
+        ws.external_locations.delete(name, force=True)
+    except NotFound:
+        # If test failed with exception threw before external location is created,
+        # don't fail the test with external location cannot be deleted error,
+        # instead let the original exception be reported.
+        pass
 
+
+@pytest.mark.skip
+def test_run(caplog, ws, sql_backend, inventory_schema):
     locations = [
         ExternalLocation("abfss://uctest@ziyuanqintest.dfs.core.windows.net/one", 1),
         ExternalLocation("abfss://uctest@ziyuanqintest.dfs.core.windows.net/two", 2),
+        ExternalLocation("abfss://ucx2@ziyuanqintest.dfs.core.windows.net/", 2),
     ]
     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
     location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
@@ -22,46 +34,98 @@ def test_run(caplog, ws, sql_backend, inventory_schema):
             "azure_storage_account_info.csv": [
                 {
                     'prefix': 'abfss://uctest@ziyuanqintest.dfs.core.windows.net/',
-                    'client_id': "0cb5b9c2-b5e3-4bb5-89a8-ebcef6708997",
-                    'principal': "labsazurethings-access",
+                    'client_id': "redacted-for-github-929e765443eb",
+                    'principal': "oneenv-adls",
+                    'privilege': "WRITE_FILES",
+                    'type': "Application",
+                },
+                {
+                    'prefix': 'abfss://ucx2@ziyuanqintest.dfs.core.windows.net/',
+                    'client_id': "redacted-for-github-ebcef6708997",
+                    'principal': "ziyuan-user-assigned-mi",
                     'privilege': "WRITE_FILES",
                     'type': "ManagedIdentity",
                 },
             ]
         }
     )
-    resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+    azurerm = AzureResources(ws)
 
-    location_migration = ExternalLocationsMigration(ws, location_crawler, resource_permissions, azurerm)
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
+    )
+    try:
+        location_migration.run()
+        assert "All UC external location are created." in caplog.text
+        assert ws.external_locations.get("uctest_ziyuanqintest_one").credential_name == "oneenv-adls"
+        assert ws.external_locations.get("uctest_ziyuanqintest_two").credential_name == "oneenv-adls"
+        assert ws.external_locations.get("ucx2_ziyuanqintest").credential_name == "ziyuan-user-assigned-mi"
+    finally:
+        save_delete_location(ws, "uctest_ziyuanqintest_one")
+        save_delete_location(ws, "uctest_ziyuanqintest_two")
+        save_delete_location(ws, "ucx2_ziyuanqintest")
 
-    location_migration.run()
 
-    assert "All UC external location are created." in caplog.text
+@pytest.mark.skip
+def test_read_only_location(caplog, ws, sql_backend, inventory_schema):
+    locations = [ExternalLocation("abfss://ucx1@ziyuanqintest.dfs.core.windows.net/", 1)]
+    sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
+    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
+
+    installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'abfss://ucx1@ziyuanqintest.dfs.core.windows.net/',
+                    'client_id': "redacted-for-github-ff66ffe1d728",
+                    'principal': "ziyuanqin-uc-test-ac",
+                    'privilege': "READ_FILES",
+                    'type': "ManagedIdentity",
+                }
+            ]
+        }
+    )
+    azurerm = AzureResources(ws)
+
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
+    )
+    try:
+        location_migration.run()
+        assert ws.external_locations.get("ucx1_ziyuanqintest").credential_name == "ziyuanqin-uc-test-ac"
+        assert ws.external_locations.get("ucx1_ziyuanqintest").read_only
+    finally:
+        save_delete_location(ws, "ucx1_ziyuanqintest")
 
 
-# def test_run(ws, env_or_skip, sql_backend, inventory_schema, make_random):
-#     azurerm = AzureResources(ws)
-#
-#     locations = [
-#         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/one", 1),
-#         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/two", 2),
-#     ]
-#     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
-#     location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
-#
-#     installation = MockInstallation({
-#         "azure_storage_account_info.csv": [
-#             {
-#                 'prefix': 'abfss://things@labsazurethings.dfs.core.windows.net/',
-#                 'client_id': "9cbd8a1a-8169-4ff8-a929-f1e9572c090c",
-#                 'principal': "labsazurethings-access",
-#                 'privilege': "WRITE_FILES",
-#                 'directory_id': "9f37a392-f0ae-4280-9796-f1864a10effc",
-#             },
-#         ]
-#     })
-#     resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
-#
-#     location_migration = ExternalLocationsMigration(ws, location_crawler, resource_permissions, azurerm)
-#
-#     location_migration.run()
+@pytest.mark.skip
+def test_missing_credential(caplog, ws, sql_backend, inventory_schema):
+    locations = [
+        ExternalLocation("abfss://ucx3@ziyuanqintest.dfs.core.windows.net/one", 1),
+        ExternalLocation("abfss://ucx3@ziyuanqintest.dfs.core.windows.net/two", 2),
+    ]
+    sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
+    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
+
+    installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'abfss://ucx3@ziyuanqintest.dfs.core.windows.net/',
+                    'client_id': "no-such-id",
+                    'principal': "dummy_principal",
+                    'privilege': "WRITE_FILES",
+                    'type': "Application",
+                },
+            ]
+        }
+    )
+    azurerm = AzureResources(ws)
+
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(installation, ws, azurerm, location_crawler), azurerm
+    )
+    leftover_loc = location_migration.run()
+
+    assert "External locations below are not created in UC" in caplog.text
+    assert len(leftover_loc) == 2

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -1,0 +1,64 @@
+from databricks.labs.blueprint.installation import MockInstallation
+
+from databricks.labs.ucx.azure.access import AzureResourcePermissions
+from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
+from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.hive_metastore import ExternalLocations
+from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
+
+
+
+def test_run(ws, env_or_skip, sql_backend, inventory_schema, make_random):
+    azurerm = AzureResources(ws)
+
+    locations = [
+        ExternalLocation("abfss://uctest@ziyuanqintest.dfs.core.windows.net/one", 1),
+        ExternalLocation("abfss://uctest@ziyuanqintest.dfs.core.windows.net/two", 2),
+    ]
+    sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
+    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
+
+    installation = MockInstallation({
+        "azure_storage_account_info.csv": [
+            {
+                'prefix': 'abfss://uctest@ziyuanqintest.dfs.core.windows.net/',
+                'client_id': "0cb5b9c2-b5e3-4bb5-89a8-ebcef6708997",
+                'principal': "labsazurethings-access",
+                'privilege': "WRITE_FILES",
+                'directory_id': "9f37a392-f0ae-4280-9796-f1864a10effc",
+            },
+        ]
+    })
+    resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+
+    location_migration = ExternalLocationsMigration(ws, location_crawler, resource_permissions, azurerm)
+
+    location_migration.run()
+
+
+# def test_run(ws, env_or_skip, sql_backend, inventory_schema, make_random):
+#     azurerm = AzureResources(ws)
+#
+#     locations = [
+#         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/one", 1),
+#         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/two", 2),
+#     ]
+#     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
+#     location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
+#
+#     installation = MockInstallation({
+#         "azure_storage_account_info.csv": [
+#             {
+#                 'prefix': 'abfss://things@labsazurethings.dfs.core.windows.net/',
+#                 'client_id': "9cbd8a1a-8169-4ff8-a929-f1e9572c090c",
+#                 'principal': "labsazurethings-access",
+#                 'privilege': "WRITE_FILES",
+#                 'directory_id': "9f37a392-f0ae-4280-9796-f1864a10effc",
+#             },
+#         ]
+#     })
+#     resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+#
+#     location_migration = ExternalLocationsMigration(ws, location_crawler, resource_permissions, azurerm)
+#
+#     location_migration.run()

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -25,7 +25,7 @@ def test_run(ws, env_or_skip, sql_backend, inventory_schema, make_random):
                 'client_id': "0cb5b9c2-b5e3-4bb5-89a8-ebcef6708997",
                 'principal': "labsazurethings-access",
                 'privilege': "WRITE_FILES",
-                'directory_id': "9f37a392-f0ae-4280-9796-f1864a10effc",
+                'type': "ManagedIdentity",
             },
         ]
     })

--- a/tests/unit/azure/azure/mappings.json
+++ b/tests/unit/azure/azure/mappings.json
@@ -197,6 +197,29 @@
     },
     "/v1.0/applications": {
       "appId": "appIduser1"
+    },
+    "/subscriptions/123/resourcegroups/abc/providers/Microsoft.Databricks/accessConnectors/credential_system_assigned_mi": {
+      "identity": {
+        "principalId": "principal_id_system_assigned_mi-123",
+        "type": "SystemAssigned"
+      }
+    },
+    "/subscriptions/123/resourcegroups/abc/providers/Microsoft.ManagedIdentity/accessConnectors/credential_user_assigned_mi": {
+      "identity": {
+        "userAssignedIdentities": {
+          "/subscriptions/123/resourceGroups/abc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/credential_user_assigned_mi": {
+            "principalId": "principal_id_user_assigned_mi-123",
+            "clientId": "application_id_user_assigned_mi-123"
+          }
+        },
+        "type": "UserAssigned"
+      }
+    },
+    "/v1.0/directoryObjects/principal_id_system_assigned_mi-123": {
+      "appId": "application_id_system_assigned_mi-123",
+      "displayName": "credential_system_assigned_mi",
+      "id": "id_system_assigned_mi-123",
+      "servicePrincipalType": "ManagedIdentity"
     }
   }
 ]

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -340,6 +340,10 @@ def test_for_cli(ws):
             "config.yml": {
                 'version': 2,
                 'inventory_database': 'test',
+                'connect': {
+                    'host': 'test',
+                    'token': 'test',
+                },
             },
             "azure_storage_account_info.csv": [
                 {

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -33,7 +33,7 @@ def test_run_service_principal(ws):
     row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
     mock_backend = MockBackend(
         rows={
-            "SELECT \* FROM location_test.external_locations": [
+            r"SELECT \* FROM location_test.external_locations": [
                 row_factory(["abfss://container1@test.dfs.core.windows.net/one/", 1]),
                 row_factory(["abfss://container2@test.dfs.core.windows.net/", 2]),
             ]
@@ -113,7 +113,7 @@ def test_run_managed_identity(ws, mocker):
     row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
     mock_backend = MockBackend(
         rows={
-            "SELECT \* FROM location_test.external_locations": [
+            r"SELECT \* FROM location_test.external_locations": [
                 row_factory(["abfss://container4@test.dfs.core.windows.net/", 4]),
                 row_factory(["abfss://container5@test.dfs.core.windows.net/a/b/", 5]),
             ]
@@ -188,7 +188,7 @@ def test_run_managed_identity(ws, mocker):
     )
 
 
-def create_side_effect(location_name, *args, **kwargs):
+def create_side_effect(location_name, *args, **kwargs):  # pylint: disable=unused-argument
     # if not external_locations.create is called without skip_validation=True, raise PermissionDenied
     if not kwargs.get('skip_validation'):
         if "empty" in location_name:
@@ -204,7 +204,7 @@ def test_location_failed_to_read(ws):
     row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
     mock_backend = MockBackend(
         rows={
-            "SELECT \* FROM location_test.external_locations": [
+            r"SELECT \* FROM location_test.external_locations": [
                 row_factory(["abfss://empty@test.dfs.core.windows.net/", 1]),
                 row_factory(["abfss://exception@test.dfs.core.windows.net/", 2]),
             ]
@@ -277,7 +277,7 @@ def test_corner_cases_with_missing_fields(ws, caplog, mocker):
     row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
     mock_backend = MockBackend(
         rows={
-            "SELECT \* FROM location_test.external_locations": [
+            r"SELECT \* FROM location_test.external_locations": [
                 row_factory(["abfss://container1@test.dfs.core.windows.net/", 1]),
                 row_factory(["abfss://container2@test.dfs.core.windows.net/", 2]),
             ]
@@ -339,11 +339,7 @@ def test_for_cli(ws):
         {
             "config.yml": {
                 'version': 2,
-                'inventory_database': 'ucx',
-                'connect': {
-                    'host': 'foo',
-                    'token': 'bar',
-                },
+                'inventory_database': 'test',
             },
             "azure_storage_account_info.csv": [
                 {

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -1,0 +1,360 @@
+import logging
+from unittest.mock import create_autospec
+
+import pytest
+from databricks.labs.blueprint.installation import MockInstallation
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors.platform import PermissionDenied
+from databricks.sdk.service.catalog import (
+    AzureManagedIdentity,
+    AzureServicePrincipal,
+    ExternalLocationInfo,
+    StorageCredentialInfo,
+)
+
+from databricks.labs.ucx.azure.access import AzureResourcePermissions
+from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
+from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.hive_metastore import ExternalLocations
+from databricks.labs.ucx.mixins.sql import Row
+from tests.unit.azure import get_az_api_mapping
+from tests.unit.framework.mocks import MockBackend
+
+
+@pytest.fixture
+def ws():
+    return create_autospec(WorkspaceClient)
+
+
+def test_run_service_principal(ws):
+    """test run with service principal based storage credentials"""
+
+    # mock crawled HMS external locations
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
+    mock_backend = MockBackend(
+        rows={
+            "SELECT \* FROM location_test.external_locations": [
+                row_factory(["abfss://container1@test.dfs.core.windows.net/one/", 1]),
+                row_factory(["abfss://container2@test.dfs.core.windows.net/", 2]),
+            ]
+        }
+    )
+
+    # mock listing storage credentials
+    ws.storage_credentials.list.return_value = [
+        StorageCredentialInfo(
+            name="credential_sp1",
+            azure_service_principal=AzureServicePrincipal(
+                "directory_id_1",
+                "application_id_1",
+                "test_secret",
+            ),
+        ),
+        StorageCredentialInfo(
+            name="credential_sp2",
+            azure_service_principal=AzureServicePrincipal("directory_id_2", "application_id_2", "test_secret"),
+            read_only=True,
+        ),
+    ]
+
+    # mock listing UC external locations, no HMS external location will be matched
+    ws.external_locations.list.return_value = [ExternalLocationInfo(name="none", url="none")]
+
+    # mock installation with permission mapping
+    mock_installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'abfss://container1@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_1',
+                    'principal': 'credential_sp1',
+                    'privilege': 'WRITE_FILES',
+                    'type': 'Application',
+                    'directory_id': 'directory_id_1',
+                },
+                {
+                    'prefix': 'abfss://container2@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_2',
+                    'principal': 'credential_sp2',
+                    'privilege': 'READ_FILES',
+                    'type': 'Application',
+                    'directory_id': 'directory_id_1',
+                },
+            ],
+        }
+    )
+
+    location_crawler = ExternalLocations(ws, mock_backend, "location_test")
+    azurerm = AzureResources(ws)
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler), azurerm
+    )
+
+    location_migration.run()
+    ws.external_locations.create.assert_any_call(
+        "container1_test_one",
+        "abfss://container1@test.dfs.core.windows.net/one/",
+        "credential_sp1",
+        comment="Created by UCX",
+    )
+    ws.external_locations.create.assert_any_call(
+        "container2_test",
+        "abfss://container2@test.dfs.core.windows.net/",
+        "credential_sp2",
+        comment="Created by UCX",
+        read_only=True,
+    )
+
+
+def test_run_managed_identity(ws, mocker):
+    """test run with managed identity based storage credentials"""
+
+    # mock crawled HMS external locations
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
+    mock_backend = MockBackend(
+        rows={
+            "SELECT \* FROM location_test.external_locations": [
+                row_factory(["abfss://container4@test.dfs.core.windows.net/", 4]),
+                row_factory(["abfss://container5@test.dfs.core.windows.net/a/b/", 5]),
+            ]
+        }
+    )
+
+    # mock listing storage credentials
+    ws.storage_credentials.list.return_value = [
+        StorageCredentialInfo(
+            name="credential_system_assigned_mi",
+            azure_managed_identity=AzureManagedIdentity(
+                "/subscriptions/123/resourcegroups/abc/providers/Microsoft.Databricks/accessConnectors/credential_system_assigned_mi"
+            ),
+        ),
+        StorageCredentialInfo(
+            name="credential_user_assigned_mi",
+            azure_managed_identity=AzureManagedIdentity(
+                "/subscriptions/123/resourcegroups/abc/providers/Microsoft.ManagedIdentity/accessConnectors/credential_user_assigned_mi",
+                managed_identity_id="/subscriptions/123/resourceGroups/abc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/credential_user_assigned_mi",
+            ),
+            read_only=True,
+        ),
+    ]
+
+    # mock listing UC external locations, no HMS external location will be matched
+    ws.external_locations.list.return_value = [ExternalLocationInfo(name="none", url="none")]
+
+    # mock installation with permission mapping
+    mock_installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'abfss://container4@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_system_assigned_mi-123',
+                    'principal': 'credential_system_assigned_mi',
+                    'privilege': 'WRITE_FILES',
+                    'type': 'ManagedIdentity',
+                },
+                {
+                    'prefix': 'abfss://container5@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_user_assigned_mi-123',
+                    'principal': 'credential_user_assigned_mi',
+                    'privilege': 'READ_FILES',
+                    'type': 'ManagedIdentity',
+                },
+            ],
+        }
+    )
+
+    # mock Azure resource manager and graph API calls for getting application_id of managed identity
+    mocker.patch("databricks.sdk.core.ApiClient.do", side_effect=get_az_api_mapping)
+
+    location_crawler = ExternalLocations(ws, mock_backend, "location_test")
+    azurerm = AzureResources(ws)
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler), azurerm
+    )
+    location_migration.run()
+
+    ws.external_locations.create.assert_any_call(
+        "container4_test",
+        "abfss://container4@test.dfs.core.windows.net/",
+        "credential_system_assigned_mi",
+        comment="Created by UCX",
+    )
+    ws.external_locations.create.assert_any_call(
+        "container5_test_a_b",
+        "abfss://container5@test.dfs.core.windows.net/a/b/",
+        "credential_user_assigned_mi",
+        comment="Created by UCX",
+        read_only=True,
+    )
+
+
+def create_side_effect(location_name, *args, **kwargs):
+    # if not external_locations.create is called without skip_validation=True, raise PermissionDenied
+    if not kwargs.get('skip_validation'):
+        if "empty" in location_name:
+            raise PermissionDenied("No file available under the location to read")
+        if "exception" in location_name:
+            raise PermissionDenied("Other PermissionDenied exception")
+
+
+def test_location_failed_to_read(ws):
+    """If read-only location is empty, READ permission check will fail with PermissionDenied"""
+
+    # mock crawled HMS external locations
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
+    mock_backend = MockBackend(
+        rows={
+            "SELECT \* FROM location_test.external_locations": [
+                row_factory(["abfss://empty@test.dfs.core.windows.net/", 1]),
+                row_factory(["abfss://exception@test.dfs.core.windows.net/", 2]),
+            ]
+        }
+    )
+    # mock listing storage credentials
+    ws.storage_credentials.list.return_value = [
+        StorageCredentialInfo(
+            name="credential_sp2",
+            azure_service_principal=AzureServicePrincipal("directory_id_2", "application_id_2", "test_secret"),
+            read_only=True,
+        ),
+    ]
+    # mock listing UC external locations, no HMS external location will be matched
+    ws.external_locations.list.return_value = [ExternalLocationInfo(name="none", url="none")]
+
+    # mock installation with permission mapping
+    mock_installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'abfss://empty@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_2',
+                    'principal': 'credential_sp2',
+                    'privilege': 'READ_FILES',
+                    'type': 'Application',
+                    'directory_id': 'directory_id_1',
+                },
+                {
+                    'prefix': 'abfss://exception@test.dfs.core.windows.net/',
+                    'client_id': 'application_id_2',
+                    'principal': 'credential_sp2',
+                    'privilege': 'READ_FILES',
+                    'type': 'Application',
+                    'directory_id': 'directory_id_1',
+                },
+            ],
+        }
+    )
+
+    # make external_locations.create to raise PermissionDenied when first called.
+    ws.external_locations.create.side_effect = create_side_effect
+
+    location_crawler = ExternalLocations(ws, mock_backend, "location_test")
+    azurerm = AzureResources(ws)
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler), azurerm
+    )
+
+    # assert PermissionDenied got re-threw if the exception
+    with pytest.raises(PermissionDenied):
+        location_migration.run()
+
+    # assert the PermissionDenied due to empty location is handled and external_locations.create is called again with skip_validation=True
+    ws.external_locations.create.assert_any_call(
+        "empty_test",
+        "abfss://empty@test.dfs.core.windows.net/",
+        "credential_sp2",
+        comment="Created by UCX",
+        read_only=True,
+        skip_validation=True,
+    )
+
+
+def test_corner_cases_with_missing_fields(ws, caplog, mocker):
+    """test corner cases with: missing credential name, missing application_id"""
+    caplog.set_level(logging.INFO)
+
+    # mock crawled HMS external locations
+    row_factory = type("Row", (Row,), {"__columns__": ["location", "table_count"]})
+    mock_backend = MockBackend(
+        rows={
+            "SELECT \* FROM location_test.external_locations": [
+                row_factory(["abfss://container1@test.dfs.core.windows.net/", 1]),
+                row_factory(["abfss://container2@test.dfs.core.windows.net/", 2]),
+            ]
+        }
+    )
+
+    # mock listing storage credentials
+    ws.storage_credentials.list.return_value = [
+        # credential without name
+        StorageCredentialInfo(
+            azure_service_principal=AzureServicePrincipal(
+                "directory_id_1",
+                "application_id_1",
+                "test_secret",
+            ),
+        ),
+        StorageCredentialInfo(
+            name="credential_no_id_mi",
+            azure_managed_identity=AzureManagedIdentity(
+                "/subscriptions/123/no_id_test/accessConnectors/credential_no_id_mi",
+            ),
+        ),
+    ]
+
+    # mock listing UC external locations, no HMS external location will be matched
+    ws.external_locations.list.return_value = [ExternalLocationInfo(name="none", url="none")]
+
+    # mock installation with permission mapping
+    mock_installation = MockInstallation(
+        {
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'dummy',
+                    'client_id': 'dummy',
+                    'principal': 'dummy',
+                    'privilege': 'WRITE_FILES',
+                    'type': 'Application',
+                    'directory_id': 'dummy',
+                },
+            ],
+        }
+    )
+    # return None when getting application_id of managed identity
+    mocker.patch("databricks.sdk.core.ApiClient.do", return_value={"dummy": "dummy"})
+
+    location_crawler = ExternalLocations(ws, mock_backend, "location_test")
+    azurerm = AzureResources(ws)
+    location_migration = ExternalLocationsMigration(
+        ws, location_crawler, AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler), azurerm
+    )
+
+    location_migration.run()
+    ws.external_locations.create.assert_not_called()
+    assert "External locations below are not created in UC." in caplog.text
+
+
+def test_for_cli(ws):
+    mock_installation = MockInstallation(
+        {
+            "config.yml": {
+                'version': 2,
+                'inventory_database': 'ucx',
+                'connect': {
+                    'host': 'foo',
+                    'token': 'bar',
+                },
+            },
+            "azure_storage_account_info.csv": [
+                {
+                    'prefix': 'dummy',
+                    'client_id': 'dummy',
+                    'principal': 'dummy',
+                    'privilege': 'WRITE_FILES',
+                    'type': 'Application',
+                    'directory_id': 'dummy',
+                },
+            ],
+        }
+    )
+    assert isinstance(ExternalLocationsMigration.for_cli(ws, mock_installation), ExternalLocationsMigration)

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -189,7 +189,7 @@ def test_run_managed_identity(ws, mocker):
 
 
 def create_side_effect(location_name, *args, **kwargs):  # pylint: disable=unused-argument
-    # if not external_locations.create is called without skip_validation=True, raise PermissionDenied
+    # if external_locations.create is called without skip_validation=True, raise PermissionDenied
     if not kwargs.get('skip_validation'):
         if "empty" in location_name:
             raise PermissionDenied("No file available under the location to read")

--- a/tests/unit/azure/test_resources.py
+++ b/tests/unit/azure/test_resources.py
@@ -1,5 +1,9 @@
 import pytest
-from databricks.sdk.errors import PermissionDenied, ResourceConflict
+
+from unittest.mock import create_autospec
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import PermissionDenied, ResourceConflict, NotFound
 
 from databricks.labs.ucx.azure.resources import (
     AzureAPIClient,
@@ -7,6 +11,7 @@ from databricks.labs.ucx.azure.resources import (
     AzureResources,
     Principal,
 )
+
 
 from . import azure_api_client, get_az_api_mapping
 
@@ -192,3 +197,77 @@ def test_azure_client_api_delete_spn(mocker):
     api_client = AzureAPIClient("foo", "bar")
     api_client.api_client.do = get_az_api_mapping
     api_client.delete("/applications/1234")
+
+
+def test_managed_identity_client_id(mocker):
+    w = create_autospec(WorkspaceClient)
+    mocker.patch("databricks.sdk.core.ApiClient.do", side_effect=get_az_api_mapping)
+    azure_resource = AzureResources(w)
+    assert (
+        azure_resource.managed_identity_client_id(
+            "/subscriptions/123/resourcegroups/abc/providers/Microsoft.Databricks/accessConnectors/credential_system_assigned_mi"
+        )
+        == "application_id_system_assigned_mi-123"
+    )
+    assert (
+        azure_resource.managed_identity_client_id(
+            "/subscriptions/123/resourcegroups/abc/providers/Microsoft.ManagedIdentity/accessConnectors/credential_user_assigned_mi",
+            "/subscriptions/123/resourcegroups/abc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/credential_user_assigned_mi",
+        )
+        == "application_id_user_assigned_mi-123"
+    )
+
+
+def test_access_connector_not_found(mocker):
+    w = create_autospec(WorkspaceClient)
+    mocker.patch("databricks.sdk.core.ApiClient.do", side_effect=NotFound())
+    azure_resource = AzureResources(w)
+    assert azure_resource.managed_identity_client_id("test") is None
+
+
+def test_non_app_id_access_connector(mocker):
+    w = create_autospec(WorkspaceClient)
+    azure_resource = AzureResources(w)
+
+    mocker.patch(
+        "databricks.sdk.core.ApiClient.do",
+        return_value={
+            "identity": {
+                "userAssignedIdentities": {
+                    "test_mi_id": {"principalId": "test_principal_id", "clientId": "test_client_id"}
+                },
+                "type": "UserAssigned",
+            }
+        },
+    )
+    # test managed_identity_client_id is called without providing user_assigned_identity_id when userAssignedIdentity is encountered
+    assert azure_resource.managed_identity_client_id("no_user_assigned_identity_id_provided") is None
+    # test no application_id of the user assigned managed identity is found
+    assert azure_resource.managed_identity_client_id("no_such_access_connector", "no_such_identity") is None
+
+    # test if identity type is not UserAssigned nor SystemAssigned
+    mocker.patch(
+        "databricks.sdk.core.ApiClient.do",
+        return_value={"identity": {"principalId": "test_principal_id", "type": "Other"}},
+    )
+    assert azure_resource.managed_identity_client_id("other_type") is None
+
+
+def azure_api_side_effect(*args, **kwargs):
+    if "/v1.0/directoryObjects/" in args[1]:
+        raise NotFound()
+    return get_az_api_mapping(*args, **kwargs)
+
+
+def test_managed_identity_not_found(mocker):
+    w = create_autospec(WorkspaceClient)
+    azure_resource = AzureResources(w)
+
+    # test if identity type is not UserAssigned nor SystemAssigned#
+    mocker.patch("databricks.sdk.core.ApiClient.do", side_effect=azure_api_side_effect)
+    assert (
+        azure_resource.managed_identity_client_id(
+            "/subscriptions/123/resourcegroups/abc/providers/Microsoft.Databricks/accessConnectors/credential_system_assigned_mi"
+        )
+        is None
+    )


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Create UC external locations for missing locations reported by `ExternalLocations` in `hive_metastore/locations.py`.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Partially resolve #100 

### Functionality 

- [ ] added relevant user documentation
- [x] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
