### PR TITLE
Remove the "Is Terraform used" prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,6 @@ access the configuration file from the command line. Here's the description of c
   * `spark_conf`: An optional dictionary of Spark configuration properties.
   * `override_clusters`: An optional dictionary mapping job cluster names to existing cluster IDs.
   * `policy_id`: An optional string representing the ID of the cluster policy.
-  * `is_terraform_used`: A boolean value indicating whether some workspace resources are managed by Terraform.
   * `include_databases`: An optional list of strings representing the names of databases to include for migration.
 
 [[back to top](#databricks-labs-ucx)]

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -41,8 +41,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     uber_spn_id: str | None = None
     uber_instance_profile: str | None = None
 
-    # Flag to see if terraform has been used for deploying certain entities
-    is_terraform_used: bool = False
+    is_terraform_used: bool = False  # Not used, keep for backwards compatability
 
     # Whether the assessment should capture a specific list of databases, if not specified, it will list all databases.
     include_databases: list[str] | None = None

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -212,8 +212,6 @@ class WorkspaceInstaller(WorkspaceContext):
         num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))
         configure_groups = ConfigureGroups(self.prompts)
         configure_groups.run()
-        # Check if terraform is being used
-        is_terraform_used = self.prompts.confirm("Do you use Terraform to deploy your infrastructure?")
         include_databases = self._select_databases()
         trigger_job = self.prompts.confirm("Do you want to trigger assessment job after installation?")
         return WorkspaceConfig(
@@ -226,7 +224,6 @@ class WorkspaceInstaller(WorkspaceContext):
             renamed_group_prefix=configure_groups.renamed_group_prefix,
             log_level=log_level,
             num_threads=num_threads,
-            is_terraform_used=is_terraform_used,
             include_databases=include_databases,
             trigger_job=trigger_job,
         )


### PR DESCRIPTION
## Changes
The outcome of the prompt is not used and might confuse users. (We received feedback that it does confuse an user.) Moreover, in the near future we don't expect to use the Terraform state for ucx migration.

### Linked issues
Was introduced for #393

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
