### PR TITLE
Let migration status test have one assert

### DIFF
--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -27,7 +27,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow(workflow)
 
-    errors = []
+    asserts = []
     for table in tables.values():
         # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
         query_migration_status = (
@@ -38,12 +38,12 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
 
         assert_message_postfix = f" found for {table.table_type} {table.full_name}"
         if len(migration_status) == 0:
-            errors.append("No migration status" + assert_message_postfix)
+            asserts.append("No migration status" + assert_message_postfix)
         elif len(migration_status) > 1:
-            errors.append("Multiple migration statuses" + assert_message_postfix)
+            asserts.append("Multiple migration statuses" + assert_message_postfix)
         elif migration_status[0].dst_schema is None:
-            errors.append("No destination schema" + assert_message_postfix)
+            asserts.append("No destination schema" + assert_message_postfix)
         elif migration_status[0].dst_table is None:
-            errors.append("No destination table" + assert_message_postfix)
+            asserts.append("No destination table" + assert_message_postfix)
 
-    assert len(errors) == 0, "\n".join(errors)
+    assert len(asserts) == 0, "\n".join(asserts)

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -27,6 +27,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow(workflow)
 
+    errors = []
     for table in tables.values():
         # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
         query_migration_status = (
@@ -34,7 +35,15 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
             f"WHERE src_schema = '{table.schema_name}' AND src_table = '{table.name}'"
         )
         migration_status = list(ctx.sql_backend.fetch(query_migration_status))
+
         assert_message_postfix = f" found for {table.table_type} {table.full_name}"
-        assert len(migration_status) == 1, "No migration status" + assert_message_postfix
-        assert migration_status[0].dst_schema is not None, "No destination schema" + assert_message_postfix
-        assert migration_status[0].dst_table is not None, "No destination table" + assert_message_postfix
+        if len(migration_status) == 0:
+            errors.append("No migration status" + assert_message_postfix)
+        elif len(migration_status) > 1:
+            errors.append("Multiple migration statuses" + assert_message_postfix)
+        elif migration_status[0].dst_schema is None:
+            errors.append("No destination schema" + assert_message_postfix)
+        elif migration_status[0].dst_table is None:
+            errors.append("No destination table" + assert_message_postfix)
+
+    assert len(errors) == 0, "\n".join(errors)


### PR DESCRIPTION
## Changes
Reqwrite migration status test to have one assert in an attempt to better understand when it fails.

### Linked issues
Hopefully provides more information for #1615

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
