### PR TITLE
Added ability to install UCX on workspaces without Public Internet connectivity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 
 dependencies = ["databricks-sdk>=0.27,<0.29",
                 "databricks-labs-lsql~=0.4.0",
-                "databricks-labs-blueprint>=0.4.3,<0.7.0",
+                "databricks-labs-blueprint>=0.6.0",
                 "PyYAML>=6.0.0,<7.0.0",
                 "sqlglot>=23.9,<24.1"]
 

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -61,6 +61,9 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     # Threshold for row count comparison during data reconciliation, in percentage
     recon_tolerance_percent: int = 5
 
+    # Whether to upload dependent libraries to the workspace
+    upload_dependencies: bool = False
+
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -216,6 +216,7 @@ class WorkspaceInstaller(WorkspaceContext):
         configure_groups = ConfigureGroups(self.prompts)
         configure_groups.run()
         include_databases = self._select_databases()
+        upload_dependencies = self.prompts.confirm("Does given workspace block Internet access?")
         trigger_job = self.prompts.confirm("Do you want to trigger assessment job after installation?")
         recon_tolerance_percent = int(
             self.prompts.question("Reconciliation threshold, in percentage", default="5", valid_number=True)
@@ -233,6 +234,7 @@ class WorkspaceInstaller(WorkspaceContext):
             include_databases=include_databases,
             trigger_job=trigger_job,
             recon_tolerance_percent=recon_tolerance_percent,
+            upload_dependencies=upload_dependencies,
         )
 
     def _compare_remote_local_versions(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -216,7 +216,9 @@ class WorkspaceInstaller(WorkspaceContext):
         configure_groups = ConfigureGroups(self.prompts)
         configure_groups.run()
         include_databases = self._select_databases()
-        upload_dependencies = self.prompts.confirm("Does given workspace block Internet access?")
+        upload_dependencies = self.prompts.confirm(
+            f"Does given workspace {self.workspace_client.get_workspace_id()} " f"block Internet access?"
+        )
         trigger_job = self.prompts.confirm("Do you want to trigger assessment job after installation?")
         recon_tolerance_percent = int(
             self.prompts.question("Reconciliation threshold, in percentage", default="5", valid_number=True)

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -98,7 +98,7 @@ class ClusterPolicyInstaller:
             return None
 
     def _definition(self, conf: dict, instance_profile: str | None, instance_pool_id: str | None) -> str:
-        latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
+        latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True)
         node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
         policy_definition = {
             "spark_version": self._policy_config(latest_lts_dbr),

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -533,14 +533,14 @@ class WorkflowsDeployment(InstallationMixin):
         wheel_paths = []
         with self._wheels:
             if self._config.upload_dependencies:
-                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot"])
-                wheel_paths = [f"/Workspace{wheel_path}" for wheel_path in wheel_paths]
-            wheel_paths.append(f"/Workspace{self._wheels.upload_to_wsfs()}")
+                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks_sdk", "sqlglot"])
+            wheel_paths.append(self._wheels.upload_to_wsfs())
+            wheel_paths = [f"/Workspace{wheel}" for wheel in wheel_paths]
             return wheel_paths
 
     def _upload_wheel_runner(self, remote_wheels: list[str]):
         # TODO: we have to be doing this workaround until ES-897453 is solved in the platform
-        remote_wheels_str = " ".join(list(remote_wheels))
+        remote_wheels_str = " ".join(remote_wheels)
         code = TEST_RUNNER_NOTEBOOK.format(remote_wheel=remote_wheels_str, config_file=self._config_file).encode("utf8")
         return self._installation.upload(f"wheels/wheel-test-runner-{self._product_info.version()}.py", code)
 
@@ -644,12 +644,7 @@ class WorkflowsDeployment(InstallationMixin):
             ),
         )
 
-    def _job_wheel_task(
-        self,
-        jobs_task: jobs.Task,
-        workflow: str,
-        remote_wheels: list[str],
-    ) -> jobs.Task:
+    def _job_wheel_task(self, jobs_task: jobs.Task, workflow: str, remote_wheels: list[str]) -> jobs.Task:
         libraries = []
         for wheel in remote_wheels:
             libraries.append(compute.Library(whl=wheel))
@@ -713,12 +708,7 @@ class WorkflowsDeployment(InstallationMixin):
             )
         return clusters
 
-    def _job_parse_logs_task(
-        self,
-        job_tasks: list[jobs.Task],
-        workflow: str,
-        remote_wheels: list[str],
-    ) -> jobs.Task:
+    def _job_parse_logs_task(self, job_tasks: list[jobs.Task], workflow: str, remote_wheels: list[str]) -> jobs.Task:
         jobs_task = jobs.Task(
             task_key="parse_logs",
             job_cluster_key=Task.job_cluster,

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -533,7 +533,7 @@ class WorkflowsDeployment(InstallationMixin):
         wheel_paths = []
         with self._wheels:
             if self._config.upload_dependencies:
-                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks_sdk", "sqlglot"])
+                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot"])
             wheel_paths.append(self._wheels.upload_to_wsfs())
             wheel_paths = [f"/Workspace{wheel}" for wheel in wheel_paths]
             return wheel_paths

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -533,7 +533,7 @@ class WorkflowsDeployment(InstallationMixin):
         wheel_paths = []
         with self._wheels:
             if self._config.upload_dependencies:
-                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot"])
+                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "google"])
             wheel_paths.append(self._wheels.upload_to_wsfs())
             wheel_paths = [f"/Workspace{wheel}" for wheel in wheel_paths]
             return wheel_paths

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -528,12 +528,13 @@ class WorkflowsDeployment(InstallationMixin):
         assert new_job.job_id is not None
         self._install_state.jobs[step_name] = str(new_job.job_id)
         return None
+
     @staticmethod
     def _library_dep_order(library: str):
         match library:
-            case x if 'sdk' in x:
+            case library if 'sdk' in library:
                 return 0
-            case x if 'blueprint' in x:
+            case library if 'blueprint' in library:
                 return 1
             case _:
                 return 2

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -471,3 +471,15 @@ def test_new_collection(ws, sql_backend, installation_ctx, env_or_skip):
     config = installation_ctx.installation.load(WorkspaceConfig)
     workspace_id = installation_ctx.workspace_installer.workspace_client.get_workspace_id()
     assert config.installed_workspace_ids == [workspace_id]
+
+
+def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
+    config = dataclasses.replace(installation_ctx.config, upload_dependencies=True)
+    installation_ctx = installation_ctx.replace(config=config)
+    mocker.patch("webbrowser.open")
+    installation_ctx.workspace_installation.run()
+    with pytest.raises(ManyError):
+        installation_ctx.deployed_workflows.run_workflow("failing")
+
+    installation_ctx.deployed_workflows.repair_run("failing")
+    assert installation_ctx.deployed_workflows.validate_step("failing")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -155,7 +155,7 @@ def test_job_cluster_policy(ws, installation_ctx):
 
     assert cluster_policy.name == f"Unity Catalog Migration ({installation_ctx.inventory_database}) ({user_name})"
 
-    spark_version = ws.clusters.select_spark_version(latest=True, long_term_support=True)
+    spark_version = ws.clusters.select_spark_version(latest=True)
     assert policy_definition["spark_version"]["value"] == spark_version
     assert policy_definition["node_type_id"]["value"] == ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
     if ws.config.is_azure:

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1906,7 +1906,7 @@ def test_upload_dependencies(ws, mock_installation):
             r".*": "",
             r"Choose how to map the workspace groups.*": "0",
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
-            r".*Does given workspace block Internet access.*": "Yes",
+            r".*Does given workspace.* block Internet access.*": "Yes",
         }
     )
     wheels = create_autospec(WheelsV2)

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1898,3 +1898,25 @@ def test_save_config_ext_hms(ws, mock_installation):
             'recon_tolerance_percent': 5,
         },
     )
+
+
+def test_upload_dependencies(ws, mock_installation):
+    prompts = MockPrompts(
+        {
+            r".*": "",
+            r"Choose how to map the workspace groups.*": "0",
+            r".*PRO or SERVERLESS SQL warehouse.*": "1",
+            r".*Does given workspace block Internet access.*": "Yes",
+        }
+    )
+    wheels = create_autospec(WheelsV2)
+    workspace_installation = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=mock_installation,
+        product_info=PRODUCT_INFO,
+        sql_backend=MockBackend(),
+        wheels=wheels,
+    )
+    workspace_installation.run()
+    wheels.upload_wheel_dependencies.assert_called_once()
+    wheels.upload_to_wsfs.assert_called_once()

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1910,6 +1910,11 @@ def test_upload_dependencies(ws, mock_installation):
         }
     )
     wheels = create_autospec(WheelsV2)
+    wheels.upload_wheel_dependencies.return_value = [
+        'databricks_labs_blueprint-0.6.2-py3-none-any.whl',
+        'databricks_sdk-0.28.0-py3-none-any.whl',
+        'databricks_labs_ucx-0.23.2+4920240527095658-py3-none-any.whl',
+    ]
     workspace_installation = WorkspaceInstaller(ws).replace(
         prompts=prompts,
         installation=mock_installation,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

`upload_dependencies` flag has been added to WorkspaceConfig to upload dependencies to air-gapped workspaces. This flag is set by the user through the installation prompt.

### Linked issues

<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #573

### Functionality 

- [x] added a new prompt question

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
