### PR TITLE
Add CTAS migration workflow for external tables cannot be in place migrated

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -163,13 +163,26 @@ class TablesMigrator:
         if src_table.src.what == What.DBFS_ROOT_DELTA:
             return self._migrate_dbfs_root_table(src_table.src, src_table.rule, grants)
         if src_table.src.what == What.DBFS_ROOT_NON_DELTA:
-            return self._migrate_table_create_ctas(src_table.src, src_table.rule, grants)
+            return self._migrate_table_create_ctas(src_table.src, src_table.rule, grants, mounts)
         if src_table.src.what == What.EXTERNAL_SYNC:
             return self._migrate_external_table(src_table.src, src_table.rule, grants)
         if src_table.src.what == What.EXTERNAL_HIVESERDE:
-            return self._migrate_external_table_hiveserde(
-                src_table.src, src_table.rule, grants, mounts, hiveserde_in_place_migrate
-            )
+            # This hiveserde_in_place_migrate is used to determine if current hiveserde migration should use in-place migration or CTAS.
+            # We will provide two workflows for hiveserde table migration:
+            # 1. One will migrate all hiveserde tables using CTAS which we officially support.
+            # 2. The other one will migrate certain types of hiveserde in place, which is technically working, but the user
+            # need to accept the risk that the old files created by hiveserde may not be processed correctly by Spark
+            # datasource in corner cases.
+            # User will need to decide which workflow to runs first which will migrate the hiveserde tables and mark the
+            # `upgraded_to` property and hence those tables will be skipped in the migration workflow runs later.
+            if hiveserde_in_place_migrate:
+                return self._migrate_external_table_hiveserde_in_place(
+                    src_table.src, src_table.rule, grants, mounts
+                )
+            return self._migrate_table_create_ctas(src_table.src, src_table.rule, grants, mounts)
+        if src_table.src.what == What.EXTERNAL_NO_SYNC:
+            # use CTAS if table cannot be upgraded using SYNC and table is not hiveserde table
+            return self._migrate_table_create_ctas(src_table.src, src_table.rule, grants, mounts)
         logger.info(f"Table {src_table.src.key} is not supported for migration")
         return True
 
@@ -224,26 +237,13 @@ class TablesMigrator:
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
 
-    def _migrate_external_table_hiveserde(
+    def _migrate_external_table_hiveserde_in_place(
         self,
         src_table: Table,
         rule: Rule,
         grants: list[Grant],
         mounts: list[Mount],
-        hiveserde_in_place_migrate: bool = False,
     ):
-        # This hiveserde_in_place_migrate is used to determine if current migration should use in-place migration or CTAS.
-        # We will provide two workflows for hiveserde table migration:
-        # 1. One will migrate all hiveserde tables using CTAS which we officially support.
-        # 2. The other one will migrate certain types of hiveserde in place, which is technically working, but the user
-        # need to accept the risk that the old files created by hiveserde may not be processed correctly by Spark
-        # datasource in corner cases.
-        # User will need to decide which workflow to runs first which will migrate the hiveserde tables and mark the
-        # `upgraded_to` property and hence those tables will be skipped in the migration workflow runs later.
-        if not hiveserde_in_place_migrate:
-            # TODO: Add sql_migrate_external_hiveserde_ctas here
-            return False
-
         # verify hive serde type
         hiveserde_type = src_table.hiveserde_type(self._backend)
         if hiveserde_type in [
@@ -268,7 +268,7 @@ class TablesMigrator:
             )
             return False
 
-        logger.debug(f"Migrating external table {src_table.key} to using SQL query: {table_migrate_sql}")
+        logger.debug(f"Migrating external table {src_table.key} to {rule.as_uc_table_key} using SQL query: {table_migrate_sql}")
         self._backend.execute(table_migrate_sql)
         self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
@@ -277,26 +277,28 @@ class TablesMigrator:
     def _migrate_dbfs_root_table(self, src_table: Table, rule: Rule, grants: list[Grant] | None = None):
         target_table_key = rule.as_uc_table_key
         table_migrate_sql = src_table.sql_migrate_dbfs(target_table_key)
-        logger.debug(f"Migrating managed table {src_table.key} to using SQL query: {table_migrate_sql}")
+        logger.debug(f"Migrating managed table {src_table.key} to {rule.as_uc_table_key} using SQL query: {table_migrate_sql}")
         self._backend.execute(table_migrate_sql)
         self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
 
-    def _migrate_table_create_ctas(self, src_table: Table, rule: Rule, grants: list[Grant] | None = None):
-        table_migrate_sql = self._get_create_ctas_sql(src_table, rule)
-        logger.debug(f"Migrating table (Create Like) {src_table.key} to using SQL query: {table_migrate_sql}")
+    def _migrate_table_create_ctas(self, src_table: Table, rule: Rule, grants: list[Grant], mounts: list[Mount]):
+        if src_table.what != What.EXTERNAL_NO_SYNC:
+            table_migrate_sql = src_table.sql_migrate_ctas_managed(rule.as_uc_table_key)
+        elif not src_table.location:
+            table_migrate_sql = src_table.sql_migrate_ctas_managed(rule.as_uc_table_key)
+        else:
+            # if external table and src tabel location is not missing, migrate to external UC table
+            dst_table_location = src_table.location + "_ctas_migrated"
+            if mounts and src_table.is_dbfs_mnt:
+                dst_table_location = ExternalLocations.resolve_mount(src_table.location, mounts) + "_ctas_migrated"
+            table_migrate_sql = src_table.sql_migrate_ctas_external(rule.as_uc_table_key, dst_table_location)
+        logger.debug(f"Migrating table {src_table.key} to {rule.as_uc_table_key} using SQL query: {table_migrate_sql}")
         self._backend.execute(table_migrate_sql)
         self._backend.execute(src_table.sql_alter_to(rule.as_uc_table_key))
         self._backend.execute(src_table.sql_alter_from(rule.as_uc_table_key, self._ws.get_workspace_id()))
         return self._migrate_acl(src_table, rule, grants)
-
-    def _get_create_ctas_sql(self, src_table: Table, rule: Rule) -> str:
-        create_sql = (
-            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(rule.as_uc_table_key)} "
-            f"AS SELECT * FROM {src_table.safe_sql_key}"
-        )
-        return create_sql
 
     def _migrate_acl(self, src: Table, rule: Rule, grants: list[Grant] | None):
         if grants is None:

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -193,6 +193,19 @@ class Table:
             f"{escape_sql_identifier(self.key)};"
         )
 
+    def sql_migrate_ctas_external(self, target_table_key, dst_table_location) -> str:
+        return (
+            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} "
+            f"LOCATION '{dst_table_location}' "
+            f"AS SELECT * FROM {self.safe_sql_key}"
+        )
+
+    def sql_migrate_ctas_managed(self, target_table_key) -> str:
+        return (
+            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} "
+            f"AS SELECT * FROM {self.safe_sql_key}"
+        )
+
     def hiveserde_type(self, backend: SqlBackend) -> HiveSerdeType:
         if self.table_format != "HIVE":
             return HiveSerdeType.NOT_HIVESERDE

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -185,14 +185,6 @@ class Table:
     def sql_migrate_external(self, target_table_key):
         return f"SYNC TABLE {escape_sql_identifier(target_table_key)} FROM {escape_sql_identifier(self.key)};"
 
-    def sql_migrate_create_like(self, target_table_key):
-        # Create table as a copy of the source table
-        # https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-like.html
-        return (
-            f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} LIKE "
-            f"{escape_sql_identifier(self.key)};"
-        )
-
     def sql_migrate_ctas_external(self, target_table_key, dst_table_location) -> str:
         return (
             f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} "
@@ -274,7 +266,7 @@ class Table:
         self, backend: SqlBackend, catalog_name, dst_schema, dst_table, replace_location
     ) -> str | None:
         # get raw DDL from "SHOW CREATE TABLE..."
-        createtab_stmt = next(backend.fetch(self.sql_show_create()))["createtab_stmt"]
+        createtab_stmt = next(backend.fetch(f"SHOW CREATE {self.kind} {self.safe_sql_key};"))["createtab_stmt"]
         # parse the DDL and replace the old table name with the new UC table name
         try:
             statements = sqlglot.parse(createtab_stmt)
@@ -311,9 +303,6 @@ class Table:
             msg = f"{self.key} is not DELTA: {self.table_format}"
             raise ValueError(msg)
         return f"CREATE TABLE IF NOT EXISTS {escape_sql_identifier(target_table_key)} DEEP CLONE {escape_sql_identifier(self.key)};"
-
-    def sql_show_create(self):
-        return f"SHOW CREATE {self.kind} {self.safe_sql_key};"
 
     def sql_migrate_view(self, target_table_key):
         return f"CREATE VIEW IF NOT EXISTS {escape_sql_identifier(target_table_key)} AS {self.view_text};"

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -95,7 +95,6 @@ class MigrateExternalTablesCTAS(Workflow):
         ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
 
-
 class MigrateTablesInMounts(Workflow):
     def __init__(self):
         super().__init__('migrate-tables-in-mounts-experimental')

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -62,6 +62,40 @@ class MigrateHiveSerdeTablesInPlace(Workflow):
         ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
 
+class MigrateExternalTablesCTAS(Workflow):
+    def __init__(self):
+        super().__init__('migrate-external-tables-ctas')
+
+    @job_task(job_cluster="table_migration", depends_on=[Assessment.crawl_tables])
+    def migrate_other_external_ctas(self, ctx: RuntimeContext):
+        """This workflow task migrates non SYNC supported and non HiveSerde external tables using CTAS"""
+        ctx.tables_migrator.migrate_tables(
+            what=What.EXTERNAL_NO_SYNC,
+            acl_strategy=[AclMigrationWhat.LEGACY_TACL],
+            mounts_crawler=ctx.mounts_crawler,
+        )
+
+    @job_task(job_cluster="table_migration", depends_on=[Assessment.crawl_tables])
+    def migrate_hive_serde_ctas(self, ctx: RuntimeContext):
+        """This workflow task migrates HiveSerde tables using CTAS"""
+        ctx.tables_migrator.migrate_tables(
+            what=What.EXTERNAL_HIVESERDE,
+            acl_strategy=[AclMigrationWhat.LEGACY_TACL],
+            mounts_crawler=ctx.mounts_crawler,
+        )
+
+    @job_task(
+        job_cluster="table_migration",
+        depends_on=[Assessment.crawl_tables, migrate_other_external_ctas, migrate_hive_serde_ctas],
+    )
+    def migrate_views(self, ctx: RuntimeContext):
+        """This workflow task migrates views from the Hive Metastore to the Unity Catalog using create view sql statement.
+        It is dependent on the migration of the tables.
+        """
+        ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
+
+
+
 class MigrateTablesInMounts(Workflow):
     def __init__(self):
         super().__init__('migrate-tables-in-mounts-experimental')

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.installer.logs import TaskLogger
 from databricks.labs.ucx.hive_metastore.workflows import (
     MigrateTablesInMounts,
     TableMigration,
-    MigrateHiveSerdeTablesInPlace,
+    MigrateHiveSerdeTablesInPlace, MigrateExternalTablesCTAS,
 )
 from databricks.labs.ucx.workspace_access.workflows import (
     GroupMigration,
@@ -44,6 +44,7 @@ class Workflows:
                 GroupMigration(),
                 TableMigration(),
                 MigrateHiveSerdeTablesInPlace(),
+                MigrateExternalTablesCTAS(),
                 ValidateGroupPermissions(),
                 RemoveWorkspaceLocalGroups(),
                 MigrateTablesInMounts(),

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -12,7 +12,8 @@ from databricks.labs.ucx.installer.logs import TaskLogger
 from databricks.labs.ucx.hive_metastore.workflows import (
     MigrateTablesInMounts,
     TableMigration,
-    MigrateHiveSerdeTablesInPlace, MigrateExternalTablesCTAS,
+    MigrateHiveSerdeTablesInPlace,
+    MigrateExternalTablesCTAS,
 )
 from databricks.labs.ucx.workspace_access.workflows import (
     GroupMigration,

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -224,7 +224,7 @@ def test_migrate_external_table_hiveserde_in_place(
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_external_table_hiveserde_ctas(
-        ws, sql_backend, make_random, runtime_ctx, make_storage_dir, env_or_skip, make_catalog
+    ws, sql_backend, make_random, runtime_ctx, make_storage_dir, env_or_skip, make_catalog
 ):
     random = make_random(4).lower()
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore", name=f"hiveserde_ctas_{random}")

--- a/tests/integration/test_runtime.py
+++ b/tests/integration/test_runtime.py
@@ -132,10 +132,10 @@ def test_hiveserde_table_in_place_migration_job(
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 @pytest.mark.parametrize('prepare_tables_for_migration', [('hiveserde')], indirect=True)
 def test_hiveserde_table_ctas_migration_job(
-        ws,
-        installation_ctx,
-        prepare_tables_for_migration,
-        env_or_skip,
+    ws,
+    installation_ctx,
+    prepare_tables_for_migration,
+    env_or_skip,
 ):
     tables, dst_schema = prepare_tables_for_migration
     ctx = installation_ctx.replace(

--- a/tests/unit/hive_metastore/tables/external_no_sync.json
+++ b/tests/unit/hive_metastore/tables/external_no_sync.json
@@ -1,0 +1,18 @@
+{
+  "src": {
+    "catalog": "hive_metastore",
+    "database": "db1_src",
+    "name": "external_src",
+    "object_type": "EXTERNAL",
+    "table_format": "BINARYFILE",
+    "location": "s3:/bucket/test/table1"
+  },
+  "rule": {
+    "workspace_name": "workspace",
+    "catalog_name": "ucx_default",
+    "src_schema": "db1_src",
+    "dst_schema": "db1_dst",
+    "src_table": "external_src",
+    "dst_table": "external_dst"
+  }
+}

--- a/tests/unit/hive_metastore/tables/external_no_sync_missing_location.json
+++ b/tests/unit/hive_metastore/tables/external_no_sync_missing_location.json
@@ -1,0 +1,17 @@
+{
+  "src": {
+    "catalog": "hive_metastore",
+    "database": "db1_src",
+    "name": "external_src",
+    "object_type": "EXTERNAL",
+    "table_format": "BINARYFILE"
+  },
+  "rule": {
+    "workspace_name": "workspace",
+    "catalog_name": "ucx_default",
+    "src_schema": "db1_src",
+    "dst_schema": "db1_dst",
+    "src_table": "external_src",
+    "dst_table": "external_dst"
+  }
+}

--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -1,4 +1,5 @@
-from databricks.labs.ucx.hive_metastore.workflows import TableMigration
+from databricks.labs.ucx.hive_metastore.workflows import TableMigration, MigrateHiveSerdeTablesInPlace, \
+    MigrateExternalTablesCTAS
 
 
 def test_migrate_external_tables_sync(run_workflow):
@@ -8,4 +9,19 @@ def test_migrate_external_tables_sync(run_workflow):
 
 def test_migrate_dbfs_root_delta_tables(run_workflow):
     ctx = run_workflow(TableMigration.migrate_dbfs_root_delta_tables)
+    ctx.workspace_client.catalogs.list.assert_called_once()
+
+
+def test_migrate_hive_serde_in_place(run_workflow):
+    ctx = run_workflow(MigrateHiveSerdeTablesInPlace.migrate_hive_serde_in_place)
+    ctx.workspace_client.catalogs.list.assert_called_once()
+
+
+def test_migrate_other_external_ctas(run_workflow):
+    ctx = run_workflow(MigrateExternalTablesCTAS.migrate_other_external_ctas)
+    ctx.workspace_client.catalogs.list.assert_called_once()
+    
+
+def test_migrate_hive_serde_ctas(run_workflow):
+    ctx = run_workflow(MigrateExternalTablesCTAS.migrate_hive_serde_ctas)
     ctx.workspace_client.catalogs.list.assert_called_once()

--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -1,5 +1,8 @@
-from databricks.labs.ucx.hive_metastore.workflows import TableMigration, MigrateHiveSerdeTablesInPlace, \
-    MigrateExternalTablesCTAS
+from databricks.labs.ucx.hive_metastore.workflows import (
+    TableMigration,
+    MigrateHiveSerdeTablesInPlace,
+    MigrateExternalTablesCTAS,
+)
 
 
 def test_migrate_external_tables_sync(run_workflow):

--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -20,7 +20,7 @@ def test_migrate_hive_serde_in_place(run_workflow):
 def test_migrate_other_external_ctas(run_workflow):
     ctx = run_workflow(MigrateExternalTablesCTAS.migrate_other_external_ctas)
     ctx.workspace_client.catalogs.list.assert_called_once()
-    
+
 
 def test_migrate_hive_serde_ctas(run_workflow):
     ctx = run_workflow(MigrateExternalTablesCTAS.migrate_hive_serde_ctas)


### PR DESCRIPTION
## Changes
Add CTAS migration workflow for:

1. HiveSerde external tables.
2. Other type of external tables that have to be CTAS migrated.


### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #889 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
