### PR TITLE
Propagate source location information within the import package dependency graph

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -52,6 +52,9 @@ class Advice:
     def as_convention(self) -> 'Convention':
         return Convention(**self.__dict__)
 
+    def as_location(self) -> 'Location':
+        return Location(**self.__dict__)
+
 
 class Advisory(Advice):
     """A warning that does not prevent the code from running."""
@@ -67,6 +70,10 @@ class Deprecation(Advisory):
 
 class Convention(Advice):
     """A suggestion for a better way to write the code."""
+
+
+class Location(Advice):
+    """A location in the code, which is not yet an advice"""
 
 
 class Linter:

--- a/src/databricks/labs/ucx/source_code/dependencies.py
+++ b/src/databricks/labs/ucx/source_code/dependencies.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
-import abc
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 
 from databricks.sdk.service.workspace import ObjectType, ObjectInfo, ExportFormat, Language
 from databricks.sdk import WorkspaceClient
 
-from databricks.labs.ucx.source_code.base import Advice, Deprecation
+from databricks.labs.ucx.source_code.base import Advice
+from databricks.labs.ucx.source_code.python_linter import ImportSource
 from databricks.labs.ucx.source_code.whitelist import Whitelist, UCCompatibility
+
+
+class AbstractVisitor(ABC):
+    @abstractmethod
+    def process(self, graph) -> bool | None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_advices(self) -> Iterable[Advice]:
+        raise NotImplementedError()
 
 
 class Dependency:
@@ -18,9 +29,20 @@ class Dependency:
         assert object_info.path is not None
         return Dependency(object_info.object_type, object_info.path)
 
-    def __init__(self, object_type: ObjectType | None, path: str):
+    def __init__(self, object_type: ObjectType | None, path: str, source: ImportSource | None = None):
         self._type = object_type
         self._path = path
+        self._source = source
+        self._compatibility: UCCompatibility | None = None
+
+    @property
+    def compatibility(self) -> UCCompatibility | None:
+        return self._compatibility
+
+    # cannot do this in construction as the resolver must decide the compatibility
+    @compatibility.setter
+    def compatibility(self, value: UCCompatibility):
+        self._compatibility = value
 
     @property
     def type(self) -> ObjectType | None:
@@ -30,6 +52,10 @@ class Dependency:
     def path(self) -> str:
         return self._path
 
+    @property
+    def source(self) -> ImportSource | None:
+        return self._source
+
     def __hash__(self):
         return hash(self.path)
 
@@ -37,14 +63,14 @@ class Dependency:
         return isinstance(other, Dependency) and self.path == other.path
 
 
-class SourceContainer(abc.ABC):
+class SourceContainer(ABC):
 
     @property
-    @abc.abstractmethod
+    @abstractmethod
     def object_type(self) -> ObjectType:
         raise NotImplementedError()
 
-    @abc.abstractmethod
+    @abstractmethod
     def build_dependency_graph(self, graph) -> None:
         raise NotImplementedError()
 
@@ -108,30 +134,16 @@ class DependencyLoader:
 class DependencyResolver:
     def __init__(self, whitelist: Whitelist | None = None):
         self._whitelist = Whitelist() if whitelist is None else whitelist
-        self._advices: list[Advice] = []
+
+    def compatibility(self, dependency: Dependency) -> UCCompatibility | None:
+        return self._whitelist.compatibility(dependency.path)
 
     def resolve(self, dependency: Dependency) -> Dependency | None:
         if dependency.type == ObjectType.NOTEBOOK:
             return dependency
-        compatibility = self._whitelist.compatibility(dependency.path)
+        dependency.compatibility = self.compatibility(dependency)
         # TODO attach compatibility to dependency, see https://github.com/databrickslabs/ucx/issues/1382
-        if compatibility is not None:
-            if compatibility == UCCompatibility.NONE:
-                self._advices.append(
-                    Deprecation(
-                        code="dependency-check",
-                        message=f"Use of dependency {dependency.path} is deprecated",
-                        start_line=0,
-                        start_col=0,
-                        end_line=0,
-                        end_col=0,
-                    )
-                )
-            return None
         return dependency
-
-    def get_advices(self) -> Iterable[Advice]:
-        yield from self._advices
 
 
 class DependencyGraph:
@@ -148,6 +160,7 @@ class DependencyGraph:
         self._loader = loader
         self._resolver = resolver or DependencyResolver()
         self._dependencies: dict[Dependency, DependencyGraph] = {}
+        self._processors: list[AbstractVisitor] = []
 
     @property
     def dependency(self):
@@ -157,19 +170,33 @@ class DependencyGraph:
     def path(self):
         return self._dependency.path
 
+    def register_processors(self, *processors: AbstractVisitor):
+        """Register processors to be run on the graph via the process method"""
+        if not processors:
+            raise ValueError("At least one processor must be provided")
+        self._processors.extend(processors)
+
     def register_dependency(self, dependency: Dependency) -> DependencyGraph | None:
         resolved = self._resolver.resolve(dependency)
         if resolved is None:
             return None
+
         # already registered ?
         child_graph = self.locate_dependency(resolved)
         if child_graph is not None:
             self._dependencies[resolved] = child_graph
             return child_graph
+
         # nay, create the child graph and populate it
         child_graph = DependencyGraph(resolved, self, self._loader, self._resolver)
         self._dependencies[resolved] = child_graph
+        if resolved.compatibility:
+            # We do not descend into dependencies that are already known in some
+            # way as they will be linted or migrated.
+            return None
+
         container = self._loader.load_dependency(resolved)
+
         if not container:
             return None
         container.build_dependency_graph(child_graph)
@@ -204,15 +231,29 @@ class DependencyGraph:
         def add_to_dependencies(graph: DependencyGraph) -> bool:
             if graph.dependency in dependencies:
                 return True
+
             dependencies.add(graph.dependency)
             return False
 
-        self.visit(add_to_dependencies)
+        # Do not add self as a dependency on itself
+        self.visit_children(add_to_dependencies)
+
         return dependencies
 
     @property
     def paths(self) -> set[str]:
         return {d.path for d in self.dependencies}
+
+    @property
+    def dependency_count(self) -> int:
+        return len(self._dependencies)
+
+    def visit_children(self, visit_node: Callable[[DependencyGraph], bool | None]) -> bool | None:
+        """Use when it is important not to visit the root node"""
+        for dependency in self._dependencies.values():
+            if dependency.visit(visit_node):
+                return True
+        return False
 
     # when visit_node returns True it interrupts the visit
     def visit(self, visit_node: Callable[[DependencyGraph], bool | None]) -> bool | None:
@@ -222,3 +263,23 @@ class DependencyGraph:
             if dependency.visit(visit_node):
                 return True
         return False
+
+    def walk(self, visitor: AbstractVisitor) -> bool | None:
+        """
+        Process the graph with the given visitor, used by linters or any other processing
+        system after the graph is constructed
+        """
+        if visitor.process(self):
+            return True
+        for dependency in self._dependencies.values():
+            if dependency.walk(visitor):
+                return True
+        return False
+
+    def process(self) -> Iterable[Advice]:
+        for processor in self._processors:
+            self.walk(processor)
+            yield from processor.get_advices()
+
+    def compatibility(self, dependency: Dependency) -> UCCompatibility | None:
+        return self._resolver.compatibility(dependency)

--- a/src/databricks/labs/ucx/source_code/dependency_linters.py
+++ b/src/databricks/labs/ucx/source_code/dependency_linters.py
@@ -1,0 +1,48 @@
+from collections.abc import Iterable
+
+from databricks.labs.ucx.source_code.base import Advice, Deprecation
+from databricks.labs.ucx.source_code.dependencies import AbstractVisitor
+from databricks.labs.ucx.source_code.whitelist import UCCompatibility
+
+
+class ImportChecker(AbstractVisitor):
+
+    def __init__(self):
+        self._advices: list[Advice] = []
+        self._trace: list[str] = []
+
+    def _build_trace(self):
+        return " <- ".join(self._trace)
+
+    def process(self, graph) -> bool | None:
+        dependency = graph.dependency
+        self._trace.append(dependency.path)
+        compatibility = graph.compatibility(dependency)
+        if compatibility and compatibility == UCCompatibility.NONE:
+            if dependency.source is not None:
+                import_type = dependency.source.location.code
+                self._advices.append(
+                    dependency.source.location.as_deprecation().replace(
+                        code="dependency-check",
+                        message="Deprecated " + import_type + ": " + self._build_trace(),
+                    )
+                )
+
+            else:
+                self._advices.append(
+                    Deprecation(
+                        code="dependency-check",
+                        message=f"Use of dependency {dependency.path} is deprecated",
+                        start_col=0,
+                        end_col=0,
+                        start_line=0,
+                        end_line=0,
+                    )
+                )
+        if graph.dependency_count == 0 and self._trace:
+            self._trace.pop()
+        # Do not interrupt the visit
+        return False
+
+    def get_advices(self) -> Iterable[Advice]:
+        yield from self._advices

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -35,10 +35,10 @@ class SourceFile(SourceContainer):
         for path in notebook_paths:
             graph.register_dependency(Dependency(ObjectType.NOTEBOOK, path))
         # TODO https://github.com/databrickslabs/ucx/issues/1287
-        import_names = PythonLinter.list_import_sources(linter)
-        for import_name in import_names:
+        imports = PythonLinter.list_import_sources(linter)
+        for import_source in imports:
             # we don't know yet if it's a file or a library
-            graph.register_dependency(Dependency(None, import_name))
+            graph.register_dependency(Dependency(None, import_source.import_string, import_source))
 
 
 class WorkspaceFile(SourceFile):

--- a/src/databricks/labs/ucx/source_code/notebook.py
+++ b/src/databricks/labs/ucx/source_code/notebook.py
@@ -85,9 +85,9 @@ class PythonCell(Cell):
             if isinstance(path, ast.Constant):
                 dependency = Dependency(ObjectType.NOTEBOOK, path.value.strip("'").strip('"'))
                 parent.register_dependency(dependency)
-        names = PythonLinter.list_import_sources(linter)
-        for name in names:
-            dependency = Dependency(None, name)
+        imports = PythonLinter.list_import_sources(linter)
+        for import_dependency in imports:
+            dependency = Dependency(None, import_dependency.import_string, import_dependency)
             parent.register_dependency(dependency)
 
 

--- a/src/databricks/labs/ucx/source_code/python_linter.py
+++ b/src/databricks/labs/ucx/source_code/python_linter.py
@@ -4,12 +4,22 @@ import abc
 import ast
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TypeVar, Generic
 
-from databricks.labs.ucx.source_code.base import Linter, Advice, Advisory
-
+from databricks.labs.ucx.source_code.base import Linter, Advice, Advisory, Location
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ImportSource:
+    """
+    Represents an import statement in a Python file, including location of the import in tits source file
+    """
+
+    import_string: str
+    location: Location
 
 
 class MatchingVisitor(ast.NodeVisitor):
@@ -219,16 +229,70 @@ class PythonLinter(Linter):
         return linter.locate(ast.Call, [("run", ast.Attribute), ("notebook", ast.Attribute), ("dbutils", ast.Name)])
 
     @staticmethod
-    def list_import_sources(linter: ASTLinter) -> list[str]:
+    def list_import_sources(linter: ASTLinter) -> list[ImportSource]:
+        import_sources: list[ImportSource] = []
         nodes = linter.locate(ast.Import, [])
-        files = [alias.name for node in nodes for alias in node.names]
+        import_sources.extend(
+            ImportSource(
+                alias.name,
+                Location(
+                    code="import",
+                    message="",
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    start_col=node.col_offset,
+                    end_col=node.end_col_offset,
+                ),
+            )
+            for node in nodes
+            for alias in node.names
+        )
         nodes = linter.locate(ast.ImportFrom, [])
-        files.extend(node.module for node in nodes)
+        import_sources.extend(
+            ImportSource(
+                node.module,
+                Location(
+                    code="import from",
+                    message="",
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    start_col=node.col_offset,
+                    end_col=node.end_col_offset,
+                ),
+            )
+            for node in nodes
+        )
         nodes = linter.locate(ast.Call, [("import_module", ast.Attribute), ("importlib", ast.Name)])
-        files.extend(node.args[0].value for node in nodes)
+        import_sources.extend(
+            ImportSource(
+                node.args[0].value,
+                Location(
+                    code="import_module",
+                    message="",
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    start_col=node.col_offset,
+                    end_col=node.end_col_offset,
+                ),
+            )
+            for node in nodes
+        )
         nodes = linter.locate(ast.Call, [("__import__", ast.Attribute), ("importlib", ast.Name)])
-        files.extend(node.args[0].value for node in nodes)
-        return files
+        import_sources.extend(
+            ImportSource(
+                node.args[0].value,
+                Location(
+                    code="__import__",
+                    message="",
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    start_col=node.col_offset,
+                    end_col=node.end_col_offset,
+                ),
+            )
+            for node in nodes
+        )
+        return import_sources
 
     @staticmethod
     def list_appended_sys_paths(linter: ASTLinter) -> list[SysPath]:

--- a/src/databricks/labs/ucx/source_code/whitelist.py
+++ b/src/databricks/labs/ucx/source_code/whitelist.py
@@ -72,6 +72,13 @@ class PipPackage(KnownPackage):
         return UCCompatibility.NONE
 
 
+@dataclass
+class IncompatiblePackage(KnownPackage):
+
+    def compatibility_of(self, name: str) -> UCCompatibility:
+        return UCCompatibility.NONE
+
+
 class Whitelist:
     @classmethod
     def parse(cls, data: str):
@@ -91,6 +98,7 @@ class Whitelist:
             PythonBuiltinPackage(Identifier(**{"name": name, "version": python_version}), name)
             for name in sys.stdlib_module_names
         ]
+        known_packages.extend(IncompatiblePackage(Identifier(**{"name": name}), name) for name in ("s3fs",))
         if pips is not None:
             known_packages.extend(pips)
         self._known_packages: dict[str, list[KnownPackage]] = {}

--- a/tests/unit/source_code/samples/s3fs-python-compatibility-catalog.yml
+++ b/tests/unit/source_code/samples/s3fs-python-compatibility-catalog.yml
@@ -13,17 +13,3 @@ packages:
     compatibility: full
     failures:
       - some failure 1
----
-identifier:
-  name: s3fs
-  # all versions are incompatible
-top_level: s3fs
-packages:
-  - name: s3fs
-    compatibility: none
-    failures:
-      - the use of s3fs is deprecated
-  - name: s3fs.core
-    compatibility: none
-    failures:
-      - deprecated

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -143,7 +143,9 @@ def test_notebook_builds_leaf_dependency_graph():
     graph = DependencyGraph(dependency, None, loader)
     container = loader.load_dependency(dependency)
     container.build_dependency_graph(graph)
-    assert graph.paths == {"leaf1.py.txt"}
+    # Note that dependencies should not include itself as it leads to
+    # infinite walks.
+    assert graph.paths == set()
 
 
 def test_notebook_builds_depth1_dependency_graph():
@@ -156,7 +158,7 @@ def test_notebook_builds_depth1_dependency_graph():
     container = loader.load_dependency(dependency)
     container.build_dependency_graph(graph)
     actual = {path[2:] if path.startswith('./') else path for path in graph.paths}
-    assert actual == set(paths)
+    assert actual == set(paths[1:])
 
 
 def test_notebook_builds_depth2_dependency_graph():
@@ -169,7 +171,9 @@ def test_notebook_builds_depth2_dependency_graph():
     container = loader.load_dependency(dependency)
     container.build_dependency_graph(graph)
     actual = {path[2:] if path.startswith('./') else path for path in graph.paths}
-    assert actual == set(paths)
+    # Note that dependencies should not include itself as it leads to
+    # infinite walks.
+    assert actual == set(paths[1:])
 
 
 def test_notebook_builds_dependency_graph_avoiding_duplicates():
@@ -217,7 +221,9 @@ def test_notebook_builds_python_dependency_graph():
     container = loader.load_dependency(dependency)
     container.build_dependency_graph(graph)
     actual = {path[2:] if path.startswith('./') else path for path in graph.paths}
-    assert actual == set(paths)
+    # Note that dependencies should not include itself as it leads to
+    # infinite walks.
+    assert actual == set(paths[1:])
 
 
 def test_detects_manual_migration_in_dbutils_notebook_run_in_python_code_():

--- a/tests/unit/source_code/test_python_linter.py
+++ b/tests/unit/source_code/test_python_linter.py
@@ -1,4 +1,5 @@
-from databricks.labs.ucx.source_code.python_linter import ASTLinter, PythonLinter
+from databricks.labs.ucx.source_code.base import Location
+from databricks.labs.ucx.source_code.python_linter import ASTLinter, PythonLinter, ImportSource
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls():
@@ -19,27 +20,47 @@ for i in z:
 
 def test_linter_returns_empty_list_of_imports():
     linter = ASTLinter.parse('')
-    assert [] == PythonLinter.list_import_sources(linter)
+    assert not PythonLinter.list_import_sources(linter)
 
 
 def test_linter_returns_import():
     linter = ASTLinter.parse('import x')
-    assert ["x"] == PythonLinter.list_import_sources(linter)
+    assert [
+        ImportSource(
+            import_string="x",
+            location=Location(code="import", message="", start_line=1, start_col=0, end_line=1, end_col=8),
+        ),
+    ] == PythonLinter.list_import_sources(linter)
 
 
 def test_linter_returns_import_from():
     linter = ASTLinter.parse('from x import z')
-    assert ["x"] == PythonLinter.list_import_sources(linter)
+    assert [
+        ImportSource(
+            import_string="x",
+            location=Location(code="import from", message="", start_line=1, start_col=0, end_line=1, end_col=15),
+        ),
+    ] == PythonLinter.list_import_sources(linter)
 
 
 def test_linter_returns_import_module():
     linter = ASTLinter.parse('importlib.import_module("x")')
-    assert ["x"] == PythonLinter.list_import_sources(linter)
+    assert [
+        ImportSource(
+            import_string="x",
+            location=Location(code="import_module", message="", start_line=1, start_col=0, end_line=1, end_col=28),
+        ),
+    ] == PythonLinter.list_import_sources(linter)
 
 
 def test_linter_returns__import__():
     linter = ASTLinter.parse('importlib.__import__("x")')
-    assert ["x"] == PythonLinter.list_import_sources(linter)
+    assert [
+        ImportSource(
+            import_string="x",
+            location=Location(code="__import__", message="", start_line=1, start_col=0, end_line=1, end_col=25),
+        ),
+    ] == PythonLinter.list_import_sources(linter)
 
 
 def test_linter_returns_appended_absolute_paths():

--- a/tests/unit/source_code/test_s3fs.py
+++ b/tests/unit/source_code/test_s3fs.py
@@ -2,16 +2,20 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from databricks.labs.ucx.source_code.base import Advice, Deprecation
+from databricks.labs.ucx.source_code.base import Advice, Deprecation, Location
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.workspace import ObjectInfo, Language, ObjectType
 
-from databricks.labs.ucx.source_code.dependencies import DependencyLoader, SourceContainer, DependencyResolver
+from databricks.labs.ucx.source_code.dependencies import (
+    DependencyLoader,
+    SourceContainer,
+    DependencyResolver,
+)
+from databricks.labs.ucx.source_code.dependency_linters import ImportChecker
+
 from databricks.labs.ucx.source_code.notebook_migrator import NotebookMigrator
 from databricks.labs.ucx.source_code.whitelist import Whitelist
 from tests.unit import _load_sources, _download_side_effect
-
-S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
 
 
 @pytest.mark.parametrize(
@@ -22,11 +26,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message=S3FS_DEPRECATION_MESSAGE,
-                    start_line=0,
+                    message="Deprecated import: --string-- <- s3fs",
+                    start_line=1,
                     start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    end_line=1,
+                    end_col=11,
                 )
             ],
         ),
@@ -35,11 +39,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message=S3FS_DEPRECATION_MESSAGE,
-                    start_line=0,
+                    message="Deprecated import from: --string-- <- s3fs",
+                    start_line=1,
                     start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    end_line=1,
+                    end_col=26,
                 )
             ],
         ),
@@ -50,11 +54,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message=S3FS_DEPRECATION_MESSAGE,
-                    start_line=0,
+                    message="Deprecated import: --string-- <- s3fs",
+                    start_line=1,
                     start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    end_line=1,
+                    end_col=18,
                 )
             ],
         ),
@@ -64,11 +68,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message=S3FS_DEPRECATION_MESSAGE,
-                    start_line=0,
-                    start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    message="Deprecated import: --string-- <- s3fs",
+                    start_line=2,
+                    start_col=4,
+                    end_line=2,
+                    end_col=15,
                 )
             ],
         ),
@@ -77,11 +81,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message=S3FS_DEPRECATION_MESSAGE,
-                    start_line=0,
+                    message="Deprecated import: --string-- <- s3fs",
+                    start_line=1,
                     start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    end_line=1,
+                    end_col=16,
                 )
             ],
         ),
@@ -90,11 +94,11 @@ S3FS_DEPRECATION_MESSAGE = "Use of dependency s3fs is deprecated"
             [
                 Deprecation(
                     code='dependency-check',
-                    message='Use of dependency s3fs.subpackage is deprecated',
-                    start_line=0,
+                    message="Deprecated import from: --string-- <- s3fs.subpackage",
+                    start_line=1,
                     start_col=0,
-                    end_line=0,
-                    end_col=0,
+                    end_line=1,
+                    end_col=37,
                 )
             ],
         ),
@@ -107,11 +111,12 @@ def test_detect_s3fs_import(empty_index, source: str, expected: list[Advice]):
     resolver = DependencyResolver(whitelist)
     ws = create_autospec(WorkspaceClient)
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = source.encode("utf-8")
-    ws.workspace.get_status.return_value = ObjectInfo(path="path", object_type=ObjectType.FILE)
+    ws.workspace.get_status.return_value = ObjectInfo(path="--string--", object_type=ObjectType.FILE)
     migrator = NotebookMigrator(ws, empty_index, DependencyLoader(ws), resolver)
-    object_info = ObjectInfo(path="path", language=Language.PYTHON, object_type=ObjectType.FILE)
-    migrator.build_dependency_graph(object_info)
-    advices = list(resolver.get_advices())
+    object_info = ObjectInfo(path="--string--", language=Language.PYTHON, object_type=ObjectType.FILE)
+    graph = migrator.build_dependency_graph(object_info)
+    graph.register_processors(ImportChecker())
+    advices = list(graph.process())
     assert advices == expected
 
 
@@ -121,11 +126,12 @@ def test_detect_s3fs_import(empty_index, source: str, expected: list[Advice]):
         [
             Deprecation(
                 code='dependency-check',
-                message='Use of dependency s3fs is deprecated',
-                start_line=0,
+                # Note test input file names
+                message="Deprecated import: root9.py.txt <- leaf9 <- s3fs",
+                start_line=1,
                 start_col=0,
-                end_line=0,
-                end_col=0,
+                end_line=1,
+                end_col=11,
             ),
         ],
     ),
@@ -147,6 +153,47 @@ def test_detect_s3fs_import_in_dependencies(empty_index, expected: list[Advice])
     ws.workspace.get_status.side_effect = get_status_side_effect
     migrator = NotebookMigrator(ws, empty_index, DependencyLoader(ws), resolver)
     object_info = ObjectInfo(path="root9.py.txt", object_type=ObjectType.FILE)
-    migrator.build_dependency_graph(object_info)
-    advices = list(resolver.get_advices())
+    graph = migrator.build_dependency_graph(object_info)
+    graph.register_processors(ImportChecker())
+    advices = list(graph.process())
     assert advices == expected
+
+
+def test_location():
+    assert Advice(
+        code='dependency-check',
+        message="message",
+        start_line=1,
+        start_col=0,
+        end_line=1,
+        end_col=11,
+    ).as_location() == Location(
+        code='dependency-check',
+        message="message",
+        start_line=1,
+        start_col=0,
+        end_line=1,
+        end_col=11,
+    )
+
+
+def test_invalid_processors(empty_index):
+    paths = ["root9.py.txt", "leaf9.py.txt"]
+    sources: dict[str, str] = dict(zip(paths, _load_sources(SourceContainer, *paths)))
+    visited: dict[str, bool] = {}
+
+    def get_status_side_effect(*args):
+        path = args[0]
+        return ObjectInfo(path=path, object_type=ObjectType.FILE)
+
+    datas = _load_sources(SourceContainer, "s3fs-python-compatibility-catalog.yml")
+    whitelist = Whitelist.parse(datas[0])
+    resolver = DependencyResolver(whitelist)
+    ws = create_autospec(WorkspaceClient)
+    ws.workspace.download.side_effect = lambda *args, **kwargs: _download_side_effect(sources, visited, *args, **kwargs)
+    ws.workspace.get_status.side_effect = get_status_side_effect
+    migrator = NotebookMigrator(ws, empty_index, DependencyLoader(ws), resolver)
+    object_info = ObjectInfo(path="root9.py.txt", object_type=ObjectType.FILE)
+    graph = migrator.build_dependency_graph(object_info)
+    with pytest.raises(ValueError):
+        graph.register_processors()


### PR DESCRIPTION
## Changes

In order to report the location of imports that are either deprecated or will be migrated automatically, the location of the origin source code needs to be preserved. The graph of package dependencies now propagates location information such that reporting can indicate the hierarchy of dependencies that led to discovery of the deprecated import, or one that will be automatically migrated.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1418 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`
- [x] modifies dependency graph build logic 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
