### PR TITLE
Rename for clarity and consistency

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -24,7 +24,7 @@ from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler
 from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
-from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrate
+from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrator
 from databricks.labs.ucx.hive_metastore.table_move import TableMove
 from databricks.labs.ucx.install import WorkspaceInstallation
 from databricks.labs.ucx.installer.workflows import WorkflowsInstallation
@@ -205,7 +205,7 @@ def revert_migrated_tables(
         question = "You haven't specified a schema or a table. All migrated tables will be reverted. Continue?"
         if not prompts.confirm(question, max_attempts=2):
             return
-    tables_migrate = TablesMigrate.for_cli(w)
+    tables_migrate = TablesMigrator.for_cli(w)
     revert = tables_migrate.print_revert_report(delete_managed=delete_managed)
     if revert and prompts.confirm("Would you like to continue?", max_attempts=2):
         tables_migrate.revert_migrated_tables(schema, table, delete_managed=delete_managed)

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -133,7 +133,7 @@ class TableMapping:
                 logger.info(f"Table {rule.as_hms_table_key} is in a database that was marked to be skipped")
                 continue
             if crawled_tables_keys[rule.as_hms_table_key].is_databricks_dataset:
-                logger.info(f"Table {rule.as_hms_table_key} is a db demo dataset and will not be upgraded")
+                logger.info(f"Table {rule.as_hms_table_key} is a db demo dataset and will not be migrated")
                 continue
             tasks.append(
                 partial(self._get_table_in_scope_task, TableToMigrate(crawled_tables_keys[rule.as_hms_table_key], rule))
@@ -177,8 +177,8 @@ class TableMapping:
                 logger.info(f"{table.key} is set as upgraded to {value['value']}")
                 if self.exists_in_uc(table, value["value"]):
                     logger.info(
-                        f"The table {table.key} was previously upgraded to {value['value']}. "
-                        f"To revert the table and allow it to be upgraded again use the CLI command:"
+                        f"The table {table.key} was previously migrated to {value['value']}. "
+                        f"To revert the table and allow it to be migrated again use the CLI command:"
                         f"databricks labs ucx revert --schema {table.database} --table {table.name}"
                     )
                     return None

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -42,7 +42,7 @@ class MigrationStatus:
         return f"{self.dst_catalog}.{self.dst_schema}.{self.dst_table}".lower()
 
 
-class TablesMigrate:
+class TablesMigrator:
     def __init__(
         self,
         table_crawler: TablesCrawler,

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -41,6 +41,7 @@ class Table:
 
     location: str | None = None
     view_text: str | None = None
+    # really means migrated_to
     upgraded_to: str | None = None
 
     storage_properties: str | None = None

--- a/src/databricks/labs/ucx/hive_metastore/views_sequencer.py
+++ b/src/databricks/labs/ucx/hive_metastore/views_sequencer.py
@@ -73,10 +73,10 @@ class ViewToMigrate:
         return hash(self._view)
 
 
-class ViewsMigrator:
+class ViewsSequencer:
 
-    def __init__(self, crawler: TablesCrawler):
-        self._crawler = crawler
+    def __init__(self, tables: list[Table]):
+        self._tables = tables
         self._result_view_list: list[ViewToMigrate] = []
         self._result_tables_set: set[Table] = set()
 
@@ -89,10 +89,9 @@ class ViewsMigrator:
         # if none, then it's safe to add that view to the next batch of views
         # the complexity for a given set of views v and a dependency depth d looks like Ov^d
         # this seems enormous but in practice d remains small and v decreases rapidly
-        table_list = self._crawler.snapshot()
         all_tables = {}
         views = set()
-        for table in table_list:
+        for table in self._tables:
             all_tables[table.key] = table
             if table.view_text is None:
                 continue

--- a/src/databricks/labs/ucx/hive_metastore/views_sequencer.py
+++ b/src/databricks/labs/ucx/hive_metastore/views_sequencer.py
@@ -3,7 +3,6 @@ from sqlglot import ParseError
 from sqlglot.expressions import Expression as SqlExpression
 from sqlglot.expressions import Table as SqlTable
 
-from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.tables import Table
 
 

--- a/src/databricks/labs/ucx/queries/assessment/estimates/03_0_data_migration.md
+++ b/src/databricks/labs/ucx/queries/assessment/estimates/03_0_data_migration.md
@@ -4,7 +4,7 @@
 Once you have defined your data model in UC and that you've created appropriate Storage Credentials and External Locations, 
 you can then migrate your data to UC 
 
-Assumptions for a single table upgrade estimates:
+Assumptions for a single table migration estimates:
 
 - UC Data model has been defined
 - Storage Credentials are in place
@@ -12,7 +12,7 @@ Assumptions for a single table upgrade estimates:
 - Target Catalogs and schemas has been defined
 - Grants has been defined
 
-Please note that depending on the table type and their location, the upgrade effort will differ.
+Please note that depending on the table type and their location, the migration effort will differ.
 [Full guidance](https://www.databricks.com/blog/migrating-tables-hive-metastore-unity-catalog-metastore)
 
 | object_type | table_format                         | location       | estimated effort | suggestion                                                                               |

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -23,7 +23,7 @@ from databricks.labs.ucx.hive_metastore.locations import TablesInMounts
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
 from databricks.labs.ucx.hive_metastore.table_migrate import (
     MigrationStatusRefresher,
-    TablesMigrate,
+    TablesMigrator,
 )
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
 from databricks.labs.ucx.hive_metastore.tables import AclMigrationWhat, What
@@ -438,7 +438,7 @@ def migrate_external_tables_sync(
     table_mapping = TableMapping(install, ws, sql_backend)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, cfg.inventory_database, table_crawler)
     group_manager = GroupManager(sql_backend, ws, cfg.inventory_database)
-    TablesMigrate(
+    TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     ).migrate_tables(what=What.EXTERNAL_SYNC, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
@@ -458,7 +458,7 @@ def migrate_dbfs_root_delta_tables(
     table_mapping = TableMapping(install, ws, sql_backend)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, cfg.inventory_database, table_crawler)
     group_manager = GroupManager(sql_backend, ws, cfg.inventory_database)
-    TablesMigrate(
+    TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     ).migrate_tables(what=What.DBFS_ROOT_DELTA, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrate
+from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrator
 from databricks.labs.ucx.source_code.languages import Languages
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class Files:
 
     @classmethod
     def for_cli(cls, ws: WorkspaceClient):
-        tables_migrate = TablesMigrate.for_cli(ws)
+        tables_migrate = TablesMigrator.for_cli(ws)
         index = tables_migrate.index()
         languages = Languages(index)
         return cls(languages)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.mapping import Rule
 from databricks.labs.ucx.hive_metastore.table_migrate import (
     MigrationStatusRefresher,
-    TablesMigrate,
+    TablesMigrator,
 )
 from databricks.labs.ucx.hive_metastore.tables import AclMigrationWhat, Table
 from databricks.labs.ucx.workspace_access.groups import GroupManager
@@ -56,7 +56,7 @@ def test_migrate_managed_tables(ws, sql_backend, inventory_schema, make_catalog,
     table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     )
 
@@ -117,7 +117,7 @@ def test_migrate_tables_with_cache_should_not_create_table(
     table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     )
 
@@ -169,7 +169,7 @@ def test_migrate_external_table(  # pylint: disable=too-many-locals
     ]
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler,
         grant_crawler,
         ws,
@@ -227,7 +227,7 @@ def test_migrate_external_table_failed_sync(
     ]
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler,
         grant_crawler,
         ws,
@@ -281,7 +281,7 @@ def test_revert_migrated_table(
     table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -393,7 +393,7 @@ def test_mapping_reverts_table(
     table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -482,7 +482,7 @@ def test_migrate_managed_tables_with_acl(
     table_mapping = StaticTableMapping(ws, sql_backend, rules=rules)
     group_manager = GroupManager(sql_backend, ws, inventory_schema)
     migration_status_refresher = MigrationStatusRefresher(ws, sql_backend, inventory_schema, table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, sql_backend, table_mapping, group_manager, migration_status_refresher
     )
 

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -290,11 +290,11 @@ def test_revert_migrated_table(
 
     # Checking that two of the tables were reverted and one was left intact.
     # The first two table belongs to schema 1 and should have not "upgraded_to" property
-    assert not table_migrate.is_upgraded(table_to_revert.schema_name, table_to_revert.name)
+    assert not table_migrate.is_migrated(table_to_revert.schema_name, table_to_revert.name)
     # The second table didn't have the "upgraded_to" property set and should remain that way.
-    assert not table_migrate.is_upgraded(table_not_migrated.schema_name, table_not_migrated.name)
+    assert not table_migrate.is_migrated(table_not_migrated.schema_name, table_not_migrated.name)
     # The third table belongs to schema2 and had the "upgraded_to" property set and should remain that way.
-    assert table_migrate.is_upgraded(table_to_not_revert.schema_name, table_to_not_revert.name)
+    assert table_migrate.is_migrated(table_to_not_revert.schema_name, table_to_not_revert.name)
 
     target_tables_schema1 = list(sql_backend.fetch(f"SHOW TABLES IN {dst_schema1.full_name}"))
     assert len(target_tables_schema1) == 0

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -433,8 +433,8 @@ def test_is_upgraded(ws):
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
-    assert table_migrate.is_upgraded("schema1", "table1")
-    assert not table_migrate.is_upgraded("schema1", "table2")
+    assert table_migrate.is_migrated("schema1", "table1")
+    assert not table_migrate.is_migrated("schema1", "table2")
 
 
 def test_table_status():

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.hive_metastore.mapping import (
 from databricks.labs.ucx.hive_metastore.table_migrate import (
     MigrationStatus,
     MigrationStatusRefresher,
-    TablesMigrate,
+    TablesMigrator,
 )
 from databricks.labs.ucx.hive_metastore.tables import (
     AclMigrationWhat,
@@ -50,7 +50,7 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     table_mapping = table_mapping_mock(["managed_dbfs", "managed_mnt", "managed_other"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -83,7 +83,7 @@ def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
     table_mapping = table_mapping_mock(["managed_dbfs"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
@@ -102,7 +102,7 @@ def test_migrate_external_tables_should_produce_proper_queries(ws):
     table_mapping = table_mapping_mock(["external_src"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -128,7 +128,7 @@ def test_migrate_external_table_failed_sync(ws, caplog):
     table_mapping = table_mapping_mock(["external_src"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -166,7 +166,7 @@ def test_migrate_already_upgraded_table_should_produce_no_queries(ws):
     ]
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -185,7 +185,7 @@ def test_migrate_unsupported_format_table_should_produce_no_queries(ws):
     table_mapping = table_mapping_mock(["external_src_unsupported"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -203,7 +203,7 @@ def test_migrate_view_should_produce_proper_queries(ws):
     table_mapping = table_mapping_mock(["view"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -220,7 +220,7 @@ def test_migrate_view_should_produce_proper_queries(ws):
     ) in backend.queries
 
 
-def get_table_migrate(backend: SqlBackend) -> TablesMigrate:
+def get_table_migrate(backend: SqlBackend) -> TablesMigrator:
     table_crawler = create_autospec(TablesCrawler)
     grant_crawler = create_autospec(GrantsCrawler)
     client = workspace_client_mock()
@@ -309,7 +309,7 @@ def get_table_migrate(backend: SqlBackend) -> TablesMigrate:
     group_manager = GroupManager(backend, client, "inventory_database")
     table_mapping = table_mapping_mock()
     migration_status_refresher = MigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, client, backend, table_mapping, group_manager, migration_status_refresher
     )
     return table_migrate
@@ -372,7 +372,7 @@ def test_no_migrated_tables(ws):
     ]
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -406,7 +406,7 @@ def test_empty_revert_report(ws):
     table_mapping = table_mapping_mock()
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -429,7 +429,7 @@ def test_is_upgraded(ws):
     table_mapping = table_mapping_mock()
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables()
@@ -625,7 +625,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
     table_mapping = table_mapping_mock(["managed_dbfs", "managed_mnt", "managed_other", "view"])
     group_manager = GroupManager(backend, ws, "inventory_database")
     migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
-    table_migrate = TablesMigrate(
+    table_migrate = TablesMigrator(
         table_crawler, grant_crawler, ws, backend, table_mapping, group_manager, migration_status_refresher
     )
     table_migrate.migrate_tables(acl_strategy=[AclMigrationWhat.LEGACY_TACL])


### PR DESCRIPTION
## Changes

- rename ViewsMigrator to ViewsSequencer for clarity
- rename TableMigrate to TableMigrator
- Rename 'upgrade' methods to 'migrate' for consistency
- 

### Linked issues
None

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)

Ran unit tests