### PR TITLE
Automatically retrying with `auth_type=azure-cli` when constructing `workspace_clients` on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@ Databricks Labs UCX
 ![UCX by Databricks Labs](docs/logo-no-background.png)
 
 The companion for upgrading to Unity Catalog. After [installation](#install-ucx), ensure to [trigger](#ensure-assessment-run-command) the [assessment workflow](#assessment-workflow), 
-so that you'll be able to [scope the migration](docs/assessment.md) and execute the [group migration workflow](#group-migration-workflow). 
-[`<installation_path>/README`](#readme-notebook) contains further instructions and explanations of these workflows. 
+so that you'll be able to [scope the migration](docs/assessment.md) and execute the [group migration workflow](#group-migration-workflow).
+
+After installation, [`<installation_path>/README`](#readme-notebook) contains further instructions and explanations of these workflows. 
 Then you can execute [table migration workflow](#table-migration-workflow).
-More workflows, like notebook code migration is coming in the future releases. 
+
+More workflows, like notebook code migration is coming in the future releases.
+
 UCX exposes a number of command line utilities accessible via `databricks labs ucx`.
 
 For questions, troubleshooting or bug fixes, please see our [troubleshooting guide](docs/troubleshooting.md) or submit [an issue](https://github.com/databrickslabs/ucx/issues). 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -128,6 +128,18 @@ By following these steps, you should be able to effectively locate, access, and 
 - Ensure you do not forget the `--profile <CONFIGPROFILENAME>` to authenticate. If the databricks command cannot authenticate, you may receive a lengthy stack traceback
 - Validate your login with `databricks auth env --profile <CONFIGPROFILENAME>` which should print out a json structure having about 8 different keys and values and secrets
 
+If Azure CLI has already been installed and authenticated, but you see the following error when running ucx commands:
+
+`14:50:33 ERROR [d.labs.ucx] In order to obtain AAD token, Please run azure cli to authenticate.`
+
+Resolve this in macOS by running the command with an explicit auth type set: `DATABRICKS_AUTH_TYPE=azure-cli databricks labs ucx ...`. 
+To resolve this issue in Windows, proceed with the following steps:
+
+1. Open `%userprofile%` (the path like `C:\Users\<username>`)
+2. Open `.databrickscfg`
+3. Change the profile definition by setting `auth_type=azure-cli`
+4. Save, close the file, re-run `databricks labs ucx ...`
+
 ### Resolving common errors on UCX install
 
 #### Error on installing the ucx inventory database

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -33,8 +33,12 @@ class AccountWorkspaces:
             if self._ac.config.is_azure and self._ac.config.auth_type != "azure-cli":
                 current_auth_type = self._ac.config.auth_type
                 self._ac.config.auth_type = "azure-cli"
-                ws = self._ac.get_workspace_client(workspace)
-                self._ac.config.auth_type = current_auth_type
+                try:
+                    ws = self._ac.get_workspace_client(workspace)
+                except (PermissionDenied, NotFound, ValueError) as exc:
+                    raise PermissionDenied(f"Failed to create client for {workspace.deployment_name}: {exc}") from exc
+                finally:
+                    self._ac.config.auth_type = current_auth_type
                 return ws
             raise PermissionDenied(f"Failed to create client for {workspace.deployment_name}: {err}") from err
 

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -24,7 +24,7 @@ class AccountWorkspaces:
                 continue
             yield workspace
 
-    def client_for(self, workspace: Workspace) -> WorkspaceClient | None:
+    def client_for(self, workspace: Workspace) -> WorkspaceClient:
         ws = self._ac.get_workspace_client(workspace)
         try:
             ws.current_user.me()
@@ -107,7 +107,7 @@ class AccountWorkspaces:
         return True
 
     def _try_create_account_groups(
-            self, group_name: str, acc_groups: dict[str | None, list[ComplexValue] | None]
+        self, group_name: str, acc_groups: dict[str | None, list[ComplexValue] | None]
     ) -> Group | None:
         try:
             if group_name in acc_groups:
@@ -139,7 +139,7 @@ class AccountWorkspaces:
         return valid_workspace_ids
 
     def _add_members_to_acc_group(
-            self, acc_client: AccountClient, acc_group_id: str, group_name: str, valid_group: Group
+        self, acc_client: AccountClient, acc_group_id: str, group_name: str, valid_group: Group
     ):
         for chunk in self._chunks(valid_group.members, 20):
             logger.debug(f"Adding {len(chunk)} members to acc group {group_name}")
@@ -153,7 +153,7 @@ class AccountWorkspaces:
     def _chunks(lst, chunk_size):
         """Yield successive n-sized chunks from lst."""
         for i in range(0, len(lst), chunk_size):
-            yield lst[i: i + chunk_size]
+            yield lst[i : i + chunk_size]
 
     def _get_valid_workspaces_groups(self, prompts: Prompts, workspace_ids: list[int]) -> dict[str, Group]:
         all_workspaces_groups: dict[str, Group] = {}
@@ -183,9 +183,9 @@ class AccountWorkspaces:
                     logger.info(f"Workspace group {group_name} already found, ignoring")
                     continue
                 if prompts.confirm(
-                        f"Group {group_name} does not have the same amount of members "
-                        f"in workspace {client.config.host} than previous workspaces which contains the same group name,"
-                        f"it will be created at the account with name : {workspace.workspace_name}_{group_name}"
+                    f"Group {group_name} does not have the same amount of members "
+                    f"in workspace {client.config.host} than previous workspaces which contains the same group name,"
+                    f"it will be created at the account with name : {workspace.workspace_name}_{group_name}"
                 ):
                     all_workspaces_groups[f"{workspace.workspace_name}_{group_name}"] = full_workspace_group
                     continue

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -121,10 +121,10 @@ def extract_major_minor(version_string):
 
 class WorkspaceInstaller(WorkspaceContext):
     def __init__(
-            self,
-            ws: WorkspaceClient,
-            environ: dict[str, str] | None = None,
-            tasks: list[Task] | None = None,
+        self,
+        ws: WorkspaceClient,
+        environ: dict[str, str] | None = None,
+        tasks: list[Task] | None = None,
     ):
         super().__init__(ws)
         if not environ:
@@ -155,10 +155,10 @@ class WorkspaceInstaller(WorkspaceContext):
             return Installation.assume_global(self.workspace_client, self.product_info.product_name())
 
     def run(
-            self,
-            default_config: WorkspaceConfig | None = None,
-            verify_timeout=timedelta(minutes=2),
-            config: WorkspaceConfig | None = None,
+        self,
+        default_config: WorkspaceConfig | None = None,
+        verify_timeout=timedelta(minutes=2),
+        config: WorkspaceConfig | None = None,
     ) -> WorkspaceConfig:
         logger.info(f"Installing UCX v{self.product_info.version()}")
         if config is None:
@@ -401,16 +401,16 @@ class WorkspaceInstaller(WorkspaceContext):
 
 class WorkspaceInstallation(InstallationMixin):
     def __init__(  # pylint: disable=too-many-arguments
-            self,
-            config: WorkspaceConfig,
-            installation: Installation,
-            install_state: InstallState,
-            sql_backend: SqlBackend,
-            ws: WorkspaceClient,
-            workflows_installer: WorkflowsDeployment,
-            prompts: Prompts,
-            product_info: ProductInfo,
-            skip_dashboards=False,
+        self,
+        config: WorkspaceConfig,
+        installation: Installation,
+        install_state: InstallState,
+        sql_backend: SqlBackend,
+        ws: WorkspaceClient,
+        workflows_installer: WorkflowsDeployment,
+        prompts: Prompts,
+        product_info: ProductInfo,
+        skip_dashboards=False,
     ):
         self._config = config
         self._installation = installation
@@ -514,8 +514,8 @@ class WorkspaceInstallation(InstallationMixin):
 
     def uninstall(self):
         if self._prompts and not self._prompts.confirm(
-                "Do you want to uninstall ucx from the workspace too, this would "
-                "remove ucx project folder, dashboards, queries and jobs"
+            "Do you want to uninstall ucx from the workspace too, this would "
+            "remove ucx project folder, dashboards, queries and jobs"
         ):
             return
         # TODO: this is incorrect, fetch the remote version (that appeared only in Feb 2024)
@@ -536,7 +536,7 @@ class WorkspaceInstallation(InstallationMixin):
 
     def _remove_database(self):
         if self._prompts and not self._prompts.confirm(
-                f"Do you want to delete the inventory database {self._config.inventory_database} too?"
+            f"Do you want to delete the inventory database {self._config.inventory_database} too?"
         ):
             return
         logger.info(f"Deleting inventory database {self._config.inventory_database}")
@@ -624,7 +624,7 @@ class AccountInstaller(AccountContext):
         msg = "\n".join([w.deployment_name for w in accessible_workspaces])
         installed_workspaces = []
         if not self.prompts.confirm(
-                f"UCX has detected the following workspaces available to install. \n{msg}\nDo you want to continue?"
+            f"UCX has detected the following workspaces available to install. \n{msg}\nDo you want to continue?"
         ):
             return
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -121,10 +121,10 @@ def extract_major_minor(version_string):
 
 class WorkspaceInstaller(WorkspaceContext):
     def __init__(
-        self,
-        ws: WorkspaceClient,
-        environ: dict[str, str] | None = None,
-        tasks: list[Task] | None = None,
+            self,
+            ws: WorkspaceClient,
+            environ: dict[str, str] | None = None,
+            tasks: list[Task] | None = None,
     ):
         super().__init__(ws)
         if not environ:
@@ -155,10 +155,10 @@ class WorkspaceInstaller(WorkspaceContext):
             return Installation.assume_global(self.workspace_client, self.product_info.product_name())
 
     def run(
-        self,
-        default_config: WorkspaceConfig | None = None,
-        verify_timeout=timedelta(minutes=2),
-        config: WorkspaceConfig | None = None,
+            self,
+            default_config: WorkspaceConfig | None = None,
+            verify_timeout=timedelta(minutes=2),
+            config: WorkspaceConfig | None = None,
     ) -> WorkspaceConfig:
         logger.info(f"Installing UCX v{self.product_info.version()}")
         if config is None:
@@ -401,16 +401,16 @@ class WorkspaceInstaller(WorkspaceContext):
 
 class WorkspaceInstallation(InstallationMixin):
     def __init__(  # pylint: disable=too-many-arguments
-        self,
-        config: WorkspaceConfig,
-        installation: Installation,
-        install_state: InstallState,
-        sql_backend: SqlBackend,
-        ws: WorkspaceClient,
-        workflows_installer: WorkflowsDeployment,
-        prompts: Prompts,
-        product_info: ProductInfo,
-        skip_dashboards=False,
+            self,
+            config: WorkspaceConfig,
+            installation: Installation,
+            install_state: InstallState,
+            sql_backend: SqlBackend,
+            ws: WorkspaceClient,
+            workflows_installer: WorkflowsDeployment,
+            prompts: Prompts,
+            product_info: ProductInfo,
+            skip_dashboards=False,
     ):
         self._config = config
         self._installation = installation
@@ -514,8 +514,8 @@ class WorkspaceInstallation(InstallationMixin):
 
     def uninstall(self):
         if self._prompts and not self._prompts.confirm(
-            "Do you want to uninstall ucx from the workspace too, this would "
-            "remove ucx project folder, dashboards, queries and jobs"
+                "Do you want to uninstall ucx from the workspace too, this would "
+                "remove ucx project folder, dashboards, queries and jobs"
         ):
             return
         # TODO: this is incorrect, fetch the remote version (that appeared only in Feb 2024)
@@ -536,7 +536,7 @@ class WorkspaceInstallation(InstallationMixin):
 
     def _remove_database(self):
         if self._prompts and not self._prompts.confirm(
-            f"Do you want to delete the inventory database {self._config.inventory_database} too?"
+                f"Do you want to delete the inventory database {self._config.inventory_database} too?"
         ):
             return
         logger.info(f"Deleting inventory database {self._config.inventory_database}")
@@ -611,36 +611,6 @@ class AccountInstaller(AccountContext):
         account_id = self.prompts.question("Please provide the Databricks account id")
         return AccountClient(host=host, account_id=account_id, product="ucx", product_version=__version__)
 
-    def _can_administer(self, workspace: Workspace):
-        # TODO: move to AccountWorkspaces
-        try:
-            # check if user is a workspace admin
-            ws = self.account_client.get_workspace_client(workspace)
-            current_user = ws.current_user.me()
-            if current_user.groups is None:
-                return False
-            if "admins" not in [g.display for g in current_user.groups]:
-                logger.warning(
-                    f"{workspace.deployment_name}: User {current_user.user_name} is not a workspace admin. Skipping..."
-                )
-                return False
-            # check if user has access to workspace
-        except (PermissionDenied, NotFound, ValueError) as err:
-            logger.warning(f"{workspace.deployment_name}: Encounter error {err}. Skipping...")
-            return False
-        return True
-
-    def _get_accessible_workspaces(self):
-        """
-        Get all workspaces that the user has access to
-        """
-        # TODO: move to AccountWorkspaces
-        accessible_workspaces = []
-        for workspace in self.account_client.workspaces.list():
-            if self._can_administer(workspace):
-                accessible_workspaces.append(workspace)
-        return accessible_workspaces
-
     def _get_installer(self, workspace: Workspace) -> WorkspaceInstaller:
         workspace_client = self.account_client.get_workspace_client(workspace)
         logger.info(f"Installing UCX on workspace {workspace.deployment_name}")
@@ -650,11 +620,11 @@ class AccountInstaller(AccountContext):
         ctx = AccountContext(self._get_safe_account_client())
         default_config = None
         confirmed = False
-        accessible_workspaces = self._get_accessible_workspaces()
+        accessible_workspaces = self.account_workspaces.get_accessible_workspaces()
         msg = "\n".join([w.deployment_name for w in accessible_workspaces])
         installed_workspaces = []
         if not self.prompts.confirm(
-            f"UCX has detected the following workspaces available to install. \n{msg}\nDo you want to continue?"
+                f"UCX has detected the following workspaces available to install. \n{msg}\nDo you want to continue?"
         ):
             return
 

--- a/tests/unit/account/test_aggregate.py
+++ b/tests/unit/account/test_aggregate.py
@@ -7,6 +7,7 @@ from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.sdk.service import sql
+from databricks.sdk.service import iam
 
 
 def test_basic_readiness_report_no_workspaces(acc_client, caplog):
@@ -67,6 +68,7 @@ def test_readiness_report_ucx_installed(acc_client, caplog):
         ),
         statement_id='123',
     )
+    ws.current_user.me.return_value = iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
 
     ctx = WorkspaceContext(ws).replace(config=WorkspaceConfig(inventory_database="something", warehouse_id="1234"))
     account_aggregate_obj = AccountAggregate(account_ws, workspace_context_factory=lambda _: ctx)

--- a/tests/unit/account/test_aggregate.py
+++ b/tests/unit/account/test_aggregate.py
@@ -1,13 +1,13 @@
 import logging
 from unittest.mock import create_autospec
+
 from databricks.sdk import Workspace, WorkspaceClient
+from databricks.sdk.service import iam, sql
+
 from databricks.labs.ucx.account.aggregate import AccountAggregate
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces
-
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
-from databricks.sdk.service import sql
-from databricks.sdk.service import iam
 
 
 def test_basic_readiness_report_no_workspaces(acc_client, caplog):

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -478,8 +478,8 @@ def test_get_accessible_workspaces():
     acc.get_workspace_client.side_effect = get_workspace_client
 
     account_workspaces = AccountWorkspaces(acc)
+    assert len(account_workspaces.get_accessible_workspaces()) == 1
     ws1.current_user.me.assert_called_once()
     ws2.current_user.me.assert_called_once()
-    assert len(account_workspaces.get_accessible_workspaces()) == 1
     # get_workspace_client should be called once for 123 & 456, then twice for workspace 3
     assert acc.get_workspace_client.call_count == 4

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -481,5 +481,5 @@ def test_get_accessible_workspaces():
     assert len(account_workspaces.get_accessible_workspaces()) == 1
     ws1.current_user.me.assert_called_once()
     ws2.current_user.me.assert_called_once()
-    # get_workspace_client should be called once for 123 & 456, then twice for workspace 3
+    # get_workspace_client should be called once for 123 & 456, then twice for workspace 789
     assert acc.get_workspace_client.call_count == 4

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -1,16 +1,18 @@
 import io
 import json
 
+
 from unittest.mock import create_autospec
 import pytest
 
 from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.sdk import WorkspaceClient
+from databricks.sdk import WorkspaceClient, AccountClient
 from databricks.sdk.errors import NotFound, ResourceConflict
 from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta, User
 from databricks.sdk.service.provisioning import Workspace
+
 
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces, WorkspaceInfo
 
@@ -448,3 +450,36 @@ def test_create_acc_groups_should_not_throw_if_acc_grp_exists(acc_client):
 
     acc_client.groups.create.assert_called_with(display_name="de")
     acc_client.groups.patch.assert_not_called()
+
+
+def test_get_accessible_workspaces():
+    acc = create_autospec(AccountClient)
+    acc.workspaces.list.return_value = [
+        Workspace(workspace_name="foo", workspace_id=123, workspace_status_message="Running", deployment_name="abc"),
+        Workspace(workspace_name="bar", workspace_id=456, workspace_status_message="Running", deployment_name="def"),
+        Workspace(workspace_name="bar", workspace_id=789, workspace_status_message="Running", deployment_name="def"),
+    ]
+    acc.config.is_azure = True
+    acc.config.auth_type = "databricks-cli"
+
+    # admin in workspace 1
+    ws1 = create_autospec(WorkspaceClient)
+    ws1.current_user.me.return_value = iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="admins")])
+    # not an admin in workspace 2
+    ws2 = create_autospec(WorkspaceClient)
+
+    def get_workspace_client(workspace) -> WorkspaceClient:
+        if workspace.workspace_id == 123:
+            return ws1
+        if workspace.workspace_id == 456:
+            return ws2
+        raise ValueError("unexpected workspace id")
+
+    acc.get_workspace_client.side_effect = get_workspace_client
+
+    account_workspaces = AccountWorkspaces(acc)
+    ws1.current_user.me.assert_called_once()
+    ws2.current_user.me.assert_called_once()
+    assert len(account_workspaces.get_accessible_workspaces()) == 1
+    # get_workspace_client should be called once for 123 & 456, then twice for workspace 3
+    assert acc.get_workspace_client.call_count == 4

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -3,8 +3,7 @@ import json
 from unittest.mock import create_autospec
 
 import pytest
-from databricks.labs.blueprint.installation import (Installation,
-                                                    MockInstallation)
+from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound, ResourceConflict
@@ -12,8 +11,7 @@ from databricks.sdk.service import iam
 from databricks.sdk.service.iam import ComplexValue, Group, ResourceMeta, User
 from databricks.sdk.service.provisioning import Workspace
 
-from databricks.labs.ucx.account.workspaces import (AccountWorkspaces,
-                                                    WorkspaceInfo)
+from databricks.labs.ucx.account.workspaces import AccountWorkspaces, WorkspaceInfo
 
 
 def test_sync_workspace_info(acc_client):


### PR DESCRIPTION
## Changes
- Automatically retrying with `auth_type=azure-cli` when constructing `workspace_clients` on Azure
- Resolved TODO items for `AccountWorkspaces`
- Added relevant suggestions in `troubleshooting.md`

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1574, closes #1430

### Functionality 

- [x] added relevant user documentation

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
