### PR TITLE
Use experimental Permissions Migration API also for Legacy Table ACLs

### DIFF
--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -481,7 +481,13 @@ def reflect_account_groups_on_workspace_experimental(
     return reflect_account_groups_on_workspace(cfg, ws, sql_backend, _install)
 
 
-@task("migrate-groups-experimental", depends_on=[reflect_account_groups_on_workspace_experimental])
+@task(
+    "migrate-groups-experimental",
+    depends_on=[
+        reflect_account_groups_on_workspace_experimental,
+        rename_workspace_local_groups_experimental,
+    ],
+)
 def apply_permissions_to_account_groups_experimental(
     cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _install: Installation
 ):
@@ -506,13 +512,11 @@ def apply_permissions_to_account_groups_experimental(
         account_group_regex=cfg.account_group_regex,
         external_id_match=cfg.group_match_by_external_id,
     )
-
     migration_state = group_manager.get_migration_state()
     if len(migration_state.groups) == 0:
         logger.info("Skipping group migration as no groups were found.")
         return
-
-    migration_state.apply_group_permissions_experimental(ws)
+    migration_state.apply_to_renamed_groups(ws)
 
 
 @task("migrate-tables-in-mounts-experimental")

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -32,7 +32,6 @@ from databricks.labs.ucx.hive_metastore.verification import VerifyHasMetastore
 from databricks.labs.ucx.workspace_access.generic import WorkspaceListing
 from databricks.labs.ucx.workspace_access.groups import GroupManager
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
-from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 logger = logging.getLogger(__name__)
 
@@ -514,51 +513,6 @@ def apply_permissions_to_account_groups_experimental(
         return
 
     migration_state.apply_group_permissions_experimental(ws)
-
-
-@task("migrate-groups-experimental", depends_on=[reflect_account_groups_on_workspace_experimental], job_cluster="tacl")
-def apply_tacl_to_account_groups_experimental(
-    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _install: Installation
-):
-    """EXPERIMENTAL
-    This task migrates Legacy Table ACLs from workspace-local group to account-level group.
-    """
-    group_manager = GroupManager(
-        sql_backend,
-        ws,
-        cfg.inventory_database,
-        cfg.include_group_names,
-        cfg.renamed_group_prefix,
-        workspace_group_regex=cfg.workspace_group_regex,
-        workspace_group_replace=cfg.workspace_group_replace,
-        account_group_regex=cfg.account_group_regex,
-        external_id_match=cfg.group_match_by_external_id,
-    )
-
-    migration_state = group_manager.get_migration_state()
-    if len(migration_state.groups) == 0:
-        logger.info("Skipping group migration as no groups were found.")
-        return
-
-    tables_crawler = TablesCrawler(sql_backend, cfg.inventory_database)
-    udfs_crawler = UdfsCrawler(sql_backend, cfg.inventory_database)
-    grants_crawler = GrantsCrawler(tables_crawler, udfs_crawler)
-    tacl_support = TableAclSupport(grants_crawler, sql_backend)
-    permission_manager = PermissionManager(sql_backend, cfg.inventory_database, [tacl_support])
-    permission_manager.apply_group_permissions(migration_state)
-
-
-@task(
-    "migrate-groups-experimental",
-    depends_on=[apply_permissions_to_account_groups_experimental, apply_tacl_to_account_groups_experimental],
-    job_cluster="tacl",
-)
-def validate_groups_permissions_experimental(
-    cfg: WorkspaceConfig, ws: WorkspaceClient, sql_backend: SqlBackend, _install: Installation
-):
-    """EXPERIMENTAL
-    Validate that all the crawled permissions are applied correctly to the destination groups."""
-    return validate_groups_permissions(cfg, ws, sql_backend, _install)
 
 
 @task("migrate-tables-in-mounts-experimental")

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -90,7 +90,7 @@ class MigrationState:
         if len(self) == 0:
             logger.info("No valid groups selected, nothing to do.")
             return True
-        logger.info(f"Applying the permissions to account groups. " f"Total groups to apply permissions: {len(self)}.")
+        logger.info(f"Applying the permissions to account groups. Total groups to apply permissions: {len(self)}.")
         items = 0
         for migrated_group in self.groups:
             items += self._migrate_group_permissions_paginated(ws, migrated_group)
@@ -98,28 +98,22 @@ class MigrationState:
         return True
 
     @staticmethod
-    def _migrate_group_permissions_paginated(ws: WorkspaceClient, migrated_group: MigratedGroup):
+    def _migrate_group_permissions_paginated(ws: WorkspaceClient, group: MigratedGroup):
         batch_size = 1000
-        logger.info(
-            f"Migrating permissions from workspace group {migrated_group.name_in_workspace} "
-            f"to account group: {migrated_group.name_in_account}."
-        )
+        logger.info(f"Migrating permissions: {group.name_in_workspace} -> {group.name_in_account}")
         permissions_migrated = 0
         while True:
-            response = ws.permission_migration.migrate_permissions(
+            result = ws.permission_migration.migrate_permissions(
                 ws.get_workspace_id(),
-                migrated_group.name_in_workspace,
-                migrated_group.name_in_account,
+                group.name_in_workspace,
+                group.name_in_account,
                 size=batch_size,
             )
-            if not response.permissions_migrated:
+            if not result.permissions_migrated:
                 logger.info("No more permission to migrated.")
                 return permissions_migrated
-            permissions_migrated += response.permissions_migrated
-            logger.info(
-                f"Migrated {response.permissions_migrated} permissions to "
-                f"{migrated_group.name_in_account} account group"
-            )
+            permissions_migrated += result.permissions_migrated
+            logger.info(f"Migrated {result.permissions_migrated} permissions to {group.name_in_account} account group")
 
 
 class GroupMigrationStrategy:

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -25,6 +25,8 @@ from databricks.sdk.service.iam import PermissionLevel
 
 import databricks
 from databricks.labs.ucx.config import WorkspaceConfig
+from databricks.labs.ucx.hive_metastore import TablesCrawler
+from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.mapping import Rule
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
 from databricks.labs.ucx.installer.workflows import WorkflowsInstallation
@@ -33,9 +35,15 @@ from databricks.labs.ucx.workspace_access.generic import (
     GenericPermissionsSupport,
     Listing,
 )
-from databricks.labs.ucx.workspace_access.groups import GroupManager
+from databricks.labs.ucx.workspace_access.groups import GroupManager, MigratedGroup
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.redash import RedashPermissionsSupport
+from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
+from tests.integration.conftest import (
+    StaticGrantsCrawler,
+    StaticTablesCrawler,
+    StaticUdfsCrawler,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +130,132 @@ def new_installation(ws, sql_backend, env_or_skip, make_random):
 
     for pending in cleanup:
         pending.uninstall()
+
+
+def test_experimental_permissions_migration_job(  # pylint: disable=too-many-locals
+    ws,
+    sql_backend,
+    new_installation,
+    make_schema,
+    migrated_group,
+    make_table,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+):
+    cluster_policy = make_cluster_policy()
+    make_cluster_policy_permissions(
+        object_id=cluster_policy.policy_id,
+        permission_level=PermissionLevel.CAN_USE,
+        group_name=migrated_group.name_in_workspace,
+    )
+    schema_a = make_schema()
+    table_a = make_table(schema_name=schema_a.name)
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA {schema_a.name} TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"ALTER SCHEMA {schema_a.name} OWNER TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{migrated_group.name_in_workspace}`")
+
+    workspace_installation, workflow_installation = new_installation(
+        config_transform=lambda wc: replace(wc, include_group_names=[migrated_group.name_in_workspace])
+    )
+    workspace_installation.run()
+
+    cfg = workspace_installation.config
+    sql_backend.save_table(f'{cfg.inventory_database}.groups', [migrated_group], MigratedGroup)
+
+    udf_crawler = StaticUdfsCrawler(sql_backend, cfg.inventory_database, [])
+    tables_crawler = StaticTablesCrawler(sql_backend, cfg.inventory_database, [table_a])
+    grants_crawler = StaticGrantsCrawler(
+        tables_crawler,
+        udf_crawler,
+        [
+            Grant(
+                catalog=table_a.catalog_name,
+                database=table_a.schema_name,
+                table=table_a.name,
+                principal=migrated_group.name_in_workspace,
+                action_type="SELECT",
+            ),
+        ],
+    )
+    tacl_support = TableAclSupport(grants_crawler, sql_backend)
+
+    generic_permissions = GenericPermissionsSupport(
+        ws, [Listing(lambda: [cluster_policy], "policy_id", "cluster-policies")]
+    )
+    permission_manager = PermissionManager(sql_backend, cfg.inventory_database, [generic_permissions, tacl_support])
+    permission_manager.inventorize_permissions()
+
+    workflow_installation.run_workflow("migrate-groups-experimental")
+
+    object_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
+    new_schema_grants = grants_crawler.for_schema_info(schema_a)
+
+    assert {"USAGE", "OWN"} == new_schema_grants[migrated_group.name_in_account]
+    assert object_permissions[migrated_group.name_in_account] == PermissionLevel.CAN_USE
+
+
+def test_experimental_permissions_migration_job_same_name(  # pylint: disable=too-many-locals
+    ws,
+    sql_backend,
+    new_installation,
+    make_schema,
+    make_ucx_group,
+    make_table,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+):
+    ws_group, acc_group = make_ucx_group()
+    migrated_group = MigratedGroup.partial_info(ws_group, acc_group)
+    cluster_policy = make_cluster_policy()
+    make_cluster_policy_permissions(
+        object_id=cluster_policy.policy_id,
+        permission_level=PermissionLevel.CAN_USE,
+        group_name=migrated_group.name_in_workspace,
+    )
+    schema_a = make_schema()
+    table_a = make_table(schema_name=schema_a.name)
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA {schema_a.name} TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"ALTER SCHEMA {schema_a.name} OWNER TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{migrated_group.name_in_workspace}`")
+
+    workspace_installation, workflow_installation = new_installation(
+        config_transform=lambda wc: replace(wc, include_group_names=[migrated_group.name_in_workspace])
+    )
+    workspace_installation.run()
+
+    cfg = workspace_installation.config
+    sql_backend.save_table(f'{cfg.inventory_database}.groups', [migrated_group], MigratedGroup)
+
+    udf_crawler = StaticUdfsCrawler(sql_backend, cfg.inventory_database, [])
+    tables_crawler = StaticTablesCrawler(sql_backend, cfg.inventory_database, [table_a])
+    grants_crawler = StaticGrantsCrawler(
+        tables_crawler,
+        udf_crawler,
+        [
+            Grant(
+                catalog=table_a.catalog_name,
+                database=table_a.schema_name,
+                table=table_a.name,
+                principal=migrated_group.name_in_workspace,
+                action_type="SELECT",
+            ),
+        ],
+    )
+    tacl_support = TableAclSupport(grants_crawler, sql_backend)
+
+    generic_permissions = GenericPermissionsSupport(
+        ws, [Listing(lambda: [cluster_policy], "policy_id", "cluster-policies")]
+    )
+    permission_manager = PermissionManager(sql_backend, cfg.inventory_database, [generic_permissions, tacl_support])
+    permission_manager.inventorize_permissions()
+
+    workflow_installation.run_workflow("migrate-groups-experimental")
+
+    object_permissions = generic_permissions.load_as_dict("cluster-policies", cluster_policy.policy_id)
+    new_schema_grants = grants_crawler.for_schema_info(schema_a)
+
+    assert {"USAGE", "OWN"} == new_schema_grants[migrated_group.name_in_account]
+    assert object_permissions[migrated_group.name_in_account] == PermissionLevel.CAN_USE
 
 
 @retried(on=[NotFound, TimeoutError], timeout=timedelta(minutes=5))

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -25,7 +25,6 @@ from databricks.sdk.service.iam import PermissionLevel
 
 import databricks
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.mapping import Rule
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
@@ -159,11 +158,11 @@ def test_experimental_permissions_migration_job(  # pylint: disable=too-many-loc
     )
     workspace_installation.run()
 
-    cfg = workspace_installation.config
-    sql_backend.save_table(f'{cfg.inventory_database}.groups', [migrated_group], MigratedGroup)
+    inventory_database = workspace_installation.config.inventory_database
+    sql_backend.save_table(f'{inventory_database}.groups', [migrated_group], MigratedGroup)
 
-    udf_crawler = StaticUdfsCrawler(sql_backend, cfg.inventory_database, [])
-    tables_crawler = StaticTablesCrawler(sql_backend, cfg.inventory_database, [table_a])
+    udf_crawler = StaticUdfsCrawler(sql_backend, inventory_database, [])
+    tables_crawler = StaticTablesCrawler(sql_backend, inventory_database, [table_a])
     grants_crawler = StaticGrantsCrawler(
         tables_crawler,
         udf_crawler,
@@ -182,7 +181,7 @@ def test_experimental_permissions_migration_job(  # pylint: disable=too-many-loc
     generic_permissions = GenericPermissionsSupport(
         ws, [Listing(lambda: [cluster_policy], "policy_id", "cluster-policies")]
     )
-    permission_manager = PermissionManager(sql_backend, cfg.inventory_database, [generic_permissions, tacl_support])
+    permission_manager = PermissionManager(sql_backend, inventory_database, [generic_permissions, tacl_support])
     permission_manager.inventorize_permissions()
 
     workflow_installation.run_workflow("migrate-groups-experimental")
@@ -223,11 +222,11 @@ def test_experimental_permissions_migration_job_same_name(  # pylint: disable=to
     )
     workspace_installation.run()
 
-    cfg = workspace_installation.config
-    sql_backend.save_table(f'{cfg.inventory_database}.groups', [migrated_group], MigratedGroup)
+    inventory_database = workspace_installation.config.inventory_database
+    sql_backend.save_table(f'{inventory_database}.groups', [migrated_group], MigratedGroup)
 
-    udf_crawler = StaticUdfsCrawler(sql_backend, cfg.inventory_database, [])
-    tables_crawler = StaticTablesCrawler(sql_backend, cfg.inventory_database, [table_a])
+    udf_crawler = StaticUdfsCrawler(sql_backend, inventory_database, [])
+    tables_crawler = StaticTablesCrawler(sql_backend, inventory_database, [table_a])
     grants_crawler = StaticGrantsCrawler(
         tables_crawler,
         udf_crawler,
@@ -246,7 +245,7 @@ def test_experimental_permissions_migration_job_same_name(  # pylint: disable=to
     generic_permissions = GenericPermissionsSupport(
         ws, [Listing(lambda: [cluster_policy], "policy_id", "cluster-policies")]
     )
-    permission_manager = PermissionManager(sql_backend, cfg.inventory_database, [generic_permissions, tacl_support])
+    permission_manager = PermissionManager(sql_backend, inventory_database, [generic_permissions, tacl_support])
     permission_manager.inventorize_permissions()
 
     workflow_installation.run_workflow("migrate-groups-experimental")

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -51,7 +51,7 @@ def test_instance_pools(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -86,7 +86,7 @@ def test_clusters(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -114,7 +114,7 @@ def test_jobs(ws: WorkspaceClient, migrated_group, make_job, make_job_permission
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -148,7 +148,7 @@ def test_pipelines(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -182,7 +182,7 @@ def test_cluster_policies(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_USE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -216,7 +216,7 @@ def test_warehouses(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -250,7 +250,7 @@ def test_models(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -281,7 +281,7 @@ def test_experiments(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -324,7 +324,7 @@ def test_directories(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -367,7 +367,7 @@ def test_notebooks(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -394,7 +394,7 @@ def test_tokens(ws: WorkspaceClient, migrated_group, make_authorization_permissi
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_USE
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -465,7 +465,7 @@ def test_endpoints(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_QUERY
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -495,7 +495,7 @@ def test_feature_tables(
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_EDIT_METADATA
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(generic_permissions, [migrated_group])
 
@@ -522,7 +522,7 @@ def test_feature_store_root_page(ws: WorkspaceClient, migrated_group, is_experim
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_EDIT_METADATA
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(
             generic_permissions,
@@ -552,7 +552,7 @@ def test_models_root_page(ws: WorkspaceClient, migrated_group, is_experimental: 
     assert before[migrated_group.name_in_workspace] == PermissionLevel.CAN_MANAGE_PRODUCTION_VERSIONS
 
     if is_experimental:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(
             generic_permissions,

--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -21,7 +21,6 @@ from databricks.labs.ucx.workspace_access.generic import (
     tokens_and_passwords,
 )
 from databricks.labs.ucx.workspace_access.groups import MigrationState
-from databricks.labs.ucx.workspace_access.manager import PermissionManager
 
 from . import apply_tasks
 
@@ -30,7 +29,6 @@ from . import apply_tasks
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_instance_pools(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_instance_pool,
     make_instance_pool_permissions,
@@ -65,7 +63,6 @@ def test_instance_pools(
 @retried(on=[BadRequest], timeout=timedelta(minutes=3))
 def test_clusters(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_cluster,
     make_cluster_permissions,
@@ -99,14 +96,7 @@ def test_clusters(
 
 @pytest.mark.parametrize("is_experimental", [True, False])
 @retried(on=[BadRequest], timeout=timedelta(minutes=3))
-def test_jobs(
-    ws: WorkspaceClient,
-    permission_manager: PermissionManager,
-    migrated_group,
-    make_job,
-    make_job_permissions,
-    is_experimental: bool,
-):
+def test_jobs(ws: WorkspaceClient, migrated_group, make_job, make_job_permissions, is_experimental: bool):
     job = make_job()
     make_job_permissions(
         object_id=job.job_id,
@@ -136,7 +126,6 @@ def test_jobs(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_pipelines(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_pipeline,
     make_pipeline_permissions,
@@ -171,7 +160,6 @@ def test_pipelines(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_cluster_policies(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_cluster_policy,
     make_cluster_policy_permissions,
@@ -206,7 +194,6 @@ def test_cluster_policies(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_warehouses(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_warehouse,
     make_warehouse_permissions,
@@ -241,7 +228,6 @@ def test_warehouses(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_models(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_model,
     make_registered_model_permissions,  # pylint: disable=invalid-name
@@ -276,7 +262,6 @@ def test_models(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_experiments(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_experiment,
     make_experiment_permissions,
@@ -310,7 +295,6 @@ def test_directories(
     ws: WorkspaceClient,
     sql_backend,
     inventory_schema,
-    permission_manager: PermissionManager,
     migrated_group,
     make_directory,
     make_directory_permissions,
@@ -352,7 +336,6 @@ def test_directories(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_notebooks(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     sql_backend,
     inventory_schema,
     migrated_group,
@@ -394,13 +377,7 @@ def test_notebooks(
 
 @retried(on=[BadRequest], timeout=timedelta(minutes=3))
 @pytest.mark.parametrize("is_experimental", [True, False])
-def test_tokens(
-    ws: WorkspaceClient,
-    permission_manager: PermissionManager,
-    migrated_group,
-    make_authorization_permissions,
-    is_experimental: bool,
-):
+def test_tokens(ws: WorkspaceClient, migrated_group, make_authorization_permissions, is_experimental: bool):
     make_authorization_permissions(
         object_id="tokens",
         permission_level=PermissionLevel.CAN_USE,
@@ -471,7 +448,6 @@ def test_verify_permissions(ws: WorkspaceClient, make_group, make_job, make_job_
 @pytest.mark.parametrize("is_experimental", [True, False])
 def test_endpoints(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_serving_endpoint,
     make_serving_endpoint_permissions,  # pylint: disable=invalid-name
@@ -500,7 +476,6 @@ def test_endpoints(
 @pytest.mark.parametrize("is_experimental", [True, False])
 def test_feature_tables(
     ws: WorkspaceClient,
-    permission_manager: PermissionManager,
     migrated_group,
     make_feature_table,
     make_feature_table_permissions,
@@ -529,12 +504,7 @@ def test_feature_tables(
 
 
 @pytest.mark.parametrize("is_experimental", [True, False])
-def test_feature_store_root_page(
-    ws: WorkspaceClient,
-    permission_manager: PermissionManager,
-    migrated_group,
-    is_experimental: bool,
-):
+def test_feature_store_root_page(ws: WorkspaceClient, migrated_group, is_experimental: bool):
     ws.permissions.update(
         "feature-tables",
         "/root",
@@ -564,12 +534,7 @@ def test_feature_store_root_page(
 
 
 @pytest.mark.parametrize("is_experimental", [True, False])
-def test_models_root_page(
-    ws: WorkspaceClient,
-    permission_manager: PermissionManager,
-    migrated_group,
-    is_experimental: bool,
-):
+def test_models_root_page(ws: WorkspaceClient, migrated_group, is_experimental: bool):
 
     ws.permissions.update(
         "registered-models",

--- a/tests/integration/workspace_access/test_redash.py
+++ b/tests/integration/workspace_access/test_redash.py
@@ -50,7 +50,7 @@ def test_permissions_for_redash(
     )
 
     if use_permission_migration_api:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(redash_permissions, [migrated_group])
 

--- a/tests/integration/workspace_access/test_redash.py
+++ b/tests/integration/workspace_access/test_redash.py
@@ -27,7 +27,6 @@ def test_permissions_for_redash(
     make_user,
     make_query,
     make_query_permissions,
-    permission_manager,
     use_permission_migration_api,
 ):
     ws_group_temp = make_group()  # simulate temp/backup group
@@ -72,8 +71,6 @@ def test_permissions_for_redash(
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_permissions_for_redash_after_group_is_renamed(
     ws,
-    sql_backend,
-    inventory_schema,
     make_group,
     make_query,
     make_query_permissions,
@@ -120,8 +117,6 @@ def test_permissions_for_redash_after_group_is_renamed(
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_verify_permissions_for_redash(
     ws,
-    sql_backend,
-    inventory_schema,
     make_group,
     make_query,
     make_query_permissions,

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -8,7 +8,6 @@ from databricks.sdk.service import iam
 
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
-from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.scim import ScimSupport
 
 from . import apply_tasks
@@ -21,7 +20,6 @@ def test_some_entitlements(
     ws: WorkspaceClient,
     make_group,
     make_acc_group,
-    permission_manager: PermissionManager,
     use_permission_migration_api: bool,
 ):
     ws_group = make_group()

--- a/tests/integration/workspace_access/test_scim.py
+++ b/tests/integration/workspace_access/test_scim.py
@@ -25,7 +25,7 @@ def test_some_entitlements(
     ws_group = make_group()
     acc_group = make_acc_group()
     acc.workspace_assignment.update(ws.get_workspace_id(), acc_group.id, [iam.WorkspacePermission.USER])
-    migrated_groups = MigratedGroup.partial_info(ws_group, acc_group)
+    migrated_group = MigratedGroup.partial_info(ws_group, acc_group)
     ws.groups.patch(
         ws_group.id,
         operations=[
@@ -43,9 +43,9 @@ def test_some_entitlements(
     assert "databricks-sql-access" in before
 
     if use_permission_migration_api:
-        MigrationState([migrated_groups]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
-        apply_tasks(scim_support, [migrated_groups])
+        apply_tasks(scim_support, [migrated_group])
 
     _, after = scim_support.load_for_group(acc_group.id)
     assert "databricks-sql-access" in after

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -11,7 +11,6 @@ from databricks.sdk.service.workspace import AclPermission
 
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.groups import MigrationState
-from databricks.labs.ucx.workspace_access.manager import PermissionManager
 from databricks.labs.ucx.workspace_access.secrets import SecretScopesSupport
 
 from . import apply_tasks
@@ -26,7 +25,6 @@ def test_permissions_for_secrets(
     migrated_group,
     make_secret_scope,
     make_secret_scope_acl,
-    permission_manager: PermissionManager,
     use_permission_migration_api: bool,
 ):
 

--- a/tests/integration/workspace_access/test_secrets.py
+++ b/tests/integration/workspace_access/test_secrets.py
@@ -36,7 +36,7 @@ def test_permissions_for_secrets(
     secret_support = SecretScopesSupport(ws)
 
     if use_permission_migration_api:
-        MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+        MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
     else:
         apply_tasks(secret_support, [migrated_group])
 

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -32,7 +32,7 @@ def test_grants_with_permission_migration_api(
     original_schema_grants = {"a": grants.for_schema_info(schema_a)}
     assert {"USAGE", "OWN"} == original_schema_grants["a"][migrated_group.name_in_workspace]
 
-    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+    MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
 
     new_table_grants = {"a": grants.for_table_info(table_a)}
     assert {"SELECT"} == new_table_grants["a"][migrated_group.name_in_account]
@@ -49,7 +49,7 @@ def test_permission_for_files_anonymous_func_migration_api(ws, sql_backend, inve
     udfs = StaticUdfsCrawler(sql_backend, inventory_schema, [])
     grants = GrantsCrawler(tables, udfs)
 
-    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+    MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
 
     any_file_actual = {}
     for any_file_grant in grants.grants(any_file=True):
@@ -89,7 +89,7 @@ def test_permission_for_udfs_migration_api(ws, sql_backend, inventory_schema, ma
     assert f"{migrated_group.name_in_workspace}.{udf_a.full_name}:OWN" in all_initial_grants
     assert f"{migrated_group.name_in_workspace}.{udf_b.full_name}:READ_METADATA" in all_initial_grants
 
-    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+    MigrationState([migrated_group]).apply_to_groups_with_different_names(ws)
 
     actual_udf_a_grants = defaultdict(set)
     for grant in grants.grants(catalog=schema.catalog_name, database=schema.name, udf=udf_a.name):

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -4,13 +4,102 @@ from collections import defaultdict
 
 from databricks.labs.ucx.hive_metastore import GrantsCrawler
 from databricks.labs.ucx.workspace_access.base import Permissions
-from databricks.labs.ucx.workspace_access.groups import MigratedGroup
+from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 from ..conftest import StaticTablesCrawler, StaticUdfsCrawler
 from . import apply_tasks
 
 logger = logging.getLogger(__name__)
+
+
+def test_grants_with_permission_migration_api(
+    ws, migrated_group, inventory_schema, make_schema, make_table, sql_backend
+):
+    schema_a = make_schema()
+    table_a = make_table(schema_name=schema_a.name)
+    sql_backend.execute(f"GRANT USAGE ON SCHEMA {schema_a.name} TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"ALTER SCHEMA {schema_a.name} OWNER TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{migrated_group.name_in_workspace}`")
+
+    tables = StaticTablesCrawler(sql_backend, inventory_schema, [table_a])
+    udfs = StaticUdfsCrawler(sql_backend, inventory_schema, [])
+    grants = GrantsCrawler(tables, udfs)
+
+    original_table_grants = {"a": grants.for_table_info(table_a)}
+    assert {"SELECT"} == original_table_grants["a"][migrated_group.name_in_workspace]
+
+    original_schema_grants = {"a": grants.for_schema_info(schema_a)}
+    assert {"USAGE", "OWN"} == original_schema_grants["a"][migrated_group.name_in_workspace]
+
+    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+
+    new_table_grants = {"a": grants.for_table_info(table_a)}
+    assert {"SELECT"} == new_table_grants["a"][migrated_group.name_in_account]
+
+    new_schema_grants = {"a": grants.for_schema_info(schema_a)}
+    assert {"USAGE", "OWN"} == new_schema_grants["a"][migrated_group.name_in_account]
+
+
+def test_permission_for_files_anonymous_func_migration_api(ws, sql_backend, inventory_schema, migrated_group):
+    sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{migrated_group.name_in_workspace}`")
+
+    tables = StaticTablesCrawler(sql_backend, inventory_schema, [])
+    udfs = StaticUdfsCrawler(sql_backend, inventory_schema, [])
+    grants = GrantsCrawler(tables, udfs)
+
+    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+
+    any_file_actual = {}
+    for any_file_grant in grants.grants(any_file=True):
+        any_file_actual[any_file_grant.principal] = any_file_grant.action_type
+
+    # both old and new group have permissions
+    assert migrated_group.name_in_workspace not in any_file_actual
+    assert migrated_group.name_in_account in any_file_actual
+
+    anonymous_function_actual = {}
+    for ano_func_grant in grants.grants(anonymous_function=True):
+        anonymous_function_actual[ano_func_grant.principal] = ano_func_grant.action_type
+
+    assert migrated_group.name_in_workspace not in anonymous_function_actual
+    assert migrated_group.name_in_account in anonymous_function_actual
+    assert anonymous_function_actual[migrated_group.name_in_account] == "SELECT"
+
+
+def test_permission_for_udfs_migration_api(ws, sql_backend, inventory_schema, make_schema, make_udf, migrated_group):
+    schema = make_schema()
+    udf_a = make_udf(schema_name=schema.name)
+    udf_b = make_udf(schema_name=schema.name)
+
+    sql_backend.execute(f"GRANT SELECT ON FUNCTION {udf_a.full_name} TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"ALTER FUNCTION {udf_a.full_name} OWNER TO `{migrated_group.name_in_workspace}`")
+    sql_backend.execute(f"GRANT READ_METADATA ON FUNCTION {udf_b.full_name} TO `{migrated_group.name_in_workspace}`")
+
+    tables = StaticTablesCrawler(sql_backend, inventory_schema, [])
+    udfs = StaticUdfsCrawler(sql_backend, inventory_schema, [udf_a, udf_b])
+    grants = GrantsCrawler(tables, udfs)
+
+    all_initial_grants = set()
+    for grant in grants.snapshot():
+        all_initial_grants.add(f"{grant.principal}.{grant.object_key}:{grant.action_type}")
+
+    assert f"{migrated_group.name_in_workspace}.{udf_a.full_name}:SELECT" in all_initial_grants
+    assert f"{migrated_group.name_in_workspace}.{udf_a.full_name}:OWN" in all_initial_grants
+    assert f"{migrated_group.name_in_workspace}.{udf_b.full_name}:READ_METADATA" in all_initial_grants
+
+    MigrationState([migrated_group]).apply_group_permissions_experimental(ws)
+
+    actual_udf_a_grants = defaultdict(set)
+    for grant in grants.grants(catalog=schema.catalog_name, database=schema.name, udf=udf_a.name):
+        actual_udf_a_grants[grant.principal].add(grant.action_type)
+    assert {"SELECT", "OWN"} == actual_udf_a_grants[migrated_group.name_in_account]
+
+    actual_udf_b_grants = defaultdict(set)
+    for grant in grants.grants(catalog=schema.catalog_name, database=schema.name, udf=udf_b.name):
+        actual_udf_b_grants[grant.principal].add(grant.action_type)
+    assert {"READ_METADATA"} == actual_udf_b_grants[migrated_group.name_in_account]
 
 
 def test_permission_for_files_anonymous_func(sql_backend, inventory_schema, make_group):

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -71,7 +71,7 @@ def test_apply_group_permissions_experimental_performance(
         )
 
     start = process_time()
-    MigrationState([migrated_group_experimental]).apply_group_permissions_experimental(ws)
+    MigrationState([migrated_group_experimental]).apply_to_groups_with_different_names(ws)
     logger.info(f"Migration using experimental API takes {process_time() - start}s")
 
     start = process_time()

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -337,9 +337,9 @@ def test_migrate_permissions_experimental():
         azure_mock_config(), ws, MockBackend(rows=rows), mock_installation()
     )
     calls = [
-        call("12345678", "workspace_group_1", "account_group_1", size=1000),
-        call("12345678", "workspace_group_2", "account_group_2", size=1000),
-        call("12345678", "workspace_group_3", "account_group_3", size=1000),
+        call("12345678", "temp_1", "account_group_1", size=1000),
+        call("12345678", "temp_2", "account_group_2", size=1000),
+        call("12345678", "temp_3", "account_group_3", size=1000),
     ]
     ws.permission_migration.migrate_permissions.assert_has_calls(calls, any_order=True)
 
@@ -362,9 +362,9 @@ def test_migrate_permissions_experimental_paginated():
         azure_mock_config(), ws, MockBackend(rows=rows), mock_installation()
     )
     calls = [
-        call("12345678", "workspace_group_1", "account_group_1", size=1000),
-        call("12345678", "workspace_group_2", "account_group_2", size=1000),
-        call("12345678", "workspace_group_3", "account_group_3", size=1000),
+        call("12345678", "temp_1", "account_group_1", size=1000),
+        call("12345678", "temp_2", "account_group_2", size=1000),
+        call("12345678", "temp_3", "account_group_3", size=1000),
     ]
     ws.permission_migration.migrate_permissions.assert_has_calls(calls, any_order=True)
 

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -36,7 +36,6 @@ from databricks.labs.ucx.runtime import (
     migrate_external_tables_sync,
     reflect_account_groups_on_workspace_experimental,
     rename_workspace_local_groups_experimental,
-    validate_groups_permissions_experimental,
     workspace_listing,
 )
 from tests.unit import GROUPS, PERMISSIONS
@@ -320,14 +319,6 @@ def test_rename_workspace_local_group(caplog):
 def test_reflect_account_groups_on_workspace(caplog):
     ws = create_autospec(WorkspaceClient)
     reflect_account_groups_on_workspace_experimental(azure_mock_config(), ws, MockBackend(), mock_installation())
-
-
-def test_validate_groups_permissions(caplog):
-    ws = create_autospec(WorkspaceClient)
-    rows = {
-        'SELECT COUNT\\(\\*\\) as cnt FROM hive_metastore.ucx.permissions': PERMISSIONS[("123", "QUERIES", "temp")],
-    }
-    validate_groups_permissions_experimental(azure_mock_config(), ws, MockBackend(rows=rows), mock_installation())
 
 
 def test_migrate_permissions_experimental():

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -336,5 +336,5 @@ def test_manager_apply_experimental_no_tasks(mock_ws, caplog):
     group_migration_state = MigrationState([])
 
     with caplog.at_level("INFO"):
-        group_migration_state.apply_group_permissions_experimental(mock_ws)
+        group_migration_state.apply_to_groups_with_different_names(mock_ws)
         assert "No valid groups selected, nothing to do." in caplog.messages


### PR DESCRIPTION
This PR removes verification step from the experimental group migration job, as platform already replaces permissions from workspace group to account group and old validation method is not required anymore.
