### PR TITLE
Prompt for warehouse choice in uninstall if the original chosen warehouse does not exist anymore

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -118,16 +118,6 @@ def extract_major_minor(version_string):
     return None
 
 
-def _replace_config(installation: Installation, **changes):
-    """
-    Persist the list of workspaces where UCX is successfully installed in the config
-    """
-    config = installation.load(WorkspaceConfig)
-    new_config = dataclasses.replace(config, **changes)
-    installation.save(new_config)
-    return new_config
-
-
 class WorkspaceInstaller:
     def __init__(
         self,
@@ -279,7 +269,7 @@ class WorkspaceInstaller:
             logger.debug(f"Cannot find previous installation: {err}")
         return self._configure_new_installation(default_config)
 
-    def replace_config(self, **changes: Any):
+    def replace_config(self, **changes: Any) -> None:
         """
         Persist the list of workspaces where UCX is successfully installed in the config
         """
@@ -596,7 +586,8 @@ class WorkspaceInstallation(InstallationMixin):
             current = self._product_info.current_installation(self._ws)
             workspace_installer = WorkspaceInstaller(self._prompts, current, self._ws, self._product_info)
             warehouse_id = workspace_installer.configure_warehouse()
-            self._config = _replace_config(self._installation, warehouse_id=warehouse_id)
+            workspace_installer.replace_config(warehouse_id=warehouse_id)
+            self._config = self._installation.load(WorkspaceConfig)
 
 
 class AccountInstaller(AccountContext):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -589,6 +589,7 @@ class WorkspaceInstallation(InstallationMixin):
             workspace_installer = WorkspaceInstaller(self._prompts, current, self._ws, self._product_info)
             warehouse_id = workspace_installer.configure_warehouse()
             self._config = workspace_installer.replace_config(warehouse_id=warehouse_id)
+            self._sql_backend = StatementExecutionBackend(self._ws, self._config.warehouse_id)
 
 
 class AccountInstaller(AccountContext):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -515,7 +515,7 @@ class WorkspaceInstallation(InstallationMixin):
         except NotFound:
             logger.error(f"Check if {self._installation.install_folder()} is present")
             return
-        self._validate_config()
+        self._check_and_fix_if_warehouse_does_not_exists()
         self._remove_database()
         self._remove_jobs()
         self._remove_warehouse()
@@ -578,7 +578,7 @@ class WorkspaceInstallation(InstallationMixin):
         if self._prompts.confirm(f"Open {step} Job url that just triggered ? {job_url}"):
             webbrowser.open(job_url)
 
-    def _validate_config(self):
+    def _check_and_fix_if_warehouse_does_not_exists(self):
         try:
             self._ws.warehouses.get(self._config.warehouse_id)
         except ResourceDoesNotExist:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -584,7 +584,7 @@ class WorkspaceInstallation(InstallationMixin):
         try:
             self._ws.warehouses.get(self._config.warehouse_id)
         except ResourceDoesNotExist:
-            logger.critical(f"warehouse does not exists anymore {self._config.warehouse_id}")
+            logger.critical(f"warehouse with id {self._config.warehouse_id} does not exists anymore")
             current = self._product_info.current_installation(self._ws)
             workspace_installer = WorkspaceInstaller(self._prompts, current, self._ws, self._product_info)
             warehouse_id = workspace_installer.configure_warehouse()


### PR DESCRIPTION
## Changes
A warehouse might be manually deleted. This will break the uninstallation process as the warehouse, for example, because the warehouse is required for dropping the database. This PR checks if the warehouse still exists during the uninstallation, it requests the use to reinstall the warehouse if it does not exist anymore

### Linked issues
Resolves #1467 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
