### PR TITLE
Assert if group name is in cluster policy

### DIFF
--- a/tests/integration/test_ext_hms.py
+++ b/tests/integration/test_ext_hms.py
@@ -170,4 +170,5 @@ def test_running_real_assessment_job_ext_hms(
     assert ext_hms_ctx.deployed_workflows.validate_step("assessment")
 
     after = ext_hms_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
+    assert ws_group_a.display_name in after, f"Group {ws_group_a.display_name} not found in cluster policy"
     assert after[ws_group_a.display_name] == PermissionLevel.CAN_USE


### PR DESCRIPTION
## Changes
Assert if group name is in cluster policy

### Linked issues
Does not resolve the issue, but asserts the key to avoid the key error in #1616 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
