### PR TITLE
Clean up the log folder created by TaskLogger in unit test

### DIFF
--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -229,7 +229,7 @@ def run_task(
     workspace_client: WorkspaceClient,
     sql_backend: RuntimeBackend,
     installation: Installation,
-):
+) -> str:
     task_name = args.get("task", "not specified")
     if task_name not in _TASKS:
         msg = f'task "{task_name}" not found. Valid tasks are: {", ".join(_TASKS.keys())}'
@@ -253,6 +253,7 @@ def run_task(
         ucx_logger = logging.getLogger("databricks.labs.ucx")
         ucx_logger.info(f"UCX v{__version__} After job finishes, see debug logs at {task_logger}")
         current_task.fn(cfg, workspace_client, sql_backend, installation)
+        return str(task_logger)
 
 
 def trigger(*argv):

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -229,7 +229,7 @@ def run_task(
     workspace_client: WorkspaceClient,
     sql_backend: RuntimeBackend,
     installation: Installation,
-) -> str:
+):
     task_name = args.get("task", "not specified")
     if task_name not in _TASKS:
         msg = f'task "{task_name}" not found. Valid tasks are: {", ".join(_TASKS.keys())}'
@@ -253,7 +253,6 @@ def run_task(
         ucx_logger = logging.getLogger("databricks.labs.ucx")
         ucx_logger.info(f"UCX v{__version__} After job finishes, see debug logs at {task_logger}")
         current_task.fn(cfg, workspace_client, sql_backend, installation)
-        return str(task_logger)
 
 
 def trigger(*argv):

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 from pathlib import Path
 from unittest.mock import create_autospec
 
@@ -103,9 +104,13 @@ def test_run_task(capsys):
     cfg = WorkspaceConfig("test_db", log_level="INFO")
 
     # test the task function is called
-    run_task(
+    log_path = run_task(
         args, Path("foo"), cfg, create_autospec(WorkspaceClient), create_autospec(RuntimeBackend), MockInstallation()
     )
+    # clean up the log folder created by TaskLogger
+    log_root_dir = Path(log_path).parents[-2]
+    shutil.rmtree(log_root_dir)
+
     assert "This mock task of migrate-tables" in capsys.readouterr().out
 
     # test KeyError if task not found

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -104,12 +104,17 @@ def test_run_task(capsys):
     cfg = WorkspaceConfig("test_db", log_level="INFO")
 
     # test the task function is called
-    test_install_dir = Path("foo")
+    install_dir = Path("foo")
     run_task(
-        args, test_install_dir, cfg, create_autospec(WorkspaceClient), create_autospec(RuntimeBackend), MockInstallation()
+        args,
+        install_dir,
+        cfg,
+        create_autospec(WorkspaceClient),
+        create_autospec(RuntimeBackend),
+        MockInstallation(),
     )
     # clean up the log folder created by TaskLogger
-    shutil.rmtree(test_install_dir)
+    shutil.rmtree(install_dir)
 
     assert "This mock task of migrate-tables" in capsys.readouterr().out
 

--- a/tests/unit/framework/test_tasks.py
+++ b/tests/unit/framework/test_tasks.py
@@ -104,12 +104,12 @@ def test_run_task(capsys):
     cfg = WorkspaceConfig("test_db", log_level="INFO")
 
     # test the task function is called
-    log_path = run_task(
-        args, Path("foo"), cfg, create_autospec(WorkspaceClient), create_autospec(RuntimeBackend), MockInstallation()
+    test_install_dir = Path("foo")
+    run_task(
+        args, test_install_dir, cfg, create_autospec(WorkspaceClient), create_autospec(RuntimeBackend), MockInstallation()
     )
     # clean up the log folder created by TaskLogger
-    log_root_dir = Path(log_path).parents[-2]
-    shutil.rmtree(log_root_dir)
+    shutil.rmtree(test_install_dir)
 
     assert "This mock task of migrate-tables" in capsys.readouterr().out
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Delete the log folder created by TaskLogger in unit test after the test is done.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
