### PR TITLE
Skip installation if remote and local version is the same, provide prompt to override

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -165,9 +165,11 @@ class WorkspaceInstaller:
                 logger.info(f"UCX v{self._product_info.version()} is already installed on this workspace")
                 msg = "Do you want to update the existing installation?"
                 if not self._prompts.confirm(msg):
-                    raise RuntimeWarning("Remote and Local versions are same and no override is requested. Exiting...")
+                    raise RuntimeWarning(
+                        "UCX workspace remote and local install versions are same and no override is requested. Exiting..."
+                    )
         except NotFound as err:
-            logger.warning(f"Remote version not found: {err}")
+            logger.warning(f"UCX workspace remote version not found: {err}")
 
     def _new_wheel_builder(self):
         return WheelsV2(self._installation, self._product_info)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -161,7 +161,7 @@ class WorkspaceInstaller:
         try:
             local_version = self._product_info.released_version()
             remote_version = self._installation.load(Version).version
-            if extract_major_minor(remote_version) == extract_major_minor(local_version[:4]):
+            if extract_major_minor(remote_version) == extract_major_minor(local_version):
                 logger.info(f"UCX v{self._product_info.version()} is already installed on this workspace")
                 msg = "Do you want to update the existing installation?"
                 if not self._prompts.confirm(msg):

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -450,6 +450,7 @@ def test_global_installation_on_existing_user_install(ws, new_installation):
             environ={'UCX_FORCE_INSTALL': 'global'},
             extend_prompts={
                 r".*UCX is already installed on this workspace.*": 'yes',
+                r".*Do you want to update the existing installation?.*": 'yes',
             },
         )
     existing_user_installation.uninstall()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -627,7 +627,8 @@ def test_compare_remote_local_install_versions(ws, new_installation):
     product_info = ProductInfo.for_testing(WorkspaceConfig)
     new_installation(product_info=product_info)
     with pytest.raises(
-        RuntimeWarning, match="Remote and Local versions are same and no override is requested. Exiting..."
+        RuntimeWarning,
+        match="UCX workspace remote and local install versions are same and no override is requested. Exiting...",
     ):
         new_installation(product_info=product_info)
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1497,3 +1497,59 @@ def test_validate_step(ws, any_prompt, result_state, expected):
     )
 
     assert workflows_installer.validate_step("assessment") == expected
+
+def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
+    ws.jobs.run_now = mocker.Mock()
+
+    mocker.patch("webbrowser.open")
+    base_prompts = MockPrompts(
+        {
+            r"Open config file in.*": "yes",
+            r"Open job overview in your browser.*": "yes",
+            r"Do you want to trigger assessment job ?.*": "yes",
+            r"Open assessment Job url that just triggered ?.*": "yes",
+            r".*": "",
+        }
+    )
+
+    product_info = create_autospec(ProductInfo)
+    product_info.version.return_value = "0.3.0"
+
+    installation = MockInstallation(
+        {
+            'config.yml': {
+                'inventory_database': 'ucx_user',
+                'connect': {
+                    'host': '...',
+                    'token': '...',
+                },
+            },
+            'version.json': {'version': '0.3.0', 'wheel': '...', 'date': '...'},
+        },
+        is_global=False,
+    )
+
+    install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
+
+    # raises runtime warning when versions match and no override provided
+    with pytest.raises(
+        RuntimeWarning, match="Remote and Local versions are same and no override is requested. Exiting..."
+    ):
+        install.configure()
+
+    first_prompts = base_prompts.extend(
+        {
+            r"Do you want to change the existing installation?": "yes",
+        }
+    )
+    install = WorkspaceInstaller(first_prompts, installation, ws, product_info)
+
+    # finishes successfully when versions match and override is provided
+    config = install.configure()
+    assert config.inventory_database == "ucx_user"
+
+    # finishes successfully when versions match and no override is provided/needed
+    product_info.version.return_value = "0.3.1"
+    install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
+    config = install.configure()
+    assert config.inventory_database == "ucx_user"

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1538,7 +1538,8 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
 
     # raises runtime warning when versions match and no override provided
     with pytest.raises(
-        RuntimeWarning, match="Remote and Local versions are same and no override is requested. Exiting..."
+        RuntimeWarning,
+        match="UCX workspace remote and local install versions are same and no override is requested. Exiting...",
     ):
         install.configure()
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -55,7 +55,11 @@ import databricks.labs.ucx.installer.mixins
 import databricks.labs.ucx.uninstall  # noqa
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
-from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
+from databricks.labs.ucx.install import (
+    WorkspaceInstallation,
+    WorkspaceInstaller,
+    extract_major_minor,
+)
 from databricks.labs.ucx.installer.workflows import WorkflowsInstallation
 
 PRODUCT_INFO = ProductInfo.from_class(WorkspaceConfig)
@@ -1554,3 +1558,11 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
     install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
     config = install.configure()
     assert config.inventory_database == "ucx_user"
+
+
+def test_extract_major_minor_versions():
+    version_string1 = "0.3.123151"
+    version_string2 = "0.17.1232141"
+
+    assert extract_major_minor(version_string1) == "0.3"
+    assert extract_major_minor(version_string2) == "0.17"

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1498,6 +1498,7 @@ def test_validate_step(ws, any_prompt, result_state, expected):
 
     assert workflows_installer.validate_step("assessment") == expected
 
+
 def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
     ws.jobs.run_now = mocker.Mock()
 
@@ -1513,7 +1514,7 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
     )
 
     product_info = create_autospec(ProductInfo)
-    product_info.version.return_value = "0.3.0"
+    product_info.released_version.return_value = "0.3.0"
 
     installation = MockInstallation(
         {
@@ -1539,7 +1540,7 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
 
     first_prompts = base_prompts.extend(
         {
-            r"Do you want to change the existing installation?": "yes",
+            r"Do you want to update the existing installation?": "yes",
         }
     )
     install = WorkspaceInstaller(first_prompts, installation, ws, product_info)
@@ -1548,8 +1549,8 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
     config = install.configure()
     assert config.inventory_database == "ucx_user"
 
-    # finishes successfully when versions match and no override is provided/needed
-    product_info.version.return_value = "0.3.1"
+    # finishes successfully when versions don't match and no override is provided/needed
+    product_info.released_version.return_value = "0.4.1"
     install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
     config = install.configure()
     assert config.inventory_database == "ucx_user"


### PR DESCRIPTION
## Changes
Compares the remote version and local wheel version and prompts for re-install confirmation if they are the same. 

### Linked issues
Closes #1072
Closes #803

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [x] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
