### PR TITLE
Fixed flaky `test_tables_crawler_should_filter_by_database`

### DIFF
--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -231,9 +231,11 @@ def test_tables_crawler_should_filter_by_database():
     tables_crawler = TablesCrawler(backend, "default", ["database"])
     results = tables_crawler.snapshot()
     assert len(results) == 2
-    assert backend.queries == [
-        'SELECT * FROM hive_metastore.default.tables',
-        'SHOW TABLES FROM hive_metastore.database',
-        'DESCRIBE TABLE EXTENDED hive_metastore.database.table1',
-        'DESCRIBE TABLE EXTENDED hive_metastore.database.table2',
-    ]
+    assert sorted(backend.queries) == sorted(
+        [
+            'SELECT * FROM hive_metastore.default.tables',
+            'SHOW TABLES FROM hive_metastore.database',
+            'DESCRIBE TABLE EXTENDED hive_metastore.database.table1',
+            'DESCRIBE TABLE EXTENDED hive_metastore.database.table2',
+        ]
+    )


### PR DESCRIPTION
Sort queries before comparing them, otherwise parallel execution will randomly fail unit tests like in https://github.com/databrickslabs/ucx/actions/runs/8479114292/job/23232581236?pr=1166 for https://github.com/databrickslabs/ucx/pull/1166

```
E       AssertionError: assert ['SELECT * FR...abase.table1'] == ['SELECT * FR...abase.table2']
E         
E         At index 2 diff: 'DESCRIBE TABLE EXTENDED hive_metastore.database.table2' != 'DESCRIBE TABLE EXTENDED hive_metastore.database.table1'
E         
E         Full diff:
E           [
E               'SELECT * FROM hive_metastore.default.tables',
E               'SHOW TABLES FROM hive_metastore.database',
E         +     'DESCRIBE TABLE EXTENDED hive_metastore.database.table2',
E               'DESCRIBE TABLE EXTENDED hive_metastore.database.table1',
E         -     'DESCRIBE TABLE EXTENDED hive_metastore.database.table2',
E           ]
```
