### PR TITLE
Add back prompts for table migration job cluster configuration

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -145,6 +145,7 @@ class WorkspaceInstaller:
         workflows_installer = WorkflowsDeployment(
             config, self._installation, self._ws, wheels, self._prompts, self._product_info, verify_timeout
         )
+        config = workflows_installer.configure()
         workspace_installation = WorkspaceInstallation(
             config,
             self._installation,

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -159,7 +159,11 @@ class WorkflowsDeployment(InstallationMixin):
                 "Max workers for auto-scale job cluster for table migration", default="10", valid_number=True
             )
         )
-        return replace(self._config, spark_conf=spark_conf_dict, min_workers=min_workers, max_workers=max_workers)
+        self._config = replace(
+            self._config, spark_conf=spark_conf_dict, min_workers=min_workers, max_workers=max_workers
+        )
+        self._installation.save(self._config)
+        return self._config
 
     def run_workflow(self, step: str):
         job_id = int(self._state.jobs[step])

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -138,6 +138,29 @@ class WorkflowsDeployment(InstallationMixin):
     def state(self):
         return self._state
 
+    def configure(self) -> WorkspaceConfig:
+        # Save configurable spark_conf for table migration cluster
+        # parallelism will not be needed if backlog is fixed in https://databricks.atlassian.net/browse/ES-975874
+        parallelism = self._prompts.question(
+            "Parallelism for migrating dbfs root delta tables with deep clone", default="200", valid_number=True
+        )
+        spark_conf_dict = self._config.spark_conf
+        if not spark_conf_dict:
+            spark_conf_dict = {}
+        spark_conf_dict.update({'spark.sql.sources.parallelPartitionDiscovery.parallelism': parallelism})
+        # mix max workers for auto-scale migration job cluster
+        min_workers = int(
+            self._prompts.question(
+                "Min workers for auto-scale job cluster for table migration", default="1", valid_number=True
+            )
+        )
+        max_workers = int(
+            self._prompts.question(
+                "Max workers for auto-scale job cluster for table migration", default="10", valid_number=True
+            )
+        )
+        return replace(self._config, spark_conf=spark_conf_dict, min_workers=min_workers, max_workers=max_workers)
+
     def run_workflow(self, step: str):
         job_id = int(self._state.jobs[step])
         logger.debug(f"starting {step} job: {self._ws.config.host}#job/{job_id}")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -115,7 +115,6 @@ def new_installation(ws, sql_backend, env_or_skip, make_random):
         workflows_installation = WorkflowsDeployment(
             workspace_config, installation, ws, product_info.wheels(ws), prompts, product_info, timedelta(minutes=3)
         )
-        workspace_config = workflows_installation.configure()
         workspace_installation = WorkspaceInstallation(
             workspace_config,
             installation,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -235,7 +235,7 @@ def test_create_database(ws, caplog, mock_installation, any_prompt):
 
 def test_install_cluster_override_jobs(ws, mock_installation, any_prompt):
     wheels = create_autospec(WheelsV2)
-    workspace_installation = WorkflowsDeployment(
+    workflows_installation = WorkflowsDeployment(
         WorkspaceConfig(inventory_database='ucx', override_clusters={"main": 'one', "tacl": 'two'}, policy_id='123'),
         mock_installation,
         ws,
@@ -245,7 +245,7 @@ def test_install_cluster_override_jobs(ws, mock_installation, any_prompt):
         timedelta(seconds=1),
     )
 
-    workspace_installation.create_jobs()
+    workflows_installation.create_jobs()
 
     tasks = created_job_tasks(ws, '[MOCK] assessment')
     assert tasks['assess_jobs'].existing_cluster_id == 'one'

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1279,6 +1279,9 @@ def test_fresh_install(ws, mock_installation):
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
             r"Choose how to map the workspace groups.*": "2",
             r"Open config file in.*": "no",
+            r"Parallelism for migrating.*": "1000",
+            r"Min workers for auto-scale.*": "2",
+            r"Max workers for auto-scale.*": "20",
             r".*": "",
         }
     )
@@ -1287,47 +1290,6 @@ def test_fresh_install(ws, mock_installation):
     install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
     install.configure()
 
-    mock_installation.assert_file_written(
-        'config.yml',
-        {
-            'version': 2,
-            'default_catalog': 'ucx_default',
-            'inventory_database': 'ucx',
-            'log_level': 'INFO',
-            'num_days_submit_runs_history': 30,
-            'num_threads': 8,
-            'policy_id': 'foo',
-            'min_workers': 1,
-            'max_workers': 10,
-            'renamed_group_prefix': 'db-temp-',
-            'warehouse_id': 'abc',
-            'workspace_start_path': '/',
-        },
-    )
-
-
-def test_fresh_install_with_workflow_configs(ws, mock_installation):
-    prompts = MockPrompts(
-        {
-            r".*PRO or SERVERLESS SQL warehouse.*": "1",
-            r"Choose how to map the workspace groups.*": "2",
-            r"Open config file in.*": "no",
-            r"Parallelism for migrating.*": "1000",
-            r"Min workers for auto-scale.*": "2",
-            r"Max workers for auto-scale.*": "20",
-            r".*": "",
-        }
-    )
-
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
-    sql_backend = MockBackend()
-    wheels = create_autospec(WheelsV2)
-
-    install.run(
-        verify_timeout=timedelta(seconds=10),
-        sql_backend_factory=lambda _: sql_backend,
-        wheel_builder_factory=lambda: wheels,
-    )
     mock_installation.assert_file_written(
         'config.yml',
         {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
#1055 removed the prompts for configuring the auto-scale and parallelism for table migration job cluster.
This PR add the prompts back in the ~~WorkflowInstallation, and update the WorkspaceConfig to persist the config values.~~ `WorkspaceInstaller._configure_new_installation`

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
