### PR TITLE
Fix Spark configuration parameter referencing secret

### DIFF
--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -122,7 +122,7 @@ class AzureResourcePermissions:
                 self._policy_config("OAuth")
             )
             policy_dict[f"spark_conf.fs.azure.account.oauth2.client.secret.{storage.name}.dfs.core.windows.net"] = (
-                self._policy_config(f"{{secrets/{inventory_database}/uber_principal_secret}}")
+                self._policy_config("{{secrets/" + inventory_database + "/uber_principal_secret}}")
             )
         return json.dumps(policy_dict)
 

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -343,7 +343,7 @@ def test_create_global_spn():
         "spark_conf.fs.azure.account.auth.type.sto2.dfs.core.windows.net": {"type": "fixed", "value": "OAuth"},
         "spark_conf.fs.azure.account.oauth2.client.secret.sto2.dfs.core.windows.net": {
             "type": "fixed",
-            "value": "{secrets/ucx/uber_principal_secret}",
+            "value": "{{secrets/ucx/uber_principal_secret}}",
         },
     }
     w.cluster_policies.edit.assert_called_with(


### PR DESCRIPTION
## Changes
A configuration parameter referencing a secret should use double curly brackets

### Linked issues

Resolves #1629

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs ucx create-uber-principal`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
