### PR TITLE
Addressed Integration Test Issue

### DIFF
--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -262,6 +262,7 @@ def trigger(*argv):
     cfg = Installation.load_local(WorkspaceConfig, config_path)
     sql_backend = RuntimeBackend(debug_truncate_bytes=cfg.connect.debug_truncate_bytes)
     workspace_client = WorkspaceClient(config=cfg.connect, product='ucx', product_version=__version__)
-    installation = Installation.current(workspace_client, "ucx")
+    install_folder = config_path.parent.as_posix().removeprefix("/Workspace")
+    installation = Installation(workspace_client, "ucx", install_folder=install_folder)
 
     run_task(args, config_path.parent, cfg, workspace_client, sql_backend, installation)


### PR DESCRIPTION
In the latest update to the `ucx` framework, the `trigger` function in `tasks.py` has been modified to include a new argument, `install_folder`, in the `Installation` object. This object is now created within the `trigger` function and is passed to the `run_task` function. The `install_folder` is calculated by obtaining the parent directory of the `config_path` variable, converting it to a POSIX-style path, and removing the leading "/Workspace" prefix. This change ensures that the `run_task` function receives the correct installation folder for the `ucx` framework, enhancing the overall functionality and accuracy of the `ucx` framework.