### PR TITLE
Extended wait time for group checking during tests

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -166,7 +166,7 @@ def test_running_real_remove_backup_groups_job(ws, installation_ctx):
 
     installation_ctx.deployed_workflows.run_workflow("remove-workspace-local-backup-groups")
 
-    @retried(on=[NotFound], timeout=timedelta(seconds=60))
+    @retried(on=[NotFound], timeout=timedelta(seconds=120))
     def wait():
         ws.groups.get(ws_group_a.id)
 

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -99,7 +99,7 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     group_manager.reflect_account_groups_on_workspace()
     group_manager.delete_original_workspace_groups()
 
-    @retried(on=[NotFound], timeout=timedelta(seconds=5))
+    @retried(on=[NotFound], timeout=timedelta(seconds=120))
     def wait():
         ws.groups.get(ws_group.id)
 


### PR DESCRIPTION
## Changes
Due to eventual consistency, wait up to 2 minutes before failed tests involved group APIs

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
