### PR TITLE
Remove prompts dependency from WorkflowsDeployment

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -143,7 +143,7 @@ class WorkspaceInstaller:
             wheel_builder_factory = self._new_wheel_builder
         wheels = wheel_builder_factory()
         workflows_installer = WorkflowsDeployment(
-            config, self._installation, self._ws, wheels, self._prompts, self._product_info, verify_timeout
+            config, self._installation, self._ws, wheels, self._product_info, verify_timeout
         )
         workspace_installation = WorkspaceInstallation(
             config,
@@ -366,7 +366,7 @@ class WorkspaceInstallation(InstallationMixin):
         wheels = product_info.wheels(ws)
         prompts = Prompts()
         timeout = timedelta(minutes=2)
-        workflows_installer = WorkflowsDeployment(config, installation, ws, wheels, prompts, product_info, timeout)
+        workflows_installer = WorkflowsDeployment(config, installation, ws, wheels, product_info, timeout)
 
         return cls(config, installation, sql_backend, ws, workflows_installer, prompts, product_info)
 
@@ -387,7 +387,7 @@ class WorkspaceInstallation(InstallationMixin):
                 self._create_database,
             ],
         )
-        self._workflows_installer.create_jobs()
+        self._workflows_installer.create_jobs(self._prompts)
         readme_url = self._create_readme()
         logger.info(f"Installation completed successfully! Please refer to the {readme_url} for the next steps.")
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -10,7 +10,6 @@ from typing import Any
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.parallel import ManyError
-from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import (
@@ -108,7 +107,6 @@ class WorkflowsDeployment(InstallationMixin):
         installation: Installation,
         ws: WorkspaceClient,
         wheels: WheelsV2,
-        prompts: Prompts,
         product_info: ProductInfo,
         verify_timeout: timedelta,
     ):
@@ -117,7 +115,6 @@ class WorkflowsDeployment(InstallationMixin):
         self._ws = ws
         self._state = InstallState.from_installation(installation)
         self._wheels = wheels
-        self._prompts = prompts
         self._product_info = product_info
         self._verify_timeout = verify_timeout
         self._this_file = Path(__file__)
@@ -129,10 +126,9 @@ class WorkflowsDeployment(InstallationMixin):
         installation = product_info.current_installation(ws)
         config = installation.load(WorkspaceConfig)
         wheels = product_info.wheels(ws)
-        prompts = Prompts()
         timeout = timedelta(minutes=2)
 
-        return cls(config, installation, ws, wheels, prompts, product_info, timeout)
+        return cls(config, installation, ws, wheels, product_info, timeout)
 
     @property
     def state(self):
@@ -151,9 +147,9 @@ class WorkflowsDeployment(InstallationMixin):
             return
         raise NotFound(f"job run not found for {step}")
 
-    def create_jobs(self):
+    def create_jobs(self, prompts):
         logger.debug(f"Creating jobs from tasks in {main.__name__}")
-        remote_wheel = self._upload_wheel()
+        remote_wheel = self._upload_wheel(prompts)
         desired_steps = {t.workflow for t in _TASKS.values() if t.cloud_compatible(self._ws.config)}
         wheel_runner = None
 
@@ -353,15 +349,15 @@ class WorkflowsDeployment(InstallationMixin):
                 return klass(match.group(1))
         return Unknown(haystack)
 
-    def _upload_wheel(self):
+    def _upload_wheel(self, prompts):
         with self._wheels:
             try:
                 self._wheels.upload_to_dbfs()
             except PermissionDenied as err:
-                if not self._prompts:
+                if not prompts:
                     raise RuntimeWarning("no Prompts instance found") from err
                 logger.warning(f"Uploading wheel file to DBFS failed, DBFS is probably write protected. {err}")
-                configure_cluster_overrides = ConfigureClusterOverrides(self._ws, self._prompts.choice_from_dict)
+                configure_cluster_overrides = ConfigureClusterOverrides(self._ws, prompts.choice_from_dict)
                 self._config.override_clusters = configure_cluster_overrides.configure()
                 self._installation.save(self._config)
             return self._wheels.upload_to_wsfs()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -113,7 +113,7 @@ def new_installation(ws, sql_backend, env_or_skip, make_random):
         # so that we can shave off couple of seconds and build wheel only once per session
         # instead of every test
         workflows_installation = WorkflowsDeployment(
-            workspace_config, installation, ws, product_info.wheels(ws), prompts, product_info, timedelta(minutes=3)
+            workspace_config, installation, ws, product_info.wheels(ws), product_info, timedelta(minutes=3)
         )
         workspace_installation = WorkspaceInstallation(
             workspace_config,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -208,7 +208,6 @@ def test_create_database(ws, caplog, mock_installation, any_prompt):
         mock_installation,
         ws,
         create_autospec(WheelsV2),
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -240,12 +239,11 @@ def test_install_cluster_override_jobs(ws, mock_installation, any_prompt):
         mock_installation,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
 
-    workflows_installation.create_jobs()
+    workflows_installation.create_jobs(any_prompt)
 
     tasks = created_job_tasks(ws, '[MOCK] assessment')
     assert tasks['assess_jobs'].existing_cluster_id == 'one'
@@ -272,12 +270,11 @@ def test_write_protected_dbfs(ws, tmp_path, mock_installation):
         mock_installation,
         ws,
         wheels,
-        prompts,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
 
-    workflows_installation.create_jobs()
+    workflows_installation.create_jobs(prompts)
 
     tasks = created_job_tasks(ws, '[MOCK] assessment')
     assert tasks['assess_jobs'].existing_cluster_id == "2222-999999-nosecuri"
@@ -310,12 +307,11 @@ def test_writeable_dbfs(ws, tmp_path, mock_installation, any_prompt):
         mock_installation,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
 
-    workflows_installation.create_jobs()
+    workflows_installation.create_jobs(any_prompt)
 
     job = created_job(ws, '[MOCK] assessment')
     job_clusters = {_.job_cluster_key: _ for _ in job['job_clusters']}
@@ -355,7 +351,6 @@ def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_instal
         mock_installation_with_jobs,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -396,7 +391,6 @@ def test_run_workflow_run_id_not_found(ws, mocker, any_prompt, mock_installation
         mock_installation_with_jobs,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -439,7 +433,6 @@ def test_run_workflow_creates_failure_from_mapping(
         mock_installation_with_jobs,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -492,7 +485,6 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, any_prompt, mock_in
         mock_installation_with_jobs,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -634,7 +626,6 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
         mock_installation,
         ws,
         create_autospec(WheelsV2),
-        prompts,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -690,7 +681,7 @@ def test_remove_jobs_no_state(ws):
     installation = create_autospec(Installation)
     config = WorkspaceConfig(inventory_database='ucx')
     workflows_installer = WorkflowsDeployment(
-        config, installation, ws, create_autospec(WheelsV2), prompts, PRODUCT_INFO, timedelta(seconds=1)
+        config, installation, ws, create_autospec(WheelsV2), PRODUCT_INFO, timedelta(seconds=1)
     )
     workspace_installation = WorkspaceInstallation(
         config, installation, sql_backend, ws, workflows_installer, prompts, PRODUCT_INFO
@@ -714,7 +705,7 @@ def test_remove_jobs_with_state_missing_job(ws, caplog, mock_installation_with_j
     config = WorkspaceConfig(inventory_database='ucx')
     installation = mock_installation_with_jobs
     workflows_installer = WorkflowsDeployment(
-        config, installation, ws, create_autospec(WheelsV2), prompts, PRODUCT_INFO, timedelta(seconds=1)
+        config, installation, ws, create_autospec(WheelsV2), PRODUCT_INFO, timedelta(seconds=1)
     )
     workspace_installation = WorkspaceInstallation(
         config, mock_installation_with_jobs, sql_backend, ws, workflows_installer, prompts, PRODUCT_INFO
@@ -870,7 +861,7 @@ def test_repair_run(ws, mocker, any_prompt, mock_installation_with_jobs):
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
     workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, create_autospec(WheelsV2), any_prompt, PRODUCT_INFO, timeout
+        config, mock_installation_with_jobs, ws, create_autospec(WheelsV2), PRODUCT_INFO, timeout
     )
 
     workflows_installer.repair_run("assessment")
@@ -894,9 +885,7 @@ def test_repair_run_success(ws, caplog, mock_installation_with_jobs, any_prompt)
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
 
     workflows_installer.repair_run("assessment")
 
@@ -921,7 +910,7 @@ def test_repair_run_no_job_id(ws, mock_installation, any_prompt, caplog):
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(config, mock_installation, ws, wheels, any_prompt, PRODUCT_INFO, timeout)
+    workflows_installer = WorkflowsDeployment(config, mock_installation, ws, wheels, PRODUCT_INFO, timeout)
 
     with caplog.at_level('WARNING'):
         workflows_installer.repair_run("assessment")
@@ -935,9 +924,7 @@ def test_repair_run_no_job_run(ws, mock_installation_with_jobs, any_prompt, capl
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
 
     with caplog.at_level('WARNING'):
         workflows_installer.repair_run("assessment")
@@ -950,9 +937,7 @@ def test_repair_run_exception(ws, mock_installation_with_jobs, any_prompt, caplo
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
 
     with caplog.at_level('WARNING'):
         workflows_installer.repair_run("assessment")
@@ -977,9 +962,7 @@ def test_repair_run_result_state(ws, caplog, mock_installation_with_jobs, any_pr
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
 
     workflows_installer.repair_run("assessment")
     assert "Please try after sometime" in caplog.text
@@ -1030,9 +1013,7 @@ def test_latest_job_status_states(ws, mock_installation_with_jobs, any_prompt, s
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
     ws.jobs.list_runs.return_value = base
     status = workflows_installer.latest_job_status()
     assert len(status) == 1
@@ -1066,9 +1047,7 @@ def test_latest_job_status_success_with_time(
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
     ws.jobs.list_runs.return_value = base
     faked_now = datetime(2024, 1, 1, 14, 0, 0)
     mock_datetime.now.return_value = faked_now
@@ -1106,7 +1085,7 @@ def test_latest_job_status_list(ws, any_prompt):
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
     mock_install = MockInstallation({'state.json': {'resources': {'jobs': {"job1": "1", "job2": "2", "job3": "3"}}}})
-    workflows_installer = WorkflowsDeployment(config, mock_install, ws, wheels, any_prompt, PRODUCT_INFO, timeout)
+    workflows_installer = WorkflowsDeployment(config, mock_install, ws, wheels, PRODUCT_INFO, timeout)
     ws.jobs.list_runs.side_effect = iter(runs)
     status = workflows_installer.latest_job_status()
     assert len(status) == 3
@@ -1122,9 +1101,7 @@ def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs, any_promp
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
     ws.jobs.list_runs.return_value = ""
     status = workflows_installer.latest_job_status()
     assert len(status) == 1
@@ -1135,9 +1112,7 @@ def test_latest_job_status_exception(ws, mock_installation_with_jobs, any_prompt
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
-    workflows_installer = WorkflowsDeployment(
-        config, mock_installation_with_jobs, ws, wheels, any_prompt, PRODUCT_INFO, timeout
-    )
+    workflows_installer = WorkflowsDeployment(config, mock_installation_with_jobs, ws, wheels, PRODUCT_INFO, timeout)
     ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
     status = workflows_installer.latest_job_status()
     assert len(status) == 0
@@ -1209,9 +1184,7 @@ def test_triggering_assessment_wf(ws, mocker, mock_installation):
     config = WorkspaceConfig(inventory_database="ucx", policy_id='123')
     wheels = create_autospec(WheelsV2)
     installation = mock_installation
-    workflows_installer = WorkflowsDeployment(
-        config, installation, ws, wheels, prompts, PRODUCT_INFO, timedelta(seconds=1)
-    )
+    workflows_installer = WorkflowsDeployment(config, installation, ws, wheels, PRODUCT_INFO, timedelta(seconds=1))
     workspace_installation = WorkspaceInstallation(
         config,
         installation,
@@ -1317,7 +1290,6 @@ def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt):
         mock_installation_extra_jobs,
         ws,
         create_autospec(WheelsV2),
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
@@ -1497,13 +1469,12 @@ def test_user_not_admin(ws, mock_installation, any_prompt):
         mock_installation,
         ws,
         wheels,
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )
 
     with pytest.raises(PermissionError) as failure:
-        workspace_installation.create_jobs()
+        workspace_installation.create_jobs(any_prompt)
     assert "Current user is not a workspace admin" in str(failure.value)
 
 
@@ -1522,7 +1493,6 @@ def test_validate_step(ws, any_prompt, result_state, expected):
         installation,
         ws,
         create_autospec(WheelsV2),
-        any_prompt,
         PRODUCT_INFO,
         timedelta(seconds=1),
     )

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -320,7 +320,7 @@ def test_writeable_dbfs(ws, tmp_path, mock_installation, any_prompt):
     assert job_clusters["main"].new_cluster.policy_id == "123"
 
 
-def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_installation_with_jobs):
+def test_run_workflow_creates_proper_failure(ws, mocker, mock_installation_with_jobs):
     def run_now(job_id):
         assert job_id == 123
 
@@ -360,7 +360,7 @@ def test_run_workflow_creates_proper_failure(ws, mocker, any_prompt, mock_instal
     assert str(failure.value) == "stuff: does not compute"
 
 
-def test_run_workflow_run_id_not_found(ws, mocker, any_prompt, mock_installation_with_jobs):
+def test_run_workflow_run_id_not_found(ws, mocker, mock_installation_with_jobs):
     def run_now(job_id):
         assert job_id == 123
 
@@ -398,9 +398,7 @@ def test_run_workflow_run_id_not_found(ws, mocker, any_prompt, mock_installation
         installer.run_workflow("assessment")
 
 
-def test_run_workflow_creates_failure_from_mapping(
-    ws, mocker, mock_installation, any_prompt, mock_installation_with_jobs
-):
+def test_run_workflow_creates_failure_from_mapping(ws, mocker, mock_installation, mock_installation_with_jobs):
     def run_now(job_id):
         assert job_id == 123
 
@@ -442,7 +440,7 @@ def test_run_workflow_creates_failure_from_mapping(
     assert str(failure.value) == "does not compute"
 
 
-def test_run_workflow_creates_failure_many_error(ws, mocker, any_prompt, mock_installation_with_jobs):
+def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_with_jobs):
     def run_now(job_id):
         assert job_id == 123
 
@@ -842,7 +840,7 @@ def test_remove_warehouse_not_exists(ws, caplog):
         assert 'Error accessing warehouse details' in caplog.messages
 
 
-def test_repair_run(ws, mocker, any_prompt, mock_installation_with_jobs):
+def test_repair_run(ws, mocker, mock_installation_with_jobs):
     mocker.patch("webbrowser.open")
     base = [
         BaseRun(
@@ -867,7 +865,7 @@ def test_repair_run(ws, mocker, any_prompt, mock_installation_with_jobs):
     workflows_installer.repair_run("assessment")
 
 
-def test_repair_run_success(ws, caplog, mock_installation_with_jobs, any_prompt):
+def test_repair_run_success(ws, caplog, mock_installation_with_jobs):
     base = [
         BaseRun(
             job_clusters=None,
@@ -892,7 +890,7 @@ def test_repair_run_success(ws, caplog, mock_installation_with_jobs, any_prompt)
     assert "job is not in FAILED state" in caplog.text
 
 
-def test_repair_run_no_job_id(ws, mock_installation, any_prompt, caplog):
+def test_repair_run_no_job_id(ws, mock_installation, caplog):
     base = [
         BaseRun(
             job_clusters=None,
@@ -917,7 +915,7 @@ def test_repair_run_no_job_id(ws, mock_installation, any_prompt, caplog):
         assert 'skipping assessment: job does not exists hence skipping repair' in caplog.messages
 
 
-def test_repair_run_no_job_run(ws, mock_installation_with_jobs, any_prompt, caplog):
+def test_repair_run_no_job_run(ws, mock_installation_with_jobs, caplog):
     ws.jobs.list_runs.return_value = ""
     ws.jobs.list_runs.repair_run = None
 
@@ -931,7 +929,7 @@ def test_repair_run_no_job_run(ws, mock_installation_with_jobs, any_prompt, capl
         assert "skipping assessment: job is not initialized yet. Can't trigger repair run now" in caplog.messages
 
 
-def test_repair_run_exception(ws, mock_installation_with_jobs, any_prompt, caplog):
+def test_repair_run_exception(ws, mock_installation_with_jobs, caplog):
     ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
 
     wheels = create_autospec(WheelsV2)
@@ -944,7 +942,7 @@ def test_repair_run_exception(ws, mock_installation_with_jobs, any_prompt, caplo
         assert "skipping assessment: Workflow does not exists" in caplog.messages
 
 
-def test_repair_run_result_state(ws, caplog, mock_installation_with_jobs, any_prompt):
+def test_repair_run_result_state(ws, caplog, mock_installation_with_jobs):
     base = [
         BaseRun(
             job_clusters=None,
@@ -1001,7 +999,7 @@ def test_repair_run_result_state(ws, caplog, mock_installation_with_jobs, any_pr
         ),
     ],
 )
-def test_latest_job_status_states(ws, mock_installation_with_jobs, any_prompt, state, expected):
+def test_latest_job_status_states(ws, mock_installation_with_jobs, state, expected):
     base = [
         BaseRun(
             job_id=123,
@@ -1030,9 +1028,7 @@ def test_latest_job_status_states(ws, mock_installation_with_jobs, any_prompt, s
         (None, "<never run>"),
     ],
 )
-def test_latest_job_status_success_with_time(
-    mock_datetime, ws, mock_installation_with_jobs, any_prompt, start_time, expected
-):
+def test_latest_job_status_success_with_time(mock_datetime, ws, mock_installation_with_jobs, start_time, expected):
     base = [
         BaseRun(
             job_id=123,
@@ -1055,7 +1051,7 @@ def test_latest_job_status_success_with_time(
     assert status[0]["started"] == expected
 
 
-def test_latest_job_status_list(ws, any_prompt):
+def test_latest_job_status_list(ws):
     runs = [
         [
             BaseRun(
@@ -1097,7 +1093,7 @@ def test_latest_job_status_list(ws, any_prompt):
     assert status[2]["state"] == "UNKNOWN"
 
 
-def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs, any_prompt):
+def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs):
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
@@ -1108,7 +1104,7 @@ def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs, any_promp
     assert status[0]["step"] == "assessment"
 
 
-def test_latest_job_status_exception(ws, mock_installation_with_jobs, any_prompt):
+def test_latest_job_status_exception(ws, mock_installation_with_jobs):
     wheels = create_autospec(WheelsV2)
     config = WorkspaceConfig(inventory_database='ucx')
     timeout = timedelta(seconds=1)
@@ -1485,7 +1481,7 @@ def test_user_not_admin(ws, mock_installation, any_prompt):
         (RunState(result_state=RunResultState.FAILED, life_cycle_state=RunLifeCycleState.TERMINATED), False),
     ],
 )
-def test_validate_step(ws, any_prompt, result_state, expected):
+def test_validate_step(ws, result_state, expected):
     installation = create_autospec(Installation)
     installation.load.return_value = RawState({'jobs': {'assessment': '123'}})
     workflows_installer = WorkflowsDeployment(


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
WorkflowsDeployment handles workflow deployment only and should not be dependent on prompts. Remove prompts from the class and only inject the prompts when uploading wheels to non writeable dbfs and need to use override cluster.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
