### PR TITLE
Avoid cyclic import issues, when we need to initialize `WorkspaceContext` from `AccountContext`

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [ opened, synchronize, ready_for_review ]
   push:
+    # required for merge queue to work. jobs.integration.if will mark it as skipped
     branches:
       - main
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,6 +3,9 @@ name: acceptance
 on:
   pull_request:
     types: [ opened, synchronize, ready_for_review ]
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
   push:
+    # required for merge queue to work. jobs.integration.if will mark it as skipped
     branches:
       - main
 

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -3,10 +3,14 @@ name: no-cheat
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches:
+      - main
 
 jobs:
   no-pylint-disable:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(['opened', 'synchronize'], github.event.action)
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   no-pylint-disable:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(['opened', 'synchronize'], github.event.action)
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -10,7 +10,8 @@ from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import AccountContext, WorkspaceContext
+from databricks.labs.ucx.contexts.account_cli import AccountContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.hive_metastore.tables import What
 
 ucx = App(__file__)

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -1,0 +1,29 @@
+from functools import cached_property
+
+from databricks.sdk import AccountClient
+
+from databricks.labs.ucx.account.metastores import AccountMetastores
+from databricks.labs.ucx.account.workspaces import AccountWorkspaces
+from databricks.labs.ucx.contexts.application import CliContext
+
+
+class AccountContext(CliContext):
+    def __init__(self, ac: AccountClient, named_parameters: dict[str, str] | None = None):
+        super().__init__(named_parameters)
+        self._ac = ac
+
+    @cached_property
+    def account_client(self) -> AccountClient:
+        return self._ac
+
+    @cached_property
+    def workspace_ids(self):
+        return [int(_.strip()) for _ in self.named_parameters.get("workspace_ids", "").split(",") if _]
+
+    @cached_property
+    def account_workspaces(self):
+        return AccountWorkspaces(self.account_client, self.workspace_ids)
+
+    @cached_property
+    def account_metastores(self):
+        return AccountMetastores(self.account_client)

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -5,6 +5,7 @@ from functools import cached_property
 
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.installer import InstallState
+from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import AccountClient, WorkspaceClient, core
@@ -314,6 +315,7 @@ class GlobalContext(abc.ABC):
     @cached_property
     def languages(self):
         index = self.tables_migrator.index()
+        # TODO: initialize Languages every time, because it has CurrentSessionState for the cache
         return Languages(index)
 
     @cached_property
@@ -392,3 +394,9 @@ class GlobalContext(abc.ABC):
     @cached_property
     def dependency_graph_builder(self):
         return DependencyGraphBuilder(self.dependency_resolver)
+
+
+class CliContext(GlobalContext, abc.ABC):
+    @cached_property
+    def prompts(self) -> Prompts:
+        return Prompts()

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -1,34 +1,21 @@
-import abc
-import logging
 import os
 import shutil
 from functools import cached_property
 
-from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.lsql.backends import SqlBackend, StatementExecutionBackend
-from databricks.sdk import AccountClient, WorkspaceClient
+from databricks.sdk import WorkspaceClient
 
-from databricks.labs.ucx.account.workspaces import AccountWorkspaces
-from databricks.labs.ucx.account.metastores import AccountMetastores
 from databricks.labs.ucx.assessment.aws import run_command, AWSResources
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.aws.credentials import IamRoleMigration, IamRoleCreation
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
-from databricks.labs.ucx.azure.credentials import ServicePrincipalMigration, StorageCredentialManager
+from databricks.labs.ucx.azure.credentials import StorageCredentialManager, ServicePrincipalMigration
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
-from databricks.labs.ucx.contexts.application import GlobalContext
-from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, LocalNotebookLoader
+from databricks.labs.ucx.contexts.application import CliContext
 from databricks.labs.ucx.source_code.files import LocalFileMigrator
+from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, LocalNotebookLoader
 from databricks.labs.ucx.workspace_access.clusters import ClusterAccess
-
-logger = logging.getLogger(__name__)
-
-
-class CliContext(GlobalContext, abc.ABC):
-    @cached_property
-    def prompts(self) -> Prompts:
-        return Prompts()
 
 
 class WorkspaceContext(CliContext):
@@ -180,25 +167,3 @@ class WorkspaceContext(CliContext):
     @cached_property
     def notebook_loader(self) -> NotebookLoader:
         return LocalNotebookLoader(self.syspath_provider)
-
-
-class AccountContext(CliContext):
-    def __init__(self, ac: AccountClient, named_parameters: dict[str, str] | None = None):
-        super().__init__(named_parameters)
-        self._ac = ac
-
-    @cached_property
-    def account_client(self) -> AccountClient:
-        return self._ac
-
-    @cached_property
-    def workspace_ids(self):
-        return [int(_.strip()) for _ in self.named_parameters.get("workspace_ids", "").split(",") if _]
-
-    @cached_property
-    def account_workspaces(self):
-        return AccountWorkspaces(self.account_client, self.workspace_ids)
-
-    @cached_property
-    def account_metastores(self):
-        return AccountMetastores(self.account_client)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -46,7 +46,8 @@ from databricks.labs.ucx.assessment.init_scripts import GlobalInitScriptInfo
 from databricks.labs.ucx.assessment.jobs import JobInfo, SubmitRunInfo
 from databricks.labs.ucx.assessment.pipelines import PipelineInfo
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import AccountContext, WorkspaceContext
+from databricks.labs.ucx.contexts.account_cli import AccountContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.framework.dashboards import DashboardFromFiles
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore.grants import Grant

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -10,7 +10,7 @@ from databricks.sdk.service.catalog import SecurableType, PermissionsChange, Pri
 from databricks.labs.ucx.assessment.aws import AWSInstanceProfile, AWSResources
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import WorkspaceContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.hive_metastore import ExternalLocations
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,7 +27,7 @@ from databricks.labs.ucx.assessment.azure import (
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.azure.access import AzureResourcePermissions, StoragePermissionMapping
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.contexts.cli_command import WorkspaceContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -11,7 +11,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 
-from databricks.labs.ucx.contexts.cli_command import WorkspaceContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -46,7 +46,8 @@ from databricks.labs.ucx.cli import (
     migrate_tables,
     create_missing_principals,
 )
-from databricks.labs.ucx.contexts.cli_command import WorkspaceContext, AccountContext
+from databricks.labs.ucx.contexts.account_cli import AccountContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.tables import Table
 

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -6,7 +6,7 @@ from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 
-from databricks.labs.ucx.contexts.cli_command import WorkspaceContext
+from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 
 
 def test_replace_installation():


### PR DESCRIPTION
This PR splits `cli_command.py` into `workspace_cli.py` and `account_cli.py`
