### PR TITLE
Download wheel dependency locally to register it to the dependency graph

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -101,10 +101,13 @@ class WorkflowTaskContainer(SourceContainer):
                     local_file.write_bytes(remote_file.read())
                     yield from graph.register_library(local_file.as_posix())
         if library.whl:
-            # TODO: download the wheel somewhere local and add it to "virtual sys.path" via graph.path_lookup.push_path
-            problems = graph.register_library(library.whl)
-            if problems:
-                yield from problems
+            with self._ws.workspace.download(library.whl, format=ExportFormat.AUTO) as remote_file:
+                with tempfile.TemporaryDirectory() as directory:
+                    local_file = Path(directory) / Path(library.whl).name
+                    local_file.write_bytes(remote_file.read())
+                    problems = graph.register_library(local_file.as_posix())
+                if problems:
+                    yield from problems
         if library.requirements:  # https://pip.pypa.io/en/stable/reference/requirements-file-format/
             logger.info(f"Registering libraries from {library.requirements}")
             with self._ws.workspace.download(library.requirements, format=ExportFormat.AUTO) as remote_file:

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -106,8 +106,8 @@ class WorkflowTaskContainer(SourceContainer):
                     local_file = Path(directory) / Path(library.whl).name
                     local_file.write_bytes(remote_file.read())
                     problems = graph.register_library(local_file.as_posix())
-                if problems:
-                    yield from problems
+            if problems:
+                yield from problems
         if library.requirements:  # https://pip.pypa.io/en/stable/reference/requirements-file-format/
             logger.info(f"Registering libraries from {library.requirements}")
             with self._ws.workspace.download(library.requirements, format=ExportFormat.AUTO) as remote_file:

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -102,8 +102,9 @@ class WorkflowTaskContainer(SourceContainer):
                     yield from graph.register_library(local_file.as_posix())
         if library.whl:
             # TODO: download the wheel somewhere local and add it to "virtual sys.path" via graph.path_lookup.push_path
-            # TODO: https://github.com/databrickslabs/ucx/issues/1640
-            yield DependencyProblem("not-yet-implemented", "Wheel library is not yet implemented")
+            problems = graph.register_library(library.whl)
+            if problems:
+                yield from problems
         if library.requirements:  # https://pip.pypa.io/en/stable/reference/requirements-file-format/
             logger.info(f"Registering libraries from {library.requirements}")
             with self._ws.workspace.download(library.requirements, format=ExportFormat.AUTO) as remote_file:

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -105,9 +105,7 @@ class WorkflowTaskContainer(SourceContainer):
                 with tempfile.TemporaryDirectory() as directory:
                     local_file = Path(directory) / Path(library.whl).name
                     local_file.write_bytes(remote_file.read())
-                    problems = graph.register_library(local_file.as_posix())
-            if problems:
-                yield from problems
+                    yield from graph.register_library(local_file.as_posix())
         if library.requirements:  # https://pip.pypa.io/en/stable/reference/requirements-file-format/
             logger.info(f"Registering libraries from {library.requirements}")
             with self._ws.workspace.download(library.requirements, format=ExportFormat.AUTO) as remote_file:

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -235,9 +235,9 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
     assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) > 0
 
     library = compute.Library(pypi=compute.PythonPyPiLibrary(package="pytest"))
-    job_without_import_pytest_problem = make_job(notebook_path=notebook, libraries=[library])
+    job_without_import_problem = make_job(notebook_path=notebook, libraries=[library])
 
-    problems = simple_ctx.workflow_linter.lint_job(job_without_import_pytest_problem.job_id)
+    problems = simple_ctx.workflow_linter.lint_job(job_without_import_problem.job_id)
 
     assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) == 0
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -272,7 +272,7 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
     assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) == 0
 
 
-def test_workflow_linter_lints_job_with_import_whl_library(
+def test_workflow_linter_lints_job_with_missing_library(
     simple_ctx,
     ws,
     make_job,
@@ -280,28 +280,43 @@ def test_workflow_linter_lints_job_with_import_whl_library(
     make_random,
     make_directory,
 ):
-    entrypoint = make_directory()
+    expected_problem_message = "Could not locate import: databricks.labs.ucx"
 
     simple_ctx = simple_ctx.replace(
         whitelist=Whitelist([]),  # databricks is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding current project
     )
 
-    notebook = f"{entrypoint}/notebook.ipynb"
-    make_notebook(path=notebook, content=b"import databricks.labs.ucx")
-    problem_message = "Could not locate import: databricks.labs.ucx"
-
+    notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=b"import databricks.labs.ucx")
     job_without_ucx_library = make_job(notebook_path=notebook)
+
     problems = simple_ctx.workflow_linter.lint_job(job_without_ucx_library.job_id)
 
-    assert len([problem for problem in problems if problem.message == problem_message]) > 0
+    assert len([problem for problem in problems if problem.message == expected_problem_message]) > 0
+
+
+def test_workflow_linter_lints_job_with_wheel_dependency(
+    simple_ctx,
+    ws,
+    make_job,
+    make_notebook,
+    make_random,
+    make_directory,
+):
+    expected_problem_message = "Could not locate import: databricks.labs.ucx"
+
+    simple_ctx = simple_ctx.replace(
+        whitelist=Whitelist([]),  # databricks is in default list
+        path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding current project
+    )
 
     simple_ctx.workspace_installation.run()  # Creates ucx wheel
-
     wheels = [file for file in simple_ctx.installation.files() if file.path.endswith(".whl")]
     library = compute.Library(whl=wheels[0].path)
+
+    notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=b"import databricks.labs.ucx")
     job_with_ucx_library = make_job(notebook_path=notebook, libraries=[library])
 
     problems = simple_ctx.workflow_linter.lint_job(job_with_ucx_library.job_id)
 
-    assert len([problem for problem in problems if problem.message == problem_message]) == 0
+    assert len([problem for problem in problems if problem.message == expected_problem_message]) == 0

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -139,6 +139,37 @@ display(spark.read.parquet("/mnt/something"))
     assert all(any(message.endswith(expected) for message in last_messages) for expected in expected_messages)
 
 
+def test_workflow_linter_lints_job_with_import_pypi_library(
+    simple_ctx,
+    ws,
+    make_job,
+    make_notebook,
+    make_random,
+):
+    entrypoint = WorkspacePath(ws, f"~/linter-{make_random(4)}").expanduser()
+    entrypoint.mkdir()
+
+    simple_ctx = simple_ctx.replace(
+        whitelist=Whitelist(),  # pytest is in default list
+        path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the pytest you are running
+    )
+
+    notebook = entrypoint / "notebook.ipynb"
+    make_notebook(path=notebook, content=b"import pytest")
+
+    job_with_import_pytest_problem = make_job(notebook_path=notebook)
+    problems = simple_ctx.workflow_linter.lint_job(job_with_import_pytest_problem.job_id)
+
+    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) > 0
+
+    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="pytest"))
+    job_without_import_problem = make_job(notebook_path=notebook, libraries=[library])
+
+    problems = simple_ctx.workflow_linter.lint_job(job_without_import_problem.job_id)
+
+    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) == 0
+
+
 def test_lint_local_code(simple_ctx):
     # no need to connect
     linter_context = LinterContext(MigrationIndex([]))
@@ -209,37 +240,6 @@ def test_workflow_linter_lints_job_with_egg_dependency(
     problems = simple_ctx.workflow_linter.lint_job(job_with_egg_dependency.job_id)
 
     assert len([problem for problem in problems if problem.message == expected_problem_message]) == 0
-
-
-def test_workflow_linter_lints_job_with_import_pypi_library(
-    simple_ctx,
-    ws,
-    make_job,
-    make_notebook,
-    make_random,
-):
-    entrypoint = WorkspacePath(ws, f"~/linter-{make_random(4)}").expanduser()
-    entrypoint.mkdir()
-
-    simple_ctx = simple_ctx.replace(
-        whitelist=Whitelist(),  # pytest is in default list
-        path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the pytest you are running
-    )
-
-    notebook = entrypoint / "notebook.ipynb"
-    make_notebook(path=notebook, content=b"import pytest")
-
-    job_with_import_pytest_problem = make_job(notebook_path=notebook)
-    problems = simple_ctx.workflow_linter.lint_job(job_with_import_pytest_problem.job_id)
-
-    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) > 0
-
-    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="pytest"))
-    job_without_import_problem = make_job(notebook_path=notebook, libraries=[library])
-
-    problems = simple_ctx.workflow_linter.lint_job(job_without_import_problem.job_id)
-
-    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) == 0
 
 
 def test_workflow_linter_lints_job_with_missing_library(

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -22,7 +22,12 @@ from databricks.labs.ucx.mixins.wspath import WorkspacePath
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_running_real_workflow_linter_job(installation_ctx):
+def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_directory, make_job):
+    # Deprecated file system path in call to: /mnt/things/e/f/g
+    lint_problem = b"display(spark.read.csv('/mnt/things/e/f/g'))"
+    notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=lint_problem)
+    make_job(notebook_path=notebook)
+
     ctx = installation_ctx
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow("experimental-workflow-linter")

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -5,14 +5,14 @@ from datetime import timedelta
 from io import StringIO
 from pathlib import Path
 
+from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.compute import Library, PythonPyPiLibrary
 from databricks.sdk.service.workspace import ImportFormat
 
-from databricks.labs.blueprint.tui import Prompts
-
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.source_code.known import Whitelist
 from databricks.labs.ucx.source_code.linters.files import LocalCodeLinter
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
@@ -242,11 +242,11 @@ def test_workflow_linter_lints_job_with_egg_dependency(
 
 
 def test_workflow_linter_lints_job_with_import_pypi_library(
-        simple_ctx,
-        ws,
-        make_job,
-        make_notebook,
-        make_random,
+    simple_ctx,
+    ws,
+    make_job,
+    make_notebook,
+    make_random,
 ):
     entrypoint = WorkspacePath(ws, f"~/linter-{make_random(4)}").expanduser()
     entrypoint.mkdir()

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -278,17 +278,16 @@ def test_workflow_linter_lints_job_with_import_whl_library(
     make_job,
     make_notebook,
     make_random,
+    make_directory,
 ):
-    # TODO: Clean this directory
-    entrypoint = WorkspacePath(ws, f"~/linter-{make_random(4)}").expanduser()
-    entrypoint.mkdir()
+    entrypoint = make_directory()
 
     simple_ctx = simple_ctx.replace(
         whitelist=Whitelist([]),  # databricks is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding current project
     )
 
-    notebook = entrypoint / "notebook.ipynb"
+    notebook = f"{entrypoint}/notebook.ipynb"
     make_notebook(path=notebook, content=b"import databricks.labs.ucx")
     problem_message = "Could not locate import: databricks.labs.ucx"
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -222,7 +222,7 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
     entrypoint.mkdir()
 
     simple_ctx = simple_ctx.replace(
-        whitelist=Whitelist([]),  # pytest is in default list
+        whitelist=Whitelist(),  # pytest is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the pytest you are running
     )
 
@@ -253,7 +253,7 @@ def test_workflow_linter_lints_job_with_missing_library(
     expected_problem_message = "Could not locate import: databricks.labs.ucx"
 
     simple_ctx = simple_ctx.replace(
-        whitelist=Whitelist([]),  # databricks is in default list
+        whitelist=Whitelist(),  # databricks is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding current project
     )
 
@@ -276,7 +276,7 @@ def test_workflow_linter_lints_job_with_wheel_dependency(
     expected_problem_message = "Could not locate import: databricks.labs.ucx"
 
     simple_ctx = simple_ctx.replace(
-        whitelist=Whitelist([]),  # databricks is in default list
+        whitelist=Whitelist(),  # databricks is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding current project
     )
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -150,24 +150,23 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
     entrypoint.mkdir()
 
     simple_ctx = simple_ctx.replace(
-        whitelist=Whitelist(),  # pytest is in default list
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the pytest you are running
     )
 
     notebook = entrypoint / "notebook.ipynb"
-    make_notebook(path=notebook, content=b"import pytest")
+    make_notebook(path=notebook, content=b"import greenlet")
 
-    job_with_import_pytest_problem = make_job(notebook_path=notebook)
-    problems = simple_ctx.workflow_linter.lint_job(job_with_import_pytest_problem.job_id)
+    job_without_pytest_library = make_job(notebook_path=notebook)
+    problems = simple_ctx.workflow_linter.lint_job(job_without_pytest_library.job_id)
 
-    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) > 0
+    assert len([problem for problem in problems if problem.message == "Could not locate import: greenlet"]) > 0
 
-    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="pytest"))
-    job_without_import_problem = make_job(notebook_path=notebook, libraries=[library])
+    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="greenlet"))
+    job_with_pytest_library = make_job(notebook_path=notebook, libraries=[library])
 
-    problems = simple_ctx.workflow_linter.lint_job(job_without_import_problem.job_id)
+    problems = simple_ctx.workflow_linter.lint_job(job_with_pytest_library.job_id)
 
-    assert len([problem for problem in problems if problem.message == "Could not locate import: pytest"]) == 0
+    assert len([problem for problem in problems if problem.message == "Could not locate import: greenlet"]) == 0
 
 
 def test_lint_local_code(simple_ctx):

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -1,5 +1,5 @@
-import logging
 import io
+import logging
 from pathlib import Path
 from unittest.mock import create_autospec
 

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -110,8 +110,8 @@ def test_workflow_task_container_builds_dependency_graph_for_python_wheel(mock_p
     problems = workflow_task_container.build_dependency_graph(graph)
 
     assert len(problems) == 1
-    assert problems[0].code == "no-dist-info"
-    assert problems[0].message.startswith("No dist-info found for test.whl")
+    assert problems[0].code == "library-install-failed"
+    assert problems[0].message.startswith("Failed to install")
     assert mock_path_lookup.resolve(Path("test")) is None
     ws.assert_not_called()
 

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -49,13 +49,13 @@ def graph(mock_path_lookup, dependency_resolver) -> DependencyGraph:
 def test_workflow_task_container_builds_dependency_graph_not_yet_implemented(mock_path_lookup, graph):
     # Goal of test is to raise test coverage, remove after implementing
     ws = create_autospec(WorkspaceClient)
-    library = compute.Library(jar="library.jar", whl="library.whl")
+    library = compute.Library(jar="library.jar")
     task = jobs.Task(task_key="test", libraries=[library], existing_cluster_id="id")
 
     workflow_task_container = WorkflowTaskContainer(ws, task)
     problems = workflow_task_container.build_dependency_graph(graph)
 
-    assert len(problems) == 2
+    assert len(problems) == 1
     assert all(problem.code == "not-yet-implemented" for problem in problems)
     ws.assert_not_called()
 


### PR DESCRIPTION
## Changes
This PR downloads a wheel dependency locally (in a temporary location) to register it to the dependency graph

### Linked issues
Part of #1640

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [x] modified existing workflow: `experimental-linter`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
