### PR TITLE
Detect direct access to cloud storage and raise a deprecation warning

### DIFF
--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -237,8 +237,6 @@ class SparkMatchers:
             TableNameMatcher("register", 1, 2, 0, "name"),
         ]
 
-        # TODO: Identify all methods in the Spark API that may refer to direct cloud storage,
-        #  check parameter location/name
         spark_cloud_matchers = [
             CloudAccessMatcher("ls", 1, 1, 0),
             CloudAccessMatcher("cp", 1, 2, 0),
@@ -259,6 +257,15 @@ class SparkMatchers:
             CloudAccessMatcher("binaryFiles", 1, 2, 0),
             CloudAccessMatcher("binaryRecords", 1, 2, 0),
             CloudAccessMatcher("dump_profiles", 1, 1, 0),
+            CloudAccessMatcher("hadoopFile", 1, 8, 0),
+            CloudAccessMatcher("newAPIHadoopFile", 1, 8, 0),
+            CloudAccessMatcher("pickleFile", 1, 3, 0),
+            CloudAccessMatcher("saveAsHadoopFile", 1, 8, 0),
+            CloudAccessMatcher("saveAsNewAPIHadoopFile", 1, 7, 0),
+            CloudAccessMatcher("saveAsPickleFile", 1, 2, 0),
+            CloudAccessMatcher("saveAsSequenceFile", 1, 2, 0),
+            CloudAccessMatcher("saveAsTextFile", 1, 2, 0),
+            CloudAccessMatcher("load_from_path", 1, 1, 0),
         ]
 
         # nothing to migrate in UserDefinedFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedFunction.html

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -157,9 +157,8 @@ class ReturnValueMatcher(Matcher):
 class CloudAccessMatcher(Matcher):
 
     def matches(self, node: ast.AST):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
-            return False
-        return self._get_table_arg(node) is not None
+        return isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and self._get_table_arg(
+            node) is not None
 
     def lint(self, from_table: FromTable, index: MigrationIndex, node: ast.Call) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -52,6 +52,8 @@ class Matcher(ABC):
         if len(node.args) > 0:
             return node.args[self.table_arg_index] if self.min_args <= len(node.args) <= self.max_args else None
         assert self.table_arg_name is not None
+        if not node.keywords:
+            return None
         arg = next(kw for kw in node.keywords if kw.arg == self.table_arg_name)
         return arg.value if arg is not None else None
 
@@ -238,17 +240,25 @@ class SparkMatchers:
         # TODO: Identify all methods in the Spark API that may refer to direct cloud storage,
         #  check parameter location/name
         spark_cloud_matchers = [
-            CloudAccessMatcher("read", 1, 1, 0),
-            CloudAccessMatcher("write", 1, 1, 0),
             CloudAccessMatcher("ls", 1, 1, 0),
-            CloudAccessMatcher("cp", 1, 1, 0),
+            CloudAccessMatcher("cp", 1, 2, 0),
             CloudAccessMatcher("rm", 1, 1, 0),
             CloudAccessMatcher("head", 1, 1, 0),
-            CloudAccessMatcher("put", 1, 1, 0),
+            CloudAccessMatcher("put", 1, 2, 0),
             CloudAccessMatcher("mkdirs", 1, 1, 0),
-            CloudAccessMatcher("move", 1, 1, 0),
-            CloudAccessMatcher("text", 1, 1, 0),
-            CloudAccessMatcher("csv", 1, 1, 0),
+            CloudAccessMatcher("move", 1, 2, 0),
+            CloudAccessMatcher("text", 1, 3, 0),
+            CloudAccessMatcher("csv", 1, 1000, 0),
+            CloudAccessMatcher("json", 1, 1000, 0),
+            CloudAccessMatcher("orc", 1, 1000, 0),
+            CloudAccessMatcher("parquet", 1, 1000, 0),
+            CloudAccessMatcher("save", 0, 1000, -1, "path"),
+            CloudAccessMatcher("load", 0, 1000, -1, "path"),
+            CloudAccessMatcher("option", 1, 1000, 1),  # Only .option("path", "xxx://bucket/path") will hit
+            CloudAccessMatcher("addFile", 1, 3, 0),
+            CloudAccessMatcher("binaryFiles", 1, 2, 0),
+            CloudAccessMatcher("binaryRecords", 1, 2, 0),
+            CloudAccessMatcher("dump_profiles", 1, 1, 0),
         ]
 
         # nothing to migrate in UserDefinedFunction, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UserDefinedFunction.html

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -157,8 +157,11 @@ class ReturnValueMatcher(Matcher):
 class CloudAccessMatcher(Matcher):
 
     def matches(self, node: ast.AST):
-        return isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and self._get_table_arg(
-            node) is not None
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and self._get_table_arg(node) is not None
+        )
 
     def lint(self, from_table: FromTable, index: MigrationIndex, node: ast.Call) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -174,7 +174,8 @@ class ReturnValueMatcher(Matcher):
         )
 
     def apply(self, from_table: FromTable, index: MigrationIndex, node: ast.Call) -> None:
-        raise NotImplementedError("Should never get there!")
+        # No transformations to apply
+        return
 
 
 @dataclass
@@ -208,7 +209,7 @@ class DirectFilesystemAccessMatcher(Matcher):
         if any(table_arg.value.startswith(prefix) for prefix in self._DIRECT_FS_REFS):
             yield Deprecation(
                 code='direct-filesystem-access',
-                message=f"The use of cloud direct references is deprecated: {table_arg.value}",
+                message=f"The use of direct filesystem references is deprecated: {table_arg.value}",
                 start_line=node.lineno,
                 start_col=node.col_offset,
                 end_line=node.end_lineno or 0,

--- a/src/databricks/labs/ucx/source_code/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/pyspark.py
@@ -13,6 +13,19 @@ from databricks.labs.ucx.source_code.base import (
 )
 from databricks.labs.ucx.source_code.queries import FromTable
 
+CLOUD_DIRECT_REFS = {
+    "s3a://",
+    "s3n://",
+    "s3://",
+    "wasb://",
+    "wasbs://",
+    "abfs://",
+    "abfss://",
+    "dbfs:/",
+    "hdfs://",
+    "file:/",
+}
+
 
 @dataclass
 class Matcher(ABC):

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -154,6 +154,22 @@ SELECT * FROM delta.`/mnt/...` WHERE foo > 6
 MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED THEN DELETE
     """,
             [
+                Deprecation(
+                    code='cloud-access',
+                    message='The use of cloud direct references is deprecated: ' "'dbfs:/mnt/foo/bar'",
+                    start_line=16,
+                    start_col=0,
+                    end_line=16,
+                    end_col=39,
+                ),
+                Deprecation(
+                    code='cloud-access',
+                    message='The use of cloud direct references is deprecated: ' "'dbfs://mnt/foo/bar'",
+                    start_line=17,
+                    start_col=0,
+                    end_line=17,
+                    end_col=40,
+                ),
                 Advisory(
                     code='dbfs-usage',
                     message='Possible deprecated file system path: dbfs:/...',

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -40,6 +40,14 @@ SELECT * FROM csv.`dbfs:/mnt/whatever`
                     end_col=1024,
                 ),
                 Deprecation(
+                    code='cloud-access',
+                    message='The use of default dbfs: references is deprecated: ' '/mnt/things/e/f/g',
+                    start_line=14,
+                    start_col=8,
+                    end_line=14,
+                    end_col=43,
+                ),
+                Deprecation(
                     code='dbfs-usage',
                     message='Deprecated file system path in call to: /mnt/things/e/f/g',
                     start_line=14,
@@ -82,6 +90,14 @@ display(spark.read.csv('/mnt/things/e/f/g'))
 
 """,
             [
+                Deprecation(
+                    code='cloud-access',
+                    message='The use of default dbfs: references is deprecated: ' '/mnt/things/e/f/g',
+                    start_line=5,
+                    start_col=8,
+                    end_line=5,
+                    end_col=43,
+                ),
                 Deprecation(
                     code='dbfs-usage',
                     message='Deprecated file system path in call to: /mnt/things/e/f/g',
@@ -156,7 +172,15 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
             [
                 Deprecation(
                     code='cloud-access',
-                    message='The use of cloud direct references is deprecated: ' "'dbfs:/mnt/foo/bar'",
+                    message='The use of default dbfs: references is deprecated: /mnt/foo/bar',
+                    start_line=15,
+                    start_col=0,
+                    end_line=15,
+                    end_col=34,
+                ),
+                Deprecation(
+                    code='cloud-access',
+                    message='The use of cloud direct references is deprecated: dbfs:/mnt/foo/bar',
                     start_line=16,
                     start_col=0,
                     end_line=16,
@@ -164,7 +188,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
                 ),
                 Deprecation(
                     code='cloud-access',
-                    message='The use of cloud direct references is deprecated: ' "'dbfs://mnt/foo/bar'",
+                    message='The use of cloud direct references is deprecated: dbfs://mnt/foo/bar',
                     start_line=17,
                     start_col=0,
                     end_line=17,

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -40,7 +40,7 @@ SELECT * FROM csv.`dbfs:/mnt/whatever`
                     end_col=1024,
                 ),
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of default dbfs: references is deprecated: ' '/mnt/things/e/f/g',
                     start_line=14,
                     start_col=8,
@@ -91,7 +91,7 @@ display(spark.read.csv('/mnt/things/e/f/g'))
 """,
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of default dbfs: references is deprecated: ' '/mnt/things/e/f/g',
                     start_line=5,
                     start_col=8,
@@ -171,7 +171,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
     """,
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of default dbfs: references is deprecated: /mnt/foo/bar',
                     start_line=15,
                     start_col=0,
@@ -179,7 +179,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
                     end_col=34,
                 ),
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of cloud direct references is deprecated: dbfs:/mnt/foo/bar',
                     start_line=16,
                     start_col=0,
@@ -187,7 +187,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
                     end_col=39,
                 ),
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of cloud direct references is deprecated: dbfs://mnt/foo/bar',
                     start_line=17,
                     start_col=0,

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -180,7 +180,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
                 ),
                 Deprecation(
                     code='direct-filesystem-access',
-                    message='The use of cloud direct references is deprecated: dbfs:/mnt/foo/bar',
+                    message='The use of direct filesystem references is deprecated: dbfs:/mnt/foo/bar',
                     start_line=16,
                     start_col=0,
                     end_line=16,
@@ -188,7 +188,7 @@ MERGE INTO delta.`/dbfs/...` t USING source ON t.key = source.key WHEN MATCHED T
                 ),
                 Deprecation(
                     code='direct-filesystem-access',
-                    message='The use of cloud direct references is deprecated: dbfs://mnt/foo/bar',
+                    message='The use of direct filesystem references is deprecated: dbfs://mnt/foo/bar',
                     start_line=17,
                     start_col=0,
                     end_line=17,

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -37,7 +37,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -67,7 +67,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -120,7 +120,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -185,7 +185,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -214,7 +214,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -243,7 +243,7 @@ for i in range(10):
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -271,7 +271,7 @@ for table in spark.listTables():
 """
     assert [
         Deprecation(
-            code='cloud-access',
+            code='direct-filesystem-access',
             message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
@@ -316,7 +316,7 @@ for i in range(10):
             """dbutils.fs.ls("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -330,7 +330,7 @@ for i in range(10):
             """dbutils.fs.cp("s3n://bucket/path", "s3n://another_bucket/another_path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3n://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -344,7 +344,7 @@ for i in range(10):
             """dbutils.fs.rm("s3://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -358,7 +358,7 @@ for i in range(10):
             """dbutils.fs.head("wasb://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: wasb://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -372,7 +372,7 @@ for i in range(10):
             """dbutils.fs.put("wasbs://bucket/path", "data")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: wasbs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -386,7 +386,7 @@ for i in range(10):
             """dbutils.fs.mkdirs("abfs://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: abfs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -400,7 +400,7 @@ for i in range(10):
             """dbutils.fs.mv("wasb://bucket/path", "wasb://another_bucket/another_path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: wasb://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -414,7 +414,7 @@ for i in range(10):
             """spark.read.text("wasbs://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: wasbs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -428,7 +428,7 @@ for i in range(10):
             """spark.read.csv("abfs://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: abfs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -447,7 +447,7 @@ for i in range(10):
   .save())""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message='The use of cloud direct references is deprecated: '
                     "s3a://your_bucket_name/your_directory/",
                     start_line=1,
@@ -462,7 +462,7 @@ for i in range(10):
             """spark.read.json("abfss://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: abfss://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -476,7 +476,7 @@ for i in range(10):
             """spark.read.orc("dbfs://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: dbfs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -490,7 +490,7 @@ for i in range(10):
             """spark.read.parquet("hdfs://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: hdfs://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -504,7 +504,7 @@ for i in range(10):
             """spark.write.save("file://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: file://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -518,7 +518,7 @@ for i in range(10):
             """spark.read.load("/bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of default dbfs: references is deprecated: /bucket/path",
                     start_line=1,
                     start_col=0,
@@ -532,7 +532,7 @@ for i in range(10):
             """spark.addFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -546,7 +546,7 @@ for i in range(10):
             """spark.binaryFiles("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -560,7 +560,7 @@ for i in range(10):
             """spark.binaryRecords("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -574,7 +574,7 @@ for i in range(10):
             """spark.dump_profiles("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -588,7 +588,7 @@ for i in range(10):
             """spark.hadoopFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -602,7 +602,7 @@ for i in range(10):
             """spark.newAPIHadoopFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -616,7 +616,7 @@ for i in range(10):
             """spark.pickleFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -630,7 +630,7 @@ for i in range(10):
             """spark.saveAsHadoopFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -644,7 +644,7 @@ for i in range(10):
             """spark.saveAsNewAPIHadoopFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -658,7 +658,7 @@ for i in range(10):
             """spark.saveAsPickleFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -672,7 +672,7 @@ for i in range(10):
             """spark.saveAsSequenceFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -686,7 +686,7 @@ for i in range(10):
             """spark.saveAsTextFile("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
@@ -700,7 +700,7 @@ for i in range(10):
             """spark.load_from_path("s3a://bucket/path")""",
             [
                 Deprecation(
-                    code='cloud-access',
+                    code='direct-filesystem-access',
                     message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -530,9 +530,134 @@ for i in range(10):
                 )
             ],
         ),
+        # Test for 'hadoopFile' function
+        (
+            """spark.hadoopFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=37,
+                )
+            ],
+        ),
+        # Test for 'newAPIHadoopFile' function
+        (
+            """spark.newAPIHadoopFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=43,
+                )
+            ],
+        ),
+        # Test for 'pickleFile' function
+        (
+            """spark.pickleFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=37,
+                )
+            ],
+        ),
+        # Test for 'saveAsHadoopFile' function
+        (
+            """spark.saveAsHadoopFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=43,
+                )
+            ],
+        ),
+        # Test for 'saveAsNewAPIHadoopFile' function
+        (
+            """spark.saveAsNewAPIHadoopFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=49,
+                )
+            ],
+        ),
+        # Test for 'saveAsPickleFile' function
+        (
+            """spark.saveAsPickleFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=43,
+                )
+            ],
+        ),
+        # Test for 'saveAsSequenceFile' function
+        (
+            """spark.saveAsSequenceFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=45,
+                )
+            ],
+        ),
+        # Test for 'saveAsTextFile' function
+        (
+            """spark.saveAsTextFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=41,
+                )
+            ],
+        ),
+        # Test for 'load_from_path' function
+        (
+            """spark.load_from_path("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=41,
+                )
+            ],
+        ),
     ],
 )
-# TODO Add more tests
 def test_spark_cloud_direct_access(empty_index, code, expected):
     ftf = FromTable(empty_index, CurrentSessionState())
     sqf = SparkSql(ftf, empty_index)

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -258,6 +258,119 @@ for i in range(10):
 @pytest.mark.parametrize(
     "code, expected",
     [
+        # Test for 'ls' function
+        (
+            """spark.ls("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=29,
+                )
+            ],
+        ),
+        # Test for 'cp' function. Note that the current code will stop at the first deprecation found.
+        (
+            """spark.cp("s3a://bucket/path", "s3a://another_bucket/another_path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=66,
+                )
+            ],
+        ),
+        # Test for 'rm' function
+        (
+            """spark.rm("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=29,
+                )
+            ],
+        ),
+        # Test for 'head' function
+        (
+            """spark.head("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=31,
+                )
+            ],
+        ),
+        # Test for 'put' function
+        (
+            """spark.put("s3a://bucket/path", "data")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=38,
+                )
+            ],
+        ),
+        # Test for 'mkdirs' function
+        (
+            """spark.mkdirs("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=33,
+                )
+            ],
+        ),
+        # Test for 'move' function
+        (
+            """spark.move("s3a://bucket/path", "s3a://another_bucket/another_path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=68,
+                )
+            ],
+        ),
+        # Test for 'text' function
+        (
+            """spark.read.text("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=36,
+                )
+            ],
+        ),
+        # Test for 'csv' function
         (
             """spark.read.csv("s3a://bucket/path")""",
             [
@@ -268,6 +381,152 @@ for i in range(10):
                     start_col=0,
                     end_line=1,
                     end_col=35,
+                )
+            ],
+        ),
+        # Test for option function
+        (
+            """(df.write
+  .format("parquet")
+  .option("path", "s3a://your_bucket_name/your_directory/")
+  .option("spark.hadoop.fs.s3a.access.key", "your_access_key")
+  .option("spark.hadoop.fs.s3a.secret.key", "your_secret_key")
+  .save())""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message='The use of cloud direct references is deprecated: '
+                    "'s3a://your_bucket_name/your_directory/'",
+                    start_line=1,
+                    start_col=1,
+                    end_line=3,
+                    end_col=59,
+                )
+            ],
+        ),
+        # Test for 'json' function
+        (
+            """spark.read.json("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=36,
+                )
+            ],
+        ),
+        # Test for 'orc' function
+        (
+            """spark.read.orc("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=35,
+                )
+            ],
+        ),
+        # Test for 'parquet' function
+        (
+            """spark.read.parquet("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=39,
+                )
+            ],
+        ),
+        # Test for 'save' function
+        (
+            """spark.write.save("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=37,
+                )
+            ],
+        ),
+        # Test for 'load' function
+        (
+            """spark.read.load("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=36,
+                )
+            ],
+        ),
+        # Test for 'addFile' function
+        (
+            """spark.addFile("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=34,
+                )
+            ],
+        ),
+        # Test for 'binaryFiles' function
+        (
+            """spark.binaryFiles("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=38,
+                )
+            ],
+        ),
+        # Test for 'binaryRecords' function
+        (
+            """spark.binaryRecords("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=40,
+                )
+            ],
+        ),
+        # Test for 'dump_profiles' function
+        (
+            """spark.dump_profiles("s3a://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=40,
                 )
             ],
         ),

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -731,12 +731,23 @@ def test_spark_cloud_direct_access(empty_index, code, expected):
     assert advisories == expected
 
 
-# TODO: Expand the tests  to cover all dbutils.fs functions
-def test_direct_cloud_access_reports_nothing(empty_index):
+FS_FUNCTIONS = [
+    "ls",
+    "cp",
+    "rm",
+    "mv",
+    "head",
+    "put",
+    "mkdirs",
+]
+
+
+@pytest.mark.parametrize("fs_function", FS_FUNCTIONS)
+def test_direct_cloud_access_reports_nothing(empty_index, fs_function):
     ftf = FromTable(empty_index, CurrentSessionState())
     sqf = SparkSql(ftf, empty_index)
     # ls function calls have to be from dbutils.fs, or we ignore them
-    code = """spark.ls("/bucket/path")"""
+    code = f"""spark.{fs_function}("/bucket/path")"""
     advisories = list(sqf.lint(code))
     assert not advisories
 

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -38,7 +38,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -68,7 +68,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -121,7 +121,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -186,7 +186,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -215,7 +215,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -244,7 +244,7 @@ for i in range(10):
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -272,7 +272,7 @@ for table in spark.listTables():
     assert [
         Deprecation(
             code='direct-filesystem-access',
-            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            message='The use of direct filesystem references is deprecated: ' 's3://bucket/path',
             start_line=2,
             start_col=0,
             end_line=2,
@@ -287,6 +287,17 @@ for table in spark.listTables():
             end_col=31,
         ),
     ] == list(sqf.lint(old_code))
+
+
+def test_spark_table_return_value_apply(migration_index):
+    ftf = FromTable(migration_index, CurrentSessionState())
+    sqf = SparkSql(ftf, migration_index)
+    old_code = """spark.read.csv('s3://bucket/path')
+for table in spark.listTables():
+    do_stuff_with_table(table)"""
+    fixed_code = sqf.apply(old_code)
+    # no transformations to apply, only lint messages
+    assert fixed_code == old_code
 
 
 def test_spark_sql_fix(migration_index):
@@ -317,7 +328,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -331,7 +342,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3n://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3n://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -345,7 +356,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -359,7 +370,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: wasb://bucket/path",
+                    message="The use of direct filesystem references is deprecated: wasb://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -373,7 +384,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: wasbs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: wasbs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -387,7 +398,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: abfs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: abfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -401,7 +412,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: wasb://bucket/path",
+                    message="The use of direct filesystem references is deprecated: wasb://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -415,7 +426,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: wasbs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: wasbs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -429,7 +440,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: abfs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: abfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -448,7 +459,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message='The use of cloud direct references is deprecated: '
+                    message='The use of direct filesystem references is deprecated: '
                     "s3a://your_bucket_name/your_directory/",
                     start_line=1,
                     start_col=1,
@@ -463,7 +474,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: abfss://bucket/path",
+                    message="The use of direct filesystem references is deprecated: abfss://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -477,7 +488,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: dbfs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: dbfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -491,7 +502,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: hdfs://bucket/path",
+                    message="The use of direct filesystem references is deprecated: hdfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -505,7 +516,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: file://bucket/path",
+                    message="The use of direct filesystem references is deprecated: file://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -533,7 +544,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -547,7 +558,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -561,7 +572,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -575,7 +586,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -589,7 +600,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -603,7 +614,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -617,7 +628,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -631,7 +642,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -645,7 +656,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -659,7 +670,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -673,7 +684,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -687,7 +698,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -701,7 +712,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='direct-filesystem-access',
-                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
+                    message="The use of direct filesystem references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -17,7 +17,6 @@ def test_spark_sql_no_match(empty_index):
     sqf = SparkSql(ftf, empty_index)
 
     old_code = """
-spark.read.csv("/bucket/path")
 for i in range(10):
     result = spark.sql("SELECT * FROM old.things").collect()
     print(len(result))
@@ -31,12 +30,20 @@ def test_spark_sql_match(migration_index):
     sqf = SparkSql(ftf, migration_index)
 
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     result = spark.sql("SELECT * FROM old.things").collect()
     print(len(result))
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Deprecation(
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
@@ -44,7 +51,7 @@ for i in range(10):
             start_col=13,
             end_line=4,
             end_col=50,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -53,12 +60,20 @@ def test_spark_sql_match_named(migration_index):
     sqf = SparkSql(ftf, migration_index)
 
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     result = spark.sql(args=[1], sqlQuery = "SELECT * FROM old.things").collect()
     print(len(result))
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Deprecation(
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
@@ -66,7 +81,7 @@ for i in range(10):
             start_col=13,
             end_line=4,
             end_col=71,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -98,12 +113,20 @@ def test_spark_table_match(migration_index, method_name):
     args_list[matcher.table_arg_index] = '"old.things"'
     args = ",".join(args_list)
     old_code = f"""
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Deprecation(
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
@@ -125,7 +148,6 @@ def test_spark_table_no_match(migration_index, method_name):
     args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
     args = ",".join(args_list)
     old_code = f"""
-spark.read.csv("/some/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
@@ -145,7 +167,6 @@ def test_spark_table_too_many_args(migration_index, method_name):
     args_list[matcher.table_arg_index] = '"table.we.know.nothing.about"'
     args = ",".join(args_list)
     old_code = f"""
-spark.read.csv("/some/path")
 for i in range(10):
     df = spark.{method_name}({args})
     do_stuff_with_df(df)
@@ -157,12 +178,20 @@ def test_spark_table_named_args(migration_index):
     ftf = FromTable(migration_index, CurrentSessionState())
     sqf = SparkSql(ftf, migration_index)
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.saveAsTable(format="xyz", name="old.things")
     do_stuff_with_df(df)
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Deprecation(
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
@@ -170,7 +199,7 @@ for i in range(10):
             start_col=9,
             end_line=4,
             end_col=59,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -178,12 +207,20 @@ def test_spark_table_variable_arg(migration_index):
     ftf = FromTable(migration_index, CurrentSessionState())
     sqf = SparkSql(ftf, migration_index)
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.saveAsTable(name)
     do_stuff_with_df(df)
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Advisory(
             code='table-migrate',
             message="Can't migrate 'saveAsTable' because its table name argument is not a constant",
@@ -191,7 +228,7 @@ for i in range(10):
             start_col=9,
             end_line=4,
             end_col=32,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -199,12 +236,20 @@ def test_spark_table_fstring_arg(migration_index):
     ftf = FromTable(migration_index, CurrentSessionState())
     sqf = SparkSql(ftf, migration_index)
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for i in range(10):
     df = spark.saveAsTable(f"boop{stuff}")
     do_stuff_with_df(df)
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Advisory(
             code='table-migrate',
             message="Can't migrate 'saveAsTable' because its table name argument is not a constant",
@@ -212,7 +257,7 @@ for i in range(10):
             start_col=9,
             end_line=4,
             end_col=42,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -220,11 +265,19 @@ def test_spark_table_return_value(migration_index):
     ftf = FromTable(migration_index, CurrentSessionState())
     sqf = SparkSql(ftf, migration_index)
     old_code = """
-spark.read.csv("/some/path")
+spark.read.csv("s3://bucket/path")
 for table in spark.listTables():
     do_stuff_with_table(table)
 """
     assert [
+        Deprecation(
+            code='cloud-access',
+            message='The use of cloud direct references is deprecated: ' 's3://bucket/path',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=34,
+        ),
         Advisory(
             code='table-migrate',
             message="Call to 'listTables' will return a list of <catalog>.<database>.<table> instead of <database>.<table>.",
@@ -232,7 +285,7 @@ for table in spark.listTables():
             start_col=13,
             end_line=3,
             end_col=31,
-        )
+        ),
     ] == list(sqf.lint(old_code))
 
 
@@ -240,7 +293,7 @@ def test_spark_sql_fix(migration_index):
     ftf = FromTable(migration_index, CurrentSessionState())
     sqf = SparkSql(ftf, migration_index)
 
-    old_code = """spark.read.csv("/some/path")
+    old_code = """spark.read.csv("s3://bucket/path")
 for i in range(10):
     result = spark.sql("SELECT * FROM old.things").collect()
     print(len(result))
@@ -248,7 +301,7 @@ for i in range(10):
     fixed_code = sqf.apply(old_code)
     assert (
         fixed_code
-        == """spark.read.csv('/some/path')
+        == """spark.read.csv('s3://bucket/path')
 for i in range(10):
     result = spark.sql('SELECT * FROM brand.new.stuff').collect()
     print(len(result))"""
@@ -260,81 +313,39 @@ for i in range(10):
     [
         # Test for 'ls' function
         (
-            """spark.ls("s3a://bucket/path")""",
+            """dbutils.fs.ls("s3a://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=29,
+                    end_col=34,
                 )
             ],
         ),
         # Test for 'cp' function. Note that the current code will stop at the first deprecation found.
         (
-            """spark.cp("s3a://bucket/path", "s3a://another_bucket/another_path")""",
+            """dbutils.fs.cp("s3n://bucket/path", "s3n://another_bucket/another_path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3n://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=66,
+                    end_col=71,
                 )
             ],
         ),
         # Test for 'rm' function
         (
-            """spark.rm("s3a://bucket/path")""",
+            """dbutils.fs.rm("s3://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
-                    start_line=1,
-                    start_col=0,
-                    end_line=1,
-                    end_col=29,
-                )
-            ],
-        ),
-        # Test for 'head' function
-        (
-            """spark.head("s3a://bucket/path")""",
-            [
-                Deprecation(
-                    code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
-                    start_line=1,
-                    start_col=0,
-                    end_line=1,
-                    end_col=31,
-                )
-            ],
-        ),
-        # Test for 'put' function
-        (
-            """spark.put("s3a://bucket/path", "data")""",
-            [
-                Deprecation(
-                    code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
-                    start_line=1,
-                    start_col=0,
-                    end_line=1,
-                    end_col=38,
-                )
-            ],
-        ),
-        # Test for 'mkdirs' function
-        (
-            """spark.mkdirs("s3a://bucket/path")""",
-            [
-                Deprecation(
-                    code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -342,45 +353,87 @@ for i in range(10):
                 )
             ],
         ),
-        # Test for 'move' function
+        # Test for 'head' function
         (
-            """spark.move("s3a://bucket/path", "s3a://another_bucket/another_path")""",
+            """dbutils.fs.head("wasb://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: wasb://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=68,
+                    end_col=37,
+                )
+            ],
+        ),
+        # Test for 'put' function
+        (
+            """dbutils.fs.put("wasbs://bucket/path", "data")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: wasbs://bucket/path",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=45,
+                )
+            ],
+        ),
+        # Test for 'mkdirs' function
+        (
+            """dbutils.fs.mkdirs("abfs://bucket/path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: abfs://bucket/path",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=39,
+                )
+            ],
+        ),
+        # Test for 'move' function
+        (
+            """dbutils.fs.mv("wasb://bucket/path", "wasb://another_bucket/another_path")""",
+            [
+                Deprecation(
+                    code='cloud-access',
+                    message="The use of cloud direct references is deprecated: wasb://bucket/path",
+                    start_line=1,
+                    start_col=0,
+                    end_line=1,
+                    end_col=73,
                 )
             ],
         ),
         # Test for 'text' function
         (
-            """spark.read.text("s3a://bucket/path")""",
+            """spark.read.text("wasbs://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: wasbs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=36,
+                    end_col=38,
                 )
             ],
         ),
         # Test for 'csv' function
         (
-            """spark.read.csv("s3a://bucket/path")""",
+            """spark.read.csv("abfs://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: abfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=35,
+                    end_col=36,
                 )
             ],
         ),
@@ -396,7 +449,7 @@ for i in range(10):
                 Deprecation(
                     code='cloud-access',
                     message='The use of cloud direct references is deprecated: '
-                    "'s3a://your_bucket_name/your_directory/'",
+                    "s3a://your_bucket_name/your_directory/",
                     start_line=1,
                     start_col=1,
                     end_line=3,
@@ -406,71 +459,71 @@ for i in range(10):
         ),
         # Test for 'json' function
         (
-            """spark.read.json("s3a://bucket/path")""",
+            """spark.read.json("abfss://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: abfss://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=36,
+                    end_col=38,
                 )
             ],
         ),
         # Test for 'orc' function
         (
-            """spark.read.orc("s3a://bucket/path")""",
+            """spark.read.orc("dbfs://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: dbfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=35,
+                    end_col=36,
                 )
             ],
         ),
         # Test for 'parquet' function
         (
-            """spark.read.parquet("s3a://bucket/path")""",
+            """spark.read.parquet("hdfs://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: hdfs://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=39,
+                    end_col=40,
                 )
             ],
         ),
         # Test for 'save' function
         (
-            """spark.write.save("s3a://bucket/path")""",
+            """spark.write.save("file://bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: file://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=37,
+                    end_col=38,
                 )
             ],
         ),
-        # Test for 'load' function
+        # Test for 'load' function with default to dbfs
         (
-            """spark.read.load("s3a://bucket/path")""",
+            """spark.read.load("/bucket/path")""",
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of default dbfs: references is deprecated: /bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
-                    end_col=36,
+                    end_col=31,
                 )
             ],
         ),
@@ -480,7 +533,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -494,7 +547,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -508,7 +561,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -522,7 +575,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -536,7 +589,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -550,7 +603,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -564,7 +617,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -578,7 +631,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -592,7 +645,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -606,7 +659,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -620,7 +673,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -634,7 +687,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -648,7 +701,7 @@ for i in range(10):
             [
                 Deprecation(
                     code='cloud-access',
-                    message="The use of cloud direct references is deprecated: 's3a://bucket/path'",
+                    message="The use of cloud direct references is deprecated: s3a://bucket/path",
                     start_line=1,
                     start_col=0,
                     end_line=1,
@@ -665,9 +718,11 @@ def test_spark_cloud_direct_access(empty_index, code, expected):
     assert advisories == expected
 
 
+# TODO: Expand the tests  to cover all dbutils.fs functions
 def test_direct_cloud_access_reports_nothing(empty_index):
     ftf = FromTable(empty_index, CurrentSessionState())
     sqf = SparkSql(ftf, empty_index)
-    code = """spark.read.csv("/bucket/path")"""
+    # ls function calls have to be from dbutils.fs, or we ignore them
+    code = """spark.ls("/bucket/path")"""
     advisories = list(sqf.lint(code))
     assert not advisories

--- a/tests/unit/source_code/test_pyspark.py
+++ b/tests/unit/source_code/test_pyspark.py
@@ -663,3 +663,11 @@ def test_spark_cloud_direct_access(empty_index, code, expected):
     sqf = SparkSql(ftf, empty_index)
     advisories = list(sqf.lint(code))
     assert advisories == expected
+
+
+def test_direct_cloud_access_reports_nothing(empty_index):
+    ftf = FromTable(empty_index, CurrentSessionState())
+    sqf = SparkSql(ftf, empty_index)
+    code = """spark.read.csv("/bucket/path")"""
+    advisories = list(sqf.lint(code))
+    assert not advisories


### PR DESCRIPTION
## Changes

Uses the Pyspark linter, which detects the use of table names that should be migrated, to also detect the use of direct access to cloud storage. Additional deprecation advisories are issued when direct cloud access is detected.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1133  

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
