### PR TITLE
Fixed edge case for `RegexSubStrategy`

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -205,7 +205,9 @@ class MatchingNamesStrategy(GroupMigrationStrategy):
             temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             account_group = self.account_groups_in_account.get(group.display_name)
             if not account_group:
-                logger.info(f"Couldn't find a matching account group for {group.display_name} group")
+                logger.info(
+                    f"Couldn't find a matching account group for {group.display_name} group using name matching"
+                )
                 continue
             yield MigratedGroup(
                 id_in_workspace=group.id,
@@ -252,9 +254,7 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
                 external_id=account_group.external_id,
                 members=json.dumps([gg.as_dict() for gg in group.members]) if group.members else None,
                 roles=json.dumps([gg.as_dict() for gg in group.roles]) if group.roles else None,
-                entitlements=(
-                    json.dumps([gg.as_dict() for gg in group.entitlements]) if group.entitlements else None
-                ),
+                entitlements=(json.dumps([gg.as_dict() for gg in group.entitlements]) if group.entitlements else None),
             )
 
 
@@ -287,7 +287,9 @@ class RegexSubStrategy(GroupMigrationStrategy):
             )
             account_group = self.account_groups_in_account.get(name_in_account)
             if not account_group:
-                logger.info(f"Couldn't find a matching account group for {group.display_name} group with regex substitution")
+                logger.info(
+                    f"Couldn't find a matching account group for {group.display_name} group with regex substitution"
+                )
                 continue
             yield MigratedGroup(
                 id_in_workspace=group.id,
@@ -334,7 +336,9 @@ class RegexMatchStrategy(GroupMigrationStrategy):
             temporary_name = f"{self.renamed_groups_prefix}{ws_group.display_name}"
             account_group = account_groups_by_match.get(group_match)
             if not account_group:
-                logger.info(f"Couldn't find a match for group {ws_group.display_name}")
+                logger.info(
+                    f"Couldn't find a matching account group for {ws_group.display_name} group with regex matching"
+                )
                 continue
             yield MigratedGroup(
                 id_in_workspace=ws_group.id,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -241,21 +241,21 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
         for group in workspace_groups.values():
             temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             account_group = account_groups_by_id.get(group.external_id)
-            if account_group:
-                yield MigratedGroup(
-                    id_in_workspace=group.id,
-                    name_in_workspace=group.display_name,
-                    name_in_account=account_group.display_name,
-                    temporary_name=temporary_name,
-                    external_id=account_group.external_id,
-                    members=json.dumps([gg.as_dict() for gg in group.members]) if group.members else None,
-                    roles=json.dumps([gg.as_dict() for gg in group.roles]) if group.roles else None,
-                    entitlements=(
-                        json.dumps([gg.as_dict() for gg in group.entitlements]) if group.entitlements else None
-                    ),
-                )
-            else:
+            if not account_group:
                 logger.info(f"Couldn't find a matching account group for {group.display_name} group with external_id")
+                continue
+            yield MigratedGroup(
+                id_in_workspace=group.id,
+                name_in_workspace=group.display_name,
+                name_in_account=account_group.display_name,
+                temporary_name=temporary_name,
+                external_id=account_group.external_id,
+                members=json.dumps([gg.as_dict() for gg in group.members]) if group.members else None,
+                roles=json.dumps([gg.as_dict() for gg in group.roles]) if group.roles else None,
+                entitlements=(
+                    json.dumps([gg.as_dict() for gg in group.entitlements]) if group.entitlements else None
+                ),
+            )
 
 
 class RegexSubStrategy(GroupMigrationStrategy):
@@ -285,12 +285,16 @@ class RegexSubStrategy(GroupMigrationStrategy):
             name_in_account = self._safe_sub(
                 group.display_name, self.workspace_group_regex, self.workspace_group_replace
             )
+            account_group = self.account_groups_in_account.get(name_in_account)
+            if not account_group:
+                logger.info(f"Couldn't find a matching account group for {group.display_name} group with regex substitution")
+                continue
             yield MigratedGroup(
                 id_in_workspace=group.id,
                 name_in_workspace=group.display_name,
                 name_in_account=name_in_account,
                 temporary_name=temporary_name,
-                external_id=self.account_groups_in_account[name_in_account].external_id,
+                external_id=account_group.external_id,
                 members=json.dumps([gg.as_dict() for gg in group.members]) if group.members else None,
                 roles=json.dumps([gg.as_dict() for gg in group.roles]) if group.roles else None,
                 entitlements=json.dumps([gg.as_dict() for gg in group.entitlements]) if group.entitlements else None,
@@ -329,21 +333,21 @@ class RegexMatchStrategy(GroupMigrationStrategy):
         for group_match, ws_group in workspace_groups_by_match.items():
             temporary_name = f"{self.renamed_groups_prefix}{ws_group.display_name}"
             account_group = account_groups_by_match.get(group_match)
-            if account_group:
-                yield MigratedGroup(
-                    id_in_workspace=ws_group.id,
-                    name_in_workspace=ws_group.display_name,
-                    name_in_account=account_group.display_name,
-                    temporary_name=temporary_name,
-                    external_id=account_group.external_id,
-                    members=json.dumps([gg.as_dict() for gg in ws_group.members]) if ws_group.members else None,
-                    roles=json.dumps([gg.as_dict() for gg in ws_group.roles]) if ws_group.roles else None,
-                    entitlements=(
-                        json.dumps([gg.as_dict() for gg in ws_group.entitlements]) if ws_group.entitlements else None
-                    ),
-                )
-            else:
+            if not account_group:
                 logger.info(f"Couldn't find a match for group {ws_group.display_name}")
+                continue
+            yield MigratedGroup(
+                id_in_workspace=ws_group.id,
+                name_in_workspace=ws_group.display_name,
+                name_in_account=account_group.display_name,
+                temporary_name=temporary_name,
+                external_id=account_group.external_id,
+                members=json.dumps([gg.as_dict() for gg in ws_group.members]) if ws_group.members else None,
+                roles=json.dumps([gg.as_dict() for gg in ws_group.roles]) if ws_group.roles else None,
+                entitlements=(
+                    json.dumps([gg.as_dict() for gg in ws_group.entitlements]) if ws_group.entitlements else None
+                ),
+            )
 
 
 class GroupManager(CrawlerBase[MigratedGroup]):


### PR DESCRIPTION
## Changes
- `RegexSubStrategy` will fail if the strategy generated a non-existent account group
- Add more unit tests

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
