### PR TITLE
improved error handling for `migrate-tables` workflows

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -206,7 +206,7 @@ class TableMapping:
                 try:
                     self._sql_backend.execute(table.sql_unset_upgraded_to())
                 except DatabricksError as err:
-                    logger.info(f"Failed to unset upgraded_to property for Table {table.key}: {err}")
+                    logger.warning(f"Failed to unset upgraded_to property for Table {table.key}: {err}")
 
         return table_to_migrate
 

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -187,7 +187,7 @@ class TableMapping:
                 f"SHOW TBLPROPERTIES {escape_sql_identifier(table.database)}.{escape_sql_identifier(table.name)}"
             )
         except DatabricksError as err:
-            logger.info(f"Failed to get properties for Table {table.key}: {err!s}", exc_info=True)
+            logger.warning(f"Failed to get properties for Table {table.key}: {err}")
             return None
         for value in result:
             if value["key"] == self.UCX_SKIP_PROPERTY:

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -171,15 +171,15 @@ def test_load_mapping():
     ws.tables.get.assert_not_called()
 
     assert [
-               Rule(
-                   workspace_name="foo-bar",
-                   catalog_name="foo_bar",
-                   src_schema="foo",
-                   dst_schema="foo",
-                   src_table="bar",
-                   dst_table="bar",
-               )
-           ] == rules
+        Rule(
+            workspace_name="foo-bar",
+            catalog_name="foo_bar",
+            src_schema="foo",
+            dst_schema="foo",
+            src_table="bar",
+            dst_table="bar",
+        )
+    ] == rules
 
 
 def test_skip_happy_path(caplog):
@@ -306,14 +306,14 @@ def test_skip_tables_marked_for_skipping_or_upgraded():
     assert len(tables_to_migrate) == 2
     tables = (table_to_migrate.src for table_to_migrate in tables_to_migrate)
     assert (
-            Table(
-                object_type="EXTERNAL",
-                table_format="DELTA",
-                catalog="hive_metastore",
-                database="test_schema3",
-                name="test_table4",
-            )
-            not in tables
+        Table(
+            object_type="EXTERNAL",
+            table_format="DELTA",
+            catalog="hive_metastore",
+            database="test_schema3",
+            name="test_table4",
+        )
+        not in tables
     )
     assert (table for table in tables_to_migrate)
     assert call("fake_dest") in client.tables.get.call_args_list
@@ -606,8 +606,8 @@ def test_database_not_exists_when_checking_inscope(caplog):
     client.tables.get.assert_not_called()
     tables_crawler.snapshot.assert_called_once()
     assert (
-            "Schema hive_metastore.deleted_schema no longer exists. Skipping its properties check and migration."
-            in caplog.text
+        "Schema hive_metastore.deleted_schema no longer exists. Skipping its properties check and migration."
+        in caplog.text
     )
 
 


### PR DESCRIPTION
## Changes
- improved error handling for `migrate-tables` workflows

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1673

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] verified on staging environment (screenshot attached)
