### PR TITLE
remove `isort`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ path = "src/databricks/labs/ucx/__about__.py"
 dependencies = [
     "black~=24.3.0",
     "coverage[toml]~=7.4.4",
-    "isort~=5.13.2",
     "mypy~=1.9.0",
     "pylint~=3.1.0",
     "pylint-pytest==2.0.0a0",
@@ -86,21 +85,15 @@ path = ".venv"
 test        = "pytest -n 4 --cov src --cov-report=xml --timeout 30 tests/unit --durations 20"
 coverage    = "pytest -n auto --cov src tests/unit --timeout 30 --cov-report=html --durations 20"
 integration = "pytest -n 10 --cov src tests/integration --durations 20"
-fmt         = ["isort .",
-               "black .",
+fmt         = ["black .",
                "ruff check . --fix",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
 verify      = ["black --check .",
-               "isort . --check-only",
                "ruff .",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
-
-[tool.isort]
-skip_glob = ["notebooks/*.py"]
-profile = "black"
 
 [tool.pytest.ini_options]
 # TODO: remove `-p no:warnings`


### PR DESCRIPTION
`isort` and `pylint` disagree on import order with:
```
from databricks.sdk.service.workspace import Language
from sqlglot import ParseError as SQLParseError
from sqlglot import parse as parse_sql

```
the solution is to remove `isort` from the `make fmt` build command

## Changes
remove sort from build checks

### Linked issues
None

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)

