### PR TITLE
Fix #1289: correct keyword argument for `_aws_setup_uber_principal`

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -274,7 +274,7 @@ def _execute_for_cloud(
     func_aws: Callable,
     azure_resource_permissions: AzureResourcePermissions | None = None,
     subscription_id: str | None = None,
-    aws_permissions: AWSResourcePermissions | None = None,
+    aws_resource_permissions: AWSResourcePermissions | None = None,
     aws_profile: str | None = None,
 ):
     if w.config.is_azure:
@@ -299,7 +299,7 @@ def _execute_for_cloud(
                 "or use the '--aws-profile=[profile-name]' parameter."
             )
             return None
-        return func_aws(w, prompts, aws_profile=aws_profile, aws_permissions=aws_permissions)
+        return func_aws(w, prompts, aws_profile=aws_profile, aws_resource_permissions=aws_resource_permissions)
     logger.error("This cmd is only supported for azure and aws workspaces")
     return None
 
@@ -409,7 +409,7 @@ def _aws_principal_prefix_access(
     _: Prompts,
     *,
     aws_profile: str,
-    aws_permissions: AWSResourcePermissions | None = None,
+    aws_resource_permissions: AWSResourcePermissions | None = None,
 ):
     if not shutil.which("aws"):
         logger.error("Couldn't find AWS CLI in path. Please install the CLI from https://aws.amazon.com/cli/")
@@ -419,12 +419,12 @@ def _aws_principal_prefix_access(
     config = installation.load(WorkspaceConfig)
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
     aws = AWSResources(aws_profile)
-    if aws_permissions is None:
-        aws_permissions = AWSResourcePermissions.for_cli(w, installation, sql_backend, aws, config.inventory_database)
-    instance_role_path = aws_permissions.save_instance_profile_permissions()
+    if aws_resource_permissions is None:
+        aws_resource_permissions = AWSResourcePermissions.for_cli(w, installation, sql_backend, aws, config.inventory_database)
+    instance_role_path = aws_resource_permissions.save_instance_profile_permissions()
     logger.info(f"Instance profile and bucket info saved {instance_role_path}")
     logger.info("Generating UC roles and bucket permission info")
-    uc_role_path = aws_permissions.save_uc_compatible_roles()
+    uc_role_path = aws_resource_permissions.save_uc_compatible_roles()
     logger.info(f"UC roles and bucket info saved {uc_role_path}")
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -420,7 +420,9 @@ def _aws_principal_prefix_access(
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
     aws = AWSResources(aws_profile)
     if aws_resource_permissions is None:
-        aws_resource_permissions = AWSResourcePermissions.for_cli(w, installation, sql_backend, aws, config.inventory_database)
+        aws_resource_permissions = AWSResourcePermissions.for_cli(
+            w, installation, sql_backend, aws, config.inventory_database
+        )
     instance_role_path = aws_resource_permissions.save_instance_profile_permissions()
     logger.info(f"Instance profile and bucket info saved {instance_role_path}")
     logger.info("Generating UC roles and bucket permission info")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
`_aws_setup_uber_principal` function is expecting keyword argument `aws_resource_permissions `, but `_execute_for_cloud` was passing in keyword argument `aws_permissions`and caused #1289.
Update `aws_permissions` to `aws_resource_permissions` to fix the issue and align with the convention used for Azure.

Also, unit test is missing for `_execute_for_cloud` in aws environment, that's why this issue was not detected during test. We need a workaround to mock `shutil.which("aws")`.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1289 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
