### PR TITLE
Fixing run_workflow functionality for better error handling.

### DIFF
--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -25,7 +25,7 @@ from databricks.labs.ucx.hive_metastore.table_migrate import (
     TablesMigrate,
 )
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
-from databricks.labs.ucx.hive_metastore.tables import AclMigrationWhat, What
+from databricks.labs.ucx.hive_metastore.tables import What
 from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 from databricks.labs.ucx.hive_metastore.verification import VerifyHasMetastore
 from databricks.labs.ucx.workspace_access.generic import WorkspaceListing

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -15,9 +15,9 @@ from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.sdk.errors import (
     AlreadyExists,
-    BadRequest,
     InvalidParameterValue,
     NotFound,
+    Unknown,
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service import compute, sql
@@ -291,7 +291,7 @@ def test_running_real_validate_groups_permissions_job_fails(
         request_object_type="cluster-policies", request_object_id=cluster_policy.policy_id, access_control_list=[]
     )
 
-    with pytest.raises(BadRequest):
+    with pytest.raises(Unknown):
         workflows_install.run_workflow("validate-groups-permissions")
 
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -361,6 +361,45 @@ def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_instal
     assert str(failure.value) == "stuff: does not compute"
 
 
+def test_run_workflow_run_id_not_found(ws, mocker, any_prompt, mock_installation_with_jobs):
+    def run_now(job_id):
+        assert job_id == 123
+
+        def result():
+            raise OperationFailed(...)
+
+        waiter = mocker.Mock()
+        waiter.result = result
+        waiter.run_id = None
+        return waiter
+
+    ws.jobs.run_now = run_now
+    ws.jobs.get_run.return_value = jobs.Run(
+        state=jobs.RunState(state_message="Stuff happens."),
+        tasks=[
+            jobs.RunTask(
+                task_key="stuff",
+                state=jobs.RunState(result_state=jobs.RunResultState.FAILED),
+                run_id=123,
+            )
+        ],
+    )
+    ws.jobs.get_run_output.return_value = jobs.RunOutput(error="does not compute", error_trace="# goes to stderr")
+    ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
+    wheels = create_autospec(WheelsV2)
+    installer = WorkflowsInstallation(
+        WorkspaceConfig(inventory_database='ucx'),
+        mock_installation_with_jobs,
+        ws,
+        wheels,
+        any_prompt,
+        PRODUCT_INFO,
+        timedelta(seconds=1),
+    )
+    with pytest.raises(NotFound) as failure:
+        installer.run_workflow("assessment")
+
+
 def test_run_workflow_creates_failure_from_mapping(
     ws, mocker, mock_installation, any_prompt, mock_installation_with_jobs
 ):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -396,7 +396,7 @@ def test_run_workflow_run_id_not_found(ws, mocker, any_prompt, mock_installation
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
-    with pytest.raises(NotFound) as failure:
+    with pytest.raises(NotFound):
         installer.run_workflow("assessment")
 
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -344,6 +344,7 @@ def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_instal
         ],
     )
     ws.jobs.get_run_output.return_value = jobs.RunOutput(error="does not compute", error_trace="# goes to stderr")
+    ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     wheels = create_autospec(WheelsV2)
     installer = WorkflowsInstallation(
         WorkspaceConfig(inventory_database='ucx'),
@@ -385,6 +386,7 @@ def test_run_workflow_creates_failure_from_mapping(
             )
         ],
     )
+    ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     ws.jobs.get_run_output.return_value = jobs.RunOutput(
         error="something: PermissionDenied: does not compute", error_trace="# goes to stderr"
     )
@@ -440,6 +442,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, any_prompt, mock_in
     ws.jobs.get_run_output.return_value = jobs.RunOutput(
         error="something: DataLoss: does not compute", error_trace="# goes to stderr"
     )
+    ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     wheels = create_autospec(WheelsV2)
     installer = WorkflowsInstallation(
         WorkspaceConfig(inventory_database='ucx'),


### PR DESCRIPTION
This PR addressed issues with the integration test.
We improved handling of workflow runs.
Closes #1143
The 'run\_workflow' method in 'workflows.py' has been updated to reliably handle job failures and provide better error information. Previously, the method used 'run\_now' to start a job without waiting for it to finish, which could result in an incomplete or failed job. The updated code creates a 'job\_initial\_run' using 'run\_now' and checks if a run ID is returned, indicating that the job has started successfully. If the job fails, an error is raised with more detailed information. Additionally, a new private method '_infer\_error\_from\_job\_run' is defined to infer the error from the job run object. In the `test_installation.py` file, the error handling in the integration test for the installation process has been improved. Previously, when an error occurred, the function `wait_get_run_job_terminated_or_skipped` would raise an `OperationFailed` exception, but the error message would not be properly propagated. This commit ensures that the error message is properly propagated when `wait_get_run_job_terminated_or_skipped` raises an `OperationFailed` exception. The test in `test_install.py` has also been updated to expect an `Unknown` error instead of a `BadRequest` error when running a specific workflow. These changes improve the reliability and robustness of the library by enhancing error handling and providing better error information.