### PR TITLE
Let migration status test assert all migration statuses

### DIFF
--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -27,14 +27,18 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow(workflow)
 
+    # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
+    migration_status_query = f"SELECT * FROM {ctx.config.inventory_database}.migration_status"
+    migration_statuses = list(ctx.sql_backend.fetch(migration_status_query))
+
+    assert len(migration_statuses) > 0, "No migration statuses found"
+
     asserts = []
     for table in tables.values():
-        # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
-        query_migration_status = (
-            f"SELECT * FROM {ctx.config.inventory_database}.migration_status "
-            f"WHERE src_schema = '{table.schema_name}' AND src_table = '{table.name}'"
-        )
-        migration_status = list(ctx.sql_backend.fetch(query_migration_status))
+        migration_status = []
+        for status in migration_statuses:
+            if status.src_schema == table.schema_name and status.src_table == table.name:
+                migration_status.append(status)
 
         assert_message_postfix = f" found for {table.table_type} {table.full_name}"
         if len(migration_status) == 0:
@@ -46,4 +50,7 @@ def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, pr
         elif migration_status[0].dst_table is None:
             asserts.append("No destination table" + assert_message_postfix)
 
-    assert len(asserts) == 0, "\n".join(asserts)
+    assert_message = (
+        "\n".join(asserts) + " given migration statuses " + "\n".join([str(status) for status in migration_statuses])
+    )
+    assert len(asserts) == 0, assert_message


### PR DESCRIPTION
## Changes
- Test there are any migration statuses
- Log migration statuses with test failure

### Linked issues
In addition to #1651, hopefully provides more information for #1615

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
