### PR TITLE
Fix `migrate-credentials` command on aws

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -132,6 +132,11 @@ commands:
 
   - name: migrate-credentials
     description: Migrate credentials for storage access to UC storage credential
+    flags:
+      - name: subscription-id
+        description: Subscription to scan storage account in
+      - name: aws-profile
+        description: AWS Profile to use for authentication
 
   - name: create-account-groups
     is_account_level: true

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -268,7 +268,7 @@ class AWSResources:
         Create an AWS role with the given name and assume role policy document.
         """
         add_role = self._run_json_command(
-            f"iam create-role --role-name {role_name} " f"--assume-role-policy-document {assume_role_json}"
+            f"iam create-role --role-name {role_name} --assume-role-policy-document {assume_role_json}"
         )
         if not add_role:
             return None
@@ -289,10 +289,10 @@ class AWSResources:
         https://docs.databricks.com/en/connect/unity-catalog/storage-credentials.html
         """
         role_document = self._run_json_command(f"iam get-role --role-name {role_name}")
-        role = role_document.get("Role", {})
-        if role is None:
+        if role_document is None:
             logger.error(f"Role {role_name} doesn't exist")
             return None
+        role = role_document.get("Role")
         policy_document = role.get("AssumeRolePolicyDocument")
         if policy_document and policy_document.get("Statement"):
             for idx, statement in enumerate(policy_document["Statement"]):

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -390,7 +390,6 @@ class AWSResources:
     def _run_json_command(self, command: str):
         aws_cmd = shutil.which("aws")
         code, output, error = self._command_runner(f"{aws_cmd} {command} --profile {self._profile} --output json")
-        print(code, output, error)
         if code != 0:
             logger.error(error)
             return None

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -156,14 +156,14 @@ class AWSResources:
 
     def get_role_policy(self, role_name, policy_name: str | None = None, attached_policy_arn: str | None = None):
         if policy_name:
-            get_policy = f"iam get-role-policy --role-name {role_name} " f"--policy-name {policy_name}"
+            get_policy = f"iam get-role-policy --role-name {role_name} --policy-name {policy_name}"
         elif attached_policy_arn:
             get_attached_policy = f"iam get-policy --policy-arn {attached_policy_arn}"
             attached_policy = self._run_json_command(get_attached_policy)
             if not attached_policy:
                 return []
             policy_version = attached_policy["Policy"]["DefaultVersionId"]
-            get_policy = f"iam get-policy-version --policy-arn {attached_policy_arn} " f"--version-id {policy_version}"
+            get_policy = f"iam get-policy-version --policy-arn {attached_policy_arn} --version-id {policy_version}"
         else:
             logger.error("Failed to retrieve role. No role name or attached role ARN specified.")
             return []
@@ -315,7 +315,7 @@ class AWSResources:
         else:
             policy_document_json = self._aws_role_trust_doc(external_id)
         update_role = self._run_json_command(
-            f"iam update-assume-role-policy --role-name {role_name} " f"--policy-document {policy_document_json}"
+            f"iam update-assume-role-policy --role-name {role_name} --policy-document {policy_document_json}"
         )
         if not update_role:
             return None

--- a/src/databricks/labs/ucx/assessment/aws.py
+++ b/src/databricks/labs/ucx/assessment/aws.py
@@ -325,8 +325,7 @@ class AWSResources:
         self, role_name: str, policy_name: str, s3_prefixes: set[str], account_id: str, kms_key=None
     ) -> bool:
         if not self._run_command(
-            f"iam put-role-policy --role-name {role_name}"
-            f"--policy-name {policy_name} "
+            f"iam put-role-policy --role-name {role_name} --policy-name {policy_name} "
             f"--policy-document {self._aws_s3_policy(s3_prefixes, account_id, role_name, kms_key)}"
         ):
             return False

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -67,17 +67,15 @@ class AWSResourcePermissions:
                     role_name, policy_name, s3_prefixes, self._aws_account_id, self._kms_key
                 )
         else:
-            role_id = 1
-            for s3_prefix in sorted(list(s3_prefixes)):
-                if self._aws_resources.create_uc_role(f"{role_name}-{role_id}"):
+            for count, s3_prefix in enumerate(sorted(list(s3_prefixes))):
+                if self._aws_resources.create_uc_role(f"{role_name}-{count}"):
                     self._aws_resources.put_role_policy(
-                        f"{role_name}-{role_id}",
-                        f"{policy_name}-{role_id}",
+                        f"{role_name}-{count}",
+                        f"{policy_name}-{count}",
                         {s3_prefix},
                         self._aws_account_id,
                         self._kms_key,
                     )
-                role_id += 1
 
     def update_uc_role_trust_policy(self, role_name, external_id="0000"):
         return self._aws_resources.update_uc_trust_role(role_name, external_id)

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -67,11 +67,11 @@ class AWSResourcePermissions:
                     role_name, policy_name, s3_prefixes, self._aws_account_id, self._kms_key
                 )
         else:
-            for count, s3_prefix in enumerate(sorted(list(s3_prefixes))):
-                if self._aws_resources.create_uc_role(f"{role_name}-{count}"):
+            for idx, s3_prefix in enumerate(sorted(list(s3_prefixes))):
+                if self._aws_resources.create_uc_role(f"{role_name}-{idx+1}"):
                     self._aws_resources.put_role_policy(
-                        f"{role_name}-{count}",
-                        f"{policy_name}-{count}",
+                        f"{role_name}-{idx+1}",
+                        f"{policy_name}-{idx+1}",
                         {s3_prefix},
                         self._aws_account_id,
                         self._kms_key,

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -174,7 +174,7 @@ class IamRoleMigration:
         if execution_result:
             results_file = self.save(execution_result)
             logger.info(
-                f"Completed migration from IAM Role to UC Storage credentials"
+                f"Completed migration from IAM Role to UC Storage credentials. "
                 f"Please check {results_file} for validation results"
             )
         else:

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -166,7 +166,7 @@ class IamRoleMigration:
                 continue
 
             self._resource_permissions.update_uc_role_trust_policy(
-                iam.role_arn, storage_credential.aws_iam_role.external_id
+                iam.role_name, storage_credential.aws_iam_role.external_id
             )
 
             execution_result.append(self._storage_credential_manager.validate(iam))

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -151,6 +151,9 @@ class IamRoleMigration:
     def run(self, prompts: Prompts, include_names: set[str] | None = None) -> list[CredentialValidationResult]:
 
         iam_list = self._generate_migration_list(include_names)
+        if len(iam_list) == 0:
+            logger.info("No IAM Role to migrate")
+            return []
 
         plan_confirmed = prompts.confirm(
             "Above IAM roles will be migrated to UC storage credentials, please review and confirm."

--- a/tests/unit/assessment/test_aws.py
+++ b/tests/unit/assessment/test_aws.py
@@ -536,7 +536,7 @@ def test_create_uc_role(mocker):
         '--assume-role-policy-document '
         '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":'
         '{"AWS":"arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"}'
-        ',"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"0000"}}}]} --output json'
+        ',"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"0000"}}}]} --profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -599,7 +599,7 @@ def test_update_uc_trust_role_append(mocker):
         '{"Effect":"Allow",'
         '"Principal":{"AWS":"arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"},'
         '"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"1234"}}}]} '
-        '--output json'
+        '--profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -640,7 +640,7 @@ def test_update_uc_trust_role(mocker):
         '{"Effect":"Allow",'
         '"Principal":{"AWS":"arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"},'
         '"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"1234"}}}]} '
-        '--output json'
+        '--profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -662,7 +662,7 @@ def test_create_uc_role_policy_no_kms(mocker):
         '"s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::BUCKET1/FOLDER1",'
         '"arn:aws:s3:::BUCKET1/FOLDER1/*","arn:aws:s3:::BUCKET2/FOLDER2","arn:aws:s3:::BUCKET2/FOLDER2/*"],'
         '"Effect":"Allow"},{"Action":["sts:AssumeRole"],"Resource":["arn:aws:iam::1234:role/test_role"],'
-        '"Effect":"Allow"}]} --output json'
+        '"Effect":"Allow"}]} --profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -685,7 +685,7 @@ def test_create_uc_role_kms(mocker):
         '"arn:aws:s3:::BUCKET1/FOLDER1/*","arn:aws:s3:::BUCKET2/FOLDER2","arn:aws:s3:::BUCKET2/FOLDER2/*"],'
         '"Effect":"Allow"},{"Action":["sts:AssumeRole"],"Resource":["arn:aws:iam::1234:role/test_role"],'
         '"Effect":"Allow"},{"Action":["kms:Decrypt","kms:Encrypt","kms:GenerateDataKey*"],'
-        '"Resource":["arn:aws:kms:key_arn"],"Effect":"Allow"}]} --output json'
+        '"Resource":["arn:aws:kms:key_arn"],"Effect":"Allow"}]} --profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -699,7 +699,10 @@ def test_create_instance_profile(mocker):
 
     aws = AWSResources("Fake_Profile", command_call)
     aws.create_instance_profile("test_profile")
-    assert '/path/aws iam create-instance-profile --instance-profile-name test_profile --output json' in command_calls
+    assert (
+        '/path/aws iam create-instance-profile --instance-profile-name test_profile --profile Fake_Profile --output json'
+        in command_calls
+    )
 
     def failed_call(_):
         return -1, "", "Can't connect"
@@ -718,11 +721,14 @@ def test_delete_instance_profile(mocker):
 
     aws = AWSResources("Fake_Profile", command_call)
     aws.delete_instance_profile("test_profile", "test_profile")
-    assert '/path/aws iam delete-instance-profile --instance-profile-name test_profile --output json' in command_calls
-    assert '/path/aws iam delete-role --role-name test_profile --output json' in command_calls
+    assert (
+        '/path/aws iam delete-instance-profile --instance-profile-name test_profile --profile Fake_Profile --output json'
+        in command_calls
+    )
+    assert '/path/aws iam delete-role --role-name test_profile --profile Fake_Profile --output json' in command_calls
     assert (
         '/path/aws iam remove-role-from-instance-profile '
-        '--instance-profile-name test_profile --role-name test_profile --output json'
+        '--instance-profile-name test_profile --role-name test_profile --profile Fake_Profile --output json'
     ) in command_calls
 
 
@@ -736,7 +742,7 @@ def test_role_exists(mocker):
 
     aws = AWSResources("Fake_Profile", empty_call)
     assert aws.role_exists("test_profile") is False
-    assert '/path/aws iam list-roles --output json' in command_calls
+    assert '/path/aws iam list-roles --profile Fake_Profile --output json' in command_calls
 
     def exists_call(cmd: str):
         command_calls.append(cmd)
@@ -744,4 +750,4 @@ def test_role_exists(mocker):
 
     aws = AWSResources("Fake_Profile", exists_call)
     assert aws.role_exists("test_profile") is True
-    assert '/path/aws iam list-roles --output json' in command_calls
+    assert '/path/aws iam list-roles --profile Fake_Profile --output json' in command_calls

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -316,7 +316,7 @@ def test_migrate_credentials_azure(ws):
     ws.storage_credentials.list.assert_called()
 
 
-def test_migrate_credentials_aws(ws, mocker):
+def test_migrate_credentials_aws(ws):
     aws_resources = create_autospec(AWSResources)
     aws_resources.validate_connection.return_value = {"Account": "123456789012"}
     prompts = MockPrompts({'.*': 'yes'})


### PR DESCRIPTION
## Changes
- added missing flags to `migrate-credential` command
- passed AWS profile explicitly to all awscli commands
- passed IAM role name when updating trust policy instead of IAM ARN

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1332

### Functionality 

- [x] modified existing command: `databricks labs ucx migrate-credentials`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
