### PR TITLE
Fix test failing due to groups not being created yet

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -642,7 +642,6 @@ def _make_group(name, cfg, interface, make_random):
         else:
             logger.info(f"Workspace group {group.display_name}: {cfg.host}#setting/accounts/groups/{group.id}")
 
-        # When
         @retried(on=[NotFound], timeout=timedelta(minutes=1))
         def _wait_for_provisioning() -> None:
             interface.get(group.id)

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -642,7 +642,7 @@ def _make_group(name, cfg, interface, make_random):
         else:
             logger.info(f"Workspace group {group.display_name}: {cfg.host}#setting/accounts/groups/{group.id}")
 
-        @retried(on=[NotFound], timeout=timedelta(minutes=1))
+        @retried(on=[NotFound], timeout=timedelta(minutes=2))
         def _wait_for_provisioning() -> None:
             interface.get(group.id)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -580,9 +580,11 @@ class TestInstallationContext(TestRuntimeContext):
             display_name=workspace_group_name,
             members=members,
             entitlements=["allow-cluster-create"],
-            wait_for_provisioning=wait_for_provisioning
+            wait_for_provisioning=wait_for_provisioning,
         )
-        acc_group = self._make_acc_group(display_name=account_group_name, members=members, wait_for_provisioning=wait_for_provisioning)
+        acc_group = self._make_acc_group(
+            display_name=account_group_name, members=members, wait_for_provisioning=wait_for_provisioning
+        )
         return ws_group, acc_group
 
     @cached_property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -569,7 +569,7 @@ class TestInstallationContext(TestRuntimeContext):
         self._make_acc_group = make_acc_group_fixture
         self._make_user = make_user_fixture
 
-    def make_ucx_group(self, workspace_group_name=None, account_group_name=None):
+    def make_ucx_group(self, workspace_group_name=None, account_group_name=None, wait_for_provisioning=False):
         if not workspace_group_name:
             workspace_group_name = f"ucx_G{self._make_random(4)}"
         if not account_group_name:
@@ -580,8 +580,9 @@ class TestInstallationContext(TestRuntimeContext):
             display_name=workspace_group_name,
             members=members,
             entitlements=["allow-cluster-create"],
+            wait_for_provisioning=wait_for_provisioning
         )
-        acc_group = self._make_acc_group(display_name=account_group_name, members=members)
+        acc_group = self._make_acc_group(display_name=account_group_name, members=members, wait_for_provisioning=wait_for_provisioning)
         return ws_group, acc_group
 
     @cached_property

--- a/tests/integration/test_ext_hms.py
+++ b/tests/integration/test_ext_hms.py
@@ -153,7 +153,7 @@ def test_running_real_assessment_job_ext_hms(
             r"Choose a cluster policy": "0",
         },
     )
-    ws_group_a, _ = ext_hms_ctx.make_ucx_group()
+    ws_group_a, _ = ext_hms_ctx.make_ucx_group(wait_for_provisioning=True)
 
     cluster_policy = make_cluster_policy()
     make_cluster_policy_permissions(


### PR DESCRIPTION
## Changes
(We think that) sometimes groups are not created before the test run, e.g. [this](https://github.com/databrickslabs/ucx/actions/runs/9002466231?pr=1532) and [that](https://github.com/databrickslabs/ucx/issues/1616). This PR extends the `make_group` with an optional flag to wait for the groups to be created before continuing with the test. To limit impact on performance, we don't wait for the groups to be created by default.  

### Linked issues
Hopefully esolves #1616

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
