### PR TITLE
Added CLI Command `create_missing_principals` to create the missing UC roles.

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -113,6 +113,16 @@ commands:
       - name: aws-profile
         description: AWS Profile to use for authentication
 
+  - name: create-missing-principals
+    description: For AWS, this command identifies all the S3 locations that are missing a UC compatible role and 
+      creates them. It takes single-role optional parameter. 
+        If set to True, it will create a single role for all the S3 locations.
+    flags:
+      - name: aws-profile
+        description: AWS Profile to use for authentication
+      - name: single-role
+        description: (Optional) Create a single role for all the S3 locations (default:: True)
+
   - name: create-uber-principal
     description: For azure cloud, creates a service principal and gives STORAGE BLOB READER access on all the storage account 
       used by tables in the workspace and stores the spn info in the UCX cluster policy. For aws,

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -29,8 +29,9 @@ class AWSPolicyAction:
 
 
 @dataclass
-# Candidates for UC IAM roles with the paths they have access to
 class AWSUCRoleCandidate:
+    """Candidates for UC IAM roles with the paths they have access to"""
+
     role_name: str
     policy_name: str
     resource_paths: list[str]

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -29,6 +29,13 @@ class AWSPolicyAction:
 
 
 @dataclass
+# Candidates for UC IAM roles with the paths they have access to
+class AWSUCRoleCandidate:
+    role_name: str
+    resource_paths: list[str]
+
+
+@dataclass
 class AWSRoleAction:
     role_arn: str
     resource_type: str

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -32,6 +32,7 @@ class AWSPolicyAction:
 # Candidates for UC IAM roles with the paths they have access to
 class AWSUCRoleCandidate:
     role_name: str
+    policy_name: str
     resource_paths: list[str]
 
 

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -59,7 +59,7 @@ class AWSResourcePermissions:
         # If single_role is True, create a single role and policy for all the missing S3 prefixes
         # If single_role is False, create a role and policy for each missing S3 prefix
         roles: list[AWSUCRoleCandidate] = []
-        missing_paths = self.identify_missing_paths()
+        missing_paths = self._identify_missing_paths()
         s3_prefixes = set()
         for missing_path in missing_paths:
             match = re.match(AWSResources.S3_PATH_REGEX, missing_path)
@@ -68,10 +68,8 @@ class AWSResourcePermissions:
         if single_role:
             roles.append(AWSUCRoleCandidate(role_name, policy_name, list(s3_prefixes)))
         else:
-            role_id = 1
-            for s3_prefix in sorted(list(s3_prefixes)):
-                roles.append(AWSUCRoleCandidate(f"{role_name}_{role_id}", policy_name, [s3_prefix]))
-                role_id += 1
+            for idx, s3_prefix in enumerate(sorted(list(s3_prefixes))):
+                roles.append(AWSUCRoleCandidate(f"{role_name}_{idx+1}", policy_name, [s3_prefix]))
         return roles
 
     def create_uc_roles(self, roles: list[AWSUCRoleCandidate]):
@@ -172,7 +170,7 @@ class AWSResourcePermissions:
                 )
         return policy_actions
 
-    def identify_missing_paths(self):
+    def _identify_missing_paths(self):
         external_locations = self._locations.snapshot()
         compatible_roles = self.load_uc_compatible_roles()
         missing_paths = set()

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -18,7 +18,8 @@ from databricks.labs.ucx.assessment.aws import (
     AWSInstanceProfile,
     AWSResources,
     AWSRoleAction,
-    logger, AWSUCRoleCandidate,
+    logger,
+    AWSUCRoleCandidate,
 )
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore import ExternalLocations

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -72,6 +72,7 @@ class AWSResourcePermissions:
             for s3_prefix in sorted(list(s3_prefixes)):
                 roles.append(AWSUCRoleCandidate(f"{role_name}_{role_id}", policy_name, [s3_prefix]))
                 role_id += 1
+        return roles
 
     def create_uc_roles(self, roles: list[AWSUCRoleCandidate]):
         roles_created = []

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -52,7 +52,7 @@ class AWSResourcePermissions:
         self._filename = self.INSTANCE_PROFILES_FILE_NAMES
         self._principal_acl = principal_acl
 
-    def uc_roles_list(self, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY"):
+    def list_uc_roles(self, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY"):
         # Get the missing paths
         # Identify the S3 prefixes
         # Create the roles and policies for the missing S3 prefixes
@@ -77,7 +77,11 @@ class AWSResourcePermissions:
         for role in roles:
             if self._aws_resources.create_uc_role(role.role_name):
                 self._aws_resources.put_role_policy(
-                    role.role_name, role.policy_name, set(role.resource_paths), self._aws_account_id, self._kms_key
+                    role.role_name,
+                    role.policy_name,
+                    set(role.resource_paths),
+                    self._aws_account_id,
+                    self._kms_key,
                 )
                 roles_created.append(role)
         return roles_created

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -205,22 +205,20 @@ class IamRoleCreation:
     def save(self, migration_results: list[CredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
-    def run(
-        self, prompts: Prompts, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY"
-    ) -> list[CredentialValidationResult]:
+    def run(self, prompts: Prompts, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY"):
 
-        iam_list = self._resource_permissions.uc_roles_list(
+        iam_list = self._resource_permissions.list_uc_roles(
             single_role=single_role, role_name=role_name, policy_name=policy_name
         )
         if not iam_list:
             logger.info("No IAM Role created")
-            return []
+            return
         self._print_action_plan(iam_list)
         plan_confirmed = prompts.confirm(
             "Above UC Compatible IAM roles will be created and granted access to the corresponding paths, "
             "please review and confirm."
         )
         if plan_confirmed is not True:
-            return []
+            return
 
-        return self._resource_permissions.create_uc_roles(iam_list)
+        self._resource_permissions.create_uc_roles(iam_list)

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -190,13 +190,11 @@ class IamRoleCreation:
         installation: Installation,
         ws: WorkspaceClient,
         resource_permissions: AWSResourcePermissions,
-        storage_credential_manager: CredentialManager,
     ):
         self._output_file = "aws_iam_role_creation_result.csv"
         self._installation = installation
         self._ws = ws
         self._resource_permissions = resource_permissions
-        self._storage_credential_manager = storage_credential_manager
 
     @staticmethod
     def _print_action_plan(iam_list: list[AWSUCRoleCandidate]):
@@ -214,6 +212,9 @@ class IamRoleCreation:
         iam_list = self._resource_permissions.uc_roles_list(
             single_role=single_role, role_name=role_name, policy_name=policy_name
         )
+        if not iam_list:
+            logger.info("No IAM Role created")
+            return []
         self._print_action_plan(iam_list)
         plan_confirmed = prompts.confirm(
             "Above UC Compatible IAM roles will be created and granted access to the corresponding paths, "

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -12,7 +12,7 @@ from databricks.sdk.service.catalog import (
     ValidationResultResult,
 )
 
-from databricks.labs.ucx.assessment.aws import AWSRoleAction
+from databricks.labs.ucx.assessment.aws import AWSRoleAction, AWSUCRoleCandidate
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 
 logger = logging.getLogger(__name__)
@@ -181,3 +181,62 @@ class IamRoleMigration:
         else:
             logger.info("No IAM Role migrated to UC Storage credentials")
         return execution_result
+
+class IamRoleCreation:
+
+    def __init__(
+            self,
+            installation: Installation,
+            ws: WorkspaceClient,
+            resource_permissions: AWSResourcePermissions,
+            storage_credential_manager: CredentialManager,
+    ):
+        self._output_file = "aws_iam_role_creation_result.csv"
+        self._installation = installation
+        self._ws = ws
+        self._resource_permissions = resource_permissions
+        self._storage_credential_manager = storage_credential_manager
+
+    @staticmethod
+    def _print_action_plan(iam_list: list[AWSUCRoleCandidate]):
+        # print action plan to console for customer to review.
+        for iam in iam_list:
+            logger.info(f"Role:{iam.role_name} Policy:{iam.policy_name} Paths:{iam.resource_paths}")
+
+    def _generate_migration_list(self, include_names: set[str] | None = None) -> list[AWSRoleAction]:
+        """
+        Create the list of IAM roles that need to be migrated, output an action plan as a csv file for users to confirm
+        """
+        # load IAM role list
+        iam_list = self._resource_permissions.load_uc_compatible_roles()
+        # list existing storage credentials
+        sc_set = self._storage_credential_manager.list(include_names)
+        # check if the iam is already used in UC storage credential
+        filtered_iam_list = [iam for iam in iam_list if iam.role_arn not in sc_set]
+
+        # output the action plan for customer to confirm
+        self._print_action_plan(filtered_iam_list)
+
+        return filtered_iam_list
+
+    def save(self, migration_results: list[CredentialValidationResult]) -> str:
+        return self._installation.save(migration_results, filename=self._output_file)
+
+    def run(self, prompts: Prompts, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY") -> list[CredentialValidationResult]:
+
+        iam_list = self._resource_permissions.uc_roles_list(single_role=single_role,
+                                                            role_name=role_name,
+                                                            policy_name=policy_name)
+
+        plan_confirmed = prompts.confirm(
+            "Above UC Compatible IAM roles will be created and granted access to the corresponding paths, "
+            "please review and confirm."
+        )
+        if plan_confirmed is not True:
+            return []
+
+        return self._resource_permissions.create_uc_roles(iam_list)
+
+        execution_result = []
+
+

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -182,14 +182,15 @@ class IamRoleMigration:
             logger.info("No IAM Role migrated to UC Storage credentials")
         return execution_result
 
+
 class IamRoleCreation:
 
     def __init__(
-            self,
-            installation: Installation,
-            ws: WorkspaceClient,
-            resource_permissions: AWSResourcePermissions,
-            storage_credential_manager: CredentialManager,
+        self,
+        installation: Installation,
+        ws: WorkspaceClient,
+        resource_permissions: AWSResourcePermissions,
+        storage_credential_manager: CredentialManager,
     ):
         self._output_file = "aws_iam_role_creation_result.csv"
         self._installation = installation
@@ -203,31 +204,17 @@ class IamRoleCreation:
         for iam in iam_list:
             logger.info(f"Role:{iam.role_name} Policy:{iam.policy_name} Paths:{iam.resource_paths}")
 
-    def _generate_migration_list(self, include_names: set[str] | None = None) -> list[AWSRoleAction]:
-        """
-        Create the list of IAM roles that need to be migrated, output an action plan as a csv file for users to confirm
-        """
-        # load IAM role list
-        iam_list = self._resource_permissions.load_uc_compatible_roles()
-        # list existing storage credentials
-        sc_set = self._storage_credential_manager.list(include_names)
-        # check if the iam is already used in UC storage credential
-        filtered_iam_list = [iam for iam in iam_list if iam.role_arn not in sc_set]
-
-        # output the action plan for customer to confirm
-        self._print_action_plan(filtered_iam_list)
-
-        return filtered_iam_list
-
     def save(self, migration_results: list[CredentialValidationResult]) -> str:
         return self._installation.save(migration_results, filename=self._output_file)
 
-    def run(self, prompts: Prompts, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY") -> list[CredentialValidationResult]:
+    def run(
+        self, prompts: Prompts, *, single_role=True, role_name="UC_ROLE", policy_name="UC_POLICY"
+    ) -> list[CredentialValidationResult]:
 
-        iam_list = self._resource_permissions.uc_roles_list(single_role=single_role,
-                                                            role_name=role_name,
-                                                            policy_name=policy_name)
-
+        iam_list = self._resource_permissions.uc_roles_list(
+            single_role=single_role, role_name=role_name, policy_name=policy_name
+        )
+        self._print_action_plan(iam_list)
         plan_confirmed = prompts.confirm(
             "Above UC Compatible IAM roles will be created and granted access to the corresponding paths, "
             "please review and confirm."
@@ -236,7 +223,3 @@ class IamRoleCreation:
             return []
 
         return self._resource_permissions.create_uc_roles(iam_list)
-
-        execution_result = []
-
-

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -280,14 +280,16 @@ def principal_prefix_access(w: WorkspaceClient, ctx: WorkspaceContext | None = N
 
 
 @ucx.command
-def create_missing_principals(w: WorkspaceClient, ctx: WorkspaceContext | None = None, **named_parameters):
+def create_missing_principals(
+    w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None, **named_parameters
+):
     """No supported for Azure.
     For AWS, this command identifies all the S3 locations that are missing a UC compatible role and creates them.
     It takes single_role optional parameter. If set to True, it will create a single role for all the S3 locations."""
     if not ctx:
         ctx = WorkspaceContext(w, named_parameters)
     if ctx.is_aws:
-        return ctx.iam_create_uc_roles.run()
+        return ctx.iam_create_uc_roles.run(prompts)
     raise ValueError("Unsupported cloud provider")
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -284,16 +284,17 @@ def create_missing_principals(
     w: WorkspaceClient,
     prompts: Prompts,
     ctx: WorkspaceContext | None = None,
-    single_role: bool = False,
+    single_role: bool = True,
     **named_parameters,
 ):
-    """No supported for Azure.
+    """Not supported for Azure.
     For AWS, this command identifies all the S3 locations that are missing a UC compatible role and creates them.
-    It takes single_role optional parameter. If set to True, it will create a single role for all the S3 locations."""
+    By default, it will create a single role for all S3. Set the optional single_role parameter to False, to create one role per S3 location.
+    """
     if not ctx:
         ctx = WorkspaceContext(w, named_parameters)
     if ctx.is_aws:
-        return ctx.iam_create_uc_roles.run(prompts, single_role=single_role)
+        return ctx.iam_role_creation.run(prompts, single_role=single_role)
     raise ValueError("Unsupported cloud provider")
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -281,7 +281,11 @@ def principal_prefix_access(w: WorkspaceClient, ctx: WorkspaceContext | None = N
 
 @ucx.command
 def create_missing_principals(
-    w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None, **named_parameters
+    w: WorkspaceClient,
+    prompts: Prompts,
+    ctx: WorkspaceContext | None = None,
+    single_role: bool = False,
+    **named_parameters,
 ):
     """No supported for Azure.
     For AWS, this command identifies all the S3 locations that are missing a UC compatible role and creates them.
@@ -289,7 +293,7 @@ def create_missing_principals(
     if not ctx:
         ctx = WorkspaceContext(w, named_parameters)
     if ctx.is_aws:
-        return ctx.iam_create_uc_roles.run(prompts)
+        return ctx.iam_create_uc_roles.run(prompts, single_role=single_role)
     raise ValueError("Unsupported cloud provider")
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -280,6 +280,18 @@ def principal_prefix_access(w: WorkspaceClient, ctx: WorkspaceContext | None = N
 
 
 @ucx.command
+def create_missing_principals(w: WorkspaceClient, ctx: WorkspaceContext | None = None, **named_parameters):
+    """No supported for Azure.
+    For AWS, this command identifies all the S3 locations that are missing a UC compatible role and creates them.
+    It takes single_role optional parameter. If set to True, it will create a single role for all the S3 locations."""
+    if not ctx:
+        ctx = WorkspaceContext(w, named_parameters)
+    if ctx.is_aws:
+        return ctx.iam_create_uc_roles.run()
+    raise ValueError("Unsupported cloud provider")
+
+
+@ucx.command
 def migrate_credentials(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None, **named_parameters):
     """For Azure, this command migrates Azure Service Principals, which have Storage Blob Data Contributor,
     Storage Blob Data Reader, Storage Blob Data Owner roles on ADLS Gen2 locations that are being used in

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -170,6 +170,15 @@ class WorkspaceContext(CliContext):
         )
 
     @cached_property
+    def iam_create_uc_roles(self):
+        return IamRoleCreation(
+            self.installation,
+            self.workspace_client,
+            self.aws_resource_permissions,
+            self.iam_credential_manager,
+        )
+
+    @cached_property
     def notebook_loader(self) -> NotebookLoader:
         return LocalNotebookLoader(self.syspath_provider)
 

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -170,7 +170,7 @@ class WorkspaceContext(CliContext):
         )
 
     @cached_property
-    def iam_create_uc_roles(self):
+    def iam_role_creation(self):
         return IamRoleCreation(
             self.installation,
             self.workspace_client,

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -175,7 +175,6 @@ class WorkspaceContext(CliContext):
             self.installation,
             self.workspace_client,
             self.aws_resource_permissions,
-            self.iam_credential_manager,
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.account.metastores import AccountMetastores
 from databricks.labs.ucx.assessment.aws import run_command, AWSResources
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
-from databricks.labs.ucx.aws.credentials import IamRoleMigration
+from databricks.labs.ucx.aws.credentials import IamRoleMigration, IamRoleCreation
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.credentials import ServicePrincipalMigration, StorageCredentialManager
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -297,11 +297,12 @@ def test_create_uc_role_single(mock_ws, installation_single_role, backend, locat
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, backend, aws, locations, "ucx")
     role_creation = IamRoleCreation(installation_single_role, mock_ws, aws_resource_permissions)
-    role_creation.run(MockPrompts({"Above *": "yes"}))
     aws.list_all_uc_roles.return_value = []
-    assert not aws.create_uc_role.assert_called_with('UC_ROLE')
-    assert not aws.put_role_policy.assert_called_with(
-        'UC_ROLE', 'UC_POLICY', {'s3://BUCKET1/FOLDER1', 's3://BUCKET2/FOLDER2'}, None, None
+    role_creation.run(MockPrompts({"Above *": "yes"}))
+    assert aws.create_uc_role.assert_called
+    assert (
+        call('UC_ROLE', 'UC_POLICY', {'s3://BUCKET1/FOLDER1', 's3://BUCKET2/FOLDER2'}, None, None)
+        in aws.put_role_policy.call_args_list
     )
 
 
@@ -309,8 +310,8 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, backend, aws, locations, "ucx")
     role_creation = IamRoleCreation(installation_single_role, mock_ws, aws_resource_permissions)
-    role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
     aws.list_all_uc_roles.return_value = []
+    role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
     assert call('UC_ROLE_1') in aws.create_uc_role.call_args_list
     assert call('UC_ROLE_2') in aws.create_uc_role.call_args_list
     assert call('UC_ROLE_1', 'UC_POLICY', {'s3://BUCKET1/FOLDER1'}, None, None) in aws.put_role_policy.call_args_list

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -490,6 +490,14 @@ def test_create_missing_principal_aws(ws):
     aws_resource_permissions.create_uc_roles.assert_called_once()
 
 
+def test_create_missing_principal_aws_not_approved(ws):
+    aws_resource_permissions = create_autospec(AWSResourcePermissions)
+    ctx = WorkspaceContext(ws).replace(is_aws=True, is_azure=False, aws_resource_permissions=aws_resource_permissions)
+    prompts = MockPrompts({'.*': 'No'})
+    create_missing_principals(ws, prompts=prompts, ctx=ctx)
+    assert not aws_resource_permissions.create_uc_roles.called
+
+
 def test_create_missing_principal_azure(ws, caplog):
     ctx = WorkspaceContext(ws).replace(is_aws=False, is_azure=True)
     prompts = MockPrompts({'.*': 'yes'})

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -495,7 +495,7 @@ def test_create_missing_principal_aws_not_approved(ws):
     ctx = WorkspaceContext(ws).replace(is_aws=True, is_azure=False, aws_resource_permissions=aws_resource_permissions)
     prompts = MockPrompts({'.*': 'No'})
     create_missing_principals(ws, prompts=prompts, ctx=ctx)
-    assert not aws_resource_permissions.create_uc_roles.called
+    aws_resource_permissions.create_uc_roles.assert_not_called()
 
 
 def test_create_missing_principal_azure(ws, caplog):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -107,6 +107,11 @@ def ws():
     return workspace_client
 
 
+@pytest.fixture
+def mock_iam_role_creation():
+    return create_autospec(IamRoleCreation)
+
+
 def test_workflow(ws, caplog):
     workflows(ws)
     assert "Fetching deployed jobs..." in caplog.messages

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -488,3 +488,11 @@ def test_create_missing_principal_aws(ws):
     prompts = MockPrompts({'.*': 'yes'})
     create_missing_principals(ws, prompts=prompts, ctx=ctx)
     aws_resource_permissions.create_uc_roles.assert_called_once()
+
+
+def test_create_missing_principal_azure(ws, caplog):
+    ctx = WorkspaceContext(ws).replace(is_aws=False, is_azure=True)
+    prompts = MockPrompts({'.*': 'yes'})
+    with pytest.raises(ValueError) as failure:
+        create_missing_principals(ws, prompts=prompts, ctx=ctx)
+    assert str(failure.value) == "Unsupported cloud provider"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,7 +16,6 @@ from databricks.sdk.service.workspace import ObjectInfo, ObjectType
 
 from databricks.labs.ucx.assessment.aws import AWSResources
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
-from databricks.labs.ucx.aws.credentials import IamRoleCreation
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.cli import (
     alias,
@@ -105,11 +104,6 @@ def ws():
         statement_id='123',
     )
     return workspace_client
-
-
-@pytest.fixture
-def mock_iam_role_creation():
-    return create_autospec(IamRoleCreation)
 
 
 def test_workflow(ws, caplog):
@@ -491,8 +485,6 @@ def test_migrate_external_hiveserde_tables_in_place(ws):
 def test_create_missing_principal_aws(ws):
     aws_resource_permissions = create_autospec(AWSResourcePermissions)
     ctx = WorkspaceContext(ws).replace(is_aws=True, is_azure=False, aws_resource_permissions=aws_resource_permissions)
-    iam_role = create_autospec(IamRoleCreation)
-    ctx.iam_create_uc_roles.return_value = iam_role
     prompts = MockPrompts({'.*': 'yes'})
     create_missing_principals(ws, prompts=prompts, ctx=ctx)
     aws_resource_permissions.create_uc_roles.assert_called_once()


### PR DESCRIPTION
 The `create_missing_principals` CLI command creates UC roles with `IamRoleCreation` from `databricks.labs.ucx.aws.credentials`. It updates `AWSRoleAction` with `role_arn` and adds `AWSUCRoleCandidate`. Not supported for Azure, and `migrate_credentials` is updated to migrate Azure Service Principals.