### PR TITLE
Updates to AzureACL class to load file directly using Installation class instead of AzureResourcePermission

### DIFF
--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -11,8 +11,6 @@ from databricks.labs.ucx.assessment.clusters import ClustersCrawler, PoliciesCra
 from databricks.labs.ucx.assessment.init_scripts import GlobalInitScriptCrawler
 from databricks.labs.ucx.assessment.jobs import JobsCrawler, SubmitRunsCrawler
 from databricks.labs.ucx.assessment.pipelines import PipelinesCrawler
-from databricks.labs.ucx.azure.access import AzureResourcePermissions
-from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.tasks import task, trigger
 from databricks.labs.ucx.hive_metastore import ExternalLocations, Mounts, TablesCrawler
@@ -442,18 +440,8 @@ def migrate_external_tables_sync(
     mount_crawler = Mounts(sql_backend, ws, cfg.inventory_database)
     cluster_locations = {}
     if ws.config.is_azure:
-        locations = ExternalLocations(ws, sql_backend, cfg.inventory_database)
-        azure_client = AzureAPIClient(
-            ws.config.arm_environment.resource_manager_endpoint,
-            ws.config.arm_environment.service_management_endpoint,
-        )
-        graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
-        azurerm = AzureResources(azure_client, graph_client)
-        resource_permissions = AzureResourcePermissions(install, ws, azurerm, locations)
         spn_crawler = AzureServicePrincipalCrawler(ws, sql_backend, cfg.inventory_database)
-        cluster_locations = AzureACL(
-            ws, sql_backend, spn_crawler, resource_permissions
-        ).get_eligible_locations_principals()
+        cluster_locations = AzureACL(ws, sql_backend, spn_crawler, install).get_eligible_locations_principals()
     interactive_grants = PrincipalACL(ws, sql_backend, install, table_crawler, mount_crawler, cluster_locations)
     TablesMigrator(
         table_crawler,
@@ -485,18 +473,8 @@ def migrate_dbfs_root_delta_tables(
     mount_crawler = Mounts(sql_backend, ws, cfg.inventory_database)
     cluster_locations = {}
     if ws.config.is_azure:
-        locations = ExternalLocations(ws, sql_backend, cfg.inventory_database)
-        azure_client = AzureAPIClient(
-            ws.config.arm_environment.resource_manager_endpoint,
-            ws.config.arm_environment.service_management_endpoint,
-        )
-        graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
-        azurerm = AzureResources(azure_client, graph_client)
-        resource_permissions = AzureResourcePermissions(install, ws, azurerm, locations)
         spn_crawler = AzureServicePrincipalCrawler(ws, sql_backend, cfg.inventory_database)
-        cluster_locations = AzureACL(
-            ws, sql_backend, spn_crawler, resource_permissions
-        ).get_eligible_locations_principals()
+        cluster_locations = AzureACL(ws, sql_backend, spn_crawler, install).get_eligible_locations_principals()
     interactive_grants = PrincipalACL(ws, sql_backend, install, table_crawler, mount_crawler, cluster_locations)
     TablesMigrator(
         table_crawler,

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -13,12 +13,10 @@ from databricks.labs.ucx.assessment.azure import (
     AzureServicePrincipalInfo,
     ServicePrincipalClusterMapping,
 )
-from databricks.labs.ucx.azure.access import AzureResourcePermissions
-from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore import Mounts, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import AzureACL, Grant, PrincipalACL
-from databricks.labs.ucx.hive_metastore.locations import ExternalLocations, Mount
+from databricks.labs.ucx.hive_metastore.locations import Mount
 from databricks.labs.ucx.hive_metastore.tables import Table
 
 
@@ -63,17 +61,9 @@ def ws():
 def azure_acl(w, install, cluster_spn: list):
     config = install.load(WorkspaceConfig)
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
-    locations = create_autospec(ExternalLocations)
-    azure_client = AzureAPIClient(
-        w.config.arm_environment.resource_manager_endpoint,
-        w.config.arm_environment.service_management_endpoint,
-    )
-    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
-    azurerm = AzureResources(azure_client, graph_client)
-    resource_permissions = AzureResourcePermissions(install, w, azurerm, locations)
     spn_crawler = create_autospec(AzureServicePrincipalCrawler)
     spn_crawler.get_cluster_to_storage_mapping.return_value = cluster_spn
-    return AzureACL(w, sql_backend, spn_crawler, resource_permissions)
+    return AzureACL(w, sql_backend, spn_crawler, install)
 
 
 def principal_acl(w, install, cluster_spn: list):


### PR DESCRIPTION
## Changes
This PR is an update to the PR https://github.com/databrickslabs/ucx/pull/1077
AzureResourcePermission is used to load the azure_storage_permission_info file. Instead this PR is using the Installation class directly which makes it simpler and avoids using AzureStoragePermission class

### Linked issues
Related to https://github.com/databrickslabs/ucx/issues/907


### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [X] added unit tests
- [X] added integration tests
- [ ] verified on staging environment (screenshot attached)
