### PR TITLE
Create a new command databricks labs ucx lint-local-code

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -173,6 +173,9 @@ commands:
   - name: migrate-local-code
     description: (Experimental) Migrate files in the current directory to be more compatible with Unity Catalog.
 
+  - name:  lint-local-code
+    description: (Experimental) Lint files in the current directory to highlight incompatibilities with Unity Catalog.
+
   - name: show-all-metastores
     is_account_level: true
     description: Show all metastores available in the same region as the specified workspace

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -437,5 +437,18 @@ def migrate_tables(w: WorkspaceClient, prompts: Prompts, *, ctx: WorkspaceContex
             deployed_workflows.run_workflow("migrate-external-hiveserde-tables-in-place-experimental")
 
 
+# TODO: Add the following commands to the CLI
+# TODO: local_file_migrator is a placeholder - maybe needs local_file_linter
+@ucx.command
+def lint_local_code(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None):
+    """Lint local code files looking for problems in notebooks and python files."""
+    if ctx is None:
+        ctx = WorkspaceContext(w)
+    working_directory = Path.cwd()
+    if not prompts.confirm("Do you want to run UC linting on all files in the current directory?"):
+        return
+    ctx.local_file_migrator.lint(working_directory)
+
+
 if __name__ == "__main__":
     ucx()

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -437,16 +437,12 @@ def migrate_tables(w: WorkspaceClient, prompts: Prompts, *, ctx: WorkspaceContex
             deployed_workflows.run_workflow("migrate-external-hiveserde-tables-in-place-experimental")
 
 
-# TODO: Add the following commands to the CLI
-# TODO: local_file_migrator is a placeholder - maybe needs local_file_linter
 @ucx.command
-def lint_local_code(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None):
+def lint_local_code(w: WorkspaceClient, ctx: WorkspaceContext | None = None):
     """Lint local code files looking for problems in notebooks and python files."""
     if ctx is None:
         ctx = WorkspaceContext(w)
     working_directory = Path.cwd()
-    if not prompts.confirm("Do you want to run UC linting on all files in the current directory?"):
-        return
     ctx.local_file_linter.lint(working_directory)
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -447,7 +447,7 @@ def lint_local_code(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext 
     working_directory = Path.cwd()
     if not prompts.confirm("Do you want to run UC linting on all files in the current directory?"):
         return
-    ctx.local_file_migrator.lint(working_directory)
+    ctx.local_file_linter.lint(working_directory)
 
 
 if __name__ == "__main__":

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -10,7 +10,7 @@ from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import AccountContext, WorkspaceContext
+from databricks.labs.ucx.contexts.cli_command import AccountContext, WorkspaceContext, LocalContext
 from databricks.labs.ucx.hive_metastore.tables import What
 
 ucx = App(__file__)
@@ -387,7 +387,7 @@ def revert_cluster_remap(w: WorkspaceClient, prompts: Prompts):
 @ucx.command
 def migrate_local_code(w: WorkspaceClient, prompts: Prompts):
     """Fix the code files based on their language."""
-    ctx = WorkspaceContext(w)
+    ctx = LocalContext(w)
     working_directory = Path.cwd()
     if not prompts.confirm("Do you want to apply UC migration to all files in the current directory?"):
         return
@@ -438,10 +438,13 @@ def migrate_tables(w: WorkspaceClient, prompts: Prompts, *, ctx: WorkspaceContex
 
 
 @ucx.command
-def lint_local_code(w: WorkspaceClient, ctx: WorkspaceContext | None = None):
+def lint_local_code(w: WorkspaceClient, ctx: LocalContext | None = None):
     """Lint local code files looking for problems in notebooks and python files."""
     if ctx is None:
-        ctx = WorkspaceContext(w)
+        # TODO Add a local dependency builder to localcontext rather than Workspace, once Eric's PR hits
+        # Right now it is using the workspace loader to prove it all works but obviously will not find notebooks
+        # in the workspace
+        ctx = LocalContext(w)
     working_directory = Path.cwd()
     ctx.local_file_linter.lint(working_directory)
 

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -19,7 +19,7 @@ from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import GlobalContext
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, LocalNotebookLoader
-from databricks.labs.ucx.source_code.files import LocalFileMigrator
+from databricks.labs.ucx.source_code.files import LocalFileMigrator, LocalFileLinter
 from databricks.labs.ucx.workspace_access.clusters import ClusterAccess
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,10 @@ class WorkspaceContext(CliContext):
     @cached_property
     def local_file_migrator(self):
         return LocalFileMigrator(self.languages)
+
+    @cached_property
+    def local_file_linter(self):
+        return LocalFileLinter(self.languages)
 
     @cached_property
     def cluster_access(self):

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -50,7 +50,7 @@ class WorkspaceContext(CliContext):
 
     @cached_property
     def local_file_linter(self):
-        return LocalFileLinter(self.workspace_client)
+        return LocalFileLinter(self.workspace_client, self.tables_migrator.index(), self.file_resolver)
 
     @cached_property
     def cluster_access(self):

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -45,14 +45,6 @@ class WorkspaceContext(CliContext):
         return StatementExecutionBackend(self.workspace_client, self.config.warehouse_id)
 
     @cached_property
-    def local_file_migrator(self):
-        return LocalFileMigrator(self.languages)
-
-    @cached_property
-    def local_file_linter(self):
-        return LocalFileLinter(self.workspace_client, self.tables_migrator.index(), self.file_resolver)
-
-    @cached_property
     def cluster_access(self):
         return ClusterAccess(self.installation, self.workspace_client, self.prompts)
 
@@ -206,3 +198,16 @@ class AccountContext(CliContext):
     @cached_property
     def account_metastores(self):
         return AccountMetastores(self.account_client)
+
+
+class LocalContext(WorkspaceContext):
+    """Local context extends Workspace context to provide extra properties
+    for running local operations."""
+
+    @cached_property
+    def local_file_migrator(self):
+        return LocalFileMigrator(self.languages)
+
+    @cached_property
+    def local_file_linter(self):
+        return LocalFileLinter(self.tables_migrator.index(), self.dependency_graph_builder)

--- a/src/databricks/labs/ucx/contexts/cli_command.py
+++ b/src/databricks/labs/ucx/contexts/cli_command.py
@@ -50,7 +50,7 @@ class WorkspaceContext(CliContext):
 
     @cached_property
     def local_file_linter(self):
-        return LocalFileLinter(self.languages)
+        return LocalFileLinter(self.workspace_client)
 
     @cached_property
     def cluster_access(self):

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -244,9 +244,12 @@ class LocalFileLinter:
         language = self._extensions[path.suffix]
         if not language:
             return False
+        advised = False
         logger.info(f"Analysing {path}")
+        linter = self._languages.linter(language)
         with path.open("r") as f:
             code = f.read()
-            for advice in self._languages.linter(language).lint(code):
+            for advice in linter.lint(code):
                 logger.info(f"Found: {advice}")
-            return True
+                advised = True
+            return advised

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -2,11 +2,10 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, create_autospec
 
-from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
-from databricks.labs.ucx.source_code.files import LocalFileMigrator, LocalFileLinter
+from databricks.labs.ucx.source_code.files import LocalFileMigrator
 from databricks.labs.ucx.source_code.languages import Languages
 
 
@@ -74,10 +73,4 @@ def test_files_walks_directory():
     assert languages.fixer.call_count > 1
 
 
-def test_files_lint_ignores_unsupported_extensions():
-    # Create a mock WorkspaceClient
-    mock_ws = create_autospec(WorkspaceClient)
-    mock_ws.workspace.list.return_value = ["file1.py", "file2.py", "file3.py"]
-    files = LocalFileLinter(mock_ws)
-    path = Path('unsupported.ext')
-    assert not files.lint(path)
+# TODO: Add tests for the LocalFileLinter class once the NotebookLoader is implemented

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, create_autospec
 
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
@@ -74,45 +75,9 @@ def test_files_walks_directory():
 
 
 def test_files_lint_ignores_unsupported_extensions():
-    languages = Languages(MigrationIndex([]))
-    files = LocalFileLinter(languages)
+    # Create a mock WorkspaceClient
+    mock_ws = create_autospec(WorkspaceClient)
+    mock_ws.workspace.list.return_value = ["file1.py", "file2.py", "file3.py"]
+    files = LocalFileLinter(mock_ws)
     path = Path('unsupported.ext')
     assert not files.lint(path)
-
-
-def test_files_lint_ignores_unsupported_language():
-    languages = Languages(MigrationIndex([]))
-    files = LocalFileLinter(languages)
-    files._extensions[".py"] = None  # pylint: disable=protected-access
-    path = Path('unsupported.py')
-    assert not files.lint(path)
-
-
-def test_files_lint_reads_supported_extensions():
-    languages = Languages(MigrationIndex([]))
-    files = LocalFileLinter(languages)
-    path = Path(__file__)
-    results = files.lint(path)
-    assert not results
-
-
-def test_files_lint_supported_language_no_diagnostics():
-    languages = create_autospec(Languages)
-    languages.linter(Language.PYTHON).lint.return_value = []
-    files = LocalFileLinter(languages)
-    path = Path(__file__)
-    files.lint(path)
-    languages.fixer.assert_not_called()
-
-
-def test_files_lint_walks_directory():
-    languages = create_autospec(Languages)
-    languages.linter(Language.PYTHON).lint.return_value = [Mock()]
-    mock_linter = Mock()
-    mock_linter.lint.return_value = []
-    languages.linter.return_value = mock_linter
-    files = LocalFileLinter(languages)
-    path = Path(__file__).parent
-    files.lint(path)
-    languages.linter.assert_called_with(Language.PYTHON)
-    assert languages.linter.call_count > 1


### PR DESCRIPTION
A new command is created within the ucx cli that allows linting of local python files and local notebooks.

```sh
databricks labs ucx lint-local-code
```
Will prompt to ask if all files in the current directory and child directories should be linted. Upon confirmation, the
local python files and notebooks will be discovered and advisories will be raised for any issues identified.

## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1541 

### Functionality 

- [ ] added relevant user documentation
- [x] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
