### PR TITLE
Test if `create-catalogs-schemas` works with tables defined as mount paths

### DIFF
--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -70,7 +70,7 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
     grants = [
         Grant('user1', 'SELECT', 'catalog1', 'schema3', 'table'),
         Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
-        Grant('user1', 'SELECY', 'catalog2', 'schema2', 'table2'),
+        Grant('user1', 'SELECT', 'catalog2', 'schema2', 'table2'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema2'),
     ]

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -71,6 +71,8 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
         Grant('user1', 'SELECT', 'catalog1', 'schema3', 'table'),
         Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
         Grant('user1', 'SELECT', 'catalog2', 'schema2', 'table2'),
+        Grant('user1', 'MODIFY', 'catalog1', 'schema2', 'table3'),
+        Grant('user1', 'SELECT', 'catalog3', 'schema3', 'table1'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema2'),
     ]

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -71,8 +71,6 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
         Grant('user1', 'SELECT', 'catalog1', 'schema3', 'table'),
         Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
         Grant('user1', 'SELECT', 'catalog2', 'schema2', 'table2'),
-        Grant('user1', 'MODIFY', 'catalog1', 'schema2', 'table3'),
-        Grant('user1', 'SELECT', 'catalog3', 'schema3', 'table1'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema2'),
     ]


### PR DESCRIPTION
## Changes
Add unit test to show that the `create-catalogs-schemas` logic works with tables defined as mount paths.

### Linked issues
Resolves #1039

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
