### PR TITLE
Prefix random test group names with capital G

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -99,7 +99,7 @@ def sql_fetch_all(sql_backend):
 def make_ucx_group(make_random, make_group, make_acc_group, make_user):
     def inner(workspace_group_name=None, account_group_name=None):
         if not workspace_group_name:
-            workspace_group_name = f"ucx_{make_random(4)}"
+            workspace_group_name = f"ucx_G{make_random(4)}"
         if not account_group_name:
             account_group_name = workspace_group_name
         user = make_user()
@@ -569,7 +569,7 @@ class TestInstallationContext(TestRuntimeContext):
 
     def make_ucx_group(self, workspace_group_name=None, account_group_name=None):
         if not workspace_group_name:
-            workspace_group_name = f"ucx_{self._make_random(4)}"
+            workspace_group_name = f"ucx_G{self._make_random(4)}"
         if not account_group_name:
             account_group_name = workspace_group_name
         user = self._make_user()


### PR DESCRIPTION
## Changes
Similarly to the prefix catalogs with "C", tables with "T" and schemas with "S", also prefix random test group names with "G". 

### Linked issues
Hopefully it narrows the KeyError in: #1616

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
