### PR TITLE
Grant uber principal write permissions so that SYNC command will succeed

### DIFF
--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -186,7 +186,7 @@ class AzureResourcePermissions:
         )
         try:
             self._apply_storage_permission(
-                uber_principal.client.object_id, "STORAGE_BLOB_DATA_READER", *storage_account_info
+                uber_principal.client.object_id, "STORAGE_BLOB_DATA_CONTRIBUTOR", *storage_account_info
             )
             self._installation.save(config)
             self._update_cluster_policy_with_spn(policy_id, storage_account_info, uber_principal, inventory_database)

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -15,7 +15,8 @@ from databricks.sdk.errors import NotFound, PermissionDenied, ResourceConflict
 from databricks.labs.ucx.assessment.crawlers import logger
 
 # https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-_ROLES = {"STORAGE_BLOB_DATA_READER": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"}
+_ROLES = {"STORAGE_BLOB_DATA_READER": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+          "STORAGE_BLOB_DATA_CONTRIBUTOR": "ba92f5b4-2d11-453d-a403-e96b0029c9fe"}
 
 
 @dataclass

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -15,8 +15,10 @@ from databricks.sdk.errors import NotFound, PermissionDenied, ResourceConflict
 from databricks.labs.ucx.assessment.crawlers import logger
 
 # https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
-_ROLES = {"STORAGE_BLOB_DATA_READER": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
-          "STORAGE_BLOB_DATA_CONTRIBUTOR": "ba92f5b4-2d11-453d-a403-e96b0029c9fe"}
+_ROLES = {
+    "STORAGE_BLOB_DATA_READER": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+    "STORAGE_BLOB_DATA_CONTRIBUTOR": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+}
 
 
 @dataclass

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -55,7 +55,7 @@ def test_save_spn_permissions_local(ws, sql_backend, inventory_schema, make_rand
     assert ws.workspace.get_status(path)
 
 
-#@pytest.mark.skip
+# @pytest.mark.skip
 def test_create_global_spn(ws, sql_backend, inventory_schema, make_random, make_cluster_policy, env_or_skip):
     tables = [
         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/folder1", 1),

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -55,7 +55,7 @@ def test_save_spn_permissions_local(ws, sql_backend, inventory_schema, make_rand
     assert ws.workspace.get_status(path)
 
 
-@pytest.mark.skip
+#@pytest.mark.skip
 def test_create_global_spn(ws, sql_backend, inventory_schema, make_random, make_cluster_policy, env_or_skip):
     tables = [
         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/folder1", 1),
@@ -88,7 +88,7 @@ def test_create_global_spn(ws, sql_backend, inventory_schema, make_random, make_
             break
     assert global_spn_assignment
     assert global_spn_assignment.principal.client_id == config.uber_spn_id
-    assert global_spn_assignment.role_name == "Storage Blob Data Reader"
+    assert global_spn_assignment.role_name == "Storage Blob Data Contributor"
     assert str(global_spn_assignment.scope) == resource_id
     assert (
         policy_definition["spark_conf.fs.azure.account.oauth2.client.id.labsazurethings.dfs.core.windows.net"]["value"]


### PR DESCRIPTION
## Changes
Grant uber principal on Azure blob contributor permission, to match the implementation on AWS where uber principal is granted write permission to all the s3 buckets
https://github.com/databrickslabs/ucx/blob/10ca568cf8c7b465c513bba42431bf02669f1a61/src/databricks/labs/ucx/assessment/aws.py#L245-L257

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #939

### Functionality 

- [ ] modified existing command: `databricks labs ucx create-uber-principal`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] verified on staging environment (screenshot attached)
