### PR TITLE
Fix storage account network acls retrieved from properties

### DIFF
--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -110,7 +110,7 @@ class StorageAccount:
     id: AzureResource
     name: str
     location: str
-    default_network_action: str  # "Deny" or "Allow"
+    default_network_action: str  # "Unknown", "Deny" or "Allow"
 
     @classmethod
     def from_raw_resource(cls, raw: RawResource) -> "StorageAccount":
@@ -125,9 +125,7 @@ class StorageAccount:
         if location == "":
             raise KeyError(f"Missing location: {raw}")
 
-        default_network_action = raw.get("networkAcls", {}).get("defaultAction", "")
-        if default_network_action == "":
-            raise KeyError(f"Missing networkAcls.defaultAction: {raw}")
+        default_network_action = raw.get("properties", {}).get("networkAcls", {}).get("defaultAction", "Unknown")
 
         storage_account = cls(id=raw.id, name=name, location=location, default_network_action=default_network_action)
         return storage_account

--- a/tests/unit/azure/azure/mappings.json
+++ b/tests/unit/azure/azure/mappings.json
@@ -47,16 +47,20 @@
           "name": "sto2",
           "id": "subscriptions/002/resourceGroups/rg1/storageAccounts/sto2",
           "location": "westeu",
-          "networkAcls": {
-            "defaultAction": "Allow"
+          "properties": {
+            "networkAcls": {
+              "defaultAction": "Allow"
+            }
           }
         },
         {
           "name": "sto3",
           "id": "subscriptions/002/resourceGroups/rg1/storageAccounts/sto3",
           "location": "westeu",
-          "networkAcls": {
-            "defaultAction": "Deny"
+          "properties": {
+            "networkAcls": {
+              "defaultAction": "Deny"
+            }
           }
         }
       ]

--- a/tests/unit/azure/test_resources.py
+++ b/tests/unit/azure/test_resources.py
@@ -86,14 +86,14 @@ def test_role_assignments_container():
         assert role_assignment.resource == AzureResource(resource_id)
 
 
-@pytest.mark.parametrize("missing_field", ["id", "name", "location", "networkAcls"])
+@pytest.mark.parametrize("missing_field", ["id", "name", "location"])
 def test_storage_account_missing_fields(missing_field: str):
     """A KeyError should be raised when the fields are missing."""
     raw = {
         "name": "sto3",
         "id": "subscriptions/002/resourceGroups/rg1/storageAccounts/sto3",
         "location": "westeu",
-        "networkAcls": {"defaultAction": "Deny"},
+        "properties": {"networkAcls": {"defaultAction": "Deny"}},
     }
     raw.pop(missing_field)
     with pytest.raises(KeyError):


### PR DESCRIPTION
## Changes
The network ACLS should come from the storage account network properties.

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
