### PR TITLE
Added group members difference to the output of validate-groups-membership cli command

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -109,10 +109,10 @@ commands:
         description: AWS Profile to use for authentication
 
   - name: validate-groups-membership
-    description: Validate the groups to see if the groups at account level and workspace level have different membership
+    description: Validate groups to check if the groups at account level and workspace level have different memberships
     table_template: |-
-      Workspace Group Name\tMembers Count\tAccount Group Name\tMembers Count
-      {{range .}}{{.wf_group_name}}\t{{.wf_group_members_count}}\t{{.acc_group_name}}\t{{.acc_group_members_count}}
+      Workspace Group Name\tMembers Count\tAccount Group Name\tMembers Count\tDifference
+      {{range .}}{{.wf_group_name}}\t{{.wf_group_members_count}}\t{{.acc_group_name}}\t{{.acc_group_members_count}}\t{{.group_members_difference}}
       {{end}}
 
   - name: migrate_credentials

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -456,6 +456,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
                     "wf_group_members_count": len(ws_members_set),
                     "acc_group_name": ws_group.name_in_account,
                     "acc_group_members_count": len(acc_members_set),
+                    "group_members_difference": len(ws_members_set) - len(acc_members_set),
                 }
             )
         if not mismatch_group:

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -866,6 +866,7 @@ def test_validate_group_diff_membership():
             "wf_group_members_count": 2,
             "acc_group_name": "ac_test_1234",
             "acc_group_members_count": 1,
+            "group_members_difference": 1
         }
     ]
 

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -866,7 +866,7 @@ def test_validate_group_diff_membership():
             "wf_group_members_count": 2,
             "acc_group_name": "ac_test_1234",
             "acc_group_members_count": 1,
-            "group_members_difference": 1
+            "group_members_difference": 1,
         }
     ]
 


### PR DESCRIPTION
The `validate-groups-membership` command has been updated to include a comparison of group memberships at both the account and workspace levels, displaying the difference in members between the two levels in a new column. This enhancement allows for a more detailed analysis of group memberships, with the added functionality implemented in the `validate_group_membership` function in the `groups.py` file located in the `databricks/labs/ucx/workspace_access` directory. A new output field, "group\_members\_difference," has been added to represent the difference in the number of members between a workspace group and an associated account group. The corresponding unit test file, "test\_groups.py," has been updated to include a new test case that verifies the calculation of the "group\_members\_difference" value. This change provides users with a more comprehensive view of their group memberships and allows them to easily identify any discrepancies between the account and workspace levels. The functionality of the other commands remains unchanged.