### PR TITLE
Fix UCX policy creation when instance pool is specified

### DIFF
--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -97,14 +97,17 @@ class ClusterPolicyInstaller:
             policy_definition["instance_pool_id"] = self._policy_config(instance_pool_id)
             # 'node_type_id' cannot be supplied when an instance pool ID is provided
             policy_definition.pop("node_type_id")
+            # 'availability' cannot be supplied when an instance pool ID is provided
+            policy_definition.pop("aws_attributes.availability", "")
         for key, value in conf.items():
             policy_definition[f"spark_conf.{key}"] = self._policy_config(value)
         if self._ws.config.is_aws:
             if instance_profile:
                 policy_definition["aws_attributes.instance_profile_arn"] = self._policy_config(instance_profile)
-            policy_definition["aws_attributes.availability"] = self._policy_config(
-                compute.AwsAvailability.ON_DEMAND.value
-            )
+            if not instance_pool_id:
+                policy_definition["aws_attributes.availability"] = self._policy_config(
+                    compute.AwsAvailability.ON_DEMAND.value
+                )
         elif self._ws.config.is_azure:
             policy_definition["azure_attributes.availability"] = self._policy_config(
                 compute.AzureAvailability.ON_DEMAND_AZURE.value

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -56,6 +56,8 @@ def test_migrate_managed_tables(ws, sql_backend, runtime_ctx, make_catalog):
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_dbfs_non_delta_tables(ws, sql_backend, runtime_ctx, make_catalog):
+    if not ws.config.is_azure:
+        pytest.skip("temporary: only works in azure test env")
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(
         catalog_name=src_schema.catalog_name, non_delta=True, schema_name=src_schema.name

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -56,8 +56,6 @@ def test_migrate_managed_tables(ws, sql_backend, runtime_ctx, make_catalog):
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_dbfs_non_delta_tables(ws, sql_backend, runtime_ctx, make_catalog):
-    if not ws.config.is_azure:
-        pytest.skip("temporary: only works in azure test env")
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(
         catalog_name=src_schema.catalog_name, non_delta=True, schema_name=src_schema.name

--- a/tests/unit/installer/test_policy.py
+++ b/tests/unit/installer/test_policy.py
@@ -438,7 +438,6 @@ def test_cluster_policy_instance_pool():
     policy_expected = {
         "spark_version": {"type": "fixed", "value": "14.2.x-scala2.12"},
         "instance_pool_id": {"type": "fixed", "value": "instance_pool_1"},
-        "aws_attributes.availability": {"type": "fixed", "value": "ON_DEMAND"},
     }
     # test the instance pool is added to the cluster policy
     ws.cluster_policies.create.assert_called_with(


### PR DESCRIPTION
## Changes
In AWS, `aws_attributes.availability` now conflicts with `instance_pool_id` in a cluster policy

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
