### PR TITLE
Improved reliability of table migration status refresher

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -70,7 +70,7 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
         seen_tables: dict[str, str] = {}
         for schema in self._iter_schemas():
             try:
-                tables = self._ws.tables.list(catalog_name=schema.catalog_name, schema_name=schema.name)
+                tables = list(self._ws.tables.list(catalog_name=schema.catalog_name, schema_name=schema.name))
             except NotFound:
                 logger.warning(
                     f"Schema {schema.catalog_name}.{schema.name} no longer exists. Skipping checking its migration status."

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -70,6 +70,7 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
         seen_tables: dict[str, str] = {}
         for schema in self._iter_schemas():
             try:
+                # ws.tables.list returns Iterator[TableInfo], so we need to convert it to a list in order to catch the exception
                 tables = list(self._ws.tables.list(catalog_name=schema.catalog_name, schema_name=schema.name))
             except NotFound:
                 logger.warning(

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -57,7 +57,7 @@ class TablesMigrator:
         self._principal_grants = principal_grants
 
     def index(self):
-        # TODO: remove this method
+        self._migration_status_refresher.reset()
         return self._migration_status_refresher.index()
 
     def migrate_tables(
@@ -116,7 +116,6 @@ class TablesMigrator:
 
     def _migrate_views(self, acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants):
         tables_to_migrate = self._tm.get_tables_to_migrate(self._tc)
-        self._migration_status_refresher.reset()
         all_tasks = []
         sequencer = ViewsMigrationSequencer(tables_to_migrate, self.index())
         batches = sequencer.sequence_batches()
@@ -134,9 +133,7 @@ class TablesMigrator:
                     )
                 )
             Threads.strict("migrate views", tasks)
-            self._migration_status_refresher.reset()
             all_tasks.extend(tasks)
-        self._migration_status_refresher.reset()
         return all_tasks
 
     def _compute_grants(

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -43,7 +43,7 @@ class TablesMigrator:
         backend: SqlBackend,
         table_mapping: TableMapping,
         group_manager: GroupManager,
-        migration_status_refresher: 'MigrationStatusRefresher',
+        migration_status_refresher: MigrationStatusRefresher,
         principal_grants: PrincipalACL,
     ):
         self._tc = table_crawler

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -35,6 +35,6 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
         assert_message_postfix = f" found for {table.table_type} {table.full_name}"
-        assert len(migration_status) == 1, "No migration status found" + assert_message_postfix
+        assert len(migration_status) == 1, "No migration status" + assert_message_postfix
         assert migration_status[0].dst_schema is not None, "No destination schema" + assert_message_postfix
         assert migration_status[0].dst_table is not None, "No destination table" + assert_message_postfix


### PR DESCRIPTION
## Changes
- Always reset table migration status when requesting the latest snapshot within `table_migrate`
- Handle `NotFound` error when refreshing migration status

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1622, #1615

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
