### PR TITLE
Fix integration test with new DeployedWorkflows

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -700,7 +700,7 @@ def test_prepare_principal_acl(
     return table_migrate, f"{dst_catalog.name}.{dst_schema.name}.{src_external_table.name}", cluster.cluster_id
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=3))
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_migrate_managed_tables_with_principal_acl_azure(
     ws,
     make_user,

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -700,7 +700,7 @@ def test_prepare_principal_acl(
     return table_migrate, f"{dst_catalog.name}.{dst_schema.name}.{src_external_table.name}", cluster.cluster_id
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=5))
+@retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_migrate_managed_tables_with_principal_acl_azure(
     ws,
     make_user,
@@ -717,7 +717,7 @@ def test_migrate_managed_tables_with_principal_acl_azure(
         permission_level=PermissionLevel.CAN_ATTACH_TO,
         user_name=user.user_name,
     )
-    table_migrate.migrate_tables(what=What.DBFS_ROOT_DELTA, acl_strategy=[AclMigrationWhat.PRINCIPAL])
+    table_migrate.migrate_tables(what=What.EXTERNAL_SYNC, acl_strategy=[AclMigrationWhat.PRINCIPAL])
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
     match = False


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
1. Update `test_installation.py` integration tests with new `DeployedWorkflows`
2. Speed up table migration tests by preparing test data for `tables`, `grants`, `groups` inventory database table to avoid crawling them from scratch which slows down the test. This fixes #1245, #1243
3. Fix timed out test #1242 , because the issue [here](https://github.com/databrickslabs/ucx/commit/5d82ae024c7529cd8b549fb2372cd12dd3655efd#r140584433) caused infinite retry until timeout, as source table has `What.EXTERNAL_SYNC` but the test is trying to upgrade `What. DBFS_ROOT_DELTA `

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1242
Resolves #1245
Resolves #1243

