### PR TITLE
Allow reinstall when retry the failed table migration integration test.

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -594,6 +594,7 @@ def test_table_migration_job(
             r"Min workers for auto-scale.*": "2",
             r"Max workers for auto-scale.*": "20",
             r"Instance pool id to be set.*": env_or_skip("TEST_INSTANCE_POOL_ID"),
+            r".*Do you want to update the existing installation?.*": 'yes',
         },
         inventory_schema_name=f"ucx_S{make_random(4)}_migrate_inventory",
     )
@@ -683,7 +684,11 @@ def test_table_migration_job_cluster_override(  # pylint: disable=too-many-local
 
     product_info = ProductInfo.from_class(WorkspaceConfig)
     _, workflows_install = new_installation(
-        product_info=product_info, inventory_schema_name=f"ucx_S{make_random(4)}_migrate_inventory"
+        product_info=product_info,
+        inventory_schema_name=f"ucx_S{make_random(4)}_migrate_inventory",
+        extend_prompts={
+            r".*Do you want to update the existing installation?.*": 'yes',
+        },
     )
     installation = product_info.current_installation(ws)
     migrate_rules = [


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Add `Do you want to update the existing installation?` extend_prompts in table migration integration tests, so when test failed the try will not fail because the existing installation from previous run is there.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
