### PR TITLE
Add support for migrate-tables-ctas workflow in the cmd `databricks labs ucx migrate-tables`

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,14 +391,17 @@ flowchart TB
     subgraph workflow[Table Migration Workflows]
       subgraph mt_workflow[workflow: migrate-tables]
         dbfs_root_delta_mt_task[migrate_dbfs_root_delta_tables]
+        dbfs_root_non_delta_mt_task[migrate_dbfs_root_non_delta_tables]
         external_tables_sync_mt_task[migrate_external_tables_sync]
         view_mt_task[roadmap: migrate_views]
         dbfs_root_delta_mt_task --> view_mt_task
+        dbfs_root_non_delta_mt_task --> view_mt_task
         external_tables_sync_mt_task --> view_mt_task
       end
       
       subgraph mt_ctas_wf[roadmap workflow: migrate-tables-ctas]
         ctas_mt_task[migrate_tables_ctas] --> view_mt_task_ctas[roadmap: migrate_views]
+        ctas_mt_task[migrate_hiveserde_ctas] --> view_mt_task_ctas[roadmap: migrate_views]
       end
   
       subgraph mt_serde_inplace_wf[roadmap workflow: migrate-external-hiveserde-tables-in-place-experimental]

--- a/labs.yml
+++ b/labs.yml
@@ -207,4 +207,4 @@ commands:
   - name: migrate-tables
     description: |
       Trigger the migrate-tables workflow and, optionally, migrate-external-hiveserde-tables-in-place-experimental 
-      workflow.
+      workflow and migrate-external-tables-ctas workflow.


### PR DESCRIPTION
## Changes
This change adds support for migrate-tables-ctas into the existing cli cmd for migrate-tables.
Checks for the presence of an external table which cannot be synced and prompts the user to run the additional workflow
Also updated relevant readme doc



Resolves #1659 

### Functionality 

- [X] added relevant user documentation
- [ ] added new CLI command
- [X] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [X] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
