### PR TITLE
Fixed `AssertionError: assert '14.3.x-scala2.12' == '15.0.x-scala2.12'` from nightly integration tests

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -143,7 +143,8 @@ def test_job_cluster_policy(ws, new_installation):
 
     assert cluster_policy.name == f"Unity Catalog Migration ({install.config.inventory_database}) ({user_name})"
 
-    assert policy_definition["spark_version"]["value"] == ws.clusters.select_spark_version(latest=True)
+    spark_version = ws.clusters.select_spark_version(latest=True, long_term_support=True)
+    assert policy_definition["spark_version"]["value"] == spark_version
     assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True)
     if ws.config.is_azure:
         assert (


### PR DESCRIPTION
Follow-up to https://github.com/databrickslabs/ucx/pull/1097
