### PR TITLE
Fixing include_paths_in_mounts not being propagated

### DIFF
--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -90,6 +90,7 @@ class RuntimeContext(GlobalContext):
             self.mounts_crawler,
             self.config.include_mounts,
             self.config.exclude_paths_in_mount,
+            self.config.include_paths_in_mount
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -90,7 +90,7 @@ class RuntimeContext(GlobalContext):
             self.mounts_crawler,
             self.config.include_mounts,
             self.config.exclude_paths_in_mount,
-            self.config.include_paths_in_mount
+            self.config.include_paths_in_mount,
         )
 
     @cached_property


### PR DESCRIPTION
## Changes
Fixing configuration include_paths_in_mount not being propagated to the RuntimeContext properly
