### PR TITLE
Scan site-packages

### DIFF
--- a/src/databricks/labs/ucx/source_code/site_packages.py
+++ b/src/databricks/labs/ucx/source_code/site_packages.py
@@ -1,0 +1,53 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SitePackage:
+
+    @staticmethod
+    def parse(path: Path):
+        modules: list[str] = []
+        with open(Path(path, "RECORD")) as record_file:
+            lines = record_file.readlines()
+            modules = [line.split(',')[0] for line in lines]
+        top_levels_path = Path(path, "top_level.txt")
+        if top_levels_path.exists():
+            with open(top_levels_path) as top_levels_file:
+                top_levels = [line.strip() for line in top_levels_file.readlines()]
+        else:
+            dir_name = path.name
+            # strip extension
+            dir_name = dir_name[: dir_name.rindex('.')]
+            # strip version
+            dir_name = dir_name[:dir_name.rindex('-')]
+            top_levels = [dir_name]
+        return SitePackage(path, top_levels, modules)
+
+    def __init__(self, dist_info_path: Path, top_levels: list[str], modules: list[str]):
+        self._dist_info_path = dist_info_path
+        self._top_levels = top_levels
+        self._modules = modules
+
+    @property
+    def top_levels(self) -> list[str]:
+        return self._top_levels
+
+
+class SitePackages:
+
+    @staticmethod
+    def parse(site_packages_path: str):
+        dist_info_dirs = [dir for dir in os.listdir(site_packages_path) if dir.endswith(".dist-info")]
+        packages = [SitePackage.parse(Path(site_packages_path,dist_info_dir)) for dist_info_dir in dist_info_dirs]
+        return SitePackages(packages)
+
+    def __init__(self, packages: list[SitePackage]):
+        self._packages: dict[str, SitePackage] = {}
+        for package in packages:
+            for top_level in package.top_levels:
+                self._packages[top_level] = package
+
+    def __getitem__(self, item: str) -> SitePackage | None:
+        return self._packages.get(item, None)

--- a/src/databricks/labs/ucx/source_code/site_packages.py
+++ b/src/databricks/labs/ucx/source_code/site_packages.py
@@ -8,20 +8,20 @@ class SitePackage:
 
     @staticmethod
     def parse(path: Path):
-        modules: list[str] = []
-        with open(Path(path, "RECORD")) as record_file:
+        with open(Path(path, "RECORD"), encoding="utf-8") as record_file:
             lines = record_file.readlines()
-            modules = [line.split(',')[0] for line in lines]
+            files = [line.split(',')[0] for line in lines]
+            modules = list(filter(lambda line: line.endswith(".py"), files))
         top_levels_path = Path(path, "top_level.txt")
         if top_levels_path.exists():
-            with open(top_levels_path) as top_levels_file:
+            with open(top_levels_path, encoding="utf-8") as top_levels_file:
                 top_levels = [line.strip() for line in top_levels_file.readlines()]
         else:
             dir_name = path.name
             # strip extension
             dir_name = dir_name[: dir_name.rindex('.')]
             # strip version
-            dir_name = dir_name[:dir_name.rindex('-')]
+            dir_name = dir_name[: dir_name.rindex('-')]
             top_levels = [dir_name]
         return SitePackage(path, top_levels, modules)
 
@@ -40,7 +40,7 @@ class SitePackages:
     @staticmethod
     def parse(site_packages_path: str):
         dist_info_dirs = [dir for dir in os.listdir(site_packages_path) if dir.endswith(".dist-info")]
-        packages = [SitePackage.parse(Path(site_packages_path,dist_info_dir)) for dist_info_dir in dist_info_dirs]
+        packages = [SitePackage.parse(Path(site_packages_path, dist_info_dir)) for dist_info_dir in dist_info_dirs]
         return SitePackages(packages)
 
     def __init__(self, packages: list[SitePackage]):

--- a/src/databricks/labs/ucx/source_code/whitelist.py
+++ b/src/databricks/labs/ucx/source_code/whitelist.py
@@ -95,7 +95,7 @@ class Whitelist:
             known_packages.extend(pips)
         self._known_packages: dict[str, list[KnownPackage]] = {}
         for known in known_packages:
-            top_levels = known.top_level if isinstance(known.top_level, list) else [known.top_level]
+            top_levels: list[str] = known.top_level if isinstance(known.top_level, list) else [known.top_level]
             for top_level in top_levels:
                 packs = self._known_packages.get(top_level, None)
                 if packs is None:

--- a/src/databricks/labs/ucx/source_code/whitelist.py
+++ b/src/databricks/labs/ucx/source_code/whitelist.py
@@ -95,11 +95,13 @@ class Whitelist:
             known_packages.extend(pips)
         self._known_packages: dict[str, list[KnownPackage]] = {}
         for known in known_packages:
-            packs = self._known_packages.get(known.top_level, None)
-            if packs is None:
-                packs = []
-                self._known_packages[known.top_level] = packs
-            packs.append(known)
+            top_levels = known.top_level if isinstance(known.top_level, list) else [known.top_level]
+            for top_level in top_levels:
+                packs = self._known_packages.get(top_level, None)
+                if packs is None:
+                    packs = []
+                    self._known_packages[top_level] = packs
+                packs.append(known)
 
     def compatibility(self, name: str) -> UCCompatibility | None:
         root = name.split('.')[0]

--- a/tests/unit/source_code/samples/sample-python-compatibility-catalog.yml
+++ b/tests/unit/source_code/samples/sample-python-compatibility-catalog.yml
@@ -21,7 +21,9 @@ packages:
 identifier:
   name: databricks-sdk
   # since version is omitted, this entry applies to all versions for which there is no versioned entry
-top_level: databricks
+top_level:
+  - databricks
+  - databrix
 packages:
   - name: databricks.sdk.service.dashboards
     compatibility: full

--- a/tests/unit/source_code/test_site_packages.py
+++ b/tests/unit/source_code/test_site_packages.py
@@ -1,0 +1,13 @@
+import os
+from pathlib import Path
+
+from databricks.labs.ucx.source_code.site_packages import SitePackages
+
+
+def test_reads_site_packages():
+    project_path = Path(os.path.dirname(__file__)).parent.parent.parent
+    python_lib_path = Path(project_path, ".venv", "lib")
+    actual_python = next(file for file in os.listdir(str(python_lib_path)) if file.startswith("python3."))
+    site_packages_path = Path(python_lib_path, actual_python, "site-packages")
+    site_packages = SitePackages.parse(str(site_packages_path))
+    assert site_packages["astroid"] is not None

--- a/tests/unit/source_code/test_whitelist.py
+++ b/tests/unit/source_code/test_whitelist.py
@@ -10,3 +10,4 @@ def test_reads_whitelist():
     assert whitelist.compatibility("databricks.sdk.service.compute") == UCCompatibility.FULL
     assert whitelist.compatibility("sys") == UCCompatibility.FULL
     assert whitelist.compatibility("os.path") == UCCompatibility.FULL
+    assert whitelist.compatibility("databrix") == UCCompatibility.NONE


### PR DESCRIPTION
## Changes
Implement a SitePackages scanner that uses metadata to link module root names with actual python code belonging to installed packages

### Linked issues
#1202
Resolves #1410 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
