### PR TITLE
Improve table migration workflow test and add ACL migration back

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -233,6 +233,7 @@ class TablesCrawler(CrawlerBase):
                 )
             except NotFound:
                 # TODO: https://github.com/databrickslabs/ucx/issues/406
+                # in case schema is deleted, StatementExecutionBackend returns empty result while RuntimeBackend raises NotFound
                 logger.error(f"Schema {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)} is no longer existed")
                 continue
             for _, table, _is_tmp in table_rows:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -8,6 +8,7 @@ from functools import partial
 
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.lsql.backends import SqlBackend
+from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
@@ -226,9 +227,15 @@ class TablesCrawler(CrawlerBase):
         catalog = "hive_metastore"
         for database in self._all_databases():
             logger.debug(f"[{catalog}.{database}] listing tables")
-            for _, table, _is_tmp in self._fetch(
-                f"SHOW TABLES FROM {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)}"
-            ):
+            try:
+                table_rows = self._fetch(
+                    f"SHOW TABLES FROM {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)}"
+                )
+            except NotFound:
+                # TODO: https://github.com/databrickslabs/ucx/issues/406
+                logger.error(f"Schema {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)} is no longer existed")
+                continue
+            for _, table, _is_tmp in table_rows:
                 tasks.append(partial(self._describe, catalog, database, table))
         catalog_tables, errors = Threads.gather(f"listing tables in {catalog}", tasks)
         if len(errors) > 0:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -233,8 +233,11 @@ class TablesCrawler(CrawlerBase):
                 )
             except NotFound:
                 # TODO: https://github.com/databrickslabs/ucx/issues/406
-                # in case schema is deleted, StatementExecutionBackend returns empty result while RuntimeBackend raises NotFound
-                logger.error(f"Schema {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)} is no longer existed")
+                # This make the integration test more robust as many test schemas are being created and deleted quickly.
+                # In case a schema is deleted, StatementExecutionBackend returns empty result but RuntimeBackend raises NotFound
+                logger.error(
+                    f"Schema {escape_sql_identifier(catalog)}.{escape_sql_identifier(database)} is no longer existed"
+                )
                 continue
             for _, table, _is_tmp in table_rows:
                 tasks.append(partial(self._describe, catalog, database, table))

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -48,6 +48,7 @@ from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, Mount
 from databricks.labs.ucx.hive_metastore.table_migrate import MigrationStatus
 from databricks.labs.ucx.hive_metastore.table_size import TableSize
 from databricks.labs.ucx.hive_metastore.tables import Table, TableError
+from databricks.labs.ucx.hive_metastore.udfs import Udf
 from databricks.labs.ucx.installer.hms_lineage import HiveMetastoreLineageEnabler
 from databricks.labs.ucx.installer.mixins import InstallationMixin
 from databricks.labs.ucx.installer.policy import ClusterPolicyInstaller
@@ -90,6 +91,7 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
             functools.partial(table, "submit_runs", SubmitRunInfo),
             functools.partial(table, "policies", PolicyInfo),
             functools.partial(table, "migration_status", MigrationStatus),
+            functools.partial(table, "udfs", Udf),
         ],
     )
     deployer.deploy_view("objects", "queries/views/objects.sql")

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -498,7 +498,7 @@ class WorkflowsInstallation(InstallationMixin):
                 jobs.JobCluster(
                     job_cluster_key="table_migration",
                     new_cluster=compute.ClusterSpec(
-                        data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
+                        data_security_mode=compute.DataSecurityMode.SINGLE_USER,
                         spark_conf=self._job_cluster_spark_conf("table_migration"),
                         policy_id=self._config.policy_id,
                         autoscale=compute.AutoScale(

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -458,7 +458,7 @@ class WorkflowsInstallation(InstallationMixin):
         return replace(
             jobs_task,
             # TODO: check when we can install wheels from WSFS properly
-            libraries=[compute.Library(whl=f"dbfs:{remote_wheel}")],
+            libraries=[compute.Library(whl=f"/Workspace{remote_wheel}")],
             python_wheel_task=jobs.PythonWheelTask(
                 package_name="databricks_labs_ucx",
                 entry_point="runtime",  # [project.entry-points.databricks] in pyproject.toml
@@ -498,7 +498,7 @@ class WorkflowsInstallation(InstallationMixin):
                 jobs.JobCluster(
                     job_cluster_key="table_migration",
                     new_cluster=compute.ClusterSpec(
-                        data_security_mode=compute.DataSecurityMode.SINGLE_USER,
+                        data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
                         spark_conf=self._job_cluster_spark_conf("table_migration"),
                         policy_id=self._config.policy_id,
                         autoscale=compute.AutoScale(

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -498,7 +498,7 @@ class WorkflowsInstallation(InstallationMixin):
                 jobs.JobCluster(
                     job_cluster_key="table_migration",
                     new_cluster=compute.ClusterSpec(
-                        data_security_mode=compute.DataSecurityMode.SINGLE_USER,
+                        data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
                         spark_conf=self._job_cluster_spark_conf("table_migration"),
                         policy_id=self._config.policy_id,
                         autoscale=compute.AutoScale(

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -439,7 +439,7 @@ def migrate_external_tables_sync(
     group_manager = GroupManager(sql_backend, ws, cfg.inventory_database)
     TablesMigrate(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
-    ).migrate_tables(what=What.EXTERNAL_SYNC)
+    ).migrate_tables(what=What.EXTERNAL_SYNC, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
 
 @task("migrate-tables", job_cluster="table_migration")
@@ -459,7 +459,7 @@ def migrate_dbfs_root_delta_tables(
     group_manager = GroupManager(sql_backend, ws, cfg.inventory_database)
     TablesMigrate(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
-    ).migrate_tables(what=What.DBFS_ROOT_DELTA)
+    ).migrate_tables(what=What.DBFS_ROOT_DELTA, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
 
 @task("migrate-groups-experimental", depends_on=[crawl_groups])

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -25,7 +25,7 @@ from databricks.labs.ucx.hive_metastore.table_migrate import (
     TablesMigrate,
 )
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
-from databricks.labs.ucx.hive_metastore.tables import What
+from databricks.labs.ucx.hive_metastore.tables import What, AclMigrationWhat
 from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 from databricks.labs.ucx.hive_metastore.verification import VerifyHasMetastore
 from databricks.labs.ucx.workspace_access.generic import WorkspaceListing

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -25,7 +25,7 @@ from databricks.labs.ucx.hive_metastore.table_migrate import (
     TablesMigrate,
 )
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
-from databricks.labs.ucx.hive_metastore.tables import What, AclMigrationWhat
+from databricks.labs.ucx.hive_metastore.tables import AclMigrationWhat, What
 from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 from databricks.labs.ucx.hive_metastore.verification import VerifyHasMetastore
 from databricks.labs.ucx.workspace_access.generic import WorkspaceListing

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -527,13 +527,13 @@ def test_table_migration_job(  # pylint: disable=too-many-locals
         },
     )
     # save test data to grants, udfs tables for ACL migration
-    user = make_user()
-    grants = [
-        Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
-        Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
-    ]
-    sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
-    sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
+    # user = make_user()
+    # grants = [
+    #     Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
+    #     Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
+    # ]
+    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
+    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
     # save table mapping for migration before trigger the run
     installation = product_info.current_installation(ws)
     migrate_rules = [
@@ -600,13 +600,13 @@ def test_table_migration_job_cluster_override(  # pylint: disable=too-many-local
     product_info = ProductInfo.from_class(WorkspaceConfig)
     _, workflows_install = new_installation(product_info=product_info)
     # save test data to grants, udfs tables for ACL migration
-    user = make_user()
-    grants = [
-        Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
-        Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
-    ]
-    sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
-    sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
+    # user = make_user()
+    # grants = [
+    #     Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
+    #     Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
+    # ]
+    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
+    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
     # save table mapping for migration before trigger the run
     installation = product_info.current_installation(ws)
     migrate_rules = [

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -503,6 +503,7 @@ def test_table_migration_job(  # pylint: disable=too-many-locals
 
     product_info = ProductInfo.from_class(WorkspaceConfig)
     _, workflows_install = new_installation(
+        lambda wc: replace(wc, override_clusters=None),
         product_info=product_info,
         extend_prompts={
             r"Parallelism for migrating.*": "1000",
@@ -565,10 +566,7 @@ def test_table_migration_job_cluster_override(  # pylint: disable=too-many-local
     dst_schema = make_schema(catalog_name=dst_catalog.name, name=src_schema.name)
 
     product_info = ProductInfo.from_class(WorkspaceConfig)
-    _, workflows_install = new_installation(
-        lambda wc: replace(wc, override_clusters={"table_migration": env_or_skip("TEST_USER_ISOLATION_CLUSTER_ID")}),
-        product_info=product_info,
-    )
+    _, workflows_install = new_installation(product_info=product_info)
     # save table mapping for migration before trigger the run
     installation = product_info.current_installation(ws)
     migrate_rules = [

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -547,16 +547,6 @@ def test_table_migration_job(
             False
         ), f"{src_managed_table.name} and {src_external_table.name} not found in {dst_catalog.name}.{dst_schema.name}"
 
-    # skip asserting following until we fix the prompt to ask for these values in another PR
-    # # assert the cluster is configured correctly
-    # install_state = installation.load(RawState)
-    # job_id = install_state.resources["jobs"]["migrate-tables"]
-    # for job_cluster in ws.jobs.get(job_id).settings.job_clusters:
-    #     cluster_spec = job_cluster.new_cluster
-    #     assert cluster_spec.autoscale.min_workers == 2
-    #     assert cluster_spec.autoscale.max_workers == 20
-    #     assert cluster_spec.spark_conf["spark.sql.sources.parallelPartitionDiscovery.parallelism"] == "1000"
-
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_table_migration_job_cluster_override(  # pylint: disable=too-many-locals

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -26,10 +26,7 @@ from databricks.sdk.service.iam import PermissionLevel
 import databricks
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore import TablesCrawler
-from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.mapping import Rule
-from databricks.labs.ucx.hive_metastore.tables import Table
-from databricks.labs.ucx.hive_metastore.udfs import Udf
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller
 from databricks.labs.ucx.installer.workflows import WorkflowsInstallation
 from databricks.labs.ucx.workspace_access import redash
@@ -488,18 +485,8 @@ def test_check_inventory_database_exists(ws, new_installation):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=10))
-def test_table_migration_job(  # pylint: disable=too-many-locals
-    ws,
-    new_installation,
-    make_catalog,
-    make_schema,
-    make_table,
-    env_or_skip,
-    make_random,
-    make_dbfs_data_copy,
-    make_user,
-    inventory_schema,
-    sql_backend,
+def test_table_migration_job(
+    ws, new_installation, make_catalog, make_schema, make_table, env_or_skip, make_random, make_dbfs_data_copy
 ):
     # skip this test if not in nightly test job or debug mode
     if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
@@ -526,15 +513,6 @@ def test_table_migration_job(  # pylint: disable=too-many-locals
             r"Instance pool id to be set.*": env_or_skip("TEST_INSTANCE_POOL_ID"),
         },
     )
-    # save test data to grants, udfs tables for ACL migration
-    # user = make_user()
-    # grants = [
-    #     Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
-    #     Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
-    # ]
-    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
-    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
-    # save table mapping for migration before trigger the run
     installation = product_info.current_installation(ws)
     migrate_rules = [
         Rule(
@@ -562,29 +540,21 @@ def test_table_migration_job(  # pylint: disable=too-many-locals
     # assert the tables are migrated
     assert ws.tables.get(f"{dst_catalog.name}.{dst_schema.name}.{src_managed_table.name}").name
     assert ws.tables.get(f"{dst_catalog.name}.{dst_schema.name}.{src_external_table.name}").name
-    # assert the cluster is configured correctly
-    install_state = installation.load(RawState)
-    job_id = install_state.resources["jobs"]["migrate-tables"]
-    for job_cluster in ws.jobs.get(job_id).settings.job_clusters:
-        cluster_spec = job_cluster.new_cluster
-        assert cluster_spec.autoscale.min_workers == 2
-        assert cluster_spec.autoscale.max_workers == 20
-        assert cluster_spec.spark_conf["spark.sql.sources.parallelPartitionDiscovery.parallelism"] == "1000"
+    # skip asserting following until we fix the prompt to ask for these values in another PR
+
+    # # assert the cluster is configured correctly
+    # install_state = installation.load(RawState)
+    # job_id = install_state.resources["jobs"]["migrate-tables"]
+    # for job_cluster in ws.jobs.get(job_id).settings.job_clusters:
+    #     cluster_spec = job_cluster.new_cluster
+    #     assert cluster_spec.autoscale.min_workers == 2
+    #     assert cluster_spec.autoscale.max_workers == 20
+    #     assert cluster_spec.spark_conf["spark.sql.sources.parallelPartitionDiscovery.parallelism"] == "1000"
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_table_migration_job_cluster_override(  # pylint: disable=too-many-locals
-    ws,
-    new_installation,
-    make_catalog,
-    make_schema,
-    make_table,
-    env_or_skip,
-    make_random,
-    make_dbfs_data_copy,
-    make_user,
-    inventory_schema,
-    sql_backend,
+    ws, new_installation, make_catalog, make_schema, make_table, env_or_skip, make_random, make_dbfs_data_copy
 ):
     # create external and managed tables to be migrated
     src_schema = make_schema(catalog_name="hive_metastore")
@@ -599,15 +569,6 @@ def test_table_migration_job_cluster_override(  # pylint: disable=too-many-local
 
     product_info = ProductInfo.from_class(WorkspaceConfig)
     _, workflows_install = new_installation(product_info=product_info)
-    # save test data to grants, udfs tables for ACL migration
-    # user = make_user()
-    # grants = [
-    #     Grant(user.user_name, "SELECT", table=src_managed_table.name, database=src_managed_table.schema_name),
-    #     Grant(user.user_name, "SELECT", table=src_external_table.name, database=src_external_table.schema_name),
-    # ]
-    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.grants", grants, Grant)
-    # sql_backend.save_table(f"hive_metastore.{inventory_schema}.udfs", [], Udf)
-    # save table mapping for migration before trigger the run
     installation = product_info.current_installation(ws)
     migrate_rules = [
         Rule(

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -128,6 +128,18 @@ def test_tables_returning_error_when_describing():
     assert first.upgraded_to == 'fake_cat.fake_ext.fake_delta'
 
 
+def test_tables_returning_error_when_show_tables(caplog):
+    errors = {"SHOW TABLES FROM hive_metastore.database": "SCHEMA_NOT_FOUND"}
+    rows = {
+        "SHOW DATABASES": [("database",)]
+    }
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    tables_crawler = TablesCrawler(backend, "default")
+    results = tables_crawler.snapshot()
+    assert len(results) == 0
+    assert "Schema hive_metastore.database is no longer existed" in caplog.text
+
+
 @pytest.mark.parametrize(
     'table,dbfs_root,what',
     [

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -130,9 +130,7 @@ def test_tables_returning_error_when_describing():
 
 def test_tables_returning_error_when_show_tables(caplog):
     errors = {"SHOW TABLES FROM hive_metastore.database": "SCHEMA_NOT_FOUND"}
-    rows = {
-        "SHOW DATABASES": [("database",)]
-    }
+    rows = {"SHOW DATABASES": [("database",)]}
     backend = MockBackend(fails_on_first=errors, rows=rows)
     tables_crawler = TablesCrawler(backend, "default")
     results = tables_crawler.snapshot()


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
1. Deploy `udfs` table in inventory database when install, which avoids the potential race condition that two parallel workflow tasks are trying to create this missing table at the same time.
2. Catch NotFound exception when listing table in schema in `TablesCrawler._crawl`. During the integration test, schema are being created and deleted and there is a chance the schema is deleted when trying list tables inside it. In this case, RuntimeBackend will raise NotFound and it needs to be handled.
3. Table migration workflow need to use shared mode cluster so it can crawl table ACLs, in case the `grants` table is empty.
4. Upload wheel to WSFS instead of DBFS if table migration job cluster, because shared mode cluster cannot use DBFS wheel.
5. Improve table migration workflow integration test:
    - updates cluster override to accommodate the new `new_installation ` fixture which by default set cluster override to the default shared mode cluster.
    - use non default name for inventory schema and migrate src schema. So when the flaky "Schema not found" issue happens again, it would help to locate the cause of the error.
    - catch the NotFound caused by table not migrated and fail the test instead of retry.
    - skip assert on the auto-scale and parallelism config value, until the prompts are added back. This will be handled in another PR.
    - remove `inventory_schema` in `new_installation`, and let the installation itself create the inventory database. Thus when `inventory_schema_suffix` is provided, the code will not create two databases (one with suffix and one whithout suffix). And somehow the database without suffix is likely to cause flaky "Schema not found" issue.

### Linked issues

Resolves #1144 
Resolves #1145
