### PR TITLE
Fix failed integration test `test_migrate_external_tables_with_spn_azure`

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -493,7 +493,7 @@ def test_migrate_external_tables_with_spn_azure(
 ):
     if not ws.config.is_azure:
         pytest.skip("temporary: only works in azure test env")
-    ctx, table_full_name = prepared_principal_acl
+    ctx, table_full_name, _, _ = prepared_principal_acl
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
     ctx.with_dummy_resource_permission()
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Not sure why didn't the integration test run in PR #1413 catch the failure of this test `test_migrate_external_tables_with_spn_azure`, but we need this fix to avoid the  `ValueError: too many values to unpack (expected 2)` error.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1497

