### PR TITLE
Ignore existing corrupted installations when refreshing

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -272,7 +272,7 @@ class WorkspaceInstaller(WorkspaceContext):
             return config
         except NotFound as err:
             logger.debug(f"Cannot find previous installation: {err}")
-        except AttributeError:
+        except (PermissionDenied, SerdeError, ValueError, AttributeError):
             logger.warning(f"Existing installation at {self.installation.install_folder()} is corrupted. Skipping...")
         return self._configure_new_installation(default_config)
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -272,6 +272,8 @@ class WorkspaceInstaller(WorkspaceContext):
             return config
         except NotFound as err:
             logger.debug(f"Cannot find previous installation: {err}")
+        except AttributeError:
+            logger.warning(f"Existing installation at {self.installation.install_folder()} is corrupted. Skipping...")
         return self._configure_new_installation(default_config)
 
     def replace_config(self, **changes: Any) -> WorkspaceConfig | None:
@@ -391,7 +393,8 @@ class WorkspaceInstaller(WorkspaceContext):
                     raise AlreadyExists(
                         f"Inventory database '{inventory_database}' already exists in another installation"
                     )
-            except (PermissionDenied, NotFound, SerdeError):
+            except (PermissionDenied, NotFound, SerdeError, ValueError, AttributeError):
+                logger.warning(f"Existing installation at {installation.install_folder()} is corrupted. Skipping...")
                 continue
 
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -486,6 +486,28 @@ def test_save_config(ws, mock_installation):
     )
 
 
+def test_corrupted_config(ws, mock_installation, caplog):
+    installation = MockInstallation({'config.yml': "corrupted"})
+
+    prompts = MockPrompts(
+        {
+            r".*PRO or SERVERLESS SQL warehouse.*": "1",
+            r"Choose how to map the workspace groups.*": "2",
+            r".*": "",
+            r".*days to analyze submitted runs.*": "1",
+        }
+    )
+    install = WorkspaceInstaller(ws).replace(
+        prompts=prompts,
+        installation=installation,
+        product_info=PRODUCT_INFO,
+    )
+    with caplog.at_level('WARNING'):
+        install.configure()
+
+    assert 'Existing installation at ~/mock is corrupted' in caplog.text
+
+
 def test_save_config_strip_group_names(ws, mock_installation):
     prompts = MockPrompts(
         {


### PR DESCRIPTION
## Changes
- Add error handling when running `installation.load`

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1601

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
