### PR TITLE
Add unit test for calling refresh_migration_status in migrate table workflows

### DIFF
--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -1,7 +1,10 @@
+import pytest
+
 from databricks.labs.ucx.hive_metastore.workflows import (
     TableMigration,
-    MigrateHiveSerdeTablesInPlace,
     MigrateExternalTablesCTAS,
+    MigrateHiveSerdeTablesInPlace,
+    MigrateTablesInMounts,
 )
 
 
@@ -28,3 +31,14 @@ def test_migrate_other_external_ctas(run_workflow):
 def test_migrate_hive_serde_ctas(run_workflow):
     ctx = run_workflow(MigrateExternalTablesCTAS.migrate_hive_serde_ctas)
     ctx.workspace_client.catalogs.list.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "workflow", [TableMigration, MigrateHiveSerdeTablesInPlace, MigrateExternalTablesCTAS, MigrateTablesInMounts]
+)
+def test_refresh_migration_status_is_refreshed(run_workflow, workflow):
+    """Migration status is refreshed by deleting and showing new tables"""
+    ctx = run_workflow(getattr(workflow, "refresh_migration_status"))
+    assert "DELETE FROM hive_metastore.ucx.migration_status" in ctx.sql_backend.queries
+    assert "SHOW DATABASES" in ctx.sql_backend.queries
+    # No "SHOW TABLE FROM" query as table are not mocked


### PR DESCRIPTION
Follow up on #1630