### PR TITLE
Select DISTINCT job_run_id

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/40_2_logs.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/40_2_logs.sql
@@ -11,6 +11,6 @@ SELECT
   message
 FROM $inventory.logs
 WHERE job_run_id = (
-    SELECT job_run_id FROM $inventory.logs WHERE timestamp = (SELECT MAX(timestamp) FROM $inventory.logs)
+    SELECT DISTINCT job_run_id FROM $inventory.logs WHERE timestamp = (SELECT MAX(timestamp) FROM $inventory.logs)
 )
 ORDER BY timestamp ASC


### PR DESCRIPTION
## Changes
The logs query might not work when multiple log lines match with the max timestamp. 

### Linked issues

Resolves #1283

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
