### PR TITLE
Fix `test_migrate_managed_tables_with_principal_acl_azure`

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -442,7 +442,7 @@ def prepared_principal_acl(runtime_ctx, env_or_skip, make_mounted_location, make
 def test_migrate_managed_tables_with_principal_acl_azure(
     ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster
 ):
-    if ws.config.is_azure:
+    if not ws.config.is_azure:
         pytest.skip("only works in azure test env")
     ctx, table_full_name = prepared_principal_acl
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -442,6 +442,8 @@ def prepared_principal_acl(runtime_ctx, env_or_skip, make_mounted_location, make
 def test_migrate_managed_tables_with_principal_acl_azure(
     ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster
 ):
+    if ws.config.is_azure:
+        pytest.skip("only works in azure test env")
     ctx, table_full_name = prepared_principal_acl
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
     ctx.with_dummy_resource_permission()


### PR DESCRIPTION
## Changes
- make sure `test_migrate_managed_tables_with_principal_acl_azure` only runs on Azure

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
