### PR TITLE
Added support for one level notation for query transformer.

### DIFF
--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -41,7 +41,7 @@ class FromTable(Linter, Fixer):
             return table.catalog
         return 'hive_metastore'
 
-    def apply(self, code: str) -> str:
+    def apply(self, code: str, *, use_schema: str = "") -> str:
         new_statements = []
         for statement in sqlglot.parse(code):
             if not statement:
@@ -50,7 +50,8 @@ class FromTable(Linter, Fixer):
                 catalog = self._catalog(old_table)
                 if catalog != 'hive_metastore':
                     continue
-                dst = self._index.get(old_table.db, old_table.name)
+                src_db = old_table.db if old_table.db else use_schema
+                dst = self._index.get(src_db, old_table.name)
                 if not dst:
                     continue
                 new_table = Table(catalog=dst.dst_catalog, db=dst.dst_schema, this=dst.dst_table)

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -42,3 +42,12 @@ def test_fully_migrated_queries_match(migration_index):
     new_query = "SELECT * FROM brand.new.stuff LEFT JOIN some.certain.issues USING (x) WHERE state > 1 LIMIT 10"
 
     assert ftf.apply(old_query) == new_query
+
+
+def test_fully_migrated_queries_match_no_db(migration_index):
+    ftf = FromTable(migration_index)
+
+    old_query = "SELECT * FROM things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
+    new_query = "SELECT * FROM brand.new.stuff LEFT JOIN some.certain.issues USING (x) WHERE state > 1 LIMIT 10"
+
+    assert ftf.apply(old_query, use_schema='old') == new_query


### PR DESCRIPTION
Related to #331 
 The query transformer now supports one-level notation for schema and table name, with a new `use_schema` parameter in the `apply` method. A new test case, `test_fully_migrated_queries_match_no_db`, demonstrates this feature. The `FromTable` class is used to apply the transformation, with the `use_schema` parameter specifying the schema. This allows for more flexibility in applying transformations to queries with multiple tables and different schemas.