### PR TITLE
WhitelistResolver must be invoked before other import resolvers

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -369,10 +369,17 @@ class DependencyResolver:
 
     @staticmethod
     def _chain_import_resolvers(import_resolvers: list[BaseImportResolver]) -> BaseImportResolver:
+        # check that WhiteListResolver comes first when resolving import
+        has_whitelist_resolver = False
+        is_white_list_resolver = False
         previous: BaseImportResolver = StubImportResolver()
         for resolver in import_resolvers:
             resolver = resolver.with_next_resolver(previous)
             previous = resolver
+            # we don't allow local imports, so we check against the type name
+            is_white_list_resolver = type(resolver).__name__ == "WhitelistResolver"
+            has_whitelist_resolver |= is_white_list_resolver
+        assert is_white_list_resolver or not has_whitelist_resolver
         return previous
 
     def resolve_notebook(self, path_lookup: PathLookup, path: Path) -> MaybeDependency:

--- a/tests/unit/source_code/samples/import_typing_extensions.py.txt
+++ b/tests/unit/source_code/samples/import_typing_extensions.py.txt
@@ -1,0 +1,1 @@
+from typing_extensions import ParamSpec

--- a/tests/unit/source_code/test_dependencies.py
+++ b/tests/unit/source_code/test_dependencies.py
@@ -350,3 +350,4 @@ def test_dependency_resolver_yells_with_misplaced_whitelist_resolver(mock_notebo
     with pytest.raises(Exception):
         import_resolvers = [WhitelistResolver(Whitelist()), LocalFileResolver(FileLoader())]
         dependency_resolver = DependencyResolver([], mock_notebook_resolver, import_resolvers, mock_path_lookup)
+        assert dependency_resolver is not None

--- a/tests/unit/source_code/test_path_lookup_simulation.py
+++ b/tests/unit/source_code/test_path_lookup_simulation.py
@@ -42,8 +42,8 @@ def test_locates_notebooks(source: list[str], expected: int, mock_path_lookup):
     notebook_loader = NotebookLoader()
     notebook_resolver = NotebookResolver(notebook_loader)
     import_resolvers = [
-        WhitelistResolver(Whitelist()),
         LocalFileResolver(file_loader),
+        WhitelistResolver(Whitelist()),
     ]
     dependency_resolver = DependencyResolver([], notebook_resolver, import_resolvers, mock_path_lookup)
     maybe = dependency_resolver.build_notebook_dependency_graph(notebook_path)
@@ -70,8 +70,8 @@ def test_locates_files(source: list[str], expected: int):
     notebook_loader = NotebookLoader()
     notebook_resolver = NotebookResolver(notebook_loader)
     import_resolvers = [
-        WhitelistResolver(whitelist),
         LocalFileResolver(file_loader),
+        WhitelistResolver(whitelist),
     ]
     resolver = DependencyResolver([], notebook_resolver, import_resolvers, lookup)
     maybe = resolver.build_local_file_dependency_graph(file_path)
@@ -111,8 +111,8 @@ sys.path.append('{child_dir_path.as_posix()}')
         notebook_loader = NotebookLoader()
         notebook_resolver = NotebookResolver(notebook_loader)
         import_resolvers = [
-            WhitelistResolver(whitelist),
             LocalFileResolver(file_loader),
+            WhitelistResolver(whitelist),
         ]
         resolver = DependencyResolver([], notebook_resolver, import_resolvers, lookup)
         maybe = resolver.build_notebook_dependency_graph(parent_file_path)
@@ -152,8 +152,8 @@ def func():
         notebook_loader = NotebookLoader()
         notebook_resolver = NotebookResolver(notebook_loader)
         import_resolvers = [
-            WhitelistResolver(whitelist),
             LocalFileResolver(file_loader),
+            WhitelistResolver(whitelist),
         ]
         resolver = DependencyResolver([], notebook_resolver, import_resolvers, lookup)
         maybe = resolver.build_notebook_dependency_graph(parent_file_path)


### PR DESCRIPTION
## Changes
Ensure that WhitelistResolver, if present, is always imported first

### Linked issues
Resolves #1707 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
