### PR TITLE
Created a unique default schema when ext hms is detected

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -197,8 +197,11 @@ class WorkspaceInstaller(WorkspaceContext):
 
     def _prompt_for_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
+        default_database = "ucx"
+        if self.policy_installer.has_ext_hms():
+            default_database = f"ucx_{self.workspace_client.get_workspace_id()}"
         inventory_database = self.prompts.question(
-            "Inventory Database stored in hive_metastore", default="ucx", valid_regex=r"^\w+$"
+            "Inventory Database stored in hive_metastore", default=default_database, valid_regex=r"^\w+$"
         )
         log_level = self.prompts.question("Log level", default="INFO").upper()
         num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -22,6 +22,15 @@ class ClusterPolicyInstaller:
     def _policy_config(value: str):
         return {"type": "fixed", "value": value}
 
+    def has_ext_hms(self) -> bool:
+        policies_with_external_hms = list(self._get_cluster_policies_with_external_hive_metastores())
+        if len(policies_with_external_hms) > 0:
+            return True
+        warehouse_config = self._get_warehouse_config_with_external_hive_metastore()
+        if warehouse_config is not None:
+            return True
+        return False
+
     def create(self, inventory_database: str) -> tuple[str, str, dict, str | None]:
         instance_profile = ""
         spark_conf_dict = {}

--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -26,7 +26,7 @@ class ClusterPolicyInstaller:
         instance_profile = ""
         spark_conf_dict = {}
         # get instance pool id to be put into the cluster policy
-        instance_pool_id = self._get_instance_pool_id()
+        instance_pool_id = self._get_instance_pool_id() if self._ws.config.is_aws else None
         policies_with_external_hms = list(self._get_cluster_policies_with_external_hive_metastores())
         if len(policies_with_external_hms) > 0 and self._prompts.confirm(
             "We have identified one or more cluster policies set up for an external metastore"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
- Set `ucx_<workspace_id>' as default inventory database when ext hms config is detected
- Only prompt for instance profile on aws installation

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1469

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] verified on staging environment (screenshot attached)
