### PR TITLE
Added permission migration support for feature tables and the root permissions for models and feature tables 

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -421,10 +421,9 @@ def feature_store_listing(ws: WorkspaceClient):
             for table in result["feature_tables"]:  # type: ignore[index]
                 feature_tables.append(GenericPermissionsInfo(table["id"], "feature-tables"))
 
-            if "next_page_token" in result:
-                token = result["next_page_token"]  # type: ignore[index]
-            else:
+            if "next_page_token" not in result:
                 break
+            token = result["next_page_token"]  # type: ignore[index]
         return feature_tables
 
     return inner

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -42,6 +42,10 @@ class WorkspaceObjectInfo:
     object_id: str | None = None
     language: str | None = None
 
+@dataclass
+class FeatureTableInfo:
+    object_id: str
+    request_type: str
 
 class Listing:
     def __init__(self, func: Callable[..., Iterable], id_attribute: str, object_type: str):
@@ -408,6 +412,24 @@ def experiments_listing(ws: WorkspaceClient):
             yield experiment
 
     return inner
+
+def feature_store_listing(ws:WorkspaceClient):
+    def inner() -> list[FeatureTableInfo]:
+        feature_tables = []
+        token = None
+        while True:
+            result = ws.api_client.do("GET", "/api/2.0/feature-store/feature-tables/search",
+                                        query={"page_token": token, "max_results": 200})
+            for table in result["feature_tables"]:
+                feature_tables.append(FeatureTableInfo(table["id"], "feature-tables"))
+
+            if "next_page_token" in result:
+                token = result["next_page_token"]
+            else:
+                break
+        return feature_tables
+
+    return inner()
 
 
 def tokens_and_passwords():

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -42,10 +42,6 @@ class WorkspaceObjectInfo:
     object_id: str | None = None
     language: str | None = None
 
-@dataclass
-class FeatureTableInfo:
-    object_id: str
-    request_type: str
 
 class Listing:
     def __init__(self, func: Callable[..., Iterable], id_attribute: str, object_type: str):
@@ -413,23 +409,25 @@ def experiments_listing(ws: WorkspaceClient):
 
     return inner
 
-def feature_store_listing(ws:WorkspaceClient):
-    def inner() -> list[FeatureTableInfo]:
+
+def feature_store_listing(ws: WorkspaceClient):
+    def inner() -> list[GenericPermissionsInfo]:
         feature_tables = []
         token = None
         while True:
-            result = ws.api_client.do("GET", "/api/2.0/feature-store/feature-tables/search",
-                                        query={"page_token": token, "max_results": 200})
-            for table in result["feature_tables"]:
-                feature_tables.append(FeatureTableInfo(table["id"], "feature-tables"))
+            result = ws.api_client.do(
+                "GET", "/api/2.0/feature-store/feature-tables/search", query={"page_token": token, "max_results": 200}
+            )
+            for table in result["feature_tables"]:  # type: ignore[index]
+                feature_tables.append(GenericPermissionsInfo(table["id"], "feature-tables"))
 
             if "next_page_token" in result:
-                token = result["next_page_token"]
+                token = result["next_page_token"]  # type: ignore[index]
             else:
                 break
         return feature_tables
 
-    return inner()
+    return inner
 
 
 def tokens_and_passwords():

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -424,9 +424,18 @@ def feature_store_listing(ws: WorkspaceClient):
             if "next_page_token" not in result:
                 break
             token = result["next_page_token"]  # type: ignore[index]
+
         return feature_tables
 
     return inner
+
+
+def feature_tables_root_page():
+    return [GenericPermissionsInfo("/root", "feature-tables")]
+
+
+def models_root_page():
+    return [GenericPermissionsInfo("/root", "registered-models")]
 
 
 def tokens_and_passwords():

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -418,7 +418,7 @@ def feature_store_listing(ws: WorkspaceClient):
             result = ws.api_client.do(
                 "GET", "/api/2.0/feature-store/feature-tables/search", query={"page_token": token, "max_results": 200}
             )
-            for table in result["feature_tables"]:  # type: ignore[index]
+            for table in result.get("feature_tables", []):
                 feature_tables.append(GenericPermissionsInfo(table["id"], "feature-tables"))
 
             if "next_page_token" not in result:

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -54,8 +54,10 @@ class PermissionManager(CrawlerBase[Permissions]):
             generic.Listing(ws.serving_endpoints.list, "id", "serving-endpoints"),
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
             generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
+            generic.Listing(generic.models_root_page, "object_id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
             generic.Listing(generic.feature_store_listing(ws), "object_id", "feature-tables"),
+            generic.Listing(generic.feature_tables_root_page, "object_id", "feature-tables"),
             generic.WorkspaceListing(
                 ws,
                 sql_backend=sql_backend,

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -55,6 +55,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
             generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
+            generic.Listing(generic.feature_store_listing, "id", "feature-tables"),
             generic.WorkspaceListing(
                 ws,
                 sql_backend=sql_backend,

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -55,7 +55,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             generic.Listing(generic.experiments_listing(ws), "experiment_id", "experiments"),
             generic.Listing(generic.models_listing(ws, num_threads), "id", "registered-models"),
             generic.Listing(generic.tokens_and_passwords, "object_id", "authorization"),
-            generic.Listing(generic.feature_store_listing, "id", "feature-tables"),
+            generic.Listing(generic.feature_store_listing(ws), "object_id", "feature-tables"),
             generic.WorkspaceListing(
                 ws,
                 sql_backend=sql_backend,

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta
 
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import BadRequest, NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam
@@ -412,7 +413,6 @@ def test_verify_permissions(ws, make_group, make_job, make_job_permissions):
 
     assert result
 
-
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_endpoints(
     ws, make_group, make_serving_endpoint, make_serving_endpoint_permissions
@@ -439,3 +439,7 @@ def test_endpoints(
 
     after = generic_permissions.load_as_dict("serving-endpoints", endpoint.response.id)
     assert after[group_b.display_name] == PermissionLevel.CAN_MANAGE
+
+
+def test_feature_tables(ws:WorkspaceClient):
+    pass

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -16,7 +16,7 @@ from databricks.labs.ucx.workspace_access.generic import (
     feature_store_listing,
     feature_tables_root_page,
     models_listing,
-    tokens_and_passwords,
+    tokens_and_passwords, models_root_page,
 )
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 
@@ -513,7 +513,7 @@ def test_models_root_page(ws: WorkspaceClient, make_group):
     )
 
     generic_permissions = GenericPermissionsSupport(
-        ws, [Listing(feature_tables_root_page, "object_id", "registered-models")]
+        ws, [Listing(models_root_page, "object_id", "registered-models")]
     )
     before = generic_permissions.load_as_dict("registered-models", "/root")
     assert before[group_a.display_name] == PermissionLevel.CAN_MANAGE_PRODUCTION_VERSIONS

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -16,7 +16,8 @@ from databricks.labs.ucx.workspace_access.generic import (
     feature_store_listing,
     feature_tables_root_page,
     models_listing,
-    tokens_and_passwords, models_root_page,
+    models_root_page,
+    tokens_and_passwords,
 )
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 
@@ -512,9 +513,7 @@ def test_models_root_page(ws: WorkspaceClient, make_group):
         ],
     )
 
-    generic_permissions = GenericPermissionsSupport(
-        ws, [Listing(models_root_page, "object_id", "registered-models")]
-    )
+    generic_permissions = GenericPermissionsSupport(ws, [Listing(models_root_page, "object_id", "registered-models")])
     before = generic_permissions.load_as_dict("registered-models", "/root")
     assert before[group_a.display_name] == PermissionLevel.CAN_MANAGE_PRODUCTION_VERSIONS
 

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -29,7 +29,7 @@ from databricks.labs.ucx.workspace_access.generic import (
     feature_store_listing,
     feature_tables_root_page,
     models_listing,
-    tokens_and_passwords,
+    tokens_and_passwords, models_root_page,
 )
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 from tests.unit.framework.mocks import MockBackend
@@ -909,7 +909,7 @@ def test_models_page_listing():
     ]
 
     sup = GenericPermissionsSupport(
-        ws=ws, listings=[Listing(feature_tables_root_page, "object_id", "registered-models")]
+        ws=ws, listings=[Listing(models_root_page, "object_id", "registered-models")]
     )
     tasks = list(sup.get_crawler_tasks())
     assert len(tasks) == 1

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -29,7 +29,8 @@ from databricks.labs.ucx.workspace_access.generic import (
     feature_store_listing,
     feature_tables_root_page,
     models_listing,
-    tokens_and_passwords, models_root_page,
+    models_root_page,
+    tokens_and_passwords,
 )
 from databricks.labs.ucx.workspace_access.groups import MigrationState
 from tests.unit.framework.mocks import MockBackend
@@ -908,9 +909,7 @@ def test_models_page_listing():
         iam.ObjectPermissions(object_id="/root", object_type="registered-models", access_control_list=basic_acl),
     ]
 
-    sup = GenericPermissionsSupport(
-        ws=ws, listings=[Listing(models_root_page, "object_id", "registered-models")]
-    )
+    sup = GenericPermissionsSupport(ws=ws, listings=[Listing(models_root_page, "object_id", "registered-models")])
     tasks = list(sup.get_crawler_tasks())
     assert len(tasks) == 1
     auth_items = [task() for task in tasks]

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -27,6 +27,7 @@ from databricks.labs.ucx.workspace_access.generic import (
     WorkspaceObjectInfo,
     experiments_listing,
     feature_store_listing,
+    feature_tables_root_page,
     models_listing,
     tokens_and_passwords,
 )
@@ -868,3 +869,51 @@ def test_feature_tables_listing():
     assert len(result) == 4
     assert result[0].object_id == "table1"
     assert result[0].request_type == "feature-tables"
+
+
+def test_root_page_listing():
+    ws = MagicMock()
+
+    basic_acl = [
+        iam.AccessControlResponse(
+            group_name="test",
+            all_permissions=[iam.Permission(inherited=False, permission_level=iam.PermissionLevel.CAN_EDIT_METADATA)],
+        )
+    ]
+
+    ws.permissions.get.side_effect = [
+        iam.ObjectPermissions(object_id="/root", object_type="feature-tables", access_control_list=basic_acl),
+    ]
+
+    sup = GenericPermissionsSupport(ws=ws, listings=[Listing(feature_tables_root_page, "object_id", "feature-tables")])
+    tasks = list(sup.get_crawler_tasks())
+    assert len(tasks) == 1
+    auth_items = [task() for task in tasks]
+    for item in auth_items:
+        assert item.object_id == "/root"
+        assert item.object_type == "feature-tables"
+
+
+def test_models_page_listing():
+    ws = MagicMock()
+
+    basic_acl = [
+        iam.AccessControlResponse(
+            group_name="test",
+            all_permissions=[iam.Permission(inherited=False, permission_level=iam.PermissionLevel.CAN_EDIT_METADATA)],
+        )
+    ]
+
+    ws.permissions.get.side_effect = [
+        iam.ObjectPermissions(object_id="/root", object_type="registered-models", access_control_list=basic_acl),
+    ]
+
+    sup = GenericPermissionsSupport(
+        ws=ws, listings=[Listing(feature_tables_root_page, "object_id", "registered-models")]
+    )
+    tasks = list(sup.get_crawler_tasks())
+    assert len(tasks) == 1
+    auth_items = [task() for task in tasks]
+    for item in auth_items:
+        assert item.object_id == "/root"
+        assert item.object_type == "registered-models"

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -215,6 +215,7 @@ def test_factory(mocker):
             "entitlements",
             "roles",
             'serving-endpoints',
+            "feature-tables",
             "ANY FILE",
             "FUNCTION",
             "ANONYMOUS FUNCTION",


### PR DESCRIPTION

This commit introduces permission migration support for feature tables and assigns root permissions for models and feature tables. A new fixture, `make_feature_table`, is introduced to handle the creation and deletion of feature tables via API calls. Updates to permission levels for feature tables allow for more granular control over permissions. Additionally, new functions for listing registered models and feature tables, as well as their root pages, have been added to the `manager.py` file. Three new tests have been introduced in the project's workspace access module to ensure the proper migration of permissions for feature tables and the root pages of feature tables and models. The `GenericPermissionsSupport` class in the `workspace_access` module has also been updated to include new tests and methods, adding support for the `feature-tables` and `registered-models` object types. This comprehensive update ensures secure and flexible permission management for feature tables, models, and other resources in the workspace.