### PR TITLE
Fix failing integration tests for table migration

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -238,7 +238,7 @@ def test_migrate_external_table(  # pylint: disable=too-many-locals
         principal_grants,
     )
 
-    table_migrate.migrate_tables(what=What.DBFS_ROOT_DELTA)
+    table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     target_tables = list(sql_backend.fetch(f"SHOW TABLES IN {dst_schema.full_name}"))
     assert len(target_tables) == 1
@@ -299,7 +299,7 @@ def test_migrate_external_table_failed_sync(
         principal_grants,
     )
 
-    table_migrate.migrate_tables(what=What.DBFS_ROOT_DELTA)
+    table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
     assert "SYNC command failed to migrate" in caplog.text
 
 
@@ -717,7 +717,7 @@ def test_migrate_managed_tables_with_principal_acl_azure(
         permission_level=PermissionLevel.CAN_ATTACH_TO,
         user_name=user.user_name,
     )
-    table_migrate.migrate_tables(acl_strategy=[AclMigrationWhat.PRINCIPAL])
+    table_migrate.migrate_tables(what=What.DBFS_ROOT_DELTA, acl_strategy=[AclMigrationWhat.PRINCIPAL])
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
     match = False


### PR DESCRIPTION
## Changes
use proper scope when calling `migrate_tables`

### Linked issues
Resolves #1235 
Resolves #1236 
Resolves #1237

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)

Pending verification on staging environment