### PR TITLE
Fix: Recover lost fix for `webbrowser.open` mock

### DIFF
--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -777,6 +777,7 @@ def test_remove_warehouse_not_exists(ws, caplog):
 
 
 def test_repair_run(ws, mocker, any_prompt, mock_installation_with_jobs):
+    mocker.patch("webbrowser.open")
     base = [
         BaseRun(
             job_clusters=None,
@@ -1214,6 +1215,7 @@ def test_fresh_install(ws, mock_installation):
 
 
 def test_get_existing_installation_global(ws, mock_installation, mocker):
+    mocker.patch("webbrowser.open")
     prompts = MockPrompts(
         {
             r".*PRO or SERVERLESS SQL warehouse.*": "1",


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Fix for `webbrowser.open` mock in #1048 was overridden by #1043 
Need recover it.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
