### PR TITLE
Return correct value from `Index.is_upgraded()`

### DIFF
--- a/src/databricks/labs/ucx/source_code/languages.py
+++ b/src/databricks/labs/ucx/source_code/languages.py
@@ -1,13 +1,13 @@
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.table_migrate import Index
+from databricks.labs.ucx.hive_metastore.table_migrate import MigrationIndex
 from databricks.labs.ucx.source_code.base import Fixer, Linter, SequentialLinter
 from databricks.labs.ucx.source_code.pyspark import SparkSql
 from databricks.labs.ucx.source_code.queries import FromTable
 
 
 class Languages:
-    def __init__(self, index: Index):
+    def __init__(self, index: MigrationIndex):
         self._index = index
         from_table = FromTable(index)
         self._linters = {

--- a/src/databricks/labs/ucx/source_code/lsp.py
+++ b/src/databricks/labs/ucx/source_code/lsp.py
@@ -12,7 +12,10 @@ from urllib.parse import parse_qsl
 from databricks.labs.blueprint.logger import install_logger
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.table_migrate import Index, MigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migrate import (
+    MigrationIndex,
+    MigrationStatus,
+)
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,
@@ -326,7 +329,7 @@ if __name__ == '__main__':
     install_logger()
     logging.root.setLevel('DEBUG')
     languages = Languages(
-        Index(
+        MigrationIndex(
             [
                 MigrationStatus(
                     src_schema='old', src_table='things', dst_catalog='brand', dst_schema='new', dst_table='stuff'

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -3,12 +3,12 @@ from collections.abc import Iterable
 import sqlglot
 from sqlglot.expressions import Table
 
-from databricks.labs.ucx.hive_metastore.table_migrate import Index
+from databricks.labs.ucx.hive_metastore.table_migrate import MigrationIndex
 from databricks.labs.ucx.source_code.base import Advice, Deprecation, Fixer, Linter
 
 
 class FromTable(Linter, Fixer):
-    def __init__(self, index: Index):
+    def __init__(self, index: MigrationIndex):
         self._index = index
 
     def name(self) -> str:

--- a/tests/unit/source_code/conftest.py
+++ b/tests/unit/source_code/conftest.py
@@ -1,16 +1,19 @@
 import pytest
 
-from databricks.labs.ucx.hive_metastore.table_migrate import Index, MigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migrate import (
+    MigrationIndex,
+    MigrationStatus,
+)
 
 
 @pytest.fixture
 def empty_index():
-    return Index([])
+    return MigrationIndex([])
 
 
 @pytest.fixture
 def migration_index():
-    return Index(
+    return MigrationIndex(
         [
             MigrationStatus('old', 'things', dst_catalog='brand', dst_schema='new', dst_table='stuff'),
             MigrationStatus('other', 'matters', dst_catalog='some', dst_schema='certain', dst_table='issues'),

--- a/tests/unit/source_code/test_languages.py
+++ b/tests/unit/source_code/test_languages.py
@@ -1,11 +1,11 @@
 import pytest
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.table_migrate import Index
+from databricks.labs.ucx.hive_metastore.table_migrate import MigrationIndex
 from databricks.labs.ucx.source_code.base import Fixer, Linter
 from databricks.labs.ucx.source_code.languages import Languages
 
-index = Index([])
+index = MigrationIndex([])
 
 
 def test_linter_returns_correct_analyser_for_python():


### PR DESCRIPTION
This PR fixes the bug in `Index` that was presenting non-migrated tables as migrated. It also clarifies the intent of this class by renaming it to `MigrationIndex`.