### PR TITLE
Add `migrate-tables` workflow

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from databricks.sdk.core import Config
+from databricks.sdk.service.compute import ClusterSpec
 
 __all__ = ["WorkspaceConfig"]
 
@@ -31,7 +32,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     # Starting path for notebooks and directories crawler
     workspace_start_path: str = "/"
     instance_profile: str | None = None
-    spark_conf: dict[str, str] | None = None
+    cluster_specs: dict[str, ClusterSpec] | None = None
 
     override_clusters: dict[str, str] | None = None
     policy_id: str | None = None

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -254,7 +254,4 @@ def trigger(*argv):
     ) as task_logger:
         ucx_logger = logging.getLogger("databricks.labs.ucx")
         ucx_logger.info(f"UCX v{__version__} After job finishes, see debug logs at {task_logger}")
-        if current_task.workflow == "migrate-tables":
-            current_task.fn(cfg, workspace_client, sql_backend, installation)
-        else:
-            current_task.fn(cfg, workspace_client, sql_backend)
+        current_task.fn(cfg, workspace_client, sql_backend, installation)

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -22,13 +22,17 @@ from databricks.labs.ucx.framework.crawlers import RuntimeBackend, SqlBackend
 _TASKS: dict[str, "Task"] = {}
 
 
+AssessmentFunctions = Callable[[WorkspaceConfig, WorkspaceClient, SqlBackend], None]
+MigrationFunctions = Callable[[WorkspaceConfig, WorkspaceClient, SqlBackend, Installation], None]
+
+
 @dataclass
 class Task:
     task_id: int
     workflow: str
     name: str
     doc: str
-    fn: Callable[[WorkspaceConfig, WorkspaceClient, SqlBackend], None]
+    fn: AssessmentFunctions | MigrationFunctions
     depends_on: list[str] | None = None
     job_cluster: str = "main"
     notebook: str | None = None
@@ -238,6 +242,7 @@ def trigger(*argv):
     cfg = Installation.load_local(WorkspaceConfig, config_path)
     sql_backend = RuntimeBackend(debug_truncate_bytes=cfg.connect.debug_truncate_bytes)
     workspace_client = WorkspaceClient(config=cfg.connect, product='ucx', product_version=__version__)
+    installation = Installation.current(workspace_client, "ucx")
 
     with TaskLogger(
         config_path.parent,
@@ -249,4 +254,7 @@ def trigger(*argv):
     ) as task_logger:
         ucx_logger = logging.getLogger("databricks.labs.ucx")
         ucx_logger.info(f"UCX v{__version__} After job finishes, see debug logs at {task_logger}")
-        current_task.fn(cfg, workspace_client, sql_backend)
+        if current_task.workflow == "migrate-tables":
+            current_task.fn(cfg, workspace_client, sql_backend, installation)
+        else:
+            current_task.fn(cfg, workspace_client, sql_backend)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -782,7 +782,7 @@ class WorkspaceInstallation:
         if "migration_clone" in names:
             clusters.append(
                 jobs.JobCluster(
-                    job_cluster_key="migration_sync",
+                    job_cluster_key="migration_clone",
                     new_cluster=replace(
                         spec,
                         data_security_mode=compute.DataSecurityMode.SINGLE_USER,
@@ -790,7 +790,7 @@ class WorkspaceInstallation:
                         # the default 200 partition may not be enough for large tables, but it's hard to
                         # find a number that fits all. If we need higher parallelism, we can use config below
                         # spark_conf={"spark.sql.sources.parallelPartitionDiscovery.parallelism": "1000"},
-                        autoscale=compute.Autoscale( #number of executors matters to parallelism of file copy
+                        autoscale=compute.AutoScale(  # number of executors matters to parallelism of file copy
                             min_workers=1,
                             max_workers=10,
                         ),
@@ -800,7 +800,7 @@ class WorkspaceInstallation:
         if "migration_sync" in names:
             clusters.append(
                 jobs.JobCluster(
-                    job_cluster_key="migration_clone",
+                    job_cluster_key="migration_sync",
                     new_cluster=replace(
                         spec,
                         data_security_mode=compute.DataSecurityMode.SINGLE_USER,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -779,7 +779,7 @@ class WorkspaceInstallation:
                     ),
                 )
             )
-        if "migration_sync" in names:
+        if "migration_clone" in names:
             clusters.append(
                 jobs.JobCluster(
                     job_cluster_key="migration_sync",
@@ -788,8 +788,8 @@ class WorkspaceInstallation:
                         data_security_mode=compute.DataSecurityMode.SINGLE_USER,
                         # https://databricks.atlassian.net/browse/ES-975874
                         # the default 200 partition may not be enough for large tables, but it's hard to
-                        # find a number that fits all.
-                        spark_conf={"spark.sql.sources.parallelPartitionDiscovery.parallelism": "1000"},
+                        # find a number that fits all. If we need higher parallelism, we can use config below
+                        # spark_conf={"spark.sql.sources.parallelPartitionDiscovery.parallelism": "1000"},
                         autoscale=compute.Autoscale( #number of executors matters to parallelism of file copy
                             min_workers=1,
                             max_workers=10,
@@ -797,7 +797,7 @@ class WorkspaceInstallation:
                     ),
                 )
             )
-        if "migration_clone" in names:
+        if "migration_sync" in names:
             clusters.append(
                 jobs.JobCluster(
                     job_cluster_key="migration_clone",

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -779,6 +779,35 @@ class WorkspaceInstallation:
                     ),
                 )
             )
+        if "migration_sync" in names:
+            clusters.append(
+                jobs.JobCluster(
+                    job_cluster_key="migration_sync",
+                    new_cluster=replace(
+                        spec,
+                        data_security_mode=compute.DataSecurityMode.SINGLE_USER,
+                        # https://databricks.atlassian.net/browse/ES-975874
+                        # the default 200 partition may not be enough for large tables, but it's hard to
+                        # find a number that fits all.
+                        spark_conf={"spark.sql.sources.parallelPartitionDiscovery.parallelism": "1000"},
+                        autoscale=compute.Autoscale( #number of executors matters to parallelism of file copy
+                            min_workers=1,
+                            max_workers=10,
+                        ),
+                    ),
+                )
+            )
+        if "migration_clone" in names:
+            clusters.append(
+                jobs.JobCluster(
+                    job_cluster_key="migration_clone",
+                    new_cluster=replace(
+                        spec,
+                        data_security_mode=compute.DataSecurityMode.SINGLE_USER,
+                        num_workers=1,
+                    ),
+                )
+            )
         return clusters
 
     @staticmethod

--- a/src/databricks/labs/ucx/job_cluster_spec.yml
+++ b/src/databricks/labs/ucx/job_cluster_spec.yml
@@ -1,0 +1,26 @@
+# job cluster specifications for "main", see runtime.py for which tasks are using this cluster specifications
+main:
+  data_security_mode: 'LEGACY_SINGLE_USER'
+  num_workers: 0
+  spark_conf:
+    "spark.databricks.cluster.profile": "singleNode"
+    "spark.master": "local[*]"
+  custom_tags:
+    ResourceClass: "SingleNode"
+
+# job cluster specifications for "tacl", see runtime.py for which tasks are using this cluster specifications
+tacl:
+  data_security_mode: 'LEGACY_TABLE_ACL'
+  num_workers: 1
+  spark_conf:
+    "spark.databricks.acl.sqlOnly": "true"
+
+# job cluster specifications for "table_migration", see runtime.py for which tasks are using this cluster specifications
+table_migration:
+  data_security_mode: 'SINGLE_USER'
+  autoscale:
+    min_workers: 1
+    max_workers: 10
+  spark_conf:
+    "spark.sql.sources.parallelPartitionDiscovery.parallelism": "200"
+

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -47,7 +47,7 @@ def setup_tacl(*_):
 
 
 @task("assessment", depends_on=[crawl_tables, setup_tacl], job_cluster="tacl")
-def crawl_grants(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBackend):
+def crawl_grants(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scans the previously created Delta table named `$inventory_database.tables` and issues a `SHOW GRANTS`
     statement for every object to retrieve the permissions it has assigned to it. The permissions include information
     such as the _principal_, _action type_, and the _table_ it applies to. This is persisted in the Delta table
@@ -63,7 +63,9 @@ def crawl_grants(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBacke
 
 
 @task("assessment", depends_on=[crawl_tables])
-def estimate_table_size_for_migration(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBackend):
+def estimate_table_size_for_migration(
+    cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Scans the previously created Delta table named `$inventory_database.tables` and locate tables that cannot be
     "synced". These tables will have to be cloned in the migration process.
     Assesses the size of these tables and create `$inventory_database.table_size` table to list these sizes.
@@ -73,7 +75,7 @@ def estimate_table_size_for_migration(cfg: WorkspaceConfig, _: WorkspaceClient, 
 
 
 @task("assessment")
-def crawl_mounts(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def crawl_mounts(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Defines the scope of the _mount points_ intended for migration into Unity Catalog. As these objects are not
     compatible with the Unity Catalog paradigm, a key component of the migration process involves transferring them
     to Unity Catalog External Locations.
@@ -85,7 +87,9 @@ def crawl_mounts(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBack
 
 
 @task("assessment", depends_on=[crawl_mounts, crawl_tables])
-def guess_external_locations(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def guess_external_locations(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Determines the shared path prefixes of all the tables. Specifically, the focus is on identifying locations that
     utilize mount points. The goal is to identify the _external locations_ necessary for a successful migration and
     store this information in the `$inventory.external_locations` table.
@@ -99,7 +103,7 @@ def guess_external_locations(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_back
 
 
 @task("assessment")
-def assess_jobs(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_jobs(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scans through all the jobs and identifies those that are not compatible with UC. The list of all the jobs is
     stored in the `$inventory.jobs` table.
 
@@ -114,7 +118,7 @@ def assess_jobs(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBacke
 
 
 @task("assessment")
-def assess_clusters(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_clusters(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scan through all the clusters and identifies those that are not compatible with UC. The list of all the clusters
     is stored in the`$inventory.clusters` table.
 
@@ -129,7 +133,7 @@ def assess_clusters(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlB
 
 
 @task("assessment")
-def assess_pipelines(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_pipelines(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """This module scans through all the Pipelines and identifies those pipelines which has Azure Service Principals
     embedded (who has been given access to the Azure storage accounts via spark configurations) in the pipeline
     configurations.
@@ -144,7 +148,9 @@ def assess_pipelines(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: Sql
 
 
 @task("assessment")
-def assess_incompatible_submit_runs(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_incompatible_submit_runs(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """This module scans through all the Submit Runs and identifies those runs which may become incompatible after
     the workspace attachment.
 
@@ -159,7 +165,9 @@ def assess_incompatible_submit_runs(cfg: WorkspaceConfig, ws: WorkspaceClient, s
 
 
 @task("assessment", cloud="azure")
-def assess_azure_service_principals(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_azure_service_principals(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """This module scans through all the clusters configurations, cluster policies, job cluster configurations,
     Pipeline configurations, Warehouse configuration and identifies all the Azure Service Principals who has been
     given access to the Azure storage accounts via spark configurations referred in those entities.
@@ -175,7 +183,9 @@ def assess_azure_service_principals(cfg: WorkspaceConfig, ws: WorkspaceClient, s
 
 
 @task("assessment")
-def assess_global_init_scripts(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def assess_global_init_scripts(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """This module scans through all the global init scripts and identifies if there is an Azure Service Principal
     who has been given access to the Azure storage accounts via spark configurations referred in those scripts.
 
@@ -186,7 +196,7 @@ def assess_global_init_scripts(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_ba
 
 
 @task("assessment")
-def workspace_listing(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def workspace_listing(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scans the workspace for workspace objects. It recursively list all sub directories
     and compiles a list of directories, notebooks, files, repos and libraries in the workspace.
 
@@ -197,7 +207,7 @@ def workspace_listing(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: Sq
 
 
 @task("assessment", depends_on=[crawl_grants, workspace_listing])
-def crawl_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def crawl_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scans the workspace-local groups and all their permissions. The list is stored in the `$inventory.permissions`
     Delta table.
 
@@ -215,7 +225,7 @@ def crawl_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: Sq
 
 
 @task("assessment")
-def crawl_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def crawl_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation):
     """Scans all groups for the local group migration scope"""
     group_manager = GroupManager(
         sql_backend,
@@ -270,7 +280,9 @@ def estimates_report(*_):
 
 
 @task("migrate-groups", depends_on=[crawl_groups])
-def rename_workspace_local_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def rename_workspace_local_groups(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Renames workspace local groups by adding `ucx-renamed-` prefix."""
     verify_has_metastore = VerifyHasMetastore(ws)
     if verify_has_metastore.verify_metastore():
@@ -291,7 +303,9 @@ def rename_workspace_local_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql
 
 
 @task("migrate-groups", depends_on=[rename_workspace_local_groups])
-def reflect_account_groups_on_workspace(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def reflect_account_groups_on_workspace(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Adds matching account groups to this workspace. The matching account level group(s) must preexist(s) for this
     step to be successful. This process does not create the account level group(s)."""
     group_manager = GroupManager(
@@ -309,7 +323,9 @@ def reflect_account_groups_on_workspace(cfg: WorkspaceConfig, ws: WorkspaceClien
 
 
 @task("migrate-groups", depends_on=[reflect_account_groups_on_workspace], job_cluster="tacl")
-def apply_permissions_to_account_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def apply_permissions_to_account_groups(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Fourth phase of the workspace-local group migration process. It does the following:
       - Assigns the full set of permissions of the original group to the account-level one
 
@@ -347,7 +363,9 @@ def apply_permissions_to_account_groups(cfg: WorkspaceConfig, ws: WorkspaceClien
 
 
 @task("validate-groups-permissions", job_cluster="tacl")
-def validate_groups_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def validate_groups_permissions(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Validate that all the crawled permissions are applied correctly to the destination groups."""
     logger.info("Running validation of permissions applied to destination groups.")
     permission_manager = PermissionManager.factory(
@@ -361,7 +379,9 @@ def validate_groups_permissions(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_b
 
 
 @task("remove-workspace-local-backup-groups", depends_on=[apply_permissions_to_account_groups])
-def delete_backup_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
+def delete_backup_groups(
+    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """Last step of the group migration process. Removes all workspace-level backup groups, along with their
     permissions. Execute this workflow only after you've confirmed that workspace-local migration worked
     successfully for all the groups involved."""
@@ -380,7 +400,9 @@ def delete_backup_groups(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend:
 
 
 @task("099-destroy-schema")
-def destroy_schema(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBackend):
+def destroy_schema(
+    cfg: WorkspaceConfig, _workspace_client: WorkspaceClient, sql_backend: SqlBackend, _installation: Installation
+):
     """This _clean-up_ workflow allows to removes the `$inventory` database, with all the inventory tables created by
     the previous workflow runs. Use this to reset the entire state and start with the assessment step again."""
     sql_backend.execute(f"DROP DATABASE {cfg.inventory_database} CASCADE")

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -387,7 +387,7 @@ def destroy_schema(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBac
     sql_backend.execute(f"DROP DATABASE {cfg.inventory_database} CASCADE")
 
 
-@task("migrate_tables")
+@task("migrate_tables", job_cluster="migration_sync")
 def migrate_external_tables_sync(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
     """This workflow task migrates the *external tables that are supported by SYNC command* from the Hive Metastore to the Unity Catalog.
     Following cli commands are required to be run before running this task:
@@ -400,6 +400,7 @@ def migrate_external_tables_sync(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_
     TablesMigrate(table_crawler, ws, sql_backend, table_mapping).migrate_tables(What.EXTERNAL_SYNC)
 
 
+@task("migrate_tables", job_cluster="migration_clone")
 def migrate_dbfs_root_delta_tables(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
     """This workflow task migrates `delta tables stored in DBFS root` from the Hive Metastore to the Unity Catalog using deep clone.
     Following cli commands are required to be run before running this task:
@@ -412,6 +413,7 @@ def migrate_dbfs_root_delta_tables(cfg: WorkspaceConfig, ws: WorkspaceClient, sq
     TablesMigrate(table_crawler, ws, sql_backend, table_mapping).migrate_tables(What.DBFS_ROOT_DELTA)
 
 
+@task("migrate_tables", job_cluster="migration_sync")
 def migrate_views(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend):
     """This workflow task migrates the views from the Hive Metastore to the Unity Catalog. New views will be created in UC but base tables are still in HMS.
     Following cli commands are required to be run before running this task:

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -386,7 +386,7 @@ def destroy_schema(cfg: WorkspaceConfig, _: WorkspaceClient, sql_backend: SqlBac
     sql_backend.execute(f"DROP DATABASE {cfg.inventory_database} CASCADE")
 
 
-@task("migrate-tables", job_cluster="migration_sync")
+@task("migrate-tables", job_cluster="table_migration")
 def migrate_external_tables_sync(
     cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, installation: Installation
 ):
@@ -400,7 +400,7 @@ def migrate_external_tables_sync(
     TablesMigrate(table_crawler, ws, sql_backend, table_mapping).migrate_tables(what=What.EXTERNAL_SYNC)
 
 
-@task("migrate-tables", job_cluster="migration_clone")
+@task("migrate-tables", job_cluster="table_migration")
 def migrate_dbfs_root_delta_tables(
     cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, installation: Installation
 ):
@@ -412,18 +412,6 @@ def migrate_dbfs_root_delta_tables(
     table_crawler = TablesCrawler(sql_backend, cfg.inventory_database)
     table_mapping = TableMapping(installation, ws, sql_backend)
     TablesMigrate(table_crawler, ws, sql_backend, table_mapping).migrate_tables(what=What.DBFS_ROOT_DELTA)
-
-
-@task("migrate-tables", job_cluster="migration_sync")
-def migrate_views(cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, installation: Installation):
-    """This workflow task migrates the views from the Hive Metastore to the Unity Catalog. New views will be created in UC but base tables are still in HMS.
-    Following cli commands are required to be run before running this task:
-    - For Azure: `principal-prefix-access`, `create-table-mapping`, `create-uber-principal`, `migrate-credentials`, `migrate-locations`, `create-catalogs-schemas`
-    - For AWS: TBD
-    """
-    table_crawler = TablesCrawler(sql_backend, cfg.inventory_database)
-    table_mapping = TableMapping(installation, ws, sql_backend)
-    TablesMigrate(table_crawler, ws, sql_backend, table_mapping).migrate_tables(what=What.VIEW)
 
 
 def main(*argv):

--- a/src/databricks/labs/ucx/upgrades/v0.16.0_added_cluster_spec.py
+++ b/src/databricks/labs/ucx/upgrades/v0.16.0_added_cluster_spec.py
@@ -1,0 +1,88 @@
+# pylint: disable=invalid-name
+
+import logging
+from dataclasses import dataclass
+
+from databricks.labs.blueprint.installation import Installation
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.core import Config
+
+from databricks.labs.ucx.config import WorkspaceConfig
+from databricks.labs.ucx.install import load_cluster_specs
+
+upgrade_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class V16WorkspaceConfig:  # pylint: disable=too-many-instance-attributes, duplicate-code
+    __file__ = "config.yml"
+    __version__ = 2
+    inventory_database: str
+    workspace_group_regex: str | None = None
+    workspace_group_replace: str | None = None
+    account_group_regex: str | None = None
+    group_match_by_external_id: bool = False
+    include_group_names: list[str] | None = None
+    renamed_group_prefix: str | None = "ucx-renamed-"
+    instance_pool_id: str | None = None
+    warehouse_id: str | None = None
+    connect: Config | None = None
+    num_threads: int | None = 10
+    database_to_catalog_mapping: dict[str, str] | None = None
+    default_catalog: str | None = "ucx_default"
+    log_level: str | None = "INFO"
+    workspace_start_path: str = "/"
+    instance_profile: str | None = None
+    spark_conf: dict[str, str] | None = None
+    override_clusters: dict[str, str] | None = None
+    policy_id: str | None = None
+    num_days_submit_runs_history: int = 30
+    uber_spn_id: str | None = None
+    is_terraform_used: bool = False
+    include_databases: list[str] | None = None
+
+
+def upgrade(installation: Installation, ws: WorkspaceClient):  # pylint: disable=unused-argument
+    upgrade_logger.info("loading v0.16.0 WorkspaceConfig.")
+    v16_config = installation.load(V16WorkspaceConfig)
+    old_spark_conf = v16_config.spark_conf
+    policy_id = v16_config.policy_id
+
+    cluster_specs = load_cluster_specs()
+    for _, cluster_spec in cluster_specs.items():
+        cluster_spec.policy_id = policy_id
+        if not old_spark_conf:
+            continue
+        spark_conf = cluster_spec.spark_conf
+        if spark_conf:
+            spark_conf.update(old_spark_conf)
+            continue
+        cluster_spec.spark_conf = old_spark_conf
+
+    upgrade_logger.info("updating v0.16.0 WorkspaceConfig with spark_conf removed and cluster_specs added.")
+    new_config = WorkspaceConfig(
+        v16_config.inventory_database,
+        workspace_group_regex=v16_config.workspace_group_regex,
+        workspace_group_replace=v16_config.workspace_group_replace,
+        account_group_regex=v16_config.account_group_regex,
+        group_match_by_external_id=v16_config.group_match_by_external_id,
+        include_group_names=v16_config.include_group_names,
+        renamed_group_prefix=v16_config.renamed_group_prefix,
+        instance_pool_id=v16_config.instance_pool_id,
+        warehouse_id=v16_config.warehouse_id,
+        connect=v16_config.connect,
+        num_threads=v16_config.num_threads,
+        database_to_catalog_mapping=v16_config.database_to_catalog_mapping,
+        default_catalog=v16_config.default_catalog,
+        log_level=v16_config.log_level,
+        workspace_start_path=v16_config.workspace_start_path,
+        instance_profile=v16_config.instance_profile,
+        cluster_specs=cluster_specs,
+        override_clusters=v16_config.override_clusters,
+        policy_id=v16_config.policy_id,
+        num_days_submit_runs_history=v16_config.num_days_submit_runs_history,
+        uber_spn_id=v16_config.uber_spn_id,
+        is_terraform_used=v16_config.is_terraform_used,
+        include_databases=v16_config.include_databases,
+    )
+    installation.save(new_config)

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -1,13 +1,20 @@
+import io
 import logging
-from unittest.mock import create_autospec
-
+import os
 import pytest
-from databricks.sdk import WorkspaceClient
+import sys
+import yaml
 
+from requests import PreparedRequest, Response
+from unittest.mock import create_autospec, patch
+
+from databricks.sdk import WorkspaceClient
 from databricks.labs.ucx.framework.tasks import (
     Task,
     TaskLogger,
     remove_extra_indentation,
+    task,
+    trigger,
 )
 
 
@@ -75,3 +82,70 @@ def _log_contents(tmp_path):
             continue
         contents[path.relative_to(tmp_path).as_posix()] = path.read_text()
     return contents
+
+
+def mock_cfg_response():
+    mock_cfg = io.StringIO(
+        yaml.dump(
+            {
+                'version': 2,
+                'inventory_database': 'ucx',
+                'warehouse_id': 'test',
+                'connect': {
+                    'host': 'foo',
+                    'token': 'bar',
+                },
+            }
+        )
+    )
+
+    mock_api_request = create_autospec(PreparedRequest)
+    mock_api_request.method = "GET"
+    mock_api_request.body = None
+    mock_api_request.url = "http://example.com"
+
+    mock_api_response = create_autospec(Response)
+    mock_api_response.request = mock_api_request
+    mock_api_response.status_code = 200
+    mock_api_response.reason = None
+    mock_api_response.content.return_value = b'{"userName": "user@example.com"}'
+
+    return mock_cfg, mock_api_response
+
+
+def test_trigger_task_of_migrate_tables(mocker, capsys):
+    # define a mock task that is under "migrate-tables" workflow, which needs 4 parameters including installation
+    @task("migrate-tables", job_cluster="migration_sync")
+    def mock_migrate_external_tables_sync(cfg, workspace_client, sql_backend, installation):
+        """This mock task of migrate-tables"""
+        return f"Hello, World! {cfg} {workspace_client} {sql_backend} {installation}"
+
+    mock_cfg, mock_api_response = mock_cfg_response()
+
+    with (
+        patch('pathlib.Path.open', return_value=mock_cfg),
+        patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}),
+        patch("requests.Session.send", return_value=mock_api_response),
+    ):
+        sys.modules["pyspark.sql.session"] = mocker.Mock()
+        trigger("--config=config.yml", "--task=mock_migrate_external_tables_sync")
+        assert "This mock task of migrate-tables" in capsys.readouterr().out
+
+
+def test_trigger_task_of_assessment(mocker, capsys):
+    # define a mock task that is under "assessment" workflow, which needs 3 parameters
+    @task("assessment", job_cluster="main")
+    def mock_crawl_tables(cfg, workspace_client, sql_backend):
+        """This mock task of assessment"""
+        return f"Hello, World! {cfg} {workspace_client} {sql_backend}"
+
+    mock_cfg, mock_api_response = mock_cfg_response()
+
+    with (
+        patch('pathlib.Path.open', return_value=mock_cfg),
+        patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}),
+        patch("requests.Session.send", return_value=mock_api_response),
+    ):
+        sys.modules["pyspark.sql.session"] = mocker.Mock()
+        trigger("--config=config.yml", "--task=mock_crawl_tables")
+        assert "This mock task of assessment" in capsys.readouterr().out

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -113,7 +113,7 @@ def mock_cfg_response():
     return mock_cfg, mock_api_response
 
 
-def test_trigger_task_of_migrate_tables(mocker, capsys):
+def test_trigger_task(mocker, capsys):
     # define a mock task that is under "migrate-tables" workflow, which needs 4 parameters including installation
     @task("migrate-tables", job_cluster="migration_sync")
     def mock_migrate_external_tables_sync(cfg, workspace_client, sql_backend, installation):
@@ -130,22 +130,3 @@ def test_trigger_task_of_migrate_tables(mocker, capsys):
         sys.modules["pyspark.sql.session"] = mocker.Mock()
         trigger("--config=config.yml", "--task=mock_migrate_external_tables_sync")
         assert "This mock task of migrate-tables" in capsys.readouterr().out
-
-
-def test_trigger_task_of_assessment(mocker, capsys):
-    # define a mock task that is under "assessment" workflow, which needs 3 parameters
-    @task("assessment", job_cluster="main")
-    def mock_crawl_tables(cfg, workspace_client, sql_backend):
-        """This mock task of assessment"""
-        return f"Hello, World! {cfg} {workspace_client} {sql_backend}"
-
-    mock_cfg, mock_api_response = mock_cfg_response()
-
-    with (
-        patch('pathlib.Path.open', return_value=mock_cfg),
-        patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}),
-        patch("requests.Session.send", return_value=mock_api_response),
-    ):
-        sys.modules["pyspark.sql.session"] = mocker.Mock()
-        trigger("--config=config.yml", "--task=mock_crawl_tables")
-        assert "This mock task of assessment" in capsys.readouterr().out

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -1,15 +1,15 @@
 import io
 import logging
 import os
-import pytest
 import sys
-import yaml
-
-from requests import PreparedRequest, Response
 from unittest.mock import create_autospec, patch
 
+import pytest
+import yaml
 from databricks.sdk import WorkspaceClient
-from databricks.labs.ucx.framework.tasks import (
+from requests import PreparedRequest, Response  # pylint: disable=wrong-import-order
+
+from databricks.labs.ucx.framework.tasks import (  # pylint: disable=ungrouped-imports
     Task,
     TaskLogger,
     remove_extra_indentation,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -254,6 +254,11 @@ def test_writeable_dbfs(ws, tmp_path, mock_installation, any_prompt):
     assert 'tacl' in job_clusters
     assert job_clusters["main"].new_cluster.policy_id == "123"
 
+    job = created_job(ws, '[MOCK] migrate-tables')
+    job_clusters = {_.job_cluster_key: _ for _ in job['job_clusters']}
+    assert 'migration_clone' in job_clusters
+    assert 'migration_sync' in job_clusters
+
 
 def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_installation_with_jobs):
     def run_now(job_id):

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -63,7 +63,7 @@ def test_azure_crawler(mocker):
         )
         ws = create_autospec(WorkspaceClient)
         sql_backend = MockBackend()
-        assess_azure_service_principals(cfg, ws, sql_backend)
+        assess_azure_service_principals(cfg, ws, sql_backend, MockInstallation())
 
 
 def test_tasks():
@@ -92,7 +92,7 @@ def test_runtime_grants(mocker):
         cfg = azure_mock_config()
         ws = create_autospec(WorkspaceClient)
         sql_backend = MockBackend()
-        crawl_grants(cfg, ws, sql_backend)
+        crawl_grants(cfg, ws, sql_backend, MockInstallation())
 
         assert "SHOW DATABASES FROM hive_metastore" in sql_backend.queries
         assert "SHOW DATABASES" in sql_backend.queries

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -16,7 +16,6 @@ from databricks.labs.ucx.runtime import (
     crawl_grants,
     migrate_dbfs_root_delta_tables,
     migrate_external_tables_sync,
-    migrate_views,
 )
 
 from .framework.mocks import MockBackend
@@ -108,10 +107,4 @@ def test_migrate_external_tables_sync():
 def test_migrate_dbfs_root_delta_tables():
     ws = create_autospec(WorkspaceClient)
     migrate_dbfs_root_delta_tables(azure_mock_config(), ws, MockBackend(), mock_installation())
-    ws.catalogs.list.assert_called_once()
-
-
-def test_migrate_views():
-    ws = create_autospec(WorkspaceClient)
-    migrate_views(azure_mock_config(), ws, MockBackend(), mock_installation())
     ws.catalogs.list.assert_called_once()


### PR DESCRIPTION
## Changes
Add `migrate-tables` workflow. This PR includes the workflow only described in milestone 1 in #1035 
`table_migration_progress` table is out of scope in this PR.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Relates #333 #670 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [x] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
