### PR TITLE
Fix integration tests flakiness

### DIFF
--- a/src/databricks/labs/ucx/installer/logs.py
+++ b/src/databricks/labs/ucx/installer/logs.py
@@ -196,7 +196,7 @@ class TaskRunWarningRecorder:
                 continue
             error_messages.append(message)
         if len(error_messages) > 0:
-            raise InternalError(__version__+"\n".join(error_messages))
+            raise InternalError("\n".join(error_messages))
         return log_records
 
     @staticmethod

--- a/src/databricks/labs/ucx/installer/logs.py
+++ b/src/databricks/labs/ucx/installer/logs.py
@@ -192,7 +192,8 @@ class TaskRunWarningRecorder:
                 continue
             # This error comes up during testing, when ucx crawls tables & schemas created by other tests,
             # but couldn't fetch the grants later as they have already been dropped by those tests. Ignore them
-            if "Couldn't fetch grants" in message and self._is_testing():
+            errors_in_test = ["Couldn't fetch grants", "Couldn't find permission"]
+            if any(error in message for error in errors_in_test) and self._is_testing():
                 continue
             error_messages.append(message)
         if len(error_messages) > 0:

--- a/src/databricks/labs/ucx/installer/logs.py
+++ b/src/databricks/labs/ucx/installer/logs.py
@@ -191,9 +191,15 @@ class TaskRunWarningRecorder:
             if 'databricks workspace export /' in message:
                 continue
             error_messages.append(message)
+            if "Couldn't fetch grants" in message and self._is_testing():
+                continue
         if len(error_messages) > 0:
             raise InternalError("\n".join(error_messages))
         return log_records
+
+    @staticmethod
+    def _is_testing():
+        return "+" in __version__
 
 
 class TaskLogger(contextlib.AbstractContextManager):

--- a/src/databricks/labs/ucx/installer/logs.py
+++ b/src/databricks/labs/ucx/installer/logs.py
@@ -190,11 +190,13 @@ class TaskRunWarningRecorder:
             # Ignore the prompt to troubleshoot, which is the error
             if 'databricks workspace export /' in message:
                 continue
-            error_messages.append(message)
+            # This error comes up during testing, when ucx crawls tables & schemas created by other tests,
+            # but couldn't fetch the grants later as they have already been dropped by those tests. Ignore them
             if "Couldn't fetch grants" in message and self._is_testing():
                 continue
+            error_messages.append(message)
         if len(error_messages) > 0:
-            raise InternalError("\n".join(error_messages))
+            raise InternalError(__version__+"\n".join(error_messages))
         return log_records
 
     @staticmethod

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1209,8 +1209,10 @@ def make_dbfs_data_copy(ws, make_cluster, env_or_skip):
 
 
 @pytest.fixture
-def make_mounted_location(make_random, env_or_skip):
-    return (
-        f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/c',
-        f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{make_random(4)}',
-    )
+def make_mounted_location(make_random, make_dbfs_data_copy, env_or_skip):
+    # make a copy of src data to a new location to avoid overlapping UC table path that will fail other
+    # external table migration tests
+    existing_mounted_location = f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/c'
+    new_mounted_location = f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{make_random(4)}'
+    make_dbfs_data_copy(src_path=existing_mounted_location, dst_path=new_mounted_location)
+    return new_mounted_location

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -478,7 +478,6 @@ class TestInstallationContext(TestRuntimeContext):
         self._make_random = make_random_fixture
         self._make_acc_group = make_acc_group_fixture
         self._make_user = make_user_fixture
-        self._product_info = ProductInfo.for_testing(WorkspaceConfig)
 
     def make_ucx_group(self, workspace_group_name=None, account_group_name=None):
         if not workspace_group_name:
@@ -562,7 +561,7 @@ class TestInstallationContext(TestRuntimeContext):
 
     @cached_property
     def product_info(self):
-        return self._product_info
+        return ProductInfo.for_testing(WorkspaceConfig)
 
     @cached_property
     def tasks(self):
@@ -648,13 +647,7 @@ def installation_ctx(  # pylint: disable=too-many-arguments
         make_acc_group,
         make_user,
     )
-    yield ctx.replace(
-        workspace_client=ws,
-        sql_backend=sql_backend,
-        extend_prompts={
-            r".*We have identified one or more cluster.*": "no",
-        },
-    )
+    yield ctx.replace(workspace_client=ws, sql_backend=sql_backend)
     ctx.workspace_installation.uninstall()
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -648,9 +648,13 @@ def installation_ctx(  # pylint: disable=too-many-arguments
         make_acc_group,
         make_user,
     )
-    yield ctx.replace(workspace_client=ws,
-                      sql_backend=sql_backend,
-                      extend_prompts={r".*We have identified one or more cluster.*": "no",})
+    yield ctx.replace(
+        workspace_client=ws,
+        sql_backend=sql_backend,
+        extend_prompts={
+            r".*We have identified one or more cluster.*": "no",
+        },
+    )
     ctx.workspace_installation.uninstall()
 
 

--- a/tests/integration/framework/test_fixtures.py
+++ b/tests/integration/framework/test_fixtures.py
@@ -100,10 +100,5 @@ def test_table_fixture(make_table):
     logger.info(f'Created table with properties: {make_table(tbl_properties={"test": "tableproperty"})}')
 
 
-def test_dbfs_fixture(make_dbfs_data_copy, make_random, env_or_skip):
-    existing_mounted_location = f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/c'
-    new_mounted_location = f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{make_random(4)}'
-    logger.info(
-        f"Created new dbfs data copy: "
-        f"{make_dbfs_data_copy(src_path=existing_mounted_location, dst_path=new_mounted_location)}"
-    )
+def test_dbfs_fixture(make_mounted_location):
+    logger.info(f"Created new dbfs data copy:{make_mounted_location}")

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -144,14 +144,9 @@ def test_migrate_external_table(
     runtime_ctx,
     make_catalog,
     make_mounted_location,
-    make_dbfs_data_copy,
 ):
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
-    # make a copy of src data to a new location to avoid overlapping UC table path that will fail other
-    # external table migration tests
-    existing_mounted_location, new_mounted_location = make_mounted_location
-    make_dbfs_data_copy(src_path=existing_mounted_location, dst_path=new_mounted_location)
-    src_external_table = runtime_ctx.make_table(schema_name=src_schema.name, external_csv=new_mounted_location)
+    src_external_table = runtime_ctx.make_table(schema_name=src_schema.name, external_csv=make_mounted_location)
     dst_catalog = make_catalog()
     dst_schema = runtime_ctx.make_schema(catalog_name=dst_catalog.name, name=src_schema.name)
     logger.info(f"dst_catalog={dst_catalog.name}, external_table={src_external_table.full_name}")
@@ -426,12 +421,12 @@ def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_cata
 
 
 @pytest.fixture
-def prepared_principal_acl(runtime_ctx, env_or_skip, make_dbfs_data_copy, make_catalog, make_schema):
+def prepared_principal_acl(runtime_ctx, env_or_skip, make_mounted_location, make_catalog, make_schema):
     src_schema = make_schema(catalog_name="hive_metastore")
     src_external_table = runtime_ctx.make_table(
         catalog_name=src_schema.catalog_name,
         schema_name=src_schema.name,
-        external_csv=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/c',
+        external_csv=make_mounted_location,
     )
     dst_catalog = make_catalog()
     dst_schema = make_schema(catalog_name=dst_catalog.name, name=src_schema.name)


### PR DESCRIPTION
## Changes
- Fix `TypeError: 'tuple' object is not callable` for `test_migrate_external_table`
- Fix tests that migrate external tables failed due to UC blocking tables with overlapping paths
- Fix assessment tests that failed due to expected error messages in `parse_logs`, by skipping over these error messages if ucx version is testing

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1436, #1424

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
