### PR TITLE
Adding permission migration support for feature tables and the root permissions for models and feature tables

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -421,10 +421,9 @@ def feature_store_listing(ws: WorkspaceClient):
             for table in result["feature_tables"]:  # type: ignore[index]
                 feature_tables.append(GenericPermissionsInfo(table["id"], "feature-tables"))
 
-            if "next_page_token" in result:
-                token = result["next_page_token"]  # type: ignore[index]
-            else:
+            if "next_page_token" not in result:
                 break
+            token = result["next_page_token"]  # type: ignore[index]
         return feature_tables
 
     return inner

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -42,6 +42,10 @@ class WorkspaceObjectInfo:
     object_id: str | None = None
     language: str | None = None
 
+@dataclass
+class FeatureTableInfo:
+    object_id: str
+    request_type: str
 
 class Listing:
     def __init__(self, func: Callable[..., Iterable], id_attribute: str, object_type: str):
@@ -408,6 +412,24 @@ def experiments_listing(ws: WorkspaceClient):
             yield experiment
 
     return inner
+
+def feature_store_listing(ws:WorkspaceClient):
+    def inner() -> list[FeatureTableInfo]:
+        feature_tables = []
+        token = None
+        while True:
+            result = ws.api_client.do("GET", "/api/2.0/feature-store/feature-tables/search",
+                                        query={"page_token": token, "max_results": 200})
+            for table in result["feature_tables"]:
+                feature_tables.append(FeatureTableInfo(table["id"], "feature-tables"))
+
+            if "next_page_token" in result:
+                token = result["next_page_token"]
+            else:
+                break
+        return feature_tables
+
+    return inner()
 
 
 def tokens_and_passwords():

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -42,10 +42,6 @@ class WorkspaceObjectInfo:
     object_id: str | None = None
     language: str | None = None
 
-@dataclass
-class FeatureTableInfo:
-    object_id: str
-    request_type: str
 
 class Listing:
     def __init__(self, func: Callable[..., Iterable], id_attribute: str, object_type: str):
@@ -413,23 +409,25 @@ def experiments_listing(ws: WorkspaceClient):
 
     return inner
 
-def feature_store_listing(ws:WorkspaceClient):
-    def inner() -> list[FeatureTableInfo]:
+
+def feature_store_listing(ws: WorkspaceClient):
+    def inner() -> list[GenericPermissionsInfo]:
         feature_tables = []
         token = None
         while True:
-            result = ws.api_client.do("GET", "/api/2.0/feature-store/feature-tables/search",
-                                        query={"page_token": token, "max_results": 200})
-            for table in result["feature_tables"]:
-                feature_tables.append(FeatureTableInfo(table["id"], "feature-tables"))
+            result = ws.api_client.do(
+                "GET", "/api/2.0/feature-store/feature-tables/search", query={"page_token": token, "max_results": 200}
+            )
+            for table in result["feature_tables"]:  # type: ignore[index]
+                feature_tables.append(GenericPermissionsInfo(table["id"], "feature-tables"))
 
             if "next_page_token" in result:
-                token = result["next_page_token"]
+                token = result["next_page_token"]  # type: ignore[index]
             else:
                 break
         return feature_tables
 
-    return inner()
+    return inner
 
 
 def tokens_and_passwords():

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -55,6 +55,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
             generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
+            generic.Listing(generic.feature_store_listing, "id", "feature-tables"),
             generic.WorkspaceListing(
                 ws,
                 sql_backend=sql_backend,

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -55,7 +55,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
             generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
-            generic.Listing(generic.feature_store_listing, "id", "feature-tables"),
+            generic.Listing(generic.feature_store_listing(ws), "object_id", "feature-tables"),
             generic.WorkspaceListing(
                 ws,
                 sql_backend=sql_backend,

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta
 
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import BadRequest, NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam
@@ -412,7 +413,6 @@ def test_verify_permissions(ws, make_group, make_job, make_job_permissions):
 
     assert result
 
-
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_endpoints(
     ws, make_group, make_serving_endpoint, make_serving_endpoint_permissions
@@ -439,3 +439,7 @@ def test_endpoints(
 
     after = generic_permissions.load_as_dict("serving-endpoints", endpoint.response.id)
     assert after[group_b.display_name] == PermissionLevel.CAN_MANAGE
+
+
+def test_feature_tables(ws:WorkspaceClient):
+    pass

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -215,6 +215,7 @@ def test_factory(mocker):
             "entitlements",
             "roles",
             'serving-endpoints',
+            "feature-tables",
             "ANY FILE",
             "FUNCTION",
             "ANONYMOUS FUNCTION",


### PR DESCRIPTION
## Changes
Adding support for feature store tables in the assessment

### Linked issues
Resolves [#..](https://github.com/databrickslabs/ucx/issues/589)

### Functionality 

- [ ] modified existing workflow: `assessment`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
