### PR TITLE
Raise TimeoutError if tests contain java TimeoutException

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -340,6 +340,7 @@ class WorkflowsDeployment(InstallationMixin):
         constructors: dict[re.Pattern, type[Exception]] = {
             re.compile(r".*\[TABLE_OR_VIEW_NOT_FOUND] (.*)"): NotFound,
             re.compile(r".*\[SCHEMA_NOT_FOUND] (.*)"): NotFound,
+            re.compile(r".*\[TimeoutException] (.*)"): TimeoutError,
         }
         for klass in needles:
             constructors[re.compile(f".*{klass.__name__}: (.*)")] = klass

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -255,7 +255,7 @@ def test_new_job_cluster_with_policy_assessment(
     assert before[ws_group_a.display_name] == PermissionLevel.CAN_USE
 
 
-@retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=10))
+@retried(on=[NotFound, InvalidParameterValue, TimeoutError], timeout=timedelta(minutes=10))
 def test_running_real_assessment_job(
     ws, new_installation, make_ucx_group, make_cluster_policy, make_cluster_policy_permissions
 ):


### PR DESCRIPTION
## Changes
test_running_real_assessment_job fails due to java TimeoutException. Now it raises TimeoutError instead and retry added for the same.

### Linked issues

Resolves #1146 

