### PR TITLE
Add `migrate-locations` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,22 @@ databricks labs ucx validate-external-locations
 ```
 
 Once the [`assessment` workflow](#assessment-workflow) finished successfully, [storage credentials](#migrate-credentials-command) are configured, 
-run this command to ensure the relevant Unity Catalog external locations are created if they are missing. 
+run this command to validate and report the missing Unity Catalog external locations to be created. 
 
 This command validates and provides mapping to external tables to external locations, also as Terraform configurations.
+
+[[back to top](#databricks-labs-ucx)]
+
+
+## `migrate-locations` command
+
+```text
+databricks labs ucx migrate-locations 
+```
+
+Once the [`assessment` workflow](#assessment-workflow) finished successfully, and [storage credentials](#migrate-credentials-command) are configured, 
+run this command to have Unity Catalog external locations created. The candidate locations to be created are extracted from guess_external_locations
+task in the assessment job. You can run `validate_external_locations` command to check the candidate locations.
 
 [[back to top](#databricks-labs-ucx)]
 

--- a/labs.yml
+++ b/labs.yml
@@ -133,3 +133,6 @@ commands:
     flags:
       - name: workspace_ids
         description: List of workspace IDs to create account groups from.
+
+  - name: migrate_locations
+    description: Create UC external locations based on the output of guess_external_locations assessment task.

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -14,6 +14,7 @@ from databricks.labs.ucx.account import AccountWorkspaces, WorkspaceInfo
 from databricks.labs.ucx.assessment.aws import AWSResourcePermissions
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.credentials import ServicePrincipalMigration
+from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.crawlers import StatementExecutionBackend
 from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler
@@ -342,6 +343,23 @@ def create_uber_principal(w: WorkspaceClient, subscription_id: str):
     azure_resource_permissions = AzureResourcePermissions.for_cli(w, include_subscriptions=include_subscriptions)
     azure_resource_permissions.create_uber_principal(prompts)
     return
+
+
+@ucx.command
+def migrate_locations(w: WorkspaceClient):
+    """This command creates UC external locations. The candidate locations to be created are extracted from guess_external_locations
+    task in the assessment job. You can run validate_external_locations command to check the candidate locations. Please make sure
+    the credentials haven migrated before running this command. The command will only create the locations that have corresponded UC Storage Credentials.
+    """
+    if w.config.is_azure:
+        logger.info("Running migrate_locations for Azure")
+        installation = Installation.current(w, 'ucx')
+        service_principal_migration = ExternalLocationsMigration.for_cli(w, installation)
+        service_principal_migration.run()
+    if w.config.is_aws:
+        logger.error("migrate_locations is not yet supported in AWS")
+    if w.config.is_gcp:
+        logger.error("migrate_locations is not yet supported in GCP")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -18,6 +18,7 @@ from databricks.labs.ucx.cli import (
     installations,
     manual_workspace_info,
     migrate_credentials,
+    migrate_locations,
     move,
     open_remote_config,
     principal_prefix_access,
@@ -357,3 +358,10 @@ def test_create_master_principal(ws):
     with patch("databricks.labs.blueprint.tui.Prompts.question", return_value=True):
         with pytest.raises(ValueError):
             create_uber_principal(ws, subscription_id="12")
+
+
+def test_migrate_locations_azure(ws):
+    ws.config.is_azure = True
+    ws.workspace.upload.return_value = "test"
+    migrate_locations(ws)
+    ws.external_locations.list.assert_called()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -362,6 +362,23 @@ def test_create_master_principal(ws):
 
 def test_migrate_locations_azure(ws):
     ws.config.is_azure = True
-    ws.workspace.upload.return_value = "test"
+    ws.config.is_aws = False
+    ws.config.is_gcp = False
     migrate_locations(ws)
     ws.external_locations.list.assert_called()
+
+
+def test_migrate_locations_aws(ws, caplog):
+    ws.config.is_azure = False
+    ws.config.is_aws = True
+    ws.config.is_gcp = False
+    migrate_locations(ws)
+    assert "migrate_locations is not yet supported in AWS" in caplog.messages
+
+
+def test_migrate_locations_gcp(ws, caplog):
+    ws.config.is_azure = False
+    ws.config.is_aws = False
+    ws.config.is_gcp = True
+    migrate_locations(ws)
+    assert "migrate_locations is not yet supported in GCP" in caplog.messages


### PR DESCRIPTION
## Changes
Add cli command `migrate_locations` to create UC external location.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

#100 
#1006 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
