### PR TITLE
Migrate non delta dbfs tables using Create Table As Select (CTAS). Convert such tables to Delta tables.

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -217,7 +217,7 @@ class TablesMigrator:
         return self._migrate_acl(src_table, rule, grants)
 
     def _get_create_in_place_sql(self, src_table: Table, rule: Rule) -> str:
-        create_sql = str(next(self._backend.fetch(src_table.sql_show_create()))[0])
+        create_sql = str(next(self._backend.fetch(src_table.sql_show_create())).get("createtab_stmt"))
         statements = sqlglot.parse(create_sql, read='databricks')
         assert len(statements) == 1, 'Expected a single statement'
         create = statements[0]

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import re
 from collections import defaultdict
 from collections.abc import Iterable
 from functools import partial
@@ -236,7 +235,6 @@ class TablesMigrator:
         # safely replace current table name with the updated catalog
         for table_name in create.find_all(expressions.Table):
             if table_name.db == src_table.database and table_name.name == src_table.name:
-                # See https://github.com/tobymao/sqlglot/issues/3311
                 new_table_name = expressions.Table(
                     catalog=rule.catalog_name,
                     db=rule.dst_schema,
@@ -248,8 +246,10 @@ class TablesMigrator:
         return create.sql('databricks')
 
     def _get_create_ctas_sql(self, src_table: Table, rule: Rule) -> str:
-        create_sql = (f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(rule.as_uc_table_key)} "
-                      f"AS SELECT * FROM {src_table.safe_sql_key}")
+        create_sql = (
+            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(rule.as_uc_table_key)} "
+            f"AS SELECT * FROM {src_table.safe_sql_key}"
+        )
         return create_sql
 
     def _migrate_acl(self, src: Table, rule: Rule, grants: list[Grant] | None):

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -144,7 +144,7 @@ class TablesMigrator:
         if src_table.src.what == What.EXTERNAL_SYNC:
             return self._migrate_external_table(src_table.src, src_table.rule, grants)
         if src_table.src.what == What.EXTERNAL_NO_SYNC:
-            return self._migrate_non_sync_table(src_table.src, src_table.rule, grants)
+            return self._migrate_table_ctas(src_table.src, src_table.rule, grants)
         logger.info(f"Table {src_table.src.key} is not supported for migration")
         return True
 
@@ -208,16 +208,16 @@ class TablesMigrator:
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
 
-    def _migrate_non_sync_table(self, src_table: Table, rule: Rule, grants: list[Grant] | None = None):
-        table_migrate_sql = self._get_create_in_place_sql(src_table, rule)
+    def _migrate_table_ctas(self, src_table: Table, rule: Rule, grants: list[Grant] | None = None):
+        table_migrate_sql = self._get_ctas_sql(src_table, rule)
         logger.debug(f"Migrating table (CTAS) {src_table.key} to using SQL query: {table_migrate_sql}")
         self._backend.execute(table_migrate_sql)
         self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
 
-    def _get_create_in_place_sql(self, src_table: Table, rule: Rule) -> str:
-        create_sql = str(next(self._backend.fetch(src_table.sql_show_create())).get("createtab_stmt"))
+    def _get_ctas_sql(self, src_table: Table, rule: Rule) -> str:
+        create_sql = str(next(self._backend.fetch(src_table.sql_show_create()))[0])
         statements = sqlglot.parse(create_sql, read='databricks')
         assert len(statements) == 1, 'Expected a single statement'
         create = statements[0]

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -162,8 +162,10 @@ class Table:
     def sql_migrate_create_like(self, target_table_key):
         # Create table as a copy of the source table
         # https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-like.html
-        return (f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} LIKE "
-                f"{escape_sql_identifier(self.key)};")
+        return (
+            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} LIKE "
+            f"{escape_sql_identifier(self.key)};"
+        )
 
     def sql_migrate_dbfs(self, target_table_key):
         if not self.is_delta:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -124,6 +124,14 @@ class Table:
         return self.table_format.upper() in {"DELTA", "PARQUET", "CSV", "JSON", "ORC", "TEXT", "AVRO"}
 
     @property
+    def is_format_supported_for_create_like(self) -> bool:
+        # Based on documentation
+        # https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-like.html
+        if self.table_format is None:
+            return False
+        return self.table_format.upper() in {"DELTA", "PARQUET", "CSV", "JSON", "TEXT"}
+
+    @property
     def is_databricks_dataset(self) -> bool:
         if not self.location:
             return False
@@ -150,6 +158,12 @@ class Table:
 
     def sql_migrate_external(self, target_table_key):
         return f"SYNC TABLE {escape_sql_identifier(target_table_key)} FROM {escape_sql_identifier(self.key)};"
+
+    def sql_migrate_create_like(self, target_table_key):
+        # Create table as a copy of the source table
+        # https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-like.html
+        return (f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} LIKE "
+                f"{escape_sql_identifier(self.key)};")
 
     def sql_migrate_dbfs(self, target_table_key):
         if not self.is_delta:

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -994,10 +994,12 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Generator[Callable[
         elif non_delta:
             table_type = TableType.EXTERNAL  # pylint: disable=redefined-variable-type
             data_source_format = DataSourceFormat.JSON
-            storage_location = "dbfs:/databricks-datasets/iot-stream/data-device"
-            table_location = f"dbfs:/tmp/ucx_test_{make_random(4)}"
+            storage_location = f"dbfs:/tmp/ucx_test_{make_random(4)}"
             # Modified, otherwise it will identify the table as a DB Dataset
-            ddl = f"{ddl} USING json location '{table_location}' as SELECT * FROM JSON.`{storage_location}`"
+            ddl = (
+                f"{ddl} USING json location '{storage_location}' as SELECT * FROM "
+                f"JSON.`dbfs:/databricks-datasets/iot-stream/data-device`"
+            )
         elif external_csv is not None:
             table_type = TableType.EXTERNAL
             data_source_format = DataSourceFormat.CSV

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -992,10 +992,12 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Generator[Callable[
             # temporary (if not view)
             ddl = f"{ddl} AS {ctas}"
         elif non_delta:
-            table_type = TableType.MANAGED  # pylint: disable=redefined-variable-type
+            table_type = TableType.EXTERNAL  # pylint: disable=redefined-variable-type
             data_source_format = DataSourceFormat.JSON
             storage_location = "dbfs:/databricks-datasets/iot-stream/data-device"
-            ddl = f"{ddl} USING json LOCATION '{storage_location}'"
+            table_location = f"dbfs:/tmp/ucx_test_{make_random(4)}"
+            # Modified, otherwise it will identify the table as a DB Dataset
+            ddl = f"{ddl} USING json location '{table_location}' as SELECT * FROM JSON.`{storage_location}`"
         elif external_csv is not None:
             table_type = TableType.EXTERNAL
             data_source_format = DataSourceFormat.CSV

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -55,12 +55,13 @@ def test_migrate_managed_tables(ws, sql_backend, runtime_ctx, make_catalog):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_migrate_managed_parquet_tables(ws, sql_backend, runtime_ctx, make_catalog):
+def test_migrate_dbfs_non_delta_tables(ws, sql_backend, runtime_ctx, make_catalog):
     if not ws.config.is_azure:
         pytest.skip("temporary: only works in azure test env")
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
-    src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, non_delta=True,
-                                               schema_name=src_schema.name)
+    src_managed_table = runtime_ctx.make_table(
+        catalog_name=src_schema.catalog_name, non_delta=True, schema_name=src_schema.name
+    )
 
     dst_catalog = make_catalog()
     dst_schema = runtime_ctx.make_schema(catalog_name=dst_catalog.name, name=src_schema.name)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -55,6 +55,33 @@ def test_migrate_managed_tables(ws, sql_backend, runtime_ctx, make_catalog):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
+def test_migrate_managed_parquet_tables(ws, sql_backend, runtime_ctx, make_catalog):
+    if not ws.config.is_azure:
+        pytest.skip("temporary: only works in azure test env")
+    src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
+    src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, non_delta=True,
+                                               schema_name=src_schema.name)
+
+    dst_catalog = make_catalog()
+    dst_schema = runtime_ctx.make_schema(catalog_name=dst_catalog.name, name=src_schema.name)
+
+    logger.info(f"dst_catalog={dst_catalog.name}, managed_table={src_managed_table.full_name}")
+
+    rules = [Rule.from_src_dst(src_managed_table, dst_schema)]
+
+    runtime_ctx.with_table_mapping_rules(rules)
+    runtime_ctx.with_dummy_azure_resource_permission()
+    runtime_ctx.tables_migrator.migrate_tables(what=What.DBFS_ROOT_NON_DELTA)
+
+    target_tables = list(sql_backend.fetch(f"SHOW TABLES IN {dst_schema.full_name}"))
+    assert len(target_tables) == 1
+
+    target_table_properties = ws.tables.get(f"{dst_schema.full_name}.{src_managed_table.name}").properties
+    assert target_table_properties["upgraded_from"] == src_managed_table.full_name
+    assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_tables_with_cache_should_not_create_table(
     ws,
     sql_backend,

--- a/tests/unit/hive_metastore/tables/dbfs_parquet.json
+++ b/tests/unit/hive_metastore/tables/dbfs_parquet.json
@@ -1,0 +1,18 @@
+{
+  "src": {
+    "catalog": "hive_metastore",
+    "database": "db1_src",
+    "name": "managed_dbfs",
+    "object_type": "MANAGED",
+    "table_format": "PARQUET",
+    "location": "dbfs:/some_location"
+  },
+  "rule": {
+    "workspace_name": "workspace",
+    "catalog_name": "ucx_default",
+    "src_schema": "db1_src",
+    "dst_schema": "db1_dst",
+    "src_table": "managed_dbfs",
+    "dst_table": "managed_dbfs"
+  }
+}

--- a/tests/unit/hive_metastore/tables/external_src_non_sync.json
+++ b/tests/unit/hive_metastore/tables/external_src_non_sync.json
@@ -4,7 +4,7 @@
     "database": "db1_src",
     "name": "external_src",
     "object_type": "EXTERNAL",
-    "table_format": "XML"
+    "table_format": "AVRO"
   },
   "rule": {
     "workspace_name": "workspace",

--- a/tests/unit/hive_metastore/tables/external_src_non_sync.json
+++ b/tests/unit/hive_metastore/tables/external_src_non_sync.json
@@ -4,7 +4,7 @@
     "database": "db1_src",
     "name": "external_src",
     "object_type": "EXTERNAL",
-    "table_format": "AVRO"
+    "table_format": "XML"
   },
   "rule": {
     "workspace_name": "workspace",

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -134,7 +134,15 @@ def test_non_sync_tables_should_produce_proper_queries(ws):
 
 def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
     errors = {}
-    rows = {}
+    rows = {
+        "SHOW CREATE TABLE": [
+            {
+                "createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.managed_dbfs "
+                "(foo STRING,bar STRING) USING PARQUET "
+                "LOCATION 's3://some_location/table'"
+            }
+        ]
+    }
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     udf_crawler = UdfsCrawler(backend, "inventory_database")
@@ -156,9 +164,9 @@ def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.DBFS_ROOT_NON_DELTA)
 
     assert (
-        "CREATE TABLE IF NOT EXISTS "
-        "ucx_default.db1_dst.managed_dbfs LIKE "
-        "hive_metastore.db1_src.managed_dbfs;" in backend.queries
+        "CREATE  TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs (foo STRING, "
+        "bar STRING) USING PARQUET  AS SELECT * FROM hive_metastore.db1_src.managed_dbfs"
+        in backend.queries
     )
     assert (
         "ALTER TABLE hive_metastore.db1_src.managed_dbfs "

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -69,29 +69,33 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     assert (
-            "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
-            in backend.queries
+        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs DEEP CLONE hive_metastore.db1_src.managed_dbfs;"
+        in backend.queries
     )
     assert "SYNC TABLE ucx_default.db1_dst.managed_mnt FROM hive_metastore.db1_src.managed_mnt;" in backend.queries
     assert (
-               "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
-               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
-           ) in backend.queries
+        "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+    ) in backend.queries
     assert (
-               f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
-               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
-           ) in backend.queries
+        f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
+        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    ) in backend.queries
     assert "SYNC TABLE ucx_default.db1_dst.managed_other FROM hive_metastore.db1_src.managed_other;" in backend.queries
 
 
 def test_non_sync_tables_should_produce_proper_queries(ws):
     errors = {}
-    rows = {"SHOW CREATE TABLE":
-                [{"createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.external_src "
-                                    "(foo STRING,bar STRING) USING AVRO"
-                                    "LOCATION 's3://some_location/table';"}]
+    rows = {
+        "SHOW CREATE TABLE": [
+            {
+                "createtab_stmt": "CREATE EXTERNAL TABLE hive_metastore.db1_src.external_src "
+                "(foo STRING,bar STRING) USING XML "
+                "LOCATION 's3://some_location/table'"
             }
+        ]
+    }
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     udf_crawler = UdfsCrawler(backend, "inventory_database")
@@ -113,20 +117,19 @@ def test_non_sync_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.EXTERNAL_NO_SYNC)
 
     assert (
-            "CREATE EXTERNAL TABLE ucx_default.db1_dst.external_dst "
-            "(foo STRING,bar STRING) USING AVRO"
-            "LOCATION 's3://some_location/table';"
-            in backend.queries
+        "CREATE EXTERNAL TABLE IF NOT EXISTS "
+        "ucx_default.db1_dst.external_dst (foo STRING, bar STRING) "
+        "USING XML LOCATION 's3://some_location/table'" in backend.queries
     )
     assert (
-               "ALTER TABLE hive_metastore.db1_src.external_dst "
-               "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
-           ) in backend.queries
+        "ALTER TABLE hive_metastore.db1_src.external_src "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.external_dst');"
+    ) in backend.queries
     assert (
-               f"ALTER TABLE ucx_default.db1_dst.external_dst "
-               f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-               f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
-           ) in backend.queries
+        f"ALTER TABLE ucx_default.db1_dst.external_dst "
+        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.external_src' , "
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    ) in backend.queries
 
 
 def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
@@ -483,13 +486,13 @@ def test_revert_migrated_tables_skip_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1")
     revert_queries = backend.queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_queries
     assert (
-            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_queries
+        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_queries
 
@@ -503,18 +506,18 @@ def test_revert_migrated_tables_including_managed(ws):
     table_migrate.revert_migrated_tables(schema="test_schema1", delete_managed=True)
     revert_with_managed_queries = backend.queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest1" in revert_with_managed_queries
     assert (
-            "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER VIEW hive_metastore.test_schema1.test_view1 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP VIEW IF EXISTS cat1.schema1.dest_view1" in revert_with_managed_queries
     assert (
-            "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
-            in revert_with_managed_queries
+        "ALTER TABLE hive_metastore.test_schema1.test_table2 UNSET TBLPROPERTIES IF EXISTS('upgraded_to');"
+        in revert_with_managed_queries
     )
     assert "DROP TABLE IF EXISTS cat1.schema1.dest2" in revert_with_managed_queries
 
@@ -804,7 +807,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
         "SHOW CREATE TABLE": [
             {
                 "createtab_stmt": "CREATE OR REPLACE VIEW "
-                                  "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
+                "hive_metastore.db1_src.view_src AS SELECT * FROM db1_src.managed_dbfs"
             }
         ],
     }

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -132,6 +132,45 @@ def test_non_sync_tables_should_produce_proper_queries(ws):
     ) in backend.queries
 
 
+def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
+    errors = {}
+    rows = {}
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    table_crawler = TablesCrawler(backend, "inventory_database")
+    udf_crawler = UdfsCrawler(backend, "inventory_database")
+    grant_crawler = GrantsCrawler(table_crawler, udf_crawler)
+    table_mapping = table_mapping_mock(["dbfs_parquet"])
+    group_manager = GroupManager(backend, ws, "inventory_database")
+    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    principal_grants = create_autospec(PrincipalACL)
+    table_migrate = TablesMigrator(
+        table_crawler,
+        grant_crawler,
+        ws,
+        backend,
+        table_mapping,
+        group_manager,
+        migration_status_refresher,
+        principal_grants,
+    )
+    table_migrate.migrate_tables(what=What.DBFS_ROOT_NON_DELTA)
+
+    assert (
+        "CREATE TABLE IF NOT EXISTS "
+        "ucx_default.db1_dst.managed_dbfs LIKE "
+        "hive_metastore.db1_src.managed_dbfs;" in backend.queries
+    )
+    assert (
+        "ALTER TABLE hive_metastore.db1_src.managed_dbfs "
+        "SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');"
+    ) in backend.queries
+    assert (
+        f"ALTER TABLE ucx_default.db1_dst.managed_dbfs "
+        f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    ) in backend.queries
+
+
 def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
     errors = {}
     rows = {}

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -164,9 +164,8 @@ def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
     table_migrate.migrate_tables(what=What.DBFS_ROOT_NON_DELTA)
 
     assert (
-        "CREATE  TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs (foo STRING, "
-        "bar STRING) USING PARQUET  AS SELECT * FROM hive_metastore.db1_src.managed_dbfs"
-        in backend.queries
+        "CREATE TABLE IF NOT EXISTS ucx_default.db1_dst.managed_dbfs "
+        "AS SELECT * FROM hive_metastore.db1_src.managed_dbfs" in backend.queries
     )
     assert (
         "ALTER TABLE hive_metastore.db1_src.managed_dbfs "


### PR DESCRIPTION
Migrate Non-Delta DBFS root tables to Managed Delta tables.
closes #1340
This release enhances migration for non-delta DBFS tables, supporting more table types and configurations. New methods improve CTAS functionality with safer SQL statement generation. Additional table format compatibility, new creation methods, and updated integration tests are included. Grant assignments during migration are now supported.