### PR TITLE
Temporarily disabled tests that do not work on aws

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -239,6 +239,7 @@ class GlobalContext(abc.ABC):
     @cached_property
     def principal_acl(self):
         if not self.is_azure:
+            # test_mapping_reverts_table and test_revert_migrated_table depend on this
             raise NotImplementedError("Azure only for now")
         eligible = self.azure_acl.get_eligible_locations_principals()
         return PrincipalACL(

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -268,6 +268,8 @@ def test_migrate_view(ws, sql_backend, runtime_ctx, make_catalog, make_schema):
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_revert_migrated_table(sql_backend, runtime_ctx, make_schema, make_catalog):
+    if not runtime_ctx.workspace_client.config.is_azure:
+        pytest.skip("temporary: only works in azure test env")
     src_schema1 = make_schema(catalog_name="hive_metastore")
     src_schema2 = make_schema(catalog_name="hive_metastore")
     table_to_revert = runtime_ctx.make_table(schema_name=src_schema1.name)
@@ -379,6 +381,8 @@ def test_mapping_skips_tables_databases(ws, sql_backend, inventory_schema, make_
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_mapping_reverts_table(ws, sql_backend, runtime_ctx, make_schema, make_catalog):
+    if not ws.config.is_azure:
+        pytest.skip("temporary: only works in azure test env")
     src_schema = make_schema(catalog_name="hive_metastore")
     table_to_revert = runtime_ctx.make_table(schema_name=src_schema.name)
     table_to_skip = runtime_ctx.make_table(schema_name=src_schema.name)
@@ -499,6 +503,8 @@ def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_cata
 
 @pytest.fixture
 def prepared_principal_acl(runtime_ctx, env_or_skip, make_dbfs_data_copy, make_catalog, make_schema, make_cluster):
+    if not runtime_ctx.workspace_client.config.is_azure:
+        pytest.skip("temporary: only works in azure test env")
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
     new_mounted_location = f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{runtime_ctx.inventory_database}'
     make_dbfs_data_copy(src_path=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/c', dst_path=new_mounted_location)

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -594,6 +594,9 @@ def test_table_migration_job(
     # skip this test if not in nightly test job or debug mode
     if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
         env_or_skip("TEST_NIGHTLY")
+    # TODO - DBFS API does not support instance profile based mounts
+    if not ws.config.is_azure:
+        pytest.skip("Temporarily does not work on AWS")
     # create external and managed tables to be migrated
     schema = make_schema(catalog_name="hive_metastore", name=f"migrate_{make_random(5).lower()}")
     tables: dict[str, TableInfo] = {}
@@ -763,6 +766,9 @@ def test_table_migration_job_cluster_override(  # pylint: disable=too-many-local
     make_dbfs_data_copy,
     sql_backend,
 ):
+    # TODO - DBFS API does not support instance profile based mounts
+    if not ws.config.is_azure:
+        pytest.skip("Temporarily does not work on AWS")
     # create external and managed tables to be migrated
     schema = make_schema(catalog_name="hive_metastore", name=f"migrate_{make_random(5).lower()}")
     src_managed_table = make_table(schema_name=schema.name)


### PR DESCRIPTION
## Changes

Temporarily disabled tests that do not work on AWS, for 2 reasons:

- `make_dbfs_data_copy` does not work with mounts on aws
- `principal_acl` does not have aws implementation yet

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
