### PR TITLE
Fix: catalog/schema grants when tables with same source schema have different target schemas

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -53,7 +53,7 @@ class CatalogSchema:
             new_grants.append(
                 dataclasses.replace(
                     db_grant,
-                    # replace source database with taget UC database
+                    # replace source database with target UC database
                     database=src_trg_schema_mapping[db_grant.database]['target_schema'],
                     # replace hive_metastore with target UC catalog
                     catalog=src_trg_schema_mapping[db_grant.database]['target_catalog'],

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -1,6 +1,6 @@
 import collections
-import dataclasses
 import logging
+from dataclasses import replace
 from pathlib import PurePath
 
 from databricks.labs.blueprint.tui import Prompts
@@ -53,9 +53,9 @@ class CatalogSchema:
         database_grants = [grant for grant in grants if grant.table is None and grant.view is None]
         for db_grant in database_grants:
             for schema in src_trg_schema_mapping[db_grant.database]:
-                new_grants.append(dataclasses.replace(db_grant, catalog=schema.catalog_name, database=schema.name))
+                new_grants.append(replace(db_grant, catalog=schema.catalog_name, database=schema.name))
         for grant in new_grants:
-            catalog_grants.add(dataclasses.replace(grant, database=None))
+            catalog_grants.add(replace(grant, database=None))
         new_grants.extend(catalog_grants)
         return new_grants
 

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -1,6 +1,6 @@
+import dataclasses
 import logging
 from pathlib import PurePath
-import dataclasses
 
 from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.lsql.backends import SqlBackend

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -1,3 +1,4 @@
+import collections
 import dataclasses
 import logging
 from pathlib import PurePath
@@ -50,32 +51,20 @@ class CatalogSchema:
         # filter on grants to only get database level grants
         database_grants = [grant for grant in grants if grant.table is None and grant.view is None]
         for db_grant in database_grants:
-            new_grants.append(
-                dataclasses.replace(
-                    db_grant,
-                    # replace source database with target UC database
-                    database=src_trg_schema_mapping[db_grant.database]['target_schema'],
-                    # replace hive_metastore with target UC catalog
-                    catalog=src_trg_schema_mapping[db_grant.database]['target_catalog'],
-                )
-            )
+            for target_catalog, target_schema in src_trg_schema_mapping[db_grant.database]:
+                new_grants.append(dataclasses.replace(db_grant, catalog=target_catalog, database=target_schema))
         for grant in new_grants:
             catalog_grants.add(dataclasses.replace(grant, database=None))
         new_grants.extend(catalog_grants)
         return new_grants
 
-    def _get_database_source_target_mapping(self) -> dict[str, dict]:
-        """generate a dictionary of source database in hive_metastore and its
-        mapping of target UC catalog and schema from the table mappings."""
-        src_trg_schema_mapping: dict[str, dict] = {}
+    def _get_database_source_target_mapping(self) -> dict[str, set[tuple[str, str]]]:
+        """Generate a dictionary of source database in hive_metastore and its
+        mapping of target UC catalog and schema combinations from the table mappings."""
+        src_trg_schema_mapping: dict[str, set[tuple[str, str]]] = collections.defaultdict(set)
         table_mappings = self._table_mapping.load()
-        for mappings in table_mappings:
-            if mappings.src_schema not in src_trg_schema_mapping:
-                src_trg_schema_mapping[mappings.src_schema] = {
-                    'target_catalog': mappings.catalog_name,
-                    'target_schema': mappings.dst_schema,
-                }
-                continue
+        for table_mapping in table_mappings:
+            src_trg_schema_mapping[table_mapping.src_schema].add((table_mapping.catalog_name, table_mapping.dst_schema))
         return src_trg_schema_mapping
 
     def _create_catalog_validate(self, catalog, prompts: Prompts):

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -55,11 +55,19 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
                     'workspace_name': 'workspace',
                 },
                 {
+                    'catalog_name': 'catalog2',
+                    'dst_schema': 'schema2',
+                    'dst_table': 'table1',
+                    'src_schema': 'schema2',
+                    'src_table': 'abfss://container@msft/path/dest2',
+                    'workspace_name': 'workspace',
+                },
+                {
                     'catalog_name': 'catalog3',
                     'dst_schema': 'schema3',
                     'dst_table': 'table1',
                     'src_schema': 'schema1',
-                    'src_table': 'abfss://container@msft/path/dest2',
+                    'src_table': 'abfss://container@msft/path/dest3',
                     'workspace_name': 'workspace',
                 },
             ]

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -40,7 +40,7 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
                 },
                 {
                     'catalog_name': 'catalog2',
-                    'dst_schema': 'schema2',
+                    'dst_schema': 'schema3',
                     'dst_table': 'table2',
                     'src_schema': 'schema2',
                     'src_table': 'table2',
@@ -70,7 +70,7 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
     grants = [
         Grant('user1', 'SELECT', 'catalog1', 'schema3', 'table'),
         Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
-        Grant('user1', 'SELECT', 'catalog2', 'schema2', 'table2'),
+        Grant('user1', 'SELECT', 'catalog2', 'schema3', 'table2'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema2'),
     ]
@@ -151,9 +151,10 @@ def test_catalog_schema_acl():
     queries = [
         'GRANT USE SCHEMA ON DATABASE catalog1.schema3 TO `user1`',
         'GRANT USE SCHEMA ON DATABASE catalog2.schema2 TO `user1`',
+        'GRANT USE SCHEMA ON DATABASE catalog2.schema3 TO `user1`',
         'GRANT USE CATALOG ON CATALOG catalog1 TO `user1`',
         'GRANT USE CATALOG ON CATALOG catalog2 TO `user1`',
     ]
-    assert len(backend.queries) == 4
+    assert len(backend.queries) == len(queries)
     for query in queries:
         assert query in backend.queries


### PR DESCRIPTION
## Changes
If tables in the schema source schema are mapped to different target schemas, a collision occurs when building the grants mapping. This PR fixes the bug created by that collision.

### Linked issues

Resolves #1580

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
