### PR TITLE
Enforced removal of commented-out code on `make fmt`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "mypy~=1.9.0",
     "pylint~=3.1.0",
     "pylint-pytest==2.0.0a0",
-    "databricks-labs-pylint~=0.1.0",
+    "databricks-labs-pylint~=0.3.0",
     "pytest~=8.1.0",
     "pytest-cov~=4.1.0",
     "pytest-mock~=3.14.0",
@@ -229,6 +229,7 @@ limit-inference-results = 100
 # usually to register additional checkers.
 load-plugins = [
     "databricks.labs.pylint.mocking",
+    "databricks.labs.pylint.eradicate",
     "pylint_pytest",
     "pylint.extensions.bad_builtin",
     "pylint.extensions.broad_try_clause",

--- a/src/databricks/labs/ucx/assessment/azure.py
+++ b/src/databricks/labs/ucx/assessment/azure.py
@@ -24,7 +24,7 @@ class AzureServicePrincipalInfo:
     secret_scope: str | None = None
     # fs.azure.account.oauth2.client.secret: {{secrets/${local.secret_scope}/${local.secret_key}}}
     secret_key: str | None = None
-    # fs.azure.account.oauth2.client.endpoint: "https://login.microsoftonline.com/${local.tenant_id}/oauth2/token"
+    # fs.azure.account.oauth2.client.endpoint: https://login.microsoftonline.com/${local.tenant_id}/oauth2/token
     tenant_id: str | None = None
     # Azure Storage account to which the SP has been given access
     storage_account: str | None = None

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -90,9 +90,9 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         pattern = r"(\w+)=(.*?)(?=\s*,|\s*\])"
         # Find all matches in the input string
         # Storage properties is of the format
-        # "[personalAccessToken=*********(redacted), \
-        #  httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com, \
-        #  dbtable=samples.nyctaxi.trips]"
+        # "personalAccessToken=*********(redacted),
+        #  httpPath=/sql/1.0/warehouses/65b52fb5bd86a7be, host=dbc-test1-aa11.cloud.databricks.com,
+        #  dbtable=samples.nyctaxi.trips"
         matches = re.findall(pattern, table.storage_properties)
         # Create a dictionary from the matches
         result_dict = dict(matches)
@@ -102,7 +102,6 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         database = result_dict.get("database", "")
         httppath = result_dict.get("httpPath", "")
         provider = result_dict.get("provider", "")
-        # dbtable = result_dict.get("dbtable", "")
         # currently supporting databricks and mysql external tables
         # add other jdbc types
         if "databricks" in location.lower():

--- a/src/databricks/labs/ucx/source_code/lsp.py
+++ b/src/databricks/labs/ucx/source_code/lsp.py
@@ -301,7 +301,6 @@ class _RequestHandler(http.server.BaseHTTPRequestHandler):
 
         raw = json.dumps(response.as_dict()).encode('utf-8')
         self.wfile.write(raw)
-        # self.wfile.flush()
 
     def do_GET(self):  # pylint: disable=invalid-name
         if not self.path.startswith('/lint'):

--- a/src/databricks/labs/ucx/source_code/table_creation.py
+++ b/src/databricks/labs/ucx/source_code/table_creation.py
@@ -53,13 +53,13 @@ class NoFormatPythonMatcher:
 
         # Check 3: check presence of the format specifier:
         #   Option A: format specifier may be given as a direct parameter to the table-creating call
-        #   example: df.saveToTable("c.db.table", format="csv")
+        #   >>> df.saveToTable("c.db.table", format="csv")
         format_arg = ASTLinter(call).get_arg(self.format_arg_index, self.format_arg_name)
         if format_arg is not None and not ASTLinter(format_arg).is_none():
             # i.e., found an explicit "format" argument, and its value is not None.
             return None
         #   Option B. format specifier may be a separate ".format(...)" call in this callchain
-        #   example: df.format("csv").saveToTable("c.db.table")
+        #   >>> df.format("csv").saveToTable("c.db.table")
         format_call = ASTLinter(callchain).extract_call_by_name("format")
         if format_call is not None:
             # i.e., found an explicit ".format(...)" call in this chain.

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -806,7 +806,6 @@ def test_remove_secret_scope(ws, caplog):
     installation = MockInstallation()
     config = WorkspaceConfig(inventory_database='ucx', uber_spn_id="123")
     workflows_installer = create_autospec(WorkflowsDeployment)
-    # ws.secrets.delete_scope.side_effect = NotFound()
     workspace_installation = WorkspaceInstallation(
         config,
         installation,

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -140,11 +140,6 @@ def test_safe_get_permissions_when_error_non_retriable():
     result = sup.load_as_dict("clusters", "test")
     assert not result
 
-    # TODO uncomment after ES-892977 is fixed. The code now is retried.
-    # ws.permissions.get.side_effect = DatabricksError(error_code="SOMETHING_UNEXPECTED")
-    # with pytest.raises(DatabricksError):
-    #     sup._safe_get_permissions("clusters", "test")
-
 
 def test_safe_get_permissions_when_error_retriable():
     ws = create_autospec(WorkspaceClient)


### PR DESCRIPTION
This PR enforces the removal of commented code:

```
cmd [4] | pylint --output-format=colorized -j 0 src tests
************* Module databricks.labs.ucx.hive_metastore.locations
src/databricks/labs/ucx/hive_metastore/locations.py:105:0: C8920: Remove commented out code: # dbtable = result_dict.get("dbtable", "") (dead-code)
```
