### PR TITLE
Refactor `WorkspaceInstaller` using service factory

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -164,7 +164,7 @@ class WorkspaceInstaller(WorkspaceContext):
             config,
             self.installation,
             self.install_state,
-            self._ws,
+            self.workspace_client,
             self.wheels,
             self.product_info,
             verify_timeout,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -113,23 +113,6 @@ def extract_major_minor(version_string):
 
 class WorkspaceInstaller(WorkspaceContext):
 
-    @cached_property
-    def upgrades(self):
-        return Upgrades(self.product_info, self.installation)
-
-    @cached_property
-    def policy_installer(self):
-        return ClusterPolicyInstaller(self.installation, self.workspace_client, self.prompts)
-
-    @cached_property
-    def installation(self):
-        try:
-            installation = self.product_info.current_installation(self.workspace_client)
-        except NotFound:
-            if self._force_install == "user":
-                return Installation.assume_user_home(self.workspace_client, self.product_info.product_name())
-            return Installation.assume_global(self.workspace_client, self.product_info.product_name())
-
     def __init__(
         self,
         ws: WorkspaceClient,
@@ -146,6 +129,23 @@ class WorkspaceInstaller(WorkspaceContext):
 
         self._is_account_install = self._force_install == "account"
         self._tasks = tasks if tasks else Workflows.all().tasks()
+
+    @cached_property
+    def upgrades(self):
+        return Upgrades(self.product_info, self.installation)
+
+    @cached_property
+    def policy_installer(self):
+        return ClusterPolicyInstaller(self.installation, self.workspace_client, self.prompts)
+
+    @cached_property
+    def installation(self):
+        try:
+            return self.product_info.current_installation(self.workspace_client)
+        except NotFound:
+            if self._force_install == "user":
+                return Installation.assume_user_home(self.workspace_client, self.product_info.product_name())
+            return Installation.assume_global(self.workspace_client, self.product_info.product_name())
 
     def run(
         self,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -125,15 +125,15 @@ class WorkspaceInstaller(WorkspaceContext):
             msg = "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"
             raise SystemExit(msg)
         try:
-            current = self.product_info.current_installation(ws)
+            installation = self.product_info.current_installation(ws)
         except NotFound:
             if self._force_install == "user":
-                current = Installation.assume_user_home(ws, self.product_info.product_name())
+                installation = Installation.assume_user_home(ws, self.product_info.product_name())
             else:
-                current = Installation.assume_global(ws, self.product_info.product_name())
-        self.replace(installation=current)
+                installation = Installation.assume_global(ws, self.product_info.product_name())
+        self.replace(installation=installation)
 
-        self._is_account_install = environ.get("UCX_FORCE_INSTALL") == "account"
+        self._is_account_install = self._force_install == "account"
         self._tasks = tasks if tasks else Workflows.all().tasks()
 
     def run(

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -618,7 +618,7 @@ class AccountInstaller(AccountContext):
         logger.info(f"Installing UCX on workspace {workspace.deployment_name}")
         return WorkspaceInstaller(workspace_client).replace(product_info=self.product_info, prompts=self.prompts)
 
-    def run(self):
+    def install_on_account(self):
         ctx = AccountContext(self._get_safe_account_client())
         default_config = None
         confirmed = False
@@ -663,7 +663,7 @@ if __name__ == "__main__":
     force_install = env.get("UCX_FORCE_INSTALL")
     if force_install == "account":
         account_installer = AccountInstaller(AccountClient(product="ucx", product_version=__version__))
-        account_installer.run()
+        account_installer.install_on_account()
     else:
         workspace_installer = WorkspaceInstaller(WorkspaceClient(product="ucx", product_version=__version__))
         workspace_installer.run()

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -402,7 +402,7 @@ class WorkspaceInstallation(InstallationMixin):
         self._sql_backend = sql_backend
         self._workflows_installer = workflows_installer
         self._prompts = prompts
-        self.product_info = product_info
+        self._product_info = product_info
         environ = dict(os.environ.items())
         self._is_account_install = environ.get("UCX_FORCE_INSTALL") == "account"
         self._skip_dashboards = skip_dashboards
@@ -451,7 +451,7 @@ class WorkspaceInstallation(InstallationMixin):
         return self._installation.install_folder()
 
     def run(self):
-        logger.info(f"Installing UCX v{self.product_info.version()}")
+        logger.info(f"Installing UCX v{self._product_info.version()}")
         install_tasks = [self._create_database]
         if not self._skip_dashboards:
             install_tasks.append(self._create_dashboards)
@@ -502,7 +502,7 @@ class WorkspaceInstallation(InstallationMixin):
         ):
             return
         # TODO: this is incorrect, fetch the remote version (that appeared only in Feb 2024)
-        logger.info(f"Deleting UCX v{self.product_info.version()} from {self._ws.config.host}")
+        logger.info(f"Deleting UCX v{self._product_info.version()} from {self._ws.config.host}")
         try:
             self._installation.files()
         except NotFound:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -5,7 +5,6 @@ import os
 import re
 import time
 import webbrowser
-from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
@@ -19,7 +18,6 @@ from databricks.labs.blueprint.upgrades import Upgrades
 from databricks.labs.blueprint.wheels import (
     ProductInfo,
     Version,
-    WheelsV2,
     find_project_root,
 )
 from databricks.labs.lsql.backends import SqlBackend, StatementExecutionBackend
@@ -40,7 +38,7 @@ from databricks.labs.ucx.assessment.init_scripts import GlobalInitScriptInfo
 from databricks.labs.ucx.assessment.jobs import JobInfo, SubmitRunInfo
 from databricks.labs.ucx.assessment.pipelines import PipelineInfo
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import AccountContext
+from databricks.labs.ucx.contexts.cli_command import AccountContext, WorkspaceContext
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore.grants import Grant
@@ -112,27 +110,29 @@ def extract_major_minor(version_string):
     return None
 
 
-class WorkspaceInstaller:
+class WorkspaceInstaller(WorkspaceContext):
     def __init__(
         self,
-        prompts: Prompts,
-        installation: Installation,
         ws: WorkspaceClient,
-        product_info: ProductInfo,
         environ: dict[str, str] | None = None,
         tasks: list[Task] | None = None,
     ):
+        super().__init__(ws)
         if not environ:
             environ = dict(os.environ.items())
+        self._force_install = environ.get("UCX_FORCE_INSTALL")
         if "DATABRICKS_RUNTIME_VERSION" in environ:
             msg = "WorkspaceInstaller is not supposed to be executed in Databricks Runtime"
             raise SystemExit(msg)
-        self._ws = ws
-        self._installation = installation
-        self._prompts = prompts
-        self._policy_installer = ClusterPolicyInstaller(installation, ws, prompts)
-        self._product_info = product_info
-        self._force_install = environ.get("UCX_FORCE_INSTALL")
+        try:
+            current = self.product_info.current_installation(ws)
+        except NotFound:
+            if self._force_install == "user":
+                current = Installation.assume_user_home(ws, self.product_info.product_name())
+            else:
+                current = Installation.assume_global(ws, self.product_info.product_name())
+        self.replace(installation=current)
+
         self._is_account_install = environ.get("UCX_FORCE_INSTALL") == "account"
         self._tasks = tasks if tasks else Workflows.all().tasks()
 
@@ -140,40 +140,33 @@ class WorkspaceInstaller:
         self,
         default_config: WorkspaceConfig | None = None,
         verify_timeout=timedelta(minutes=2),
-        sql_backend_factory: Callable[[WorkspaceConfig], SqlBackend] | None = None,
-        wheel_builder_factory: Callable[[], WheelsV2] | None = None,
         config: WorkspaceConfig | None = None,
     ) -> WorkspaceConfig:
-        logger.info(f"Installing UCX v{self._product_info.version()}")
+        logger.info(f"Installing UCX v{self.product_info.version()}")
         if config is None:
             config = self.configure(default_config)
-        if not sql_backend_factory:
-            sql_backend_factory = self._new_sql_backend
-        if not wheel_builder_factory:
-            wheel_builder_factory = self._new_wheel_builder
-        wheels = wheel_builder_factory()
-        install_state = InstallState.from_installation(self._installation)
+        install_state = InstallState.from_installation(self.installation)
         if self._is_testing():
             return config
         workflows_deployment = WorkflowsDeployment(
             config,
-            self._installation,
+            self.installation,
             install_state,
             self._ws,
-            wheels,
-            self._product_info,
+            self.wheels,
+            self.product_info,
             verify_timeout,
             self._tasks,
         )
         workspace_installation = WorkspaceInstallation(
             config,
-            self._installation,
+            self.installation,
             install_state,
-            sql_backend_factory(config),
+            self.sql_backend,
             self._ws,
             workflows_deployment,
-            self._prompts,
-            self._product_info,
+            self.prompts,
+            self.product_info,
         )
         try:
             workspace_installation.run()
@@ -184,21 +177,21 @@ class WorkspaceInstaller:
         return config
 
     def _is_testing(self):
-        return self._product_info.product_name() != "ucx"
+        return self.product_info.product_name() != "ucx"
 
     def _prompt_for_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
-        inventory_database = self._prompts.question(
+        inventory_database = self.prompts.question(
             "Inventory Database stored in hive_metastore", default="ucx", valid_regex=r"^\w+$"
         )
-        log_level = self._prompts.question("Log level", default="INFO").upper()
-        num_threads = int(self._prompts.question("Number of threads", default="8", valid_number=True))
-        configure_groups = ConfigureGroups(self._prompts)
+        log_level = self.prompts.question("Log level", default="INFO").upper()
+        num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))
+        configure_groups = ConfigureGroups(self.prompts)
         configure_groups.run()
         # Check if terraform is being used
-        is_terraform_used = self._prompts.confirm("Do you use Terraform to deploy your infrastructure?")
+        is_terraform_used = self.prompts.confirm("Do you use Terraform to deploy your infrastructure?")
         include_databases = self._select_databases()
-        trigger_job = self._prompts.confirm("Do you want to trigger assessment job after installation?")
+        trigger_job = self.prompts.confirm("Do you want to trigger assessment job after installation?")
         return WorkspaceConfig(
             inventory_database=inventory_database,
             workspace_group_regex=configure_groups.workspace_group_regex,
@@ -216,45 +209,39 @@ class WorkspaceInstaller:
 
     def _compare_remote_local_versions(self):
         try:
-            local_version = self._product_info.released_version()
-            remote_version = self._installation.load(Version).version
+            local_version = self.product_info.released_version()
+            remote_version = self.installation.load(Version).version
             if extract_major_minor(remote_version) == extract_major_minor(local_version):
-                logger.info(f"UCX v{self._product_info.version()} is already installed on this workspace")
+                logger.info(f"UCX v{self.product_info.version()} is already installed on this workspace")
                 msg = "Do you want to update the existing installation?"
-                if not self._prompts.confirm(msg):
+                if not self.prompts.confirm(msg):
                     raise RuntimeWarning(
                         "UCX workspace remote and local install versions are same and no override is requested. Exiting..."
                     )
         except NotFound as err:
             logger.warning(f"UCX workspace remote version not found: {err}")
 
-    def _new_wheel_builder(self):
-        return WheelsV2(self._installation, self._product_info)
-
-    def _new_sql_backend(self, config: WorkspaceConfig) -> SqlBackend:
-        return StatementExecutionBackend(self._ws, config.warehouse_id)
-
     def _confirm_force_install(self) -> bool:
         if not self._force_install:
             return False
         msg = "[ADVANCED] UCX is already installed on this workspace. Do you want to create a new installation?"
-        if not self._prompts.confirm(msg):
+        if not self.prompts.confirm(msg):
             raise RuntimeWarning("UCX is already installed, but no confirmation")
-        if not self._installation.is_global() and self._force_install == "global":
+        if not self.installation.is_global() and self._force_install == "global":
             # TODO:
             # Logic for forced global over user install
             # Migration logic will go here
             # verify complains without full path, asks to raise NotImplementedError builtin
             raise databricks.sdk.errors.NotImplemented("Migration needed. Not implemented yet.")
-        if self._installation.is_global() and self._force_install == "user":
+        if self.installation.is_global() and self._force_install == "user":
             # Logic for forced user install over global install
-            self._installation = Installation.assume_user_home(self._ws, self._product_info.product_name())
+            self.replace(installation=Installation.assume_user_home(self._ws, self.product_info.product_name()))
             return True
         return False
 
     def configure(self, default_config: WorkspaceConfig | None = None) -> WorkspaceConfig:
         try:
-            config = self._installation.load(WorkspaceConfig)
+            config = self.installation.load(WorkspaceConfig)
             self._compare_remote_local_versions()
             if self._confirm_force_install():
                 return self._configure_new_installation(default_config)
@@ -269,15 +256,15 @@ class WorkspaceInstaller:
         Persist the list of workspaces where UCX is successfully installed in the config
         """
         try:
-            config = self._installation.load(WorkspaceConfig)
+            config = self.installation.load(WorkspaceConfig)
             new_config = dataclasses.replace(config, **changes)
-            self._installation.save(new_config)
+            self.installation.save(new_config)
         except (PermissionDenied, NotFound, ValueError):
             logger.warning(f"Failed to replace config for {self._ws.config.host}")
 
     def _apply_upgrades(self):
         try:
-            upgrades = Upgrades(self._product_info, self._installation)
+            upgrades = Upgrades(self.product_info, self.installation)
             upgrades.apply(self._ws)
         except (InvalidParameterValue, NotFound) as err:
             logger.warning(f"Installed version is too old: {err}")
@@ -285,11 +272,11 @@ class WorkspaceInstaller:
     def _configure_new_installation(self, default_config: WorkspaceConfig | None = None) -> WorkspaceConfig:
         if default_config is None:
             default_config = self._prompt_for_new_installation()
-        HiveMetastoreLineageEnabler(self._ws).apply(self._prompts, self._is_account_install)
+        HiveMetastoreLineageEnabler(self._ws).apply(self.prompts, self._is_account_install)
         self._check_inventory_database_exists(default_config.inventory_database)
         warehouse_id = self._configure_warehouse()
-
-        policy_id, instance_profile, spark_conf_dict, instance_pool_id = self._policy_installer.create(
+        policy_installer = ClusterPolicyInstaller(self.installation, self.workspace_client, self.prompts)
+        policy_id, instance_profile, spark_conf_dict, instance_pool_id = policy_installer.create(
             default_config.inventory_database
         )
 
@@ -306,11 +293,11 @@ class WorkspaceInstaller:
             policy_id=policy_id,
             instance_pool_id=instance_pool_id,
         )
-        self._installation.save(config)
+        self.installation.save(config)
         if self._is_account_install:
             return config
-        ws_file_url = self._installation.workspace_link(config.__file__)
-        if self._prompts.confirm(f"Open config file in the browser and continue installing? {ws_file_url}"):
+        ws_file_url = self.installation.workspace_link(config.__file__)
+        if self.prompts.confirm(f"Open config file in the browser and continue installing? {ws_file_url}"):
             webbrowser.open(ws_file_url)
         return config
 
@@ -318,26 +305,26 @@ class WorkspaceInstaller:
         # parallelism will not be needed if backlog is fixed in https://databricks.atlassian.net/browse/ES-975874
         if self._is_account_install:
             return 1, 10, spark_conf_dict
-        parallelism = self._prompts.question(
+        parallelism = self.prompts.question(
             "Parallelism for migrating dbfs root delta tables with deep clone", default="200", valid_number=True
         )
         if int(parallelism) > 200:
             spark_conf_dict.update({'spark.sql.sources.parallelPartitionDiscovery.parallelism': parallelism})
         # mix max workers for auto-scale migration job cluster
         min_workers = int(
-            self._prompts.question(
+            self.prompts.question(
                 "Min workers for auto-scale job cluster for table migration", default="1", valid_number=True
             )
         )
         max_workers = int(
-            self._prompts.question(
+            self.prompts.question(
                 "Max workers for auto-scale job cluster for table migration", default="10", valid_number=True
             )
         )
         return min_workers, max_workers, spark_conf_dict
 
     def _select_databases(self):
-        selected_databases = self._prompts.question(
+        selected_databases = self.prompts.question(
             "Comma-separated list of databases to migrate. If not specified, we'll use all "
             "databases in hive_metastore",
             default="<ALL>",
@@ -358,7 +345,7 @@ class WorkspaceInstaller:
         if self._is_account_install:
             warehouse_id = "create_new"
         else:
-            warehouse_id = self._prompts.choice_from_dict(
+            warehouse_id = self.prompts.choice_from_dict(
                 "Select PRO or SERVERLESS SQL warehouse to run assessment dashboards on", pro_warehouses
             )
         if warehouse_id == "create_new":
@@ -374,7 +361,7 @@ class WorkspaceInstaller:
 
     def _check_inventory_database_exists(self, inventory_database: str):
         logger.info("Fetching installations...")
-        for installation in Installation.existing(self._ws, self._product_info.product_name()):
+        for installation in Installation.existing(self._ws, self.product_info.product_name()):
             try:
                 config = installation.load(WorkspaceConfig)
                 if config.inventory_database == inventory_database:
@@ -399,13 +386,13 @@ class WorkspaceInstallation(InstallationMixin):
         skip_dashboards=False,
     ):
         self._config = config
-        self._installation = installation
+        self.installation = installation
         self._install_state = install_state
         self._ws = ws
         self._sql_backend = sql_backend
         self._workflows_installer = workflows_installer
         self._prompts = prompts
-        self._product_info = product_info
+        self.product_info = product_info
         environ = dict(os.environ.items())
         self._is_account_install = environ.get("UCX_FORCE_INSTALL") == "account"
         self._skip_dashboards = skip_dashboards
@@ -451,10 +438,10 @@ class WorkspaceInstallation(InstallationMixin):
 
     @property
     def folder(self):
-        return self._installation.install_folder()
+        return self.installation.install_folder()
 
     def run(self):
-        logger.info(f"Installing UCX v{self._product_info.version()}")
+        logger.info(f"Installing UCX v{self.product_info.version()}")
         install_tasks = [self._create_database]
         if not self._skip_dashboards:
             install_tasks.append(self._create_dashboards)
@@ -491,7 +478,7 @@ class WorkspaceInstallation(InstallationMixin):
             self._ws,
             state=self._install_state,
             local_folder=local_query_files,
-            remote_folder=f"{self._installation.install_folder()}/queries",
+            remote_folder=f"{self.installation.install_folder()}/queries",
             name_prefix=self._name("UCX "),
             warehouse_id=self._warehouse_id,
             query_text_callback=self._config.replace_inventory_variable,
@@ -505,18 +492,18 @@ class WorkspaceInstallation(InstallationMixin):
         ):
             return
         # TODO: this is incorrect, fetch the remote version (that appeared only in Feb 2024)
-        logger.info(f"Deleting UCX v{self._product_info.version()} from {self._ws.config.host}")
+        logger.info(f"Deleting UCX v{self.product_info.version()} from {self._ws.config.host}")
         try:
-            self._installation.files()
+            self.installation.files()
         except NotFound:
-            logger.error(f"Check if {self._installation.install_folder()} is present")
+            logger.error(f"Check if {self.installation.install_folder()} is present")
             return
         self._remove_database()
         self._remove_jobs()
         self._remove_warehouse()
         self._remove_policies()
         self._remove_secret_scope()
-        self._installation.remove()
+        self.installation.remove()
         logger.info("UnInstalling UCX complete")
 
     def _remove_database(self):
@@ -614,19 +601,13 @@ class AccountInstaller(AccountContext):
                 accessible_workspaces.append(workspace)
         return accessible_workspaces
 
-    def _get_installer(self, app: ProductInfo, workspace: Workspace) -> WorkspaceInstaller:
+    def _get_installer(self, workspace: Workspace) -> WorkspaceInstaller:
         workspace_client = self.account_client.get_workspace_client(workspace)
         logger.info(f"Installing UCX on workspace {workspace.deployment_name}")
-        try:
-            current = app.current_installation(workspace_client)
-        except NotFound:
-            current = Installation.assume_global(workspace_client, app.product_name())
-        return WorkspaceInstaller(self.prompts, current, workspace_client, app)
+        return WorkspaceInstaller(workspace_client).replace(product_info=self.product_info, prompts=self.prompts)
 
-    def install_on_account(self, app: ProductInfo | None = None):
+    def install_on_account(self):
         ctx = AccountContext(self._get_safe_account_client())
-        if app is None:
-            app = ProductInfo.from_class(WorkspaceConfig)
         default_config = None
         confirmed = False
         accessible_workspaces = self._get_accessible_workspaces()
@@ -639,7 +620,7 @@ class AccountInstaller(AccountContext):
 
         for workspace in accessible_workspaces:
             logger.info(f"Installing UCX on workspace {workspace.deployment_name}")
-            installer = self._get_installer(app, workspace)
+            installer = self._get_installer(workspace)
             if not confirmed:
                 default_config = None
             try:
@@ -656,24 +637,11 @@ class AccountInstaller(AccountContext):
 
         installed_workspace_ids = [w.workspace_id for w in installed_workspaces if w.workspace_id is not None]
         for workspace in installed_workspaces:
-            installer = self._get_installer(app, workspace)
+            installer = self._get_installer(workspace)
             installer.replace_config(installed_workspace_ids=installed_workspace_ids)
 
         # upload the json dump of workspace info in the .ucx folder
         ctx.account_workspaces.sync_workspace_info(installed_workspaces)
-
-
-def install_on_workspace(app: ProductInfo | None = None):
-    if app is None:
-        app = ProductInfo.from_class(WorkspaceConfig)
-    prompts = Prompts()
-    workspace_client = WorkspaceClient(product="ucx", product_version=__version__)
-    try:
-        current = app.current_installation(workspace_client)
-    except NotFound:
-        current = Installation.assume_global(workspace_client, app.product_name())
-    installer = WorkspaceInstaller(prompts, current, workspace_client, app)
-    installer.run()
 
 
 if __name__ == "__main__":
@@ -685,4 +653,5 @@ if __name__ == "__main__":
         account_installer = AccountInstaller(AccountClient(product="ucx", product_version=__version__))
         account_installer.install_on_account()
     else:
-        install_on_workspace()
+        workspace_installer = WorkspaceInstaller(WorkspaceClient(product="ucx", product_version=__version__))
+        workspace_installer.run()

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -127,10 +127,8 @@ class WorkspaceInstaller(WorkspaceContext):
             installation = self.product_info.current_installation(self.workspace_client)
         except NotFound:
             if self._force_install == "user":
-                installation = Installation.assume_user_home(self.workspace_client, self.product_info.product_name())
-            else:
-                installation = Installation.assume_global(self.workspace_client, self.product_info.product_name())
-        return installation
+                return Installation.assume_user_home(self.workspace_client, self.product_info.product_name())
+            return Installation.assume_global(self.workspace_client, self.product_info.product_name())
 
     def __init__(
         self,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -506,12 +506,9 @@ class TestInstallationContext(TestRuntimeContext):
     @cached_property
     def workspace_installer(self):
         return WorkspaceInstaller(
-            self.prompts,
-            self.installation,
             self.workspace_client,
-            self.product_info,
             self.environ,
-        )
+        ).replace(prompts=self.prompts, installation=self.installation, product_info=self.product_info)
 
     @cached_property
     def config_transform(self) -> Callable[[WorkspaceConfig], WorkspaceConfig]:

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -67,7 +67,11 @@ def new_installation(ws, env_or_skip, make_random):
 
         if not installation:
             installation = Installation(ws, product_info.product_name())
-        installer = WorkspaceInstaller(prompts, installation, ws, product_info, environ)
+        installer = WorkspaceInstaller(ws, environ).replace(
+            installation=installation,
+            product_info=product_info,
+            prompts=prompts,
+        )
         workspace_config = installer.configure()
         installation = product_info.current_installation(ws)
         installation.save(workspace_config)

--- a/tests/unit/assessment/test_dashboard.py
+++ b/tests/unit/assessment/test_dashboard.py
@@ -3,8 +3,6 @@ from unittest.mock import create_autospec
 from databricks.labs.blueprint.entrypoint import find_project_root
 from databricks.labs.blueprint.installation import MockInstallation
 from databricks.labs.blueprint.installer import InstallState
-from databricks.labs.blueprint.tui import Prompts
-from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 from databricks.sdk.service.sql import (
@@ -15,9 +13,7 @@ from databricks.sdk.service.sql import (
     Widget,
 )
 
-from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
-from databricks.labs.ucx.install import WorkspaceInstaller
 
 
 def test_dashboard():
@@ -53,8 +49,6 @@ def test_dashboard():
     ws.query_visualizations.create.return_value = Visualization(id="abc")
     ws.dashboard_widgets.create.return_value = Widget(id="abc")
     ws.warehouses.list.return_value = []
-    prompts = create_autospec(Prompts)
-    WorkspaceInstaller(prompts, installation, ws, ProductInfo.from_class(WorkspaceConfig))
     local_query_files = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     dash = DashboardFromFiles(
         ws,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1735,6 +1735,6 @@ def test_account_installer(ws):
         ),
         product_info=ProductInfo.for_testing(WorkspaceConfig),
     )
-    account_installer.install_on_account()
+    account_installer.run()
     # should have 4 uploaded call, 2 for config.yml, 2 for workspace.json
     assert ws.workspace.upload.call_count == 4

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1756,7 +1756,6 @@ def test_global_workspace_installer(mock_ws):
         mock_ws,
         {'UCX_FORCE_INSTALL': 'global'},
     )
-    workspace_installer.replace(product_info=ProductInfo.for_testing(WorkspaceConfig))
     # installation folder should start with /Applications
     assert workspace_installer.install_state.install_folder().startswith("/Applications")
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -499,7 +499,11 @@ def test_save_config(ws, mock_installation):
             r".*days to analyze submitted runs.*": "1",
         }
     )
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
 
     mock_installation.assert_file_written(
@@ -532,7 +536,11 @@ def test_save_config_strip_group_names(ws, mock_installation):
     )
     ws.workspace.get_status = not_found
 
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
 
     mock_installation.assert_file_written(
@@ -575,7 +583,11 @@ def test_create_cluster_policy(ws, mock_installation):
         }
     )
     ws.workspace.get_status = not_found
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
     mock_installation.assert_file_written(
         'config.yml',
@@ -1178,7 +1190,11 @@ def test_open_config(ws, mocker, mock_installation):
     )
     ws.workspace.get_status = not_found
 
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
 
     webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/config.yml')
@@ -1194,7 +1210,11 @@ def test_save_config_should_include_databases(ws, mock_installation):
         }
     )
     ws.workspace.get_status = not_found
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
 
     mock_installation.assert_file_written(
@@ -1259,14 +1279,16 @@ def test_runs_upgrades_on_too_old_version(ws, any_prompt):
             },
         }
     )
-    install = WorkspaceInstaller(any_prompt, existing_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=any_prompt,
+        installation=existing_installation,
+        product_info=PRODUCT_INFO,
+        sql_backend=MockBackend(),
+        wheels=create_autospec(WheelsV2),
+    )
 
-    sql_backend = MockBackend()
-    wheels = create_autospec(WheelsV2)
     install.run(
         verify_timeout=timedelta(seconds=60),
-        sql_backend_factory=lambda _: sql_backend,
-        wheel_builder_factory=lambda: wheels,
     )
 
 
@@ -1278,20 +1300,20 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
             'config.yml': {
                 'inventory_database': 'x',
                 'warehouse_id': 'abc',
-                'policy_id': 'abc',  # TODO: (HariGS-DB) remove this, once added the policy upgrade
                 'connect': {'host': '...', 'token': '...'},
             },
         }
     )
-    install = WorkspaceInstaller(any_prompt, existing_installation, ws, PRODUCT_INFO)
-
-    sql_backend = MockBackend()
-    wheels = create_autospec(WheelsV2)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=any_prompt,
+        installation=existing_installation,
+        product_info=PRODUCT_INFO,
+        sql_backend=MockBackend(),
+        wheels=create_autospec(WheelsV2),
+    )
 
     install.run(
         verify_timeout=timedelta(seconds=10),
-        sql_backend_factory=lambda _: sql_backend,
-        wheel_builder_factory=lambda: wheels,
     )
 
     existing_installation.assert_file_uploaded('logs/README.md')
@@ -1311,7 +1333,11 @@ def test_fresh_install(ws, mock_installation):
     )
     ws.workspace.get_status = not_found
 
-    install = WorkspaceInstaller(prompts, mock_installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+    )
     install.configure()
 
     mock_installation.assert_file_written(
@@ -1392,7 +1418,11 @@ def test_get_existing_installation_global(ws, mock_installation):
         }
     )
 
-    first_install = WorkspaceInstaller(first_prompts, installation, ws, PRODUCT_INFO)
+    first_install = WorkspaceInstaller(ws).replace(
+        prompts=first_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     workspace_config = first_install.configure()
     assert workspace_config.inventory_database == 'ucx_global'
 
@@ -1404,7 +1434,11 @@ def test_get_existing_installation_global(ws, mock_installation):
         }
     )
     # test for force user install variable without prompts
-    second_install = WorkspaceInstaller(second_prompts, installation, ws, PRODUCT_INFO, force_user_environ)
+    second_install = WorkspaceInstaller(ws, force_user_environ).replace(
+        prompts=second_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     with pytest.raises(RuntimeWarning, match='UCX is already installed, but no confirmation'):
         second_install.configure()
 
@@ -1415,7 +1449,11 @@ def test_get_existing_installation_global(ws, mock_installation):
             r"Inventory Database stored in hive_metastore.*": "ucx_user",
         }
     )
-    third_install = WorkspaceInstaller(third_prompts, installation, ws, PRODUCT_INFO, force_user_environ)
+    third_install = WorkspaceInstaller(ws, force_user_environ).replace(
+        prompts=third_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     workspace_config = third_install.configure()
     assert workspace_config.inventory_database == 'ucx_user'
 
@@ -1452,7 +1490,11 @@ def test_existing_installation_user(ws, mock_installation):
         },
         is_global=False,
     )
-    first_install = WorkspaceInstaller(first_prompts, installation, ws, PRODUCT_INFO)
+    first_install = WorkspaceInstaller(ws).replace(
+        prompts=first_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     workspace_config = first_install.configure()
     assert workspace_config.inventory_database == 'ucx_user'
 
@@ -1465,7 +1507,11 @@ def test_existing_installation_user(ws, mock_installation):
     )
 
     force_global_env = {'UCX_FORCE_INSTALL': 'global'}
-    second_install = WorkspaceInstaller(second_prompts, installation, ws, PRODUCT_INFO, force_global_env)
+    second_install = WorkspaceInstaller(ws, force_global_env).replace(
+        prompts=second_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     with pytest.raises(RuntimeWarning, match='UCX is already installed, but no confirmation'):
         second_install.configure()
 
@@ -1478,7 +1524,11 @@ def test_existing_installation_user(ws, mock_installation):
         }
     )
 
-    third_install = WorkspaceInstaller(third_prompts, installation, ws, PRODUCT_INFO, force_global_env)
+    third_install = WorkspaceInstaller(ws, force_global_env).replace(
+        prompts=third_prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
     with pytest.raises(NotImplemented, match="Migration needed. Not implemented yet."):
         third_install.configure()
 
@@ -1493,7 +1543,11 @@ def test_databricks_runtime_version_set(ws, mock_installation):
     environ = {'DATABRICKS_RUNTIME_VERSION': "13.3"}
 
     with pytest.raises(SystemExit, match="WorkspaceInstaller is not supposed to be executed in Databricks Runtime"):
-        WorkspaceInstaller(prompts, mock_installation, ws, product_info, environ)
+        WorkspaceInstaller(ws, environ).replace(
+            prompts=prompts,
+            installation=mock_installation,
+            product_info=product_info,
+        )
 
 
 def test_check_inventory_database_exists(ws, mock_installation):
@@ -1512,7 +1566,11 @@ def test_check_inventory_database_exists(ws, mock_installation):
     installation_type_mock.load.side_effect = NotFound
 
     installation = Installation(ws, 'ucx')
-    install = WorkspaceInstaller(prompts, installation, ws, PRODUCT_INFO)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
 
     with pytest.raises(AlreadyExists, match="Inventory database 'ucx_exists' already exists in another installation"):
         install.configure()
@@ -1606,7 +1664,11 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
         is_global=False,
     )
 
-    install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=base_prompts,
+        installation=installation,
+        product_info=product_info,
+    )
 
     # raises runtime warning when versions match and no override provided
     with pytest.raises(
@@ -1620,7 +1682,11 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
             r"Do you want to update the existing installation?": "yes",
         }
     )
-    install = WorkspaceInstaller(first_prompts, installation, ws, product_info)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=first_prompts,
+        installation=installation,
+        product_info=product_info,
+    )
 
     # finishes successfully when versions match and override is provided
     config = install.configure()
@@ -1628,7 +1694,11 @@ def test_are_remote_local_versions_equal(ws, mock_installation, mocker):
 
     # finishes successfully when versions don't match and no override is provided/needed
     product_info.released_version.return_value = "0.4.1"
-    install = WorkspaceInstaller(base_prompts, installation, ws, product_info)
+    install = WorkspaceInstaller(ws).replace(
+        prompts=base_prompts,
+        installation=installation,
+        product_info=product_info,
+    )
     config = install.configure()
     assert config.inventory_database == "ucx_user"
 
@@ -1653,15 +1723,18 @@ def test_account_installer(ws):
     acc.get_workspace_client.return_value = ws
 
     account_installer = AccountInstaller(acc)
-    account_installer.prompts = MockPrompts(
-        {
-            r"UCX has detected the following workspaces*": "Yes",
-            r".*PRO or SERVERLESS SQL warehouse.*": "1",
-            r"Choose how to map the workspace groups.*": "0",
-            r"Do you want to install UCX on the remaining*": "Yes",
-            r".*": "",
-        }
+    account_installer.replace(
+        prompts=MockPrompts(
+            {
+                r"UCX has detected the following workspaces*": "Yes",
+                r".*PRO or SERVERLESS SQL warehouse.*": "1",
+                r"Choose how to map the workspace groups.*": "0",
+                r"Do you want to install UCX on the remaining*": "Yes",
+                r".*": "",
+            }
+        ),
+        product_info=ProductInfo.for_testing(WorkspaceConfig),
     )
-    account_installer.install_on_account(ProductInfo.for_testing(WorkspaceConfig))
+    account_installer.install_on_account()
     # should have 4 uploaded call, 2 for config.yml, 2 for workspace.json
     assert ws.workspace.upload.call_count == 4


### PR DESCRIPTION
## Changes
- refactor `WorkspaceInstaller` using service factory.
  - this removes the need for `sql_backend_factory` and `wheel_builder_factory`
  - there is no more logic inside of `main` function in `install.py`, so we can achieve better test coverage through unit testing
- remove obsolete reference to `WorkspaceInstaller` in `unit/test_dashboard.py`

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This follows #1209

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] verified on staging environment (screenshot attached)
