### PR TITLE
Fix test failure: `test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only`

### DIFF
--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import time
 from datetime import timedelta
 
 import pytest
@@ -100,10 +99,11 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     group_manager.reflect_account_groups_on_workspace()
     group_manager.delete_original_workspace_groups()
 
-    time.sleep(5)  # It takes a moment to delete the group through the API
-
-    with pytest.raises(NotFound):
+    @retried(on=[NotFound], timeout=timedelta(seconds=5))
+    def wait():
         ws.groups.get(ws_group.id)
+
+    wait()
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from datetime import timedelta
 
 import pytest
@@ -98,6 +99,8 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     group_manager.rename_groups()
     group_manager.reflect_account_groups_on_workspace()
     group_manager.delete_original_workspace_groups()
+
+    time.sleep(5)  # It takes a moment to delete the group through the API
 
     with pytest.raises(NotFound):
         ws.groups.get(ws_group.id)


### PR DESCRIPTION
## Changes
Give the API five seconds to delete the group.

### Linked issues

Resolves #1277

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
