### PR TITLE
Add RemoveAfter tag on all UCX jobs for cleanup

### DIFF
--- a/tests/integration/assessment/test_jobs.py
+++ b/tests/integration/assessment/test_jobs.py
@@ -70,4 +70,3 @@ def test_removeafter_tag(ws, env_or_skip, make_job):
 
     created_job = ws.jobs.get(new_job.job_id)
     assert "RemoveAfter" in created_job.settings.tags
-

--- a/tests/integration/assessment/test_jobs.py
+++ b/tests/integration/assessment/test_jobs.py
@@ -63,3 +63,11 @@ pass
             failures = job_run.failures
             continue
     assert failures and failures == "[]"
+
+
+def test_removeafter_tag(ws, env_or_skip, make_job):
+    new_job = make_job(spark_conf=_SPARK_CONF)
+
+    created_job = ws.jobs.get(new_job.job_id)
+    assert "RemoveAfter" in created_job.settings.tags
+


### PR DESCRIPTION
## Changes
Add RemoveAfter tag on all UCX jobs, so that they're cleaned up by watchdog even if they are in the approved instance pool

### Linked issues
Partial work from #977 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
