### PR TITLE
Handled new output format of `SHOW TBLPROPERTIES` command

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -88,10 +88,12 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
         return seen_tables
 
     def is_migrated(self, schema: str, table: str) -> bool:
-        result = self._backend.fetch(
+        results = self._backend.fetch(
             f"SHOW TBLPROPERTIES {escape_sql_identifier(schema + '.' + table)} ('upgraded_to')"
         )
-        for _ in result:
+        for result in results:
+            if "does not have property" in result.value:
+                continue
             logger.info(f"{schema}.{table} is set as migrated")
             return True
         logger.info(f"{schema}.{table} is set as not migrated")

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -516,10 +516,10 @@ def test_empty_revert_report(ws):
 def test_is_upgraded(ws):
     errors = {}
     rows = {
-        "SHOW TBLPROPERTIES schema1.table1": [
-            {"value": "fake_dest"},
+        "SHOW TBLPROPERTIES schema1.table1": MockBackend.rows("key", "value")["upgrade_to", "fake_dest"],
+        "SHOW TBLPROPERTIES schema1.table2": MockBackend.rows("key", "value")[
+            "upgraded_to", "table table2 does not have property: upgraded_to"
         ],
-        "SHOW TBLPROPERTIES schema1.table2": [],
     }
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = create_autospec(TablesCrawler)
@@ -551,11 +551,7 @@ def test_table_status():
 
     datetime.datetime = FakeDate
     errors = {}
-    rows = {
-        "SHOW TBLPROPERTIES schema1.table1": [
-            {"key": "upgraded_to", "value": "cat1.schema1.dest1"},
-        ],
-    }
+    rows = {"SHOW TBLPROPERTIES schema1.table1": MockBackend.rows("key", "value")["upgrade_to", "cat1.schema1.dest1"]}
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = create_autospec(TablesCrawler)
     table_crawler.snapshot.return_value = [


### PR DESCRIPTION
## Changes
- `test_revert_migrated_table` was failing, due to new output of `SHOW TBLPROPERTIES` - previously, it is blank if a tbl prop is missing, now it shows `Table <table> does not have property: <prop>`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] verified on staging environment (screenshot attached)
