### PR TITLE
Fully refreshed table migration status in table migration workflow

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -59,7 +59,7 @@ class TablesMigrator:
     def index(self):
         return self._migration_status_refresher.index()
 
-    def _index_with_reset(self):
+    def index_full_refresh(self):
         # when we want the latest up-to-date status, e.g. to determine whether views dependencies have been migrated
         self._migration_status_refresher.reset()
         return self._migration_status_refresher.index()
@@ -121,7 +121,7 @@ class TablesMigrator:
     def _migrate_views(self, acl_strategy, all_grants_to_migrate, all_migrated_groups, all_principal_grants):
         tables_to_migrate = self._tm.get_tables_to_migrate(self._tc)
         all_tasks = []
-        sequencer = ViewsMigrationSequencer(tables_to_migrate, self._index_with_reset())
+        sequencer = ViewsMigrationSequencer(tables_to_migrate, self.index_full_refresh())
         batches = sequencer.sequence_batches()
         for batch in batches:
             tasks = []
@@ -202,7 +202,7 @@ class TablesMigrator:
     def _view_can_be_migrated(self, view: ViewToMigrate):
         # dependencies have already been computed, therefore an empty dict is good enough
         for table in view.dependencies:
-            if not self._index_with_reset().get(table.schema, table.name):
+            if not self.index_full_refresh().get(table.schema, table.name):
                 logger.info(f"View {view.src.key} cannot be migrated because {table.key} is not migrated yet")
                 return False
         return True

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -39,7 +39,7 @@ class TableMigration(Workflow):
     @job_task(job_cluster="table_migration", depends_on=[migrate_views])
     def refresh_migration_status(self, ctx: RuntimeContext):
         """Refresh the migration status to present it in the dashboard."""
-        ctx.tables_migrator.index()
+        ctx.tables_migrator.index_full_refresh()
 
     @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -74,7 +74,7 @@ class MigrateHiveSerdeTablesInPlace(Workflow):
     @job_task(job_cluster="table_migration", depends_on=[migrate_views])
     def refresh_migration_status(self, ctx: RuntimeContext):
         """Refresh the migration status to present it in the dashboard."""
-        ctx.tables_migrator.index()
+        ctx.tables_migrator.index_full_refresh()
 
     @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
@@ -117,7 +117,7 @@ class MigrateExternalTablesCTAS(Workflow):
     @job_task(job_cluster="table_migration", depends_on=[migrate_views])
     def refresh_migration_status(self, ctx: RuntimeContext):
         """Refresh the migration status to present it in the dashboard."""
-        ctx.tables_migrator.index()
+        ctx.tables_migrator.index_full_refresh()
 
     @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):
@@ -139,7 +139,7 @@ class MigrateTablesInMounts(Workflow):
     @job_task(job_cluster="table_migration", depends_on=[scan_tables_in_mounts_experimental])
     def refresh_migration_status(self, ctx: RuntimeContext):
         """Refresh the migration status to present it in the dashboard."""
-        ctx.tables_migrator.index()
+        ctx.tables_migrator.index_full_refresh()
 
     @job_task(dashboard="migration_main", depends_on=[refresh_migration_status])
     def migration_report(self, ctx: RuntimeContext):


### PR DESCRIPTION
## Changes
- This was missed in #1623 where we added a new method to fully refresh the migration status. This must be called in table migration workflow task.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1628

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
<img width="1094" alt="image" src="https://github.com/databrickslabs/ucx/assets/44292934/7c6abcb9-4128-4899-87b6-43e8b59bcae2">

