### PR TITLE
Give all access connectors `Storage Blob Data Contributor` role

### DIFF
--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -221,7 +221,13 @@ class AzureResourcePermissions:
         for storage_account in self._azurerm.storage_accounts():
             if storage_account.name not in used_storage_accounts:
                 continue
-            tasks.append(partial(self._create_access_connector_for_storage_account, storage_account=storage_account))
+            task = partial(
+                self._create_access_connector_for_storage_account,
+                storage_account=storage_account,
+                # Fine-grained access is configured within Databricks through unity
+                role_name="STORAGE_BLOB_DATA_CONTRIBUTOR",
+            )
+            tasks.append(task)
 
         thread_name = "Creating access connectors for storage accounts"
         results, errors = Threads.gather(thread_name, tasks)

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -387,4 +387,4 @@ def test_create_access_connectors_for_storage_accounts_log_permission_applied(ca
 
     with caplog.at_level(logging.DEBUG, logger="databricks.labs.ucx"):
         azure_resource_permission.create_access_connectors_for_storage_accounts()
-        assert any("STORAGE_BLOB_DATA_READER" in message for message in caplog.messages)
+        assert any("STORAGE_BLOB_DATA_CONTRIBUTOR" in message for message in caplog.messages)


### PR DESCRIPTION
## Changes
Give all access connectors STORAGE_BLOB_DATA_CONTRIBUTOR access.

More fine-grained access is configured within unity catalog. We give all access connectors (one for each storage account) the highest data access, i.e. data contributor.

### Linked issues

Resolves #1383

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
