### PR TITLE
Use `max_records_per_batch=500` as default

### DIFF
--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -123,7 +123,7 @@ class SqlBackend(ABC):
 
 
 class StatementExecutionBackend(SqlBackend):
-    def __init__(self, ws: WorkspaceClient, warehouse_id, *, max_records_per_batch: int = 1000):
+    def __init__(self, ws: WorkspaceClient, warehouse_id, *, max_records_per_batch: int = 500):
         self._sql = StatementExecutionExt(ws)
         self._warehouse_id = warehouse_id
         self._max_records_per_batch = max_records_per_batch


### PR DESCRIPTION
This PR should stabilize integration tests a bit more. There are some slight hints that this may get queries done from integration tests unstuck:
<img width="1431" alt="image" src="https://github.com/databrickslabs/ucx/assets/259697/f2833640-05b2-43f9-9c25-df92696742d2">
