### PR TITLE
Fix flaky table migration test due to schema not found

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -149,8 +149,14 @@ class TableMapping:
 
     def _get_database_in_scope_task(self, database: str) -> str | None:
         describe = {}
-        for value in self._sql_backend.fetch(f"DESCRIBE SCHEMA EXTENDED {escape_sql_identifier(database)}"):
-            describe[value["database_description_item"]] = value["database_description_value"]
+        try:
+            for value in self._sql_backend.fetch(f"DESCRIBE SCHEMA EXTENDED {escape_sql_identifier(database)}"):
+                describe[value["database_description_item"]] = value["database_description_value"]
+        except NotFound:
+            logger.warning(
+                f"Schema hive_metastore.{database} no longer exists. Skipping its properties check and migration."
+            )
+            return None
         properties = describe.get("Properties", "")
         if not properties:
             return database

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -325,7 +325,7 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
                 tables = self._ws.tables.list(catalog_name=schema.catalog_name, schema_name=schema.name)
             except NotFound:
                 logger.warning(
-                    f"Schema {schema.catalog_name}.{schema.name} no longer exists. Skipping checking it's migration status."
+                    f"Schema {schema.catalog_name}.{schema.name} no longer exists. Skipping checking its migration status."
                 )
                 continue
             for table in tables:
@@ -377,5 +377,5 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
             try:
                 yield from self._ws.schemas.list(catalog_name=catalog.name)
             except NotFound:
-                logger.warning(f"Catalog {catalog.name} no longer exists. Skipping checking it's migration status.")
+                logger.warning(f"Catalog {catalog.name} no longer exists. Skipping checking its migration status.")
                 continue

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -10,6 +10,7 @@ from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.lsql.backends import SqlBackend, StatementExecutionBackend
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
@@ -366,4 +367,8 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
 
     def _iter_schemas(self):
         for catalog in self._ws.catalogs.list():
-            yield from self._ws.schemas.list(catalog_name=catalog.name)
+            try:
+                yield from self._ws.schemas.list(catalog_name=catalog.name)
+            except NotFound:
+                logger.warning(f"Catalog {catalog.name} no longer exists. Skipping checking it's migration status.")
+                continue

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -642,43 +642,46 @@ def test_table_status_seen_tables(caplog):
     client = create_autospec(WorkspaceClient)
     client.catalogs.list.return_value = [CatalogInfo(name="cat1"), CatalogInfo(name="deleted_cat")]
     client.schemas.list.side_effect = [
-        [SchemaInfo(catalog_name="cat1", name="schema1")],
-        NotFound()
+        [SchemaInfo(catalog_name="cat1", name="schema1"), SchemaInfo(catalog_name="cat1", name="deleted_schema")],
+        NotFound(),
     ]
-    client.tables.list.return_value = [
-        TableInfo(
-            catalog_name="cat1",
-            schema_name="schema1",
-            name="table1",
-            full_name="cat1.schema1.table1",
-            properties={"upgraded_from": "hive_metastore.schema1.table1"},
-        ),
-        TableInfo(
-            catalog_name="cat1",
-            schema_name="schema1",
-            name="table2",
-            full_name="cat1.schema1.table2",
-            properties={"upgraded_from": "hive_metastore.schema1.table2"},
-        ),
-        TableInfo(
-            catalog_name="cat1",
-            schema_name="schema1",
-            name="table3",
-            full_name="cat1.schema1.table3",
-            properties={"upgraded_from": "hive_metastore.schema1.table3"},
-        ),
-        TableInfo(
-            catalog_name="cat1",
-            schema_name="schema1",
-            name="table4",
-            full_name="cat1.schema1.table4",
-        ),
-        TableInfo(
-            catalog_name="cat1",
-            schema_name="schema1",
-            name="table5",
-            properties={"upgraded_from": "hive_metastore.schema1.table2"},
-        ),
+    client.tables.list.side_effect = [
+        [
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="table1",
+                full_name="cat1.schema1.table1",
+                properties={"upgraded_from": "hive_metastore.schema1.table1"},
+            ),
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="table2",
+                full_name="cat1.schema1.table2",
+                properties={"upgraded_from": "hive_metastore.schema1.table2"},
+            ),
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="table3",
+                full_name="cat1.schema1.table3",
+                properties={"upgraded_from": "hive_metastore.schema1.table3"},
+            ),
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="table4",
+                full_name="cat1.schema1.table4",
+            ),
+            TableInfo(
+                catalog_name="cat1",
+                schema_name="schema1",
+                name="table5",
+                properties={"upgraded_from": "hive_metastore.schema1.table2"},
+            ),
+        ],
+        NotFound(),
     ]
     table_status_crawler = MigrationStatusRefresher(client, backend, "ucx", table_crawler)
     seen_tables = table_status_crawler.get_seen_tables()
@@ -688,6 +691,7 @@ def test_table_status_seen_tables(caplog):
         'cat1.schema1.table3': 'hive_metastore.schema1.table3',
     }
     assert "Catalog deleted_cat no longer exists. Skipping checking it's migration status." in caplog.text
+    assert "Schema cat1.deleted_schema no longer exists. Skipping checking it's migration status." in caplog.text
 
 
 GRANTS = MockBackend.rows("principal", "action_type", "catalog", "database", "table", "view")

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -690,8 +690,8 @@ def test_table_status_seen_tables(caplog):
         'cat1.schema1.table2': 'hive_metastore.schema1.table2',
         'cat1.schema1.table3': 'hive_metastore.schema1.table3',
     }
-    assert "Catalog deleted_cat no longer exists. Skipping checking it's migration status." in caplog.text
-    assert "Schema cat1.deleted_schema no longer exists. Skipping checking it's migration status." in caplog.text
+    assert "Catalog deleted_cat no longer exists. Skipping checking its migration status." in caplog.text
+    assert "Schema cat1.deleted_schema no longer exists. Skipping checking its migration status." in caplog.text
 
 
 GRANTS = MockBackend.rows("principal", "action_type", "catalog", "database", "table", "view")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Add try except in following places to avoid the schema NotFound error caused by test schemas from other integration test runs are deleted at the same time the table migration test are trying to access them.

- When `MigrationStatusRefresher` lists catalogs and schemas to check the migration status of the tables.
- When `TableMapping` describe schema to check the skip property.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1217 