### PR TITLE
Fix pylint & ruff warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "pytest-mock>=3.0.0,<4.0.0",
     "pytest-timeout",
     "black>=23.1.0",
-    "ruff>=0.0.243",
+    "ruff>=0.3.0",
     "isort>=2.5.0",
     "mypy",
     "types-PyYAML",
@@ -87,7 +87,7 @@ coverage    = "pytest -n auto --cov src tests/unit --timeout 30 --cov-report=htm
 integration = "pytest -n 10 --cov src tests/integration --durations 20"
 fmt         = ["isort .",
                "black .",
-               "ruff  . --fix",
+               "ruff check . --fix",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
 verify      = ["black --check .",

--- a/src/databricks/labs/ucx/assessment/clusters.py
+++ b/src/databricks/labs/ucx/assessment/clusters.py
@@ -198,7 +198,7 @@ class PoliciesCrawler(CrawlerBase[PolicyInfo], CheckClusterMixin):
         all_policices = list(self._ws.cluster_policies.list())
         return list(self._assess_policies(all_policices))
 
-    def _assess_policies(self, all_policices):
+    def _assess_policies(self, all_policices) -> Iterable[PolicyInfo]:
         for policy in all_policices:
             failures: list[str] = []
             if policy.policy_id is None:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
- Fix pylint warning `consider using --check-untyped-defs `
- Fix ruff warning `ruff <path> is deprecated`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
