### PR TITLE
Refresh migration status at the end of the `migrate_tables` workflows

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -90,9 +90,7 @@ class TablesMigrator:
                 mounts,
                 hiveserde_in_place_migrate,
             )
-        # Refresh migration status
-        self._migration_status_refresher.reset()
-        self._migration_status_refresher.snapshot()
+        self.index()  # Index migration status to show in migration dashboard
         return tasks
 
     def _migrate_tables(

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -137,6 +137,7 @@ class TablesMigrator:
                     )
                 )
             Threads.strict("migrate views", tasks)
+            self._migration_status_refresher.reset()
             all_tasks.extend(tasks)
         self._migration_status_refresher.reset()
         return all_tasks

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -139,8 +139,8 @@ class TablesMigrator:
                     )
                 )
             Threads.strict("migrate views", tasks)
-            self._migration_status_refresher.reset()
             all_tasks.extend(tasks)
+        self._migration_status_refresher.reset()
         return all_tasks
 
     def _compute_grants(

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -79,16 +79,21 @@ class TablesMigrator:
         if mounts_crawler:
             mounts = list(mounts_crawler.snapshot())
         if what == What.VIEW:
-            return self._migrate_views(acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants)
-        return self._migrate_tables(
-            what,
-            acl_strategy,
-            all_grants_to_migrate,
-            all_migrated_groups,
-            all_principal_grants,
-            mounts,
-            hiveserde_in_place_migrate,
-        )
+            tasks = self._migrate_views(acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants)
+        else:
+            tasks = self._migrate_tables(
+                what,
+                acl_strategy,
+                all_grants_to_migrate,
+                all_migrated_groups,
+                all_principal_grants,
+                mounts,
+                hiveserde_in_place_migrate,
+            )
+        # Refresh migration status
+        self._migration_status_refresher.reset()
+        self._migration_status_refresher.snapshot()
+        return tasks
 
     def _migrate_tables(
         self,

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -79,19 +79,16 @@ class TablesMigrator:
         if mounts_crawler:
             mounts = list(mounts_crawler.snapshot())
         if what == What.VIEW:
-            tasks = self._migrate_views(acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants)
-        else:
-            tasks = self._migrate_tables(
-                what,
-                acl_strategy,
-                all_grants_to_migrate,
-                all_migrated_groups,
-                all_principal_grants,
-                mounts,
-                hiveserde_in_place_migrate,
-            )
-        self.index()  # Index migration status to show in migration dashboard
-        return tasks
+            return self._migrate_views(acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants)
+        return self._migrate_tables(
+            what,
+            acl_strategy,
+            all_grants_to_migrate,
+            all_migrated_groups,
+            all_principal_grants,
+            mounts,
+            hiveserde_in_place_migrate,
+        )
 
     def _migrate_tables(
         self,

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -36,7 +36,12 @@ class TableMigration(Workflow):
         """
         ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
-    @job_task(dashboard="migration_main", depends_on=[migrate_views])
+    @job_task(job_cluster="table_migration", depends_on=[migrate_views])
+    def refresh_migration_status(self, ctx: RuntimeContext):
+        """Refresh the migration status to present it in the dashboard."""
+        ctx.tables_migrator.index()
+
+    @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
         """Refreshes the migration dashboard after all previous tasks have been completed. Note that you can access the
         dashboard _before_ all tasks have been completed, but then only already completed information is shown."""
@@ -66,7 +71,12 @@ class MigrateHiveSerdeTablesInPlace(Workflow):
         """
         ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
-    @job_task(dashboard="migration_main", depends_on=[migrate_views])
+    @job_task(job_cluster="table_migration", depends_on=[migrate_views])
+    def refresh_migration_status(self, ctx: RuntimeContext):
+        """Refresh the migration status to present it in the dashboard."""
+        ctx.tables_migrator.index()
+
+    @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
         """Refreshes the migration dashboard after all previous tasks have been completed. Note that you can access the
         dashboard _before_ all tasks have been completed, but then only already completed information is shown."""
@@ -104,7 +114,12 @@ class MigrateExternalTablesCTAS(Workflow):
         """
         ctx.tables_migrator.migrate_tables(what=What.VIEW, acl_strategy=[AclMigrationWhat.LEGACY_TACL])
 
-    @job_task(dashboard="migration_main", depends_on=[migrate_views])
+    @job_task(job_cluster="table_migration", depends_on=[migrate_views])
+    def refresh_migration_status(self, ctx: RuntimeContext):
+        """Refresh the migration status to present it in the dashboard."""
+        ctx.tables_migrator.index()
+
+    @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
         """Refreshes the migration dashboard after all previous tasks have been completed. Note that you can access the
         dashboard _before_ all tasks have been completed, but then only already completed information is shown."""
@@ -121,7 +136,12 @@ class MigrateTablesInMounts(Workflow):
         located under the assessment."""
         ctx.tables_in_mounts.snapshot()
 
-    @job_task(dashboard="migration_main", depends_on=[scan_tables_in_mounts_experimental])
+    @job_task(job_cluster="table_migration", depends_on=[scan_tables_in_mounts_experimental])
+    def refresh_migration_status(self, ctx: RuntimeContext):
+        """Refresh the migration status to present it in the dashboard."""
+        ctx.tables_migrator.index()
+
+    @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
         """Refreshes the migration dashboard after all previous tasks have been completed. Note that you can access the
         dashboard _before_ all tasks have been completed, but then only already completed information is shown."""

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from dataclasses import replace
+from datetime import timedelta
+
+import pytest
+from databricks.labs.blueprint.installer import RawState
+from databricks.sdk.errors import NotFound
+from databricks.sdk.retries import retried
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
+@pytest.mark.parametrize('prepare_tables_for_migration', [('regular')], indirect=True)
+def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, prepare_tables_for_migration):
+    """The migration status should be refreshed after the migration job."""
+    tables, dst_schema = prepare_tables_for_migration
+    ctx = installation_ctx.replace(
+        extend_prompts={
+            r".*Do you want to update the existing installation?.*": 'yes',
+        },
+    )
+
+    ctx.workspace_installation.run()
+    ctx.deployed_workflows.run_workflow("migrate-tables")
+
+    for table in tables.values():
+        # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
+        query_migration_status = (
+            f"SELECT * FROM {ctx.config.inventory_database}.migration_status "
+            f"WHERE src_schema = '{dst_schema.name}' AND src_table = '{table.name}'"
+        )
+        migration_status = list(ctx.sql_backend.fetch(query_migration_status))
+        assert len(migration_status) == 1

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -31,7 +31,9 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
         # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
         query_migration_status = (
             f"SELECT * FROM {ctx.config.inventory_database}.migration_status "
-            f"WHERE src_schema = '{dst_schema.name}' AND src_table = '{table.name}'"
+            f"WHERE src_schema = '{tables.schema_name}' AND src_table = '{table.name}'"
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
         assert len(migration_status) == 1
+        assert migration_status[0].dst_schema is not None
+        assert migration_status[0].dst_table is not None

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -19,6 +19,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     """The migration status should be refreshed after the migration job."""
     tables, _ = prepare_tables_for_migration
     ctx = installation_ctx.replace(
+        skip_dashboards=False,
         extend_prompts={
             r".*Do you want to update the existing installation?.*": 'yes',
         },
@@ -34,6 +35,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
             f"WHERE src_schema = '{table.schema_name}' AND src_table = '{table.name}'"
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
-        assert len(migration_status) == 1, f"No migration status found for table {table.full_name}"
-        assert migration_status[0].dst_schema is not None, f"No destination schema found for {table.full_name}"
-        assert migration_status[0].dst_table is not None, f"No destination table found for {table.dst_table}"
+        assert_message_postfix = f" found for {table.table_type} {table.full_name}"
+        assert len(migration_status) == 1, f"No migration status found" + assert_message_postfix
+        assert migration_status[0].dst_schema is not None, f"No destination schema" + assert_message_postfix
+        assert migration_status[0].dst_table is not None, f"No destination table" + assert_message_postfix

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -1,10 +1,6 @@
-import os
-import sys
-from dataclasses import replace
 from datetime import timedelta
 
 import pytest
-from databricks.labs.blueprint.installer import RawState
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -17,7 +17,7 @@ from databricks.sdk.retries import retried
 )
 def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, prepare_tables_for_migration, workflow):
     """The migration status should be refreshed after the migration job."""
-    tables, dst_schema = prepare_tables_for_migration
+    tables, _ = prepare_tables_for_migration
     ctx = installation_ctx.replace(
         extend_prompts={
             r".*Do you want to update the existing installation?.*": 'yes',

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -34,6 +34,6 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
             f"WHERE src_schema = '{table.schema_name}' AND src_table = '{table.name}'"
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
-        assert len(migration_status) == 1
-        assert migration_status[0].dst_schema is not None
-        assert migration_status[0].dst_table is not None
+        assert len(migration_status) == 1, f"No migration status found for table {table.full_name}"
+        assert migration_status[0].dst_schema is not None, f"No destination schema found for {table.full_name}"
+        assert migration_status[0].dst_table is not None, f"No destination table found for {table.dst_table}"

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -10,8 +10,16 @@ from databricks.sdk.retries import retried
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-@pytest.mark.parametrize('prepare_tables_for_migration', [('regular')], indirect=True)
-def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, prepare_tables_for_migration):
+@pytest.mark.parametrize(
+    "prepare_tables_for_migration,workflow",
+    [
+        ("regular", "migrate-tables"),
+        ("hiveserde", "migrate-external-hiveserde-tables-in-place-experimental"),
+        ("hiveserde", "migrate-external-tables-ctas"),
+    ],
+    indirect=("prepare_tables_for_migration",),
+)
+def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, prepare_tables_for_migration, workflow):
     """The migration status should be refreshed after the migration job."""
     tables, dst_schema = prepare_tables_for_migration
     ctx = installation_ctx.replace(
@@ -21,7 +29,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     )
 
     ctx.workspace_installation.run()
-    ctx.deployed_workflows.run_workflow("migrate-tables")
+    ctx.deployed_workflows.run_workflow(workflow)
 
     for table in tables.values():
         # Avoiding MigrationStatusRefresh as it will refresh the status before fetching

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -31,7 +31,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
         # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
         query_migration_status = (
             f"SELECT * FROM {ctx.config.inventory_database}.migration_status "
-            f"WHERE src_schema = '{tables.schema_name}' AND src_table = '{table.name}'"
+            f"WHERE src_schema = '{table.schema_name}' AND src_table = '{table.name}'"
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
         assert len(migration_status) == 1

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -19,7 +19,6 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     """The migration status should be refreshed after the migration job."""
     tables, _ = prepare_tables_for_migration
     ctx = installation_ctx.replace(
-        skip_dashboards=False,
         extend_prompts={
             r".*Do you want to update the existing installation?.*": 'yes',
         },
@@ -36,6 +35,6 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
         assert_message_postfix = f" found for {table.table_type} {table.full_name}"
-        assert len(migration_status) == 1, f"No migration status found" + assert_message_postfix
-        assert migration_status[0].dst_schema is not None, f"No destination schema" + assert_message_postfix
-        assert migration_status[0].dst_table is not None, f"No destination table" + assert_message_postfix
+        assert len(migration_status) == 1, "No migration status found" + assert_message_postfix
+        assert migration_status[0].dst_schema is not None, "No destination schema" + assert_message_postfix
+        assert migration_status[0].dst_table is not None, "No destination table" + assert_message_postfix


### PR DESCRIPTION
## Changes
Refresh migration status at the end of the `migrate_tables` task

### Linked issues
Resolves #1597

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [x] modified existing workflow: `migrate-*-tables*`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
