### PR TITLE
Adding Latest LTS spark version in job clusters

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -466,6 +466,7 @@ class WorkflowsInstallation(InstallationMixin):
 
     def _job_clusters(self, names: set[str]):
         clusters = []
+        latest_spark_version = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
         if "main" in names:
             clusters.append(
                 jobs.JobCluster(
@@ -476,6 +477,7 @@ class WorkflowsInstallation(InstallationMixin):
                         custom_tags={"ResourceClass": "SingleNode"},
                         num_workers=0,
                         policy_id=self._config.policy_id,
+                        spark_version=latest_spark_version,
                     ),
                 )
             )
@@ -488,6 +490,7 @@ class WorkflowsInstallation(InstallationMixin):
                         spark_conf=self._job_cluster_spark_conf("tacl"),
                         num_workers=1,  # ShowPermissionsCommand needs a worker
                         policy_id=self._config.policy_id,
+                        spark_version=latest_spark_version,
                     ),
                 )
             )
@@ -503,6 +506,7 @@ class WorkflowsInstallation(InstallationMixin):
                             max_workers=self._config.max_workers,
                             min_workers=self._config.min_workers,
                         ),
+                        spark_version=latest_spark_version,
                     ),
                 )
             )

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -130,7 +130,7 @@ def ws():
     workspace_client.dashboard_widgets.create.return_value = Widget(id="abc")
     workspace_client.clusters.list.return_value = mock_clusters()
     workspace_client.cluster_policies.create.return_value = CreatePolicyResponse(policy_id="foo")
-    workspace_client.clusters.select_spark_version = lambda latest: "14.2.x-scala2.12"
+    workspace_client.clusters.select_spark_version = lambda latest, long_term_support=False: "14.2.x-scala2.12"
     workspace_client.clusters.select_node_type = lambda local_disk: "Standard_F4s"
     workspace_client.workspace.download = download
 


### PR DESCRIPTION
## Changes
Adding Latest LTS spark version in job clusters to take only the LTS version

### Linked issues
#1096

Resolves #1096

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
