### PR TITLE
Use managed upload token for codecov.io

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,8 @@ env:
 
 permissions:
   id-token: write
+  contents: read
+  pull-requests: write
 
 jobs:
   ci:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,11 +17,6 @@ on:
 env:
   HATCH_VERSION: 1.9.4
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
-
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -47,7 +42,7 @@ jobs:
       - name: Publish test coverage
         uses: codecov/codecov-action@v4
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Publish test coverage
         uses: codecov/codecov-action@v4
+        with:
+          use_oidc: true
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,9 @@ on:
 env:
   HATCH_VERSION: 1.9.4
 
+permissions:
+  id-token: write
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
v4 of codecov-action no longer supports tokenless upload. ~Let's try avoiding tokens altogether by using OIDC.~ OIDC doesn't seem to work: https://github.com/codecov/codecov-action/issues/1378, using managed `CODECOV_TOKEN` secrets.