### PR TITLE
Fixing the issue in workspace id flag in create-account-group command

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -102,7 +102,7 @@ def sync_workspace_info(a: AccountClient):
 
 @ucx.command(is_account=True)
 def create_account_groups(
-    a: AccountClient, prompts: Prompts, workspace_ids: list[int] | None = None, new_workspace_client=WorkspaceClient
+    a: AccountClient, prompts: Prompts, workspace_ids: str | None = None, new_workspace_client=WorkspaceClient
 ):
     """
     Crawl all workspaces configured in workspace_ids, then creates account level groups if a WS local group is not present
@@ -116,8 +116,9 @@ def create_account_groups(
     account
     """
     logger.info(f"Account ID: {a.config.account_id}")
+    workspace_id_list = [int(x.strip()) for x in workspace_ids.split(",")]
     workspaces = AccountWorkspaces(a, new_workspace_client)
-    workspaces.create_account_level_groups(prompts, workspace_ids)
+    workspaces.create_account_level_groups(prompts, workspace_id_list)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -115,8 +115,12 @@ def create_account_groups(
     - Exist in workspaces A,B,C. It has same members in A,B, but not in C. Then, X and C_X will be created in the
     account
     """
+
     logger.info(f"Account ID: {a.config.account_id}")
-    workspace_id_list = [int(x.strip()) for x in workspace_ids.split(",")]
+    if workspace_ids is not None:
+        workspace_id_list = [int(x.strip()) for x in workspace_ids.split(",")]
+    else:
+        workspace_id_list = None
     workspaces = AccountWorkspaces(a, new_workspace_client)
     workspaces.create_account_level_groups(prompts, workspace_id_list)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -153,6 +153,16 @@ def test_create_account_groups():
     a.groups.list.assert_called_with(attributes="id")
 
 
+def test_create_account_groups_with_id():
+    a = create_autospec(AccountClient)
+    w = create_autospec(WorkspaceClient)
+    a.get_workspace_client.return_value = w
+    w.get_workspace_id.return_value = None
+    prompts = MockPrompts({})
+    with pytest.raises(ValueError, match="No workspace ids provided in the configuration found in the account"):
+        create_account_groups(a, prompts, workspace_ids="123,456", new_workspace_client=lambda: w)
+
+
 def test_manual_workspace_info(ws):
     prompts = MockPrompts({'Workspace name for 123': 'abc', 'Next workspace id': ''})
     manual_workspace_info(ws, prompts)


### PR DESCRIPTION
## Changes
Workspace Id was taj=king as string instead of list of int. Fixed the same by converting it int list of int using list comprehension.

### Linked issues
#1090

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
