### PR TITLE
Bumped databricks-sdk from 0.24.0 to 0.25.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
-dependencies = ["databricks-sdk==0.24.0",
+dependencies = ["databricks-sdk==0.25.1",
                 "databricks-labs-lsql~=0.3.0",
                 "databricks-labs-blueprint~=0.4.3",
                 "PyYAML>=6.0.0,<7.0.0"]

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -95,10 +95,10 @@ class CredentialManager:
 
         failures = []
         for result in validation.results:
-            if result.operation is None:
+            if result.aws_operation is None:
                 continue
             if result.result == ValidationResultResult.FAIL:
-                failures.append(f"{result.operation.value} validation failed with message: {result.message}")
+                failures.append(f"{result.aws_operation.value} validation failed with message: {result.message}")
         return CredentialValidationResult(
             role_action.role_name,
             role_action.role_arn,

--- a/src/databricks/labs/ucx/azure/credentials.py
+++ b/src/databricks/labs/ucx/azure/credentials.py
@@ -132,10 +132,10 @@ class StorageCredentialManager:
 
         failures = []
         for result in validation.results:
-            if result.operation is None:
+            if result.azure_operation is None:
                 continue
             if result.result == ValidationResultResult.FAIL:
-                failures.append(f"{result.operation.value} validation failed with message: {result.message}")
+                failures.append(f"{result.azure_operation.value} validation failed with message: {result.message}")
         return StorageCredentialValidationResult.from_validation(permission_mapping, None if not failures else failures)
 
 

--- a/tests/unit/aws/test_credentials.py
+++ b/tests/unit/aws/test_credentials.py
@@ -8,7 +8,7 @@ from databricks.labs.blueprint.tui import MockPrompts
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import (
     AwsIamRoleResponse,
-    AzureManagedIdentity,
+    AzureManagedIdentityResponse,
     AzureServicePrincipal,
     Privilege,
     StorageCredentialInfo,
@@ -44,7 +44,7 @@ def credential_manager(ws):
             aws_iam_role=AwsIamRoleResponse(role_arn="arn:aws:iam::123456789012:role/example-role-name")
         ),
         StorageCredentialInfo(
-            azure_managed_identity=AzureManagedIdentity("/subscriptions/.../providers/Microsoft.Databricks/...")
+            azure_managed_identity=AzureManagedIdentityResponse("/subscriptions/.../providers/Microsoft.Databricks/...")
         ),
         StorageCredentialInfo(aws_iam_role=AwsIamRoleResponse("arn:aws:iam::123456789012:role/another-role-name")),
         StorageCredentialInfo(azure_service_principal=AzureServicePrincipal("directory_id_1", "app_secret2", "secret")),

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -7,7 +7,7 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import InvalidParameterValue, PermissionDenied
 from databricks.sdk.service.catalog import (
-    AzureManagedIdentity,
+    AzureManagedIdentityResponse,
     AzureServicePrincipal,
     ExternalLocationInfo,
     StorageCredentialInfo,
@@ -203,13 +203,13 @@ def test_run_managed_identity(ws, mocker):
     ws.storage_credentials.list.return_value = [
         StorageCredentialInfo(
             name="credential_system_assigned_mi",
-            azure_managed_identity=AzureManagedIdentity(
+            azure_managed_identity=AzureManagedIdentityResponse(
                 "/subscriptions/123/resourcegroups/abc/providers/Microsoft.Databricks/accessConnectors/credential_system_assigned_mi"
             ),
         ),
         StorageCredentialInfo(
             name="credential_user_assigned_mi",
-            azure_managed_identity=AzureManagedIdentity(
+            azure_managed_identity=AzureManagedIdentityResponse(
                 "/subscriptions/123/resourcegroups/abc/providers/Microsoft.ManagedIdentity/accessConnectors/credential_user_assigned_mi",
                 managed_identity_id="/subscriptions/123/resourceGroups/abc/providers/Microsoft.ManagedIdentity/userAssignedIdentities/credential_user_assigned_mi",
             ),
@@ -432,7 +432,7 @@ def test_corner_cases_with_missing_fields(ws, caplog, mocker):
         ),
         StorageCredentialInfo(
             name="credential_no_id_mi",
-            azure_managed_identity=AzureManagedIdentity(
+            azure_managed_identity=AzureManagedIdentityResponse(
                 "/subscriptions/123/no_id_test/accessConnectors/credential_no_id_mi",
             ),
         ),


### PR DESCRIPTION
## Changes
- Bumped databricks-sdk from 0.24.0 to 0.25.1
- Fix breaking change where `AzureManagedIdentity` struct is now split into `AzureManagedIdentityResponse` and `AzureManagedIdentityRequest`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] verified on staging environment (screenshot attached)
