### PR TITLE
Fix some integration test failures

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1161,3 +1161,15 @@ def make_feature_table(ws, make_random):
             logger.info(f"Can't remove feature table {e}")
 
     yield from factory("Feature table", create, remove)
+
+
+@pytest.fixture
+def make_dbfs_data_copy(ws):
+    def create(*, src_path: str, dst_path: str):
+        ws.dbfs.copy(src_path, dst_path, recursive=True)
+        return dst_path
+
+    def remove(dst_path: str):
+        ws.dbfs.delete(dst_path, recursive=True)
+
+    yield from factory("make_dbfs_data_copy", create, remove)

--- a/tests/integration/assessment/test_clusters.py
+++ b/tests/integration/assessment/test_clusters.py
@@ -40,16 +40,18 @@ def test_cluster_crawler_no_isolation(ws, make_cluster, inventory_schema, sql_ba
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=6))
-def test_policy_crawler(ws, make_cluster_policy, inventory_schema, sql_backend):
+def test_policy_crawler(ws, make_cluster_policy, inventory_schema, sql_backend, make_random):
+    policy_1 = f"test_policy_check_{make_random(4)}"
+    policy_2 = f"test_policy_check2_{make_random(4)}"
     created_policy = make_cluster_policy(
-        name="test_policy_check",
+        name=f"{policy_1}",
         definition=json.dumps({"spark_version": {'type': 'fixed', 'value': '14.3.x-scala2.12'}}),
     )
     policy_definition = {
         "spark_version": {'type': 'fixed', 'value': '14.3.x-scala2.12'},
         "spark_conf.fs.azure.account.auth.type": {"type": "fixed", "value": "OAuth", "hidden": True},
     }
-    created_policy_2 = make_cluster_policy(name="test_policy_check2", definition=json.dumps(policy_definition))
+    created_policy_2 = make_cluster_policy(name=f"{policy_2}", definition=json.dumps(policy_definition))
     policy_crawler = PoliciesCrawler(ws=ws, sbe=sql_backend, schema=inventory_schema)
     policies = policy_crawler.snapshot()
     results = []
@@ -57,11 +59,11 @@ def test_policy_crawler(ws, make_cluster_policy, inventory_schema, sql_backend):
         if policy.policy_id in (created_policy.policy_id, created_policy_2.policy_id):
             results.append(policy)
 
-    assert results[0].policy_name == "test_policy_check"
+    assert results[0].policy_name == policy_1
     assert results[0].success == 1
     assert results[0].failures == "[]"
     assert results[0].spark_version == json.dumps({'type': 'fixed', 'value': '14.3.x-scala2.12'})
 
-    assert results[1].policy_name == "test_policy_check2"
+    assert results[1].policy_name == policy_2
     assert results[1].success == 0
     assert results[1].failures == '["Uses azure service principal credentials config in policy."]'

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -111,7 +111,17 @@ def test_migrate_tables_with_cache_should_not_create_table(
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-def test_migrate_external_table(ws, sql_backend, inventory_schema, make_catalog, make_schema, make_table, env_or_skip, make_random, make_dbfs_data_copy) :
+def test_migrate_external_table( # pylint: disable=too-many-arguments
+    ws,
+    sql_backend,
+    inventory_schema,
+    make_catalog,
+    make_schema,
+    make_table,
+    env_or_skip,
+    make_random,
+    make_dbfs_data_copy,
+):
     if not ws.config.is_azure:
         pytest.skip("temporary: only works in azure test env")
     src_schema = make_schema(catalog_name="hive_metastore")

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -111,7 +111,7 @@ def test_migrate_tables_with_cache_should_not_create_table(
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-def test_migrate_external_table( # pylint: disable=too-many-arguments
+def test_migrate_external_table(  # pylint: disable=too-many-locals
     ws,
     sql_backend,
     inventory_schema,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
1. When `test_migrate_external_table` are being executed by two different integration tests at the same time, the latter test will fail because the first test creates an UC external table occupying the table location, since a location can only be used by one UC table. This PR proposes a new test fixture that will create a random location for UC external table migration test, and delete it when test is done to avoid the location overlapping error.
2. Update `test_policy_crawler` to add a random suffix to the cluster policy name to avoid the test failure due to leftover/uncleaned cluster policy named `test_policy_check` and `test_policy_check2`. 

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
