### PR TITLE
 Add pip cell installs to dependency graph

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -80,6 +80,7 @@ class DependencyGraph:
         child_graph = DependencyGraph(dependency, self, self._resolver, self._path_lookup)
         self._dependencies[dependency] = child_graph
         container = dependency.load(self.path_lookup)
+        # TODO: Retrun either (child) graph OR problems
         if not container:
             problem = DependencyProblem('dependency-register-failed', 'Failed to register dependency', dependency.path)
             return MaybeGraph(child_graph, [problem])

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -52,13 +52,6 @@ class DependencyGraph:
         maybe_graph = self.register_dependency(maybe.dependency)
         return maybe_graph.problems
 
-    def register_library(self, name: str) -> MaybeGraph:
-        # TODO: use DistInfoResolver to load wheel/egg/pypi dependencies
-        # TODO: https://github.com/databrickslabs/ucx/issues/1642
-        # TODO: https://github.com/databrickslabs/ucx/issues/1643
-        # TODO: https://github.com/databrickslabs/ucx/issues/1640
-        return MaybeGraph(None, [DependencyProblem('not-yet-implemented', f'Library dependency: {name}')])
-
     def register_notebook(self, path: Path) -> list[DependencyProblem]:
         maybe = self._resolver.resolve_notebook(self.path_lookup, path)
         if not maybe.dependency:

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -87,7 +87,7 @@ class DependencyGraph:
         child_graph = DependencyGraph(dependency, self, self._resolver, self._path_lookup)
         self._dependencies[dependency] = child_graph
         container = dependency.load(self.path_lookup)
-        # TODO: Retrun either (child) graph OR problems
+        # TODO: Return either (child) graph OR problems
         if not container:
             problem = DependencyProblem('dependency-register-failed', 'Failed to register dependency', dependency.path)
             return MaybeGraph(child_graph, [problem])

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -52,6 +52,13 @@ class DependencyGraph:
         maybe_graph = self.register_dependency(maybe.dependency)
         return maybe_graph.problems
 
+    def register_library(self, name: str) -> MaybeGraph:
+        # TODO: use DistInfoResolver to load wheel/egg/pypi dependencies
+        # TODO: https://github.com/databrickslabs/ucx/issues/1642
+        # TODO: https://github.com/databrickslabs/ucx/issues/1643
+        # TODO: https://github.com/databrickslabs/ucx/issues/1640
+        return MaybeGraph(None, [DependencyProblem('not-yet-implemented', f'Library dependency: {name}')])
+
     def register_notebook(self, path: Path) -> list[DependencyProblem]:
         maybe = self._resolver.resolve_notebook(self.path_lookup, path)
         if not maybe.dependency:

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -193,10 +193,7 @@ class PipCell(Cell):
         # TODO: we need to support different formats of the library name and etc
         library = splits[2]
 
-        problems = graph.install_library(library)
-        if len(problems) > 0:
-            return problems
-        return graph.register_library(library)
+        return graph.install_library(library)
 
 
 class CellLanguage(Enum):

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -193,7 +193,7 @@ class PipCell(Cell):
         # TODO: we need to support different formats of the library name and etc
         library = splits[2]
 
-        return graph.install_library(library)
+        return graph.register_library(library)
 
 
 class CellLanguage(Enum):

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -182,9 +182,21 @@ class PipCell(Cell):
     def is_runnable(self) -> bool:
         return True  # TODO
 
-    def build_dependency_graph(self, _: DependencyGraph) -> list[DependencyProblem]:
+    def build_dependency_graph(self, graph: DependencyGraph) -> list[DependencyProblem]:
         # TODO: https://github.com/databrickslabs/ucx/issues/1642
-        return []
+        # TODO: this is very basic code, we need to improve it
+        splits = self.original_code.split(' ')
+        if len(splits) < 3:
+            return [DependencyProblem("library-install-failed", f"Missing arguments in '{self.original_code}'")]
+        if splits[1] != "install":
+            return [DependencyProblem("library-install-failed", f"Missing install in '{self.original_code}'")]
+        # TODO: we need to support different formats of the library name and etc
+        library = splits[2]
+
+        problems = graph.install_library(library)
+        if len(problems) > 0:
+            return problems
+        return graph.register_library(library)
 
 
 class CellLanguage(Enum):

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -189,7 +189,7 @@ class PipCell(Cell):
         if len(splits) < 3:
             return [DependencyProblem("library-install-failed", f"Missing arguments in '{self.original_code}'")]
         if splits[1] != "install":
-            return [DependencyProblem("library-install-failed", f"Missing install in '{self.original_code}'")]
+            return [DependencyProblem("library-install-failed", f"Unsupported %pip command: {splits[1]}")]
         # TODO: we need to support different formats of the library name and etc
         library = splits[2]
 

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -22,7 +22,7 @@ def test_pip_cell_build_dependency_graph_register_pip_install_library():
     problems = cell.build_dependency_graph(graph)
 
     assert len(problems) == 0
-    graph.register_library.assert_called_once_with("databricks")
+    graph.install_library.assert_called_once_with("databricks")
 
 
 def test_pip_cell_build_dependency_graph_register_pip_install_missing_library():
@@ -37,7 +37,7 @@ def test_pip_cell_build_dependency_graph_register_pip_install_missing_library():
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
     assert problems[0].message == "Missing arguments in '%pip install'"
-    graph.register_library.assert_not_called()
+    graph.install_library.assert_not_called()
 
 
 def test_pip_cell_build_dependency_graph_register_pip_missing_install():
@@ -52,7 +52,7 @@ def test_pip_cell_build_dependency_graph_register_pip_missing_install():
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
     assert problems[0].message == "Missing install in '%pip installl pytest'"
-    graph.register_library.assert_not_called()
+    graph.install_library.assert_not_called()
 
 
 def test_pip_cell_build_dependency_graph_register_pip_install_unknown_library(mock_path_lookup):

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -7,7 +7,7 @@ from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage, PipCel
 from databricks.labs.ucx.source_code.site_packages import PipInstaller
 
 
-def test_pip_cell_langauge_is_pip():
+def test_pip_cell_language_is_pip():
     assert PipCell("code").language == CellLanguage.PIP
 
 
@@ -23,7 +23,7 @@ def test_pip_cell_build_dependency_graph_invokes_install_library():
     graph.install_library.assert_called_once_with("databricks")
 
 
-def test_pip_cell_build_dependency_graph_pip_install_missing_library():
+def test_pip_cell_build_dependency_graph_pip_installs_missing_library():
     graph = create_autospec(DependencyGraph)
 
     code = "%pip install"
@@ -67,7 +67,7 @@ def test_pip_cell_build_dependency_graph_reports_unknown_library(mock_path_looku
     assert problems[0].message.startswith("Failed to install unknown-library-name")
 
 
-def test_pip_cell_build_dependency_graph_resolve_installed_library(mock_path_lookup):
+def test_pip_cell_build_dependency_graph_resolves_installed_library(mock_path_lookup):
     dependency = Dependency(FileLoader(), Path("test"))
     installer = LibraryInstaller([PipInstaller()])
     dependency_resolver = DependencyResolver([], mock_path_lookup)

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from unittest.mock import create_autospec
+
+from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver, LibraryInstaller
+from databricks.labs.ucx.source_code.files import FileLoader
+from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage, PipCell
+from databricks.labs.ucx.source_code.site_packages import PipInstaller
+
+
+def test_pip_cell_langauge():
+    """Pip cell langauge should be CellLanguage.PIP"""
+    assert PipCell("code").language == CellLanguage.PIP
+
+
+def test_pip_cell_build_dependency_graph_register_pip_install_library():
+    """A pip install library should be registered"""
+    graph = create_autospec(DependencyGraph)
+
+    code = "%pip install databricks"
+    cell = PipCell(code)
+
+    problems = cell.build_dependency_graph(graph)
+
+    assert len(problems) == 0
+    graph.register_library.assert_called_once_with("databricks")
+
+
+def test_pip_cell_build_dependency_graph_register_pip_install_missing_library():
+    """Missing pip install library"""
+    graph = create_autospec(DependencyGraph)
+
+    code = "%pip install"
+    cell = PipCell(code)
+
+    problems = cell.build_dependency_graph(graph)
+
+    assert len(problems) == 1
+    assert problems[0].code == "library-install-failed"
+    assert problems[0].message == "Missing arguments in '%pip install'"
+    graph.register_library.assert_not_called()
+
+
+def test_pip_cell_build_dependency_graph_register_pip_missing_install():
+    """Missing pip install"""
+    graph = create_autospec(DependencyGraph)
+
+    code = "%pip installl pytest"  # typo on purpose
+    cell = PipCell(code)
+
+    problems = cell.build_dependency_graph(graph)
+
+    assert len(problems) == 1
+    assert problems[0].code == "library-install-failed"
+    assert problems[0].message == "Missing install in '%pip installl pytest'"
+    graph.register_library.assert_not_called()
+
+
+def test_pip_cell_build_dependency_graph_register_pip_install_unknown_library(mock_path_lookup):
+    """Pip install unknown library"""
+    dependency = Dependency(FileLoader(), Path("test"))
+    installer = LibraryInstaller([PipInstaller()])
+    dependency_resolver = DependencyResolver([], mock_path_lookup)
+    graph = DependencyGraph(dependency, None, installer, dependency_resolver, mock_path_lookup)
+
+    code = "%pip install unknown-library-name"  # typo on purpose
+    cell = PipCell(code)
+
+    problems = cell.build_dependency_graph(graph)
+
+    assert len(problems) == 1
+    assert problems[0].code == "library-install-failed"
+    assert problems[0].message.startswith("Failed to install unknown-library-name")


### PR DESCRIPTION
## Changes
Logic for registering import installed in a pip cell

### Linked issues
#1642
Follow up on #1692

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
