### PR TITLE
Added functionality to migrate external tables using Create Table (No Sync)

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -217,7 +217,7 @@ class TablesMigrator:
         return self._migrate_acl(src_table, rule, grants)
 
     def _get_create_in_place_sql(self, src_table: Table, rule: Rule) -> str:
-        create_sql = str(next(self._backend.fetch(src_table.sql_show_create()))[0])
+        create_sql = str(next(self._backend.fetch(src_table.sql_show_create())).get("createtab_stmt"))
         statements = sqlglot.parse(create_sql, read='databricks')
         assert len(statements) == 1, 'Expected a single statement'
         create = statements[0]

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -143,6 +143,8 @@ class TablesMigrator:
             return self._migrate_dbfs_root_table(src_table.src, src_table.rule, grants)
         if src_table.src.what == What.EXTERNAL_SYNC:
             return self._migrate_external_table(src_table.src, src_table.rule, grants)
+        if src_table.src.what == What.EXTERNAL_NO_SYNC:
+            return self._migrate_table_ctas(src_table.src, src_table.rule, grants)
         logger.info(f"Table {src_table.src.key} is not supported for migration")
         return True
 

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -4,9 +4,12 @@ from collections import defaultdict
 from collections.abc import Iterable
 from functools import partial
 
+import sqlglot
+from sqlglot import expressions
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import WorkspaceClient
+
 
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant, GrantsCrawler, PrincipalACL
@@ -202,6 +205,34 @@ class TablesMigrator:
         self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
+
+    def _migrate_table_ctas(self, src_table: Table, rule: Rule, grants: list[Grant] | None = None):
+        table_migrate_sql = self._get_ctas_sql(src_table, rule)
+        logger.debug(f"Migrating table (CTAS) {src_table.key} to using SQL query: {table_migrate_sql}")
+        self._backend.execute(table_migrate_sql)
+        self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
+        self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
+        return self._migrate_acl(src_table, rule, grants)
+
+    def _get_ctas_sql(self, src_table: Table, rule: Rule) -> str:
+        create_sql = str(next(self._backend.fetch(src_table.sql_show_create()))[0])
+        statements = sqlglot.parse(create_sql, read='databricks')
+        assert len(statements) == 1, 'Expected a single statement'
+        create = statements[0]
+        assert isinstance(create, expressions.Create), 'Expected a CREATE statement'
+        # safely replace current table name with the updated catalog
+        for table_name in create.find_all(expressions.Table):
+            if table_name.db == src_table.database and table_name.name == src_table.name:
+                # See https://github.com/tobymao/sqlglot/issues/3311
+                new_table_name = expressions.Table(
+                    catalog=rule.catalog_name,
+                    db=rule.dst_schema,
+                    this=rule.dst_table,
+                )
+                table_name.replace(new_table_name)
+        # safely replace CREATE with CREATE IF NOT EXISTS
+        create.args['exists'] = True
+        return create.sql('databricks')
 
     def _migrate_acl(self, src: Table, rule: Rule, grants: list[Grant] | None):
         if grants is None:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -157,6 +157,9 @@ class Table:
             raise ValueError(msg)
         return f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} DEEP CLONE {escape_sql_identifier(self.key)};"
 
+    def sql_show_create(self):
+        return f"SHOW CREATE {self.kind} {self.safe_sql_key};"
+
     def sql_migrate_view(self, target_table_key):
         return f"CREATE VIEW IF NOT EXISTS {escape_sql_identifier(target_table_key)} AS {self.view_text};"
 

--- a/tests/unit/hive_metastore/tables/external_src_non_sync.json
+++ b/tests/unit/hive_metastore/tables/external_src_non_sync.json
@@ -1,0 +1,17 @@
+{
+  "src": {
+    "catalog": "hive_metastore",
+    "database": "db1_src",
+    "name": "external_src",
+    "object_type": "EXTERNAL",
+    "table_format": "AVRO"
+  },
+  "rule": {
+    "workspace_name": "workspace",
+    "catalog_name": "ucx_default",
+    "src_schema": "db1_src",
+    "dst_schema": "db1_dst",
+    "src_table": "external_src",
+    "dst_table": "external_dst"
+  }
+}

--- a/tests/unit/hive_metastore/tables/external_src_non_sync.json
+++ b/tests/unit/hive_metastore/tables/external_src_non_sync.json
@@ -4,7 +4,7 @@
     "database": "db1_src",
     "name": "external_src",
     "object_type": "EXTERNAL",
-    "table_format": "AVRO"
+    "table_format": "XML"
   },
   "rule": {
     "workspace_name": "workspace",

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -69,29 +69,33 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     assert (
-            "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
-            in backend.queries
+        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
+        in backend.queries
     )
     assert "SYNC TABLE ucx_default.db1_dst.managed_mnt FROM hive_metastore.db1_src.managed_mnt;" in backend.queries
     assert (
-               "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
-               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
-           ) in backend.queries
+        "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+    ) in backend.queries
     assert (
-               f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
-               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
-           ) in backend.queries
+        f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
+        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    ) in backend.queries
     assert "SYNC TABLE ucx_default.db1_dst.managed_other FROM hive_metastore.db1_src.managed_other;" in backend.queries
 
 
 def test_non_sync_tables_should_produce_proper_queries(ws):
     errors = {}
-    rows = {"SHOW CREATE TABLE":
-                [{"createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.external_src "
-                                    "(foo STRING,bar STRING) USING AVRO"
-                                    "LOCATION 's3://some_location/table';"}]
+    rows = {
+        "SHOW CREATE TABLE": [
+            {
+                "createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.external_src "
+                "(foo STRING,bar STRING) USING XML "
+                "LOCATION 's3://some_location/table'"
             }
+        ]
+    }
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     udf_crawler = UdfsCrawler(backend, "inventory_database")
@@ -113,20 +117,19 @@ def test_non_sync_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.EXTERNAL_NO_SYNC)
 
     assert (
-            "CREATE EXTERNAL TABLE ucx_default.db1_dst.external_dst "
-            "(foo STRING,bar STRING) USING AVRO"
-            "LOCATION 's3://some_location/table';"
-            in backend.queries
+        "CREATE EXTERNAL TABLE IF NOT EXISTS "
+        "ucx_default.db1_dst.external_dst (foo STRING, bar STRING) "
+        "USING XML LOCATION 's3://some_location/table'" in backend.queries
     )
     assert (
-               "ALTER TABLE hive_metastore.db1_src.external_dst "
-               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
-           ) in backend.queries
+        "ALTER TABLE hive_metastore.db1_src.external_src "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.external_dst');"
+    ) in backend.queries
     assert (
-               f"ALTER TABLE ucx_default.db1_dst.external_dst "
-               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
-           ) in backend.queries
+        f"ALTER TABLE ucx_default.db1_dst.external_dst "
+        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.external_src' , "
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    ) in backend.queries
 
 
 def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
@@ -483,13 +486,13 @@ def test_revert_migrated_tables_skip_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1")
     revert_queries = backend.queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_queries
     assert (
-            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_queries
+        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_queries
 
@@ -503,18 +506,18 @@ def test_revert_migrated_tables_including_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1", delete_managed=True)
     revert_with_managed_queries = backend.queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_with_managed_queries
     assert (
-            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_with_managed_queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest2" in revert_with_managed_queries
 
@@ -804,7 +807,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
         "SHOW CREATE TABLE": [
             {
                 "createtab_stmt": "CREATE OR REPLACE VIEW "
-                                  "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
+                "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
             }
         ],
     }

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -69,20 +69,64 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     assert (
-        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
-        in backend.queries
+            "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
+            in backend.queries
     )
     assert "SYNC TABLE ucx_default.db1_dst.managed_mnt FROM hive_metastore.db1_src.managed_mnt;" in backend.queries
     assert (
-        "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
-        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
-    ) in backend.queries
+               "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
+               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+           ) in backend.queries
     assert (
-        f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
-        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
-    ) in backend.queries
+               f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
+               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
+               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+           ) in backend.queries
     assert "SYNC TABLE ucx_default.db1_dst.managed_other FROM hive_metastore.db1_src.managed_other;" in backend.queries
+
+
+def test_non_sync_tables_should_produce_proper_queries(ws):
+    errors = {}
+    rows = {"SHOW CREATE TABLE":
+                [{"createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.external_src "
+                                    "(foo STRING,bar STRING) USING AVRO"
+                                    "LOCATION 's3://some_location/table';"}]
+            }
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_crawler = TablesCrawler(backend, "inventory_database")
+    udf_crawler = UdfsCrawler(backend, "inventory_database")
+    grant_crawler = GrantsCrawler(table_crawler, udf_crawler)
+    table_mapping = table_mapping_mock(["external_src_non_sync"])
+    group_manager = GroupManager(backend, ws, "inventory_database")
+    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    principal_grants = create_autospec(PrincipalACL)
+    table_migrate = TablesMigrator(
+        table_crawler,
+        grant_crawler,
+        ws,
+        backend,
+        table_mapping,
+        group_manager,
+        migration_status_refresher,
+        principal_grants,
+    )
+    table_migrate.migrate_tables(what=What.EXTERNAL_NO_SYNC)
+
+    assert (
+            "CREATE EXTERNAL TABLE ucx_default.db1_dst.external_dst "
+            "(foo STRING,bar STRING) USING AVRO"
+            "LOCATION 's3://some_location/table';"
+            in backend.queries
+    )
+    assert (
+               "ALTER TABLE hive_metastore.db1_src.external_dst "
+               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+           ) in backend.queries
+    assert (
+               f"ALTER TABLE ucx_default.db1_dst.external_dst "
+               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
+               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+           ) in backend.queries
 
 
 def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
@@ -439,13 +483,13 @@ def test_revert_migrated_tables_skip_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1")
     revert_queries = backend.queries
     assert (
-        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-        in revert_queries
+            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+            in revert_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_queries
     assert (
-        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-        in revert_queries
+            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+            in revert_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_queries
 
@@ -459,18 +503,18 @@ def test_revert_migrated_tables_including_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1", delete_managed=True)
     revert_with_managed_queries = backend.queries
     assert (
-        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-        in revert_with_managed_queries
+            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+            in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_with_managed_queries
     assert (
-        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-        in revert_with_managed_queries
+            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+            in revert_with_managed_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_with_managed_queries
     assert (
-        "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-        in revert_with_managed_queries
+            "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+            in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest2" in revert_with_managed_queries
 
@@ -760,7 +804,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
         "SHOW CREATE TABLE": [
             {
                 "createtab_stmt": "CREATE OR REPLACE VIEW "
-                "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
+                                  "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
             }
         ],
     }


### PR DESCRIPTION
relates to #1340
 A new feature allows migration of external tables in Databricks' Hive metastore using "Create Table (No Sync)" method, with new methods `_migrate_non_sync_table` and `_get_create_in_place_sql` for migration and SQL query generation. The `_migrate_dbfs_root_table` and `_migrate_acl` methods have also been updated. A new test case demonstrates migration of external tables while preserving their location and properties.