### PR TITLE
Always refresh HMS stats when getting table size

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -71,6 +71,8 @@ class TableSizeCrawler(CrawlerBase):
     def _safe_get_table_size(self, table_full_name: str) -> int | None:
         logger.debug(f"Evaluating {table_full_name} table size.")
         try:
+            # refresh table statistics to avoid stale stats in HMS
+            self._backend.execute(f"ANALYZE table {table_full_name} compute STATISTICS NOSCAN")
             # pylint: disable-next=protected-access
             return self._spark._jsparkSession.table(table_full_name).queryExecution().analyzed().stats().sizeInBytes()
         except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/unit/hive_metastore/test_table_size.py
+++ b/tests/unit/hive_metastore/test_table_size.py
@@ -34,6 +34,8 @@ def test_table_size_crawler(mocker):
     tsc = TableSizeCrawler(backend, "inventory_database")
     tsc._spark._jsparkSession.table().queryExecution().analyzed().stats().sizeInBytes.side_effect = [100, 200, 300]
     results = tsc.snapshot()
+    assert "ANALYZE table hive_metastore.db1.table1 compute STATISTICS NOSCAN" in backend.queries
+    assert "ANALYZE table hive_metastore.db1.table2 compute STATISTICS NOSCAN" in backend.queries
     assert len(results) == 2
     assert TableSize("hive_metastore", "db1", "table1", 100) in results
     assert TableSize("hive_metastore", "db1", "table2", 200) in results


### PR DESCRIPTION
## Changes
- Always refresh HMS stats when getting table size, to avoid getting stale stats

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1712

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] verified on staging environment (screenshot attached)
