### PR TITLE
Increased memory for ucx clusters

### DIFF
--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -19,9 +19,6 @@ class ClusterPolicyInstaller:
         self._installation = installation
         self._prompts = prompts
 
-    def _is_testing(self):
-        return self._installation.product() != "ucx"
-
     @staticmethod
     def _policy_config(value: str):
         return {"type": "fixed", "value": value}
@@ -93,10 +90,7 @@ class ClusterPolicyInstaller:
 
     def _definition(self, conf: dict, instance_profile: str | None, instance_pool_id: str | None) -> str:
         latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
-        if self._is_testing():
-            node_type_id = self._ws.clusters.select_node_type(local_disk=True)
-        else:
-            node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
+        node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
         policy_definition = {
             "spark_version": self._policy_config(latest_lts_dbr),
             "node_type_id": self._policy_config(node_type_id),

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -91,7 +91,7 @@ class ClusterPolicyInstaller:
         latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
         policy_definition = {
             "spark_version": self._policy_config(latest_lts_dbr),
-            "node_type_id": self._policy_config(self._ws.clusters.select_node_type(local_disk=True)),
+            "node_type_id": self._policy_config(self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)),
         }
         for key, value in conf.items():
             policy_definition[f"spark_conf.{key}"] = self._policy_config(value)

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -9,7 +9,6 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.service import compute
 from databricks.sdk.service.sql import GetWorkspaceWarehouseConfigResponse
 
-from databricks.labs.ucx.config import WorkspaceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +33,8 @@ class ClusterPolicyInstaller:
         instance_pool_id = self._get_instance_pool_id()
         policies_with_external_hms = list(self._get_cluster_policies_with_external_hive_metastores())
         if len(policies_with_external_hms) > 0 and self._prompts.confirm(
-                "We have identified one or more cluster policies set up for an external metastore"
-                "Would you like to set UCX to connect to the external metastore?"
+            "We have identified one or more cluster policies set up for an external metastore"
+            "Would you like to set UCX to connect to the external metastore?"
         ):
             logger.info("Setting up an external metastore")
             cluster_policies = {conf.name: conf.definition for conf in policies_with_external_hms}
@@ -45,8 +44,8 @@ class ClusterPolicyInstaller:
         else:
             warehouse_config = self._get_warehouse_config_with_external_hive_metastore()
             if warehouse_config and self._prompts.confirm(
-                    "We have identified the workspace warehouse is set up for an external metastore"
-                    "Would you like to set UCX to connect to the external metastore?"
+                "We have identified the workspace warehouse is set up for an external metastore"
+                "Would you like to set UCX to connect to the external metastore?"
             ):
                 logger.info("Setting up an external metastore")
                 instance_profile, spark_conf_dict = self._extract_external_hive_metastore_sql_conf(warehouse_config)
@@ -138,10 +137,10 @@ class ClusterPolicyInstaller:
             logger.info(f"Instance Profile is Set to {instance_profile}")
         for key in cluster_policy.keys():
             if (
-                    key.startswith("spark_conf.spark.sql.hive.metastore")
-                    or key.startswith("spark_conf.spark.hadoop.javax.jdo.option")
-                    or key.startswith("spark_conf.spark.databricks.hive.metastore")
-                    or key.startswith("spark_conf.spark.hadoop.hive.metastore.glue")
+                key.startswith("spark_conf.spark.sql.hive.metastore")
+                or key.startswith("spark_conf.spark.hadoop.javax.jdo.option")
+                or key.startswith("spark_conf.spark.databricks.hive.metastore")
+                or key.startswith("spark_conf.spark.hadoop.hive.metastore.glue")
             ):
                 spark_conf_dict[key[11:]] = cluster_policy[key]["value"]
         return instance_profile, spark_conf_dict
@@ -173,10 +172,10 @@ class ClusterPolicyInstaller:
             if conf.value is None:
                 continue
             if (
-                    conf.key.startswith("spark.sql.hive.metastore")
-                    or conf.key.startswith("spark.hadoop.javax.jdo.option")
-                    or conf.key.startswith("spark.databricks.hive.metastore")
-                    or conf.key.startswith("spark.hadoop.hive.metastore.glue")
+                conf.key.startswith("spark.sql.hive.metastore")
+                or conf.key.startswith("spark.hadoop.javax.jdo.option")
+                or conf.key.startswith("spark.databricks.hive.metastore")
+                or conf.key.startswith("spark.hadoop.hive.metastore.glue")
             ):
                 spark_conf_dict[conf.key] = conf.value
         return instance_profile, spark_conf_dict

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -9,6 +9,8 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.service import compute
 from databricks.sdk.service.sql import GetWorkspaceWarehouseConfigResponse
 
+from databricks.labs.ucx.config import WorkspaceConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,6 +19,9 @@ class ClusterPolicyInstaller:
         self._ws = ws
         self._installation = installation
         self._prompts = prompts
+
+    def _is_testing(self):
+        return self._installation.product() != "ucx"
 
     @staticmethod
     def _policy_config(value: str):
@@ -29,8 +34,8 @@ class ClusterPolicyInstaller:
         instance_pool_id = self._get_instance_pool_id()
         policies_with_external_hms = list(self._get_cluster_policies_with_external_hive_metastores())
         if len(policies_with_external_hms) > 0 and self._prompts.confirm(
-            "We have identified one or more cluster policies set up for an external metastore"
-            "Would you like to set UCX to connect to the external metastore?"
+                "We have identified one or more cluster policies set up for an external metastore"
+                "Would you like to set UCX to connect to the external metastore?"
         ):
             logger.info("Setting up an external metastore")
             cluster_policies = {conf.name: conf.definition for conf in policies_with_external_hms}
@@ -40,8 +45,8 @@ class ClusterPolicyInstaller:
         else:
             warehouse_config = self._get_warehouse_config_with_external_hive_metastore()
             if warehouse_config and self._prompts.confirm(
-                "We have identified the workspace warehouse is set up for an external metastore"
-                "Would you like to set UCX to connect to the external metastore?"
+                    "We have identified the workspace warehouse is set up for an external metastore"
+                    "Would you like to set UCX to connect to the external metastore?"
             ):
                 logger.info("Setting up an external metastore")
                 instance_profile, spark_conf_dict = self._extract_external_hive_metastore_sql_conf(warehouse_config)
@@ -89,9 +94,13 @@ class ClusterPolicyInstaller:
 
     def _definition(self, conf: dict, instance_profile: str | None, instance_pool_id: str | None) -> str:
         latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
+        if self._is_testing():
+            node_type_id = self._ws.clusters.select_node_type(local_disk=True)
+        else:
+            node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
         policy_definition = {
             "spark_version": self._policy_config(latest_lts_dbr),
-            "node_type_id": self._policy_config(self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)),
+            "node_type_id": self._policy_config(node_type_id),
         }
         for key, value in conf.items():
             policy_definition[f"spark_conf.{key}"] = self._policy_config(value)
@@ -129,10 +138,10 @@ class ClusterPolicyInstaller:
             logger.info(f"Instance Profile is Set to {instance_profile}")
         for key in cluster_policy.keys():
             if (
-                key.startswith("spark_conf.spark.sql.hive.metastore")
-                or key.startswith("spark_conf.spark.hadoop.javax.jdo.option")
-                or key.startswith("spark_conf.spark.databricks.hive.metastore")
-                or key.startswith("spark_conf.spark.hadoop.hive.metastore.glue")
+                    key.startswith("spark_conf.spark.sql.hive.metastore")
+                    or key.startswith("spark_conf.spark.hadoop.javax.jdo.option")
+                    or key.startswith("spark_conf.spark.databricks.hive.metastore")
+                    or key.startswith("spark_conf.spark.hadoop.hive.metastore.glue")
             ):
                 spark_conf_dict[key[11:]] = cluster_policy[key]["value"]
         return instance_profile, spark_conf_dict
@@ -164,10 +173,10 @@ class ClusterPolicyInstaller:
             if conf.value is None:
                 continue
             if (
-                conf.key.startswith("spark.sql.hive.metastore")
-                or conf.key.startswith("spark.hadoop.javax.jdo.option")
-                or conf.key.startswith("spark.databricks.hive.metastore")
-                or conf.key.startswith("spark.hadoop.hive.metastore.glue")
+                    conf.key.startswith("spark.sql.hive.metastore")
+                    or conf.key.startswith("spark.hadoop.javax.jdo.option")
+                    or conf.key.startswith("spark.databricks.hive.metastore")
+                    or conf.key.startswith("spark.hadoop.hive.metastore.glue")
             ):
                 spark_conf_dict[conf.key] = conf.value
         return instance_profile, spark_conf_dict

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -185,9 +185,9 @@ class DeployedWorkflows:
                 return True
         for run in current_runs:
             if (
-                    run.run_id
-                    and run.state
-                    and run.state.life_cycle_state in (RunLifeCycleState.RUNNING, RunLifeCycleState.PENDING)
+                run.run_id
+                and run.state
+                and run.state.life_cycle_state in (RunLifeCycleState.RUNNING, RunLifeCycleState.PENDING)
             ):
                 logger.info("Identified a run in progress waiting for run completion")
                 self._ws.jobs.wait_get_run_job_terminated_or_skipped(run_id=run.run_id)
@@ -376,16 +376,16 @@ class DeployedWorkflows:
 
 class WorkflowsDeployment(InstallationMixin):
     def __init__(  # pylint: disable=too-many-arguments
-            self,
-            config: WorkspaceConfig,
-            installation: Installation,
-            install_state: InstallState,
-            ws: WorkspaceClient,
-            wheels: WheelsV2,
-            product_info: ProductInfo,
-            verify_timeout: timedelta,
-            tasks: list[Task],
-            skip_dashboards=False,
+        self,
+        config: WorkspaceConfig,
+        installation: Installation,
+        install_state: InstallState,
+        ws: WorkspaceClient,
+        wheels: WheelsV2,
+        product_info: ProductInfo,
+        verify_timeout: timedelta,
+        tasks: list[Task],
+        skip_dashboards=False,
     ):
         self._config = config
         self._installation = installation
@@ -542,10 +542,10 @@ class WorkflowsDeployment(InstallationMixin):
 
     @staticmethod
     def _apply_cluster_overrides(
-            workflow_name: str,
-            settings: dict[str, Any],
-            overrides: dict[str, str],
-            wheel_runner: str,
+        workflow_name: str,
+        settings: dict[str, Any],
+        overrides: dict[str, str],
+        wheel_runner: str,
     ) -> dict:
         settings["job_clusters"] = [_ for _ in settings["job_clusters"] if _.job_cluster_key not in overrides]
         for job_task in settings["tasks"]:
@@ -627,10 +627,10 @@ class WorkflowsDeployment(InstallationMixin):
                 notebook_path=remote_notebook,
                 # ES-872211: currently, we cannot read WSFS files from Scala context
                 base_parameters={
-                                    "task": task.name,
-                                    "config": f"/Workspace{self._config_file}",
-                                }
-                                | EXTRA_TASK_PARAMS,
+                    "task": task.name,
+                    "config": f"/Workspace{self._config_file}",
+                }
+                | EXTRA_TASK_PARAMS,
             ),
         )
 
@@ -658,7 +658,6 @@ class WorkflowsDeployment(InstallationMixin):
 
     def _job_clusters(self, names: set[str]):
         clusters = []
-        node_type = self._ws.clusters.select_node_type(min_memory_gb=16)
         if "main" in names:
             clusters.append(
                 jobs.JobCluster(
@@ -681,7 +680,6 @@ class WorkflowsDeployment(InstallationMixin):
                         spark_conf=self._job_cluster_spark_conf("tacl"),
                         num_workers=1,  # ShowPermissionsCommand needs a worker
                         policy_id=self._config.policy_id,
-                        node_type_id=node_type
                     ),
                 )
             )
@@ -694,7 +692,6 @@ class WorkflowsDeployment(InstallationMixin):
                         data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
                         spark_conf=self._job_cluster_spark_conf("table_migration"),
                         policy_id=self._config.policy_id,
-                        node_type_id=node_type,
                         autoscale=compute.AutoScale(
                             max_workers=self._config.max_workers,
                             min_workers=self._config.min_workers,

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -185,9 +185,9 @@ class DeployedWorkflows:
                 return True
         for run in current_runs:
             if (
-                run.run_id
-                and run.state
-                and run.state.life_cycle_state in (RunLifeCycleState.RUNNING, RunLifeCycleState.PENDING)
+                    run.run_id
+                    and run.state
+                    and run.state.life_cycle_state in (RunLifeCycleState.RUNNING, RunLifeCycleState.PENDING)
             ):
                 logger.info("Identified a run in progress waiting for run completion")
                 self._ws.jobs.wait_get_run_job_terminated_or_skipped(run_id=run.run_id)
@@ -376,16 +376,16 @@ class DeployedWorkflows:
 
 class WorkflowsDeployment(InstallationMixin):
     def __init__(  # pylint: disable=too-many-arguments
-        self,
-        config: WorkspaceConfig,
-        installation: Installation,
-        install_state: InstallState,
-        ws: WorkspaceClient,
-        wheels: WheelsV2,
-        product_info: ProductInfo,
-        verify_timeout: timedelta,
-        tasks: list[Task],
-        skip_dashboards=False,
+            self,
+            config: WorkspaceConfig,
+            installation: Installation,
+            install_state: InstallState,
+            ws: WorkspaceClient,
+            wheels: WheelsV2,
+            product_info: ProductInfo,
+            verify_timeout: timedelta,
+            tasks: list[Task],
+            skip_dashboards=False,
     ):
         self._config = config
         self._installation = installation
@@ -542,10 +542,10 @@ class WorkflowsDeployment(InstallationMixin):
 
     @staticmethod
     def _apply_cluster_overrides(
-        workflow_name: str,
-        settings: dict[str, Any],
-        overrides: dict[str, str],
-        wheel_runner: str,
+            workflow_name: str,
+            settings: dict[str, Any],
+            overrides: dict[str, str],
+            wheel_runner: str,
     ) -> dict:
         settings["job_clusters"] = [_ for _ in settings["job_clusters"] if _.job_cluster_key not in overrides]
         for job_task in settings["tasks"]:
@@ -627,10 +627,10 @@ class WorkflowsDeployment(InstallationMixin):
                 notebook_path=remote_notebook,
                 # ES-872211: currently, we cannot read WSFS files from Scala context
                 base_parameters={
-                    "task": task.name,
-                    "config": f"/Workspace{self._config_file}",
-                }
-                | EXTRA_TASK_PARAMS,
+                                    "task": task.name,
+                                    "config": f"/Workspace{self._config_file}",
+                                }
+                                | EXTRA_TASK_PARAMS,
             ),
         )
 
@@ -658,6 +658,7 @@ class WorkflowsDeployment(InstallationMixin):
 
     def _job_clusters(self, names: set[str]):
         clusters = []
+        node_type = self._ws.clusters.select_node_type(min_memory_gb=16)
         if "main" in names:
             clusters.append(
                 jobs.JobCluster(
@@ -680,6 +681,7 @@ class WorkflowsDeployment(InstallationMixin):
                         spark_conf=self._job_cluster_spark_conf("tacl"),
                         num_workers=1,  # ShowPermissionsCommand needs a worker
                         policy_id=self._config.policy_id,
+                        node_type_id=node_type
                     ),
                 )
             )
@@ -692,6 +694,7 @@ class WorkflowsDeployment(InstallationMixin):
                         data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
                         spark_conf=self._job_cluster_spark_conf("table_migration"),
                         policy_id=self._config.policy_id,
+                        node_type_id=node_type,
                         autoscale=compute.AutoScale(
                             max_workers=self._config.max_workers,
                             min_workers=self._config.min_workers,

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -697,7 +697,7 @@ def make_cluster(ws, make_random):
                 kwargs["spark_conf"] = {"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"}
             kwargs["custom_tags"] = {"ResourceClass": "SingleNode"}
         if "instance_pool_id" not in kwargs:
-            kwargs["node_type_id"] = ws.clusters.select_node_type(local_disk=True)
+            kwargs["node_type_id"] = ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
 
         return ws.clusters.create(
             cluster_name=cluster_name,
@@ -738,7 +738,7 @@ def make_instance_pool(ws, make_random):
         if instance_pool_name is None:
             instance_pool_name = f"sdk-{make_random(4)}"
         if node_type_id is None:
-            node_type_id = ws.clusters.select_node_type(local_disk=True)
+            node_type_id = ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
         return ws.instance_pools.create(instance_pool_name, node_type_id, **kwargs)
 
     yield from factory("instance pool", create, lambda item: ws.instance_pools.delete(item.instance_pool_id))
@@ -761,7 +761,7 @@ def make_job(ws, make_random, make_notebook):
                         description=make_random(4),
                         new_cluster=compute.ClusterSpec(
                             num_workers=1,
-                            node_type_id=ws.clusters.select_node_type(local_disk=True),
+                            node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
                             spark_version=ws.clusters.select_spark_version(latest=True),
                             spark_conf=task_spark_conf,
                         ),
@@ -776,7 +776,7 @@ def make_job(ws, make_random, make_notebook):
                         description=make_random(4),
                         new_cluster=compute.ClusterSpec(
                             num_workers=1,
-                            node_type_id=ws.clusters.select_node_type(local_disk=True),
+                            node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
                             spark_version=ws.clusters.select_spark_version(latest=True),
                         ),
                         notebook_task=jobs.NotebookTask(notebook_path=make_notebook()),
@@ -817,7 +817,7 @@ def make_pipeline(ws, make_random, make_notebook):
         if "clusters" not in kwargs:
             kwargs["clusters"] = [
                 pipelines.PipelineCluster(
-                    node_type_id=ws.clusters.select_node_type(local_disk=True),
+                    node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
                     label="default",
                     num_workers=1,
                     custom_tags={

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -149,7 +149,7 @@ def test_job_cluster_policy(ws, installation_ctx):
 
     spark_version = ws.clusters.select_spark_version(latest=True, long_term_support=True)
     assert policy_definition["spark_version"]["value"] == spark_version
-    assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True)
+    assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
     if ws.config.is_azure:
         assert (
             policy_definition["azure_attributes.availability"]["value"]

--- a/tests/unit/installer/test_policy.py
+++ b/tests/unit/installer/test_policy.py
@@ -28,7 +28,7 @@ def common():
 
     w.cluster_policies.list.return_value = [policy]
     w.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
-    w.clusters.select_node_type = lambda local_disk: "Standard_F4s"
+    w.clusters.select_node_type = lambda **_: "Standard_F4s"
     w.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     prompts = MockPrompts(
         {

--- a/tests/unit/installer/test_policy.py
+++ b/tests/unit/installer/test_policy.py
@@ -28,7 +28,7 @@ def common():
 
     w.cluster_policies.list.return_value = [policy]
     w.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
-    w.clusters.select_node_type = lambda local_disk: "Standard_F4s"
+    w.clusters.select_node_type = lambda **_: "Standard_F4s"
     w.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     prompts = MockPrompts(
         {
@@ -210,7 +210,7 @@ def test_update_job_policy():
                 '123',
                 new_cluster=ClusterSpec(
                     num_workers=1,
-                    node_type_id=ws.clusters.select_node_type(local_disk=True),
+                    node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
                     spark_version=ws.clusters.select_spark_version(latest=True),
                 ),
             )

--- a/tests/unit/installer/test_policy.py
+++ b/tests/unit/installer/test_policy.py
@@ -28,7 +28,7 @@ def common():
 
     w.cluster_policies.list.return_value = [policy]
     w.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
-    w.clusters.select_node_type = lambda **_: "Standard_F4s"
+    w.clusters.select_node_type = lambda local_disk: "Standard_F4s"
     w.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
     prompts = MockPrompts(
         {

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -142,7 +142,7 @@ def ws():
     workspace_client.clusters.list.return_value = mock_clusters()
     workspace_client.cluster_policies.create.return_value = CreatePolicyResponse(policy_id="foo")
     workspace_client.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
-    workspace_client.clusters.select_node_type = lambda **_: "Standard_F4s"
+    workspace_client.clusters.select_node_type = lambda local_disk: "Standard_F4s"
     workspace_client.workspace.download = download
 
     return workspace_client

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -142,7 +142,7 @@ def ws():
     workspace_client.clusters.list.return_value = mock_clusters()
     workspace_client.cluster_policies.create.return_value = CreatePolicyResponse(policy_id="foo")
     workspace_client.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
-    workspace_client.clusters.select_node_type = lambda local_disk: "Standard_F4s"
+    workspace_client.clusters.select_node_type = lambda **_: "Standard_F4s"
     workspace_client.workspace.download = download
 
     return workspace_client


### PR DESCRIPTION
## Changes
- Choose instance types with 16GB memory to avoid OOM for assessment tasks
### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1364

### Functionality 

-  Switch cluster policy to minimum 16gb RAM, as instances with 8gb RAM only has 710MB memory for executors

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] verified on staging environment (screenshot attached)
