### PR TITLE
Addressed Issue with Disabled Feature in certain regions

### DIFF
--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -1,11 +1,11 @@
 import json
 from unittest.mock import create_autospec
 
-import databricks.sdk.errors
 import pytest
 from databricks.labs.lsql import Row
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import DatabricksError
 from databricks.sdk.service import iam
 
 from databricks.labs.ucx.workspace_access.base import AclSupport
@@ -95,11 +95,14 @@ def test_manager_inventorize(mock_ws, mock_backend, mocker):
 
 def test_manager_inventorize_ignore_error(mock_ws, mock_backend, mocker):
     def raise_error():
-        raise databricks.sdk.errors.DatabricksError("Model serving is not enabled for your shard. "
-                                                    "Please contact your organization admin or Databricks support.",
-                                                    error_code="FEATURE_DISABLED")
+        raise DatabricksError(
+            "Model serving is not enabled for your shard. "
+            "Please contact your organization admin or Databricks support.",
+            error_code="FEATURE_DISABLED",
+        )
+
     some_crawler = mocker.Mock()
-    some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), lambda: raise_error()]
+    some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), raise_error()]
     permission_manager = PermissionManager(mock_backend, "test_database", [some_crawler])
 
     permission_manager.inventorize_permissions()

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import create_autospec
 
+import databricks.sdk.errors
 import pytest
 from databricks.labs.lsql import Row
 from databricks.labs.lsql.backends import MockBackend
@@ -83,6 +84,22 @@ def test_load_all_no_rows_present():
 def test_manager_inventorize(mock_ws, mock_backend, mocker):
     some_crawler = mocker.Mock()
     some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), lambda: None]
+    permission_manager = PermissionManager(mock_backend, "test_database", [some_crawler])
+
+    permission_manager.inventorize_permissions()
+
+    assert [Row(object_id="a", object_type="b", raw="c")] == mock_backend.rows_written_for(
+        "hive_metastore.test_database.permissions", "append"
+    )
+
+
+def test_manager_inventorize_ignore_error(mock_ws, mock_backend, mocker):
+    def raise_error():
+        raise databricks.sdk.errors.DatabricksError("Model serving is not enabled for your shard. "
+                                                    "Please contact your organization admin or Databricks support.",
+                                                    error_code="FEATURE_DISABLED")
+    some_crawler = mocker.Mock()
+    some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), lambda: raise_error()]
     permission_manager = PermissionManager(mock_backend, "test_database", [some_crawler])
 
     permission_manager.inventorize_permissions()

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -102,7 +102,7 @@ def test_manager_inventorize_ignore_error(mock_ws, mock_backend, mocker):
         )
 
     some_crawler = mocker.Mock()
-    some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), raise_error()]
+    some_crawler.get_crawler_tasks = lambda: [lambda: None, lambda: Permissions("a", "b", "c"), raise_error]
     permission_manager = PermissionManager(mock_backend, "test_database", [some_crawler])
 
     permission_manager.inventorize_permissions()


### PR DESCRIPTION
closes #1228 
 The PermissionManager class in manager.py has been updated to ignore errors caused by disabled features in specific regions when inventorying permissions. A new attribute, ERRORS\_TO\_IGNORE, has been added and is initialized with ["FEATURE\_DISABLED"]. Errors not in this list will be logged and raise a ManyError exception if present. This change allows for disabling features without causing inventory errors.