### PR TITLE
Support table migration to Unity Catalog in Python code

### DIFF
--- a/src/databricks/labs/ucx/source_code/languages.py
+++ b/src/databricks/labs/ucx/source_code/languages.py
@@ -11,11 +11,11 @@ class Languages:
         self._index = index
         from_table = FromTable(index)
         self._linters = {
-            Language.PYTHON: SequentialLinter([SparkSql(from_table)]),
+            Language.PYTHON: SequentialLinter([SparkSql(from_table, index)]),
             Language.SQL: SequentialLinter([from_table]),
         }
         self._fixers: dict[Language, list[Fixer]] = {
-            Language.PYTHON: [SparkSql(from_table)],
+            Language.PYTHON: [SparkSql(from_table, index)],
             Language.SQL: [from_table],
         }
 

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -59,7 +59,7 @@ class QueryMatcher(Matcher):
         else:
             yield Advisory(
                 code='table-migrate',
-                message="Table",
+                message=f"Can't migrate '{node}' because its table name argument is not a constant",
                 start_line=node.lineno,
                 start_col=node.col_offset,
                 end_line=node.end_lineno or 0,

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -1,59 +1,152 @@
 import ast
+from _ast import AST
 from collections.abc import Iterable
 
-from databricks.labs.ucx.source_code.base import Advice, Fixer, Linter
+from databricks.labs.ucx.source_code.base import Advice, Fixer, Linter, Deprecation
 from databricks.labs.ucx.source_code.queries import FromTable
+
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.html
+SPARK_SESSION_CALLS = [
+    ("sql", 1, 1000, 0, True),
+    ("table", 1, 1, 0)]
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Catalog.html
+SPARK_CATALOG_CALLS = [
+    ("cacheTable", 1, 2, 0),
+    ("createTable", 1, 1000, 0),
+    ("createExternalTable", 1, 1000, 0),
+    ("getTable", 1, 1, 0),
+    ("isCached", 1, 1, 0),
+    ("listColumns", 1, 2, 0),
+    ("tableExists", 1, 2, 0),
+    ("recoverPartitions", 1, 1, 0),
+    ("refreshTable", 1, 1, 0),
+    ("uncacheTable", 1, 1, 0),
+    # TODO listTables: raise warning ?
+]
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html
+SPARK_DATAFRAME_CALLS = [
+    ("writeTo", 1, 1, 0),
+]
+
+# nothing to migrate in Column, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Column.html
+# nothing to migrate in Observation, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Observation.html
+# nothing to migrate in Row, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Row.html
+# nothing to migrate in GroupedData, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.GroupedData.html
+# nothing to migrate in PandasCogroupedOps, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.PandasCogroupedOps.html
+# nothing to migrate in DataFrameNaFunctions, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameNaFunctions.html
+# nothing to migrate in DataFrameStatFunctions, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameStatFunctions.html
+# nothing to migrate in Window, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Window.html
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameReader.html
+SPARK_DATAFRAMEREADER_CALLS = [
+    ("table", 1, 1, 0), # TODO good example of collision, see SPARK_SESSION_CALLS
+]
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.html
+SPARK_DATAFRAMEWRITER_CALLS = [
+    ("insertInto", 1, 2, 0),
+    # TODO jdbc: could the url be a databricks url, raise warning ?
+    ("saveAsTable", 1, 4, 0),
+]
+
+# nothing to migrate in DataFrameWriterV2, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriterV2.html
+# nothing to migrate in UDFRegistration, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDFRegistration.html
+
+# see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDTFRegistration.html
+SPARK_UDTFREGISTRATION_CALLS = [
+    ("register", 1, 2, 0),
+]
+
+# nothing to migrate in UserDefinedFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedFunction.html
+# nothing to migrate in UserDefinedTableFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedTableFunction.html
+
+SPARK_CALLS = {}
+for call in SPARK_SESSION_CALLS + SPARK_CATALOG_CALLS + SPARK_DATAFRAME_CALLS + SPARK_DATAFRAMEREADER_CALLS + SPARK_DATAFRAMEWRITER_CALLS + SPARK_UDTFREGISTRATION_CALLS:
+    SPARK_CALLS[call[0]] = call
 
 
 class SparkSql(Linter, Fixer):
     def __init__(self, from_table: FromTable):
         self._from_table = from_table
 
+
     def name(self) -> str:
         # this is the same fixer, just in a different language context
         return self._from_table.name()
 
+
     def lint(self, code: str) -> Iterable[Advice]:
         tree = ast.parse(code)
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+            table_arg, is_query = SparkSql._find_table_arg_if_eligible(node)
+            if table_arg is None:
                 continue
-            if not isinstance(node.func, ast.Attribute):
-                continue
-            if node.func.attr != "sql":
-                continue
-            if len(node.args) != 1:
-                continue
-            first_arg = node.args[0]
-            if not isinstance(first_arg, ast.Constant):
-                # `astroid` library supports inference and parent node lookup,
-                # which makes traversing the AST a bit easier.
-                continue
-            query = first_arg.value
-            for advice in self._from_table.lint(query):
-                yield advice.replace(
+            if is_query:
+                query = table_arg.value
+                for advice in self._from_table.lint(query):
+                    yield advice.replace(
+                        start_line=node.lineno,
+                        start_col=node.col_offset,
+                        end_line=node.end_lineno,
+                        end_col=node.end_col_offset,
+                    )
+            else:
+                dst = self._find_dest(table_arg.value)
+                if dst is None:
+                    continue
+                yield Deprecation(
+                    code='table-migrate',
+                    message=f"Table {table_arg.value} is migrated to {dst.destination()} in Unity Catalog",
+                    # SQLGlot does not propagate tokens yet. See https://github.com/tobymao/sqlglot/issues/3159
                     start_line=node.lineno,
                     start_col=node.col_offset,
                     end_line=node.end_lineno,
                     end_col=node.end_col_offset,
                 )
 
+
     def apply(self, code: str) -> str:
         tree = ast.parse(code)
         # we won't be doing it like this in production, but for the sake of the example
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+            table_arg, is_query = SparkSql._find_table_arg_if_eligible(node)
+            if table_arg is None:
                 continue
-            if not isinstance(node.func, ast.Attribute):
-                continue
-            if node.func.attr != "sql":
-                continue
-            if len(node.args) != 1:
-                continue
-            first_arg = node.args[0]
-            if not isinstance(first_arg, ast.Constant):
-                continue
-            query = first_arg.value
-            new_query = self._from_table.apply(query)
-            first_arg.value = new_query
+            if is_query:
+                query = table_arg.value
+                new_query = self._from_table.apply(query)
+                table_arg.value = new_query
+            else:
+                dst = self._find_dest(table_arg.value)
+                if dst is None:
+                    continue
+                table_arg.value = dst.destination()
         return ast.unparse(tree)
+
+
+    @staticmethod
+    def _find_table_arg_if_eligible(node: AST):
+        NoneResult = None, None
+        if not isinstance(node, ast.Call):
+            return NoneResult
+        if not isinstance(node.func, ast.Attribute):
+            return NoneResult
+        call = SPARK_CALLS.get(node.func.attr, None)
+        if call is None or len(node.args) < call[1] or len(node.args) > call[2]:
+            return NoneResult
+        table_arg = node.args[call[3]]
+        if not isinstance(table_arg, ast.Constant):
+            # `astroid` library supports inference and parent node lookup,
+            # which makes traversing the AST a bit easier.
+            return NoneResult
+        is_query = call[4] if len(call) > 4 else False
+        return table_arg, is_query
+
+    def _find_dest(self, table_value: str):
+        parts = table_value.split(".")
+        if len(parts) != 2:
+            return None
+        return self._from_table.index().get(parts[0], parts[1])

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -1,34 +1,109 @@
 import ast
-from _ast import AST
-from collections.abc import Iterable
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 
-from databricks.labs.ucx.source_code.base import Advice, Fixer, Linter, Deprecation
+from databricks.labs.ucx.source_code.base import Advice, Deprecation, Fixer, Linter
 from databricks.labs.ucx.source_code.queries import FromTable
 
 
+@dataclass
+class Matcher(ABC):
+    method_name: str
+    min_args: int
+    max_args: int
+    table_arg_index: int
+
+    def matches(self, node: ast.AST):
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and self.min_args <= len(node.args) <= self.max_args
+            and isinstance(node.args[self.table_arg_index], ast.Constant)
+        )
+
+    @abstractmethod
+    def lint(self, from_table: FromTable, node: ast.Call) -> Iterator[Advice]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def apply(self, from_table: FromTable, node: ast.Call) -> None:
+        raise NotImplementedError()
+
+
+@dataclass
+class QueryMatcher(Matcher):
+
+    def lint(self, from_table: FromTable, node: ast.Call) -> Iterator[Advice]:
+        table_arg = node.args[self.table_arg_index]
+        assert isinstance(table_arg, ast.Constant)
+        for advice in from_table.lint(table_arg.value):
+            yield advice.replace(
+                start_line=node.lineno,
+                start_col=node.col_offset,
+                end_line=node.end_lineno,
+                end_col=node.end_col_offset,
+            )
+
+    def apply(self, from_table: FromTable, node: ast.Call) -> None:
+        table_arg = node.args[self.table_arg_index]
+        assert isinstance(table_arg, ast.Constant)
+        new_query = from_table.apply(table_arg.value)
+        table_arg.value = new_query
+
+
+@dataclass
+class TableNameMatcher(Matcher):
+
+    def lint(self, from_table: FromTable, node: ast.Call) -> Iterator[Advice]:
+        table_arg = node.args[self.table_arg_index]
+        assert isinstance(table_arg, ast.Constant)
+        dst = self._find_dest(from_table, table_arg.value)
+        if dst is not None:
+            yield Deprecation(
+                code='table-migrate',
+                message=f"Table {table_arg.value} is migrated to {dst.destination()} in Unity Catalog",
+                # SQLGlot does not propagate tokens yet. See https://github.com/tobymao/sqlglot/issues/3159
+                start_line=node.lineno,
+                start_col=node.col_offset,
+                end_line=node.end_lineno or 0,
+                end_col=node.end_col_offset or 0,
+            )
+
+    def apply(self, from_table: FromTable, node: ast.Call) -> None:
+        table_arg = node.args[self.table_arg_index]
+        assert isinstance(table_arg, ast.Constant)
+        dst = self._find_dest(from_table, table_arg.value)
+        if dst is not None:
+            table_arg.value = dst.destination()
+
+    @staticmethod
+    def _find_dest(from_table: FromTable, value: str):
+        parts = value.split(".")
+        return None if len(parts) != 2 else from_table.index().get(parts[0], parts[1])
+
+
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.SparkSession.html
-SPARK_SESSION_CALLS = [
-    ("sql", 1, 1000, 0, True),
-    ("table", 1, 1, 0)]
+SPARK_SESSION_MATCHERS = [QueryMatcher("sql", 1, 1000, 0), TableNameMatcher("table", 1, 1, 0)]
 
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Catalog.html
-SPARK_CATALOG_CALLS = [
-    ("cacheTable", 1, 2, 0),
-    ("createTable", 1, 1000, 0),
-    ("createExternalTable", 1, 1000, 0),
-    ("getTable", 1, 1, 0),
-    ("isCached", 1, 1, 0),
-    ("listColumns", 1, 2, 0),
-    ("tableExists", 1, 2, 0),
-    ("recoverPartitions", 1, 1, 0),
-    ("refreshTable", 1, 1, 0),
-    ("uncacheTable", 1, 1, 0),
+SPARK_CATALOG_MATCHERS = [
+    TableNameMatcher("cacheTable", 1, 2, 0),
+    TableNameMatcher("createTable", 1, 1000, 0),
+    TableNameMatcher("createExternalTable", 1, 1000, 0),
+    TableNameMatcher("getTable", 1, 1, 0),
+    TableNameMatcher("isCached", 1, 1, 0),
+    TableNameMatcher("listColumns", 1, 2, 0),
+    TableNameMatcher("tableExists", 1, 2, 0),
+    TableNameMatcher("recoverPartitions", 1, 1, 0),
+    TableNameMatcher("refreshTable", 1, 1, 0),
+    TableNameMatcher("uncacheTable", 1, 1, 0),
     # TODO listTables: raise warning ?
 ]
 
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.html
-SPARK_DATAFRAME_CALLS = [
-    ("writeTo", 1, 1, 0),
+SPARK_DATAFRAME_MATCHERS = [
+    TableNameMatcher("writeTo", 1, 1, 0),
 ]
 
 # nothing to migrate in Column, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Column.html
@@ -41,112 +116,75 @@ SPARK_DATAFRAME_CALLS = [
 # nothing to migrate in Window, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Window.html
 
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameReader.html
-SPARK_DATAFRAMEREADER_CALLS = [
-    ("table", 1, 1, 0), # TODO good example of collision, see SPARK_SESSION_CALLS
+SPARK_DATAFRAMEREADER_MATCHERS = [
+    TableNameMatcher("table", 1, 1, 0),  # TODO good example of collision, see SPARK_SESSION_CALLS
 ]
 
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.html
-SPARK_DATAFRAMEWRITER_CALLS = [
-    ("insertInto", 1, 2, 0),
+SPARK_DATAFRAMEWRITER_MATCHERS = [
+    TableNameMatcher("insertInto", 1, 2, 0),
     # TODO jdbc: could the url be a databricks url, raise warning ?
-    ("saveAsTable", 1, 4, 0),
+    TableNameMatcher("saveAsTable", 1, 4, 0),
 ]
 
 # nothing to migrate in DataFrameWriterV2, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriterV2.html
 # nothing to migrate in UDFRegistration, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDFRegistration.html
 
 # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDTFRegistration.html
-SPARK_UDTFREGISTRATION_CALLS = [
-    ("register", 1, 2, 0),
+SPARK_UDTFREGISTRATION_MATCHERS = [
+    TableNameMatcher("register", 1, 2, 0),
 ]
 
 # nothing to migrate in UserDefinedFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedFunction.html
 # nothing to migrate in UserDefinedTableFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedTableFunction.html
 
-SPARK_CALLS = {}
-for call in SPARK_SESSION_CALLS + SPARK_CATALOG_CALLS + SPARK_DATAFRAME_CALLS + SPARK_DATAFRAMEREADER_CALLS + SPARK_DATAFRAMEWRITER_CALLS + SPARK_UDTFREGISTRATION_CALLS:
-    SPARK_CALLS[call[0]] = call
+SPARK_MATCHERS = {}
+for sm in (
+    SPARK_SESSION_MATCHERS
+    + SPARK_CATALOG_MATCHERS
+    + SPARK_DATAFRAME_MATCHERS
+    + SPARK_DATAFRAMEREADER_MATCHERS
+    + SPARK_DATAFRAMEWRITER_MATCHERS
+    + SPARK_UDTFREGISTRATION_MATCHERS
+):
+    SPARK_MATCHERS[sm.method_name] = sm
 
 
 class SparkSql(Linter, Fixer):
     def __init__(self, from_table: FromTable):
         self._from_table = from_table
 
-
     def name(self) -> str:
         # this is the same fixer, just in a different language context
         return self._from_table.name()
 
-
     def lint(self, code: str) -> Iterable[Advice]:
         tree = ast.parse(code)
         for node in ast.walk(tree):
-            table_arg, is_query = SparkSql._find_table_arg_if_eligible(node)
-            if table_arg is None:
+            matcher = SparkSql._find_matcher(node)
+            if matcher is None:
                 continue
-            if is_query:
-                query = table_arg.value
-                for advice in self._from_table.lint(query):
-                    yield advice.replace(
-                        start_line=node.lineno,
-                        start_col=node.col_offset,
-                        end_line=node.end_lineno,
-                        end_col=node.end_col_offset,
-                    )
-            else:
-                dst = self._find_dest(table_arg.value)
-                if dst is None:
-                    continue
-                yield Deprecation(
-                    code='table-migrate',
-                    message=f"Table {table_arg.value} is migrated to {dst.destination()} in Unity Catalog",
-                    # SQLGlot does not propagate tokens yet. See https://github.com/tobymao/sqlglot/issues/3159
-                    start_line=node.lineno,
-                    start_col=node.col_offset,
-                    end_line=node.end_lineno,
-                    end_col=node.end_col_offset,
-                )
-
+            assert isinstance(node, ast.Call)
+            yield from matcher.lint(self._from_table, node)
 
     def apply(self, code: str) -> str:
         tree = ast.parse(code)
         # we won't be doing it like this in production, but for the sake of the example
         for node in ast.walk(tree):
-            table_arg, is_query = SparkSql._find_table_arg_if_eligible(node)
-            if table_arg is None:
+            matcher = SparkSql._find_matcher(node)
+            if matcher is None:
                 continue
-            if is_query:
-                query = table_arg.value
-                new_query = self._from_table.apply(query)
-                table_arg.value = new_query
-            else:
-                dst = self._find_dest(table_arg.value)
-                if dst is None:
-                    continue
-                table_arg.value = dst.destination()
+            assert isinstance(node, ast.Call)
+            matcher.apply(self._from_table, node)
         return ast.unparse(tree)
 
-
     @staticmethod
-    def _find_table_arg_if_eligible(node: AST):
-        NoneResult = None, None
+    def _find_matcher(node: ast.AST):
         if not isinstance(node, ast.Call):
-            return NoneResult
-        if not isinstance(node.func, ast.Attribute):
-            return NoneResult
-        call = SPARK_CALLS.get(node.func.attr, None)
-        if call is None or len(node.args) < call[1] or len(node.args) > call[2]:
-            return NoneResult
-        table_arg = node.args[call[3]]
-        if not isinstance(table_arg, ast.Constant):
-            # `astroid` library supports inference and parent node lookup,
-            # which makes traversing the AST a bit easier.
-            return NoneResult
-        is_query = call[4] if len(call) > 4 else False
-        return table_arg, is_query
-
-    def _find_dest(self, table_value: str):
-        parts = table_value.split(".")
-        if len(parts) != 2:
             return None
-        return self._from_table.index().get(parts[0], parts[1])
+        if not isinstance(node.func, ast.Attribute):
+            return None
+        matcher = SPARK_MATCHERS.get(node.func.attr, None)
+        if matcher is None:
+            return None
+        return matcher if matcher.matches(node) else None

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -11,6 +11,10 @@ class FromTable(Linter, Fixer):
     def __init__(self, index: MigrationIndex):
         self._index = index
 
+
+    def index(self):
+        return self._index
+
     def name(self) -> str:
         return 'table-migrate'
 

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -11,9 +11,6 @@ class FromTable(Linter, Fixer):
     def __init__(self, index: MigrationIndex):
         self._index = index
 
-    def index(self):
-        return self._index
-
     def name(self) -> str:
         return 'table-migrate'
 

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -11,7 +11,6 @@ class FromTable(Linter, Fixer):
     def __init__(self, index: MigrationIndex):
         self._index = index
 
-
     def index(self):
         return self._index
 

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -1,18 +1,20 @@
+import pytest
+
 from databricks.labs.ucx.source_code.base import Deprecation
-from databricks.labs.ucx.source_code.pyspark import SparkSql, SPARK_MATCHERS
+from databricks.labs.ucx.source_code.pyspark import SparkMatchers, SparkSql
 from databricks.labs.ucx.source_code.queries import FromTable
 
 
 def test_spark_no_sql(empty_index):
     ftf = FromTable(empty_index)
-    sqf = SparkSql(ftf)
+    sqf = SparkSql(ftf, empty_index)
 
     assert not list(sqf.lint("print(1)"))
 
 
 def test_spark_sql_no_match(empty_index):
     ftf = FromTable(empty_index)
-    sqf = SparkSql(ftf)
+    sqf = SparkSql(ftf, empty_index)
 
     old_code = """
 spark.read.csv("s3://bucket/path")
@@ -26,7 +28,7 @@ for i in range(10):
 
 def test_spark_sql_match(migration_index):
     ftf = FromTable(migration_index)
-    sqf = SparkSql(ftf)
+    sqf = SparkSql(ftf, migration_index)
 
     old_code = """
 spark.read.csv("s3://bucket/path")
@@ -46,78 +48,92 @@ for i in range(10):
     ] == list(sqf.lint(old_code))
 
 
-def test_spark_table_match(migration_index):
-    # import SPARK_MATCHERS from
-    for method_name in ["cacheTable", "createTable", "createExternalTable", "getTable", "isCached",
-                        "listColumns", "tableExists", "recoverPartitions", "refreshTable", "uncacheTable",
-                        "table", "insertInto", "saveAsTable", "register" ]:
-        ftf = FromTable(migration_index)
-        sqf = SparkSql(ftf)
-        matcher = SPARK_MATCHERS[method_name]
-        args_list = ["a"] * min(5, matcher.max_args)
-        args_list[matcher.table_arg_index] = '"old.things"'
-        args = ",".join(args_list)
-        old_code = f"""
+METHOD_NAMES = [
+    "cacheTable",
+    "createTable",
+    "createExternalTable",
+    "getTable",
+    "isCached",
+    "listColumns",
+    "tableExists",
+    "recoverPartitions",
+    "refreshTable",
+    "uncacheTable",
+    "table",
+    "insertInto",
+    "saveAsTable",
+    "register",
+]
+
+
+@pytest.mark.parametrize("method_name", METHOD_NAMES)
+def test_spark_table_match(migration_index, method_name):
+    spark_matchers = SparkMatchers()
+    ftf = FromTable(migration_index)
+    sqf = SparkSql(ftf, migration_index)
+    matcher = spark_matchers.matchers[method_name]
+    args_list = ["a"] * min(5, matcher.max_args)
+    args_list[matcher.table_arg_index] = '"old.things"'
+    args = ",".join(args_list)
+    old_code = f"""
 spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
 """
-        assert [
-            Deprecation(
-                code='table-migrate',
-                message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
-                start_line=4,
-                start_col=9,
-                end_line=4,
-                end_col=17+len(method_name)+len(args),
-            )
-        ] == list(sqf.lint(old_code))
+    assert [
+        Deprecation(
+            code='table-migrate',
+            message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
+            start_line=4,
+            start_col=9,
+            end_line=4,
+            end_col=17 + len(method_name) + len(args),
+        )
+    ] == list(sqf.lint(old_code))
 
 
-def test_spark_table_no_match(migration_index):
-    for method_name in ["cacheTable", "createTable", "createExternalTable", "getTable", "isCached",
-                        "listColumns", "tableExists", "recoverPartitions", "refreshTable", "uncacheTable",
-                        "table", "insertInto", "saveAsTable", "register" ]:
-        ftf = FromTable(migration_index)
-        sqf = SparkSql(ftf)
-        matcher = SPARK_MATCHERS[method_name]
-        args_list = ["a"] * min(5, matcher.max_args)
-        args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
-        args = ",".join(args_list)
-        old_code = f"""
+@pytest.mark.parametrize("method_name", METHOD_NAMES)
+def test_spark_table_no_match(migration_index, method_name):
+    spark_matchers = SparkMatchers()
+    ftf = FromTable(migration_index)
+    sqf = SparkSql(ftf, migration_index)
+    matcher = spark_matchers.matchers[method_name]
+    args_list = ["a"] * min(5, matcher.max_args)
+    args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
+    args = ",".join(args_list)
+    old_code = f"""
 spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
 """
-        assert [] == list(sqf.lint(old_code))
+    assert not list(sqf.lint(old_code))
 
 
-def test_spark_table_too_many_args(migration_index):
-    for method_name in ["cacheTable", "createTable", "createExternalTable", "getTable", "isCached",
-                        "listColumns", "tableExists", "recoverPartitions", "refreshTable", "uncacheTable",
-                        "table", "insertInto", "saveAsTable", "register"]:
-        ftf = FromTable(migration_index)
-        sqf = SparkSql(ftf)
-        matcher = SPARK_MATCHERS[method_name]
-        if matcher.max_args > 100:
-            continue
-        args_list = ["a"] * (matcher.max_args + 1)
-        args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
-        args = ",".join(args_list)
-        old_code = f"""
+@pytest.mark.parametrize("method_name", METHOD_NAMES)
+def test_spark_table_too_many_args(migration_index, method_name):
+    spark_matchers = SparkMatchers()
+    ftf = FromTable(migration_index)
+    sqf = SparkSql(ftf, migration_index)
+    matcher = spark_matchers.matchers[method_name]
+    if matcher.max_args > 100:
+        return
+    args_list = ["a"] * (matcher.max_args + 1)
+    args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
+    args = ",".join(args_list)
+    old_code = f"""
 spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
 """
-        assert [] == list(sqf.lint(old_code))
+    assert not list(sqf.lint(old_code))
 
 
 def test_spark_sql_fix(migration_index):
     ftf = FromTable(migration_index)
-    sqf = SparkSql(ftf)
+    sqf = SparkSql(ftf, migration_index)
 
     old_code = """spark.read.csv("s3://bucket/path")
 for i in range(10):

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -3,7 +3,7 @@ from databricks.labs.ucx.source_code.pyspark import SparkSql
 from databricks.labs.ucx.source_code.queries import FromTable
 
 
-def test_spark_not_sql(empty_index):
+def test_spark_no_sql(empty_index):
     ftf = FromTable(empty_index)
     sqf = SparkSql(ftf)
 
@@ -42,6 +42,28 @@ for i in range(10):
             start_col=13,
             end_line=4,
             end_col=50,
+        )
+    ] == list(sqf.lint(old_code))
+
+
+def test_spark_table_match(migration_index):
+    ftf = FromTable(migration_index)
+    sqf = SparkSql(ftf)
+
+    old_code = """
+spark.read.csv("s3://bucket/path")
+for i in range(10):
+    df = spark.table("old.things")
+    do_stuff_with_df(df)
+"""
+    assert [
+        Deprecation(
+            code='table-migrate',
+            message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
+            start_line=4,
+            start_col=9,
+            end_line=4,
+            end_col=34,
         )
     ] == list(sqf.lint(old_code))
 

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -216,6 +216,26 @@ for i in range(10):
     ] == list(sqf.lint(old_code))
 
 
+def test_spark_table_return_value(migration_index):
+    ftf = FromTable(migration_index)
+    sqf = SparkSql(ftf, migration_index)
+    old_code = """
+spark.read.csv("s3://bucket/path")
+for table in spark.listTables():
+    do_stuff_with_table(table)
+"""
+    assert [
+        Advisory(
+            code='table-migrate',
+            message="Call to 'listTables' will return a list of <catalog>.<database>.<table> instead of <database>.<table>.",
+            start_line=3,
+            start_col=13,
+            end_line=3,
+            end_col=31,
+        )
+    ] == list(sqf.lint(old_code))
+
+
 def test_spark_sql_fix(migration_index):
     ftf = FromTable(migration_index)
     sqf = SparkSql(ftf, migration_index)


### PR DESCRIPTION
## Changes
Enhance SparkSql linter/fixer to support migration of spark.sql function calls that receive a table name as parameter

### Linked issues
Resolves # 1082

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs ucx migrate_local_code`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)

missing integration tests