### PR TITLE
Fix unused arguments in CommandContextBackend

### DIFF
--- a/tests/integration/test_ext_hms.py
+++ b/tests/integration/test_ext_hms.py
@@ -37,10 +37,12 @@ class CommandContextBackend(SqlBackend):
         self._debug_truncate_bytes = debug_truncate_bytes if isinstance(debug_truncate_bytes, int) else 96
 
     def execute(self, sql: str, *, catalog: str | None = None, schema: str | None = None) -> None:
+        _ = catalog, schema
         logger.debug(f"[api][execute] {self._only_n_bytes(sql, self._debug_truncate_bytes)}")
         self._sql.run(sql)
 
     def fetch(self, sql: str, *, catalog: str | None = None, schema: str | None = None) -> Iterator[Row]:
+        _ = catalog, schema
         logger.debug(f"[api][fetch] {self._only_n_bytes(sql, self._debug_truncate_bytes)}")
         return self._sql.run(sql, result_as_json=True)
 


### PR DESCRIPTION
## Changes
Mark the unused arguments with the `_ = <parameter>` convention to avoid the linter complaining

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
