### PR TITLE
improved exception handling for `migrate_acl`

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -599,7 +599,10 @@ class PrincipalACL:
     def _get_cluster_principal_mapping(self, cluster_id: str) -> list[str]:
         # gets all the users,groups,spn which have access to the clusters and returns a dataclass of that mapping
         principal_list = []
-        cluster_permission = self._ws.permissions.get("clusters", cluster_id)
+        try:
+            cluster_permission = self._ws.permissions.get("clusters", cluster_id)
+        except ResourceDoesNotExist:
+            return []
         if cluster_permission.access_control_list is None:
             return []
         for acl in cluster_permission.access_control_list:

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -29,7 +29,7 @@ from databricks.labs.ucx.hive_metastore.view_migrate import (
     ViewToMigrate,
 )
 from databricks.labs.ucx.workspace_access.groups import GroupManager, MigratedGroup
-from databricks.sdk.errors.platform import BadRequest
+from databricks.sdk.errors.platform import BadRequest, NotFound
 
 logger = logging.getLogger(__name__)
 
@@ -313,8 +313,8 @@ class TablesMigrator:
             logger.debug(f"Migrating acls on {rule.as_uc_table_key} using SQL query: {acl_migrate_sql}")
             try:
                 self._backend.execute(acl_migrate_sql)
-            except BadRequest as e:
-                logger.error(f"Failed to migrate ACL for {src.key} to {rule.as_uc_table_key}: {e.details}")
+            except (BadRequest, NotFound) as e:
+                logger.warning(f"Failed to migrate ACL for {src.key} to {rule.as_uc_table_key}: {e}")
         return True
 
     def _table_already_migrated(self, target) -> bool:

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -455,7 +455,7 @@ def test_mapping_reverts_table(ws, sql_backend, runtime_ctx, make_catalog):
     assert "upgraded_to" not in results
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=2))
+@retried(on=[NotFound], timeout=timedelta(minutes=4))
 def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_catalog, make_user):
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -455,7 +455,7 @@ def test_mapping_reverts_table(ws, sql_backend, runtime_ctx, make_catalog):
     assert "upgraded_to" not in results
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=4))
+@retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_catalog, make_user):
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -233,9 +233,23 @@ def test_get_eligible_locations_principals(ws, installation):
 
 def test_interactive_cluster_no_acl(ws, installation):
     ws.config.is_azure = True
+    ws.config.is_aws = False
     cluster_spn = ServicePrincipalClusterMapping(
         'cluster3', {AzureServicePrincipalInfo(application_id='client1', storage_account='storage1')}
     )
+    grants = principal_acl(ws, installation, [cluster_spn])
+    actual_grants = grants.get_interactive_cluster_grants()
+    assert len(actual_grants) == 0
+
+
+def test_interactive_cluster_not_found(ws, installation):
+    ws.config.is_azure = True
+    ws.config.is_aws = False
+    cluster_spn = ServicePrincipalClusterMapping(
+        'cluster1',
+        {AzureServicePrincipalInfo(application_id='client1', storage_account='storage1')},
+    )
+    ws.permissions.get.side_effect = ResourceDoesNotExist
     grants = principal_acl(ws, installation, [cluster_spn])
     actual_grants = grants.get_interactive_cluster_grants()
     assert len(actual_grants) == 0

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -959,7 +959,8 @@ GRANTS = MockBackend.rows("principal", "action_type", "catalog", "database", "ta
 
 
 def test_migrate_acls_should_produce_proper_queries(ws, caplog):
-    errors = {}
+    # all grants succeed except for one
+    errors = {"GRANT SELECT ON VIEW ucx_default.db1_dst.view_dst TO `account group`": "TABLE_OR_VIEW_NOT_FOUND: error"}
     rows = {
         'SELECT \\* FROM hive_metastore.inventory_database.grants': GRANTS[
             ("workspace_group", "SELECT", "", "db1_src", "managed_dbfs", ""),
@@ -1031,6 +1032,10 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
     assert "GRANT MODIFY ON VIEW ucx_default.db1_dst.view_dst TO `account group`" not in backend.queries
 
     assert "Cannot identify UC grant" in caplog.text
+    assert (
+        "Failed to migrate ACL for hive_metastore.db1_src.view_src to ucx_default.db1_dst.view_dst: "
+        "TABLE_OR_VIEW_NOT_FOUND: error"
+    ) in caplog.text
 
 
 def test_migrate_principal_acls_should_produce_proper_queries(ws):


### PR DESCRIPTION
## Changes
`test_migrate_managed_tables_with_acl` is flaky, because there are multiple not found exceptions that are not handled, which happens when tests are running in parallel

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1549

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] verified on staging environment (screenshot attached)
