### PR TITLE
Removed dependency on internal `pathlib` implementations

### DIFF
--- a/tests/integration/mixins/test_wspath.py
+++ b/tests/integration/mixins/test_wspath.py
@@ -7,8 +7,8 @@ from databricks.labs.ucx.mixins.wspath import WorkspacePath
 
 
 def test_exists(ws):
-    wsp = WorkspacePath(ws, "/Users")
-    assert wsp.exists()
+    wsp = WorkspacePath(ws, "/Users/foo/bar/baz")
+    assert not wsp.exists()
 
 
 def test_mkdirs(ws, make_random):


### PR DESCRIPTION
This PR removes the dependency on internal `pathlib._Flavor` implementations, which could be not available on Windows.