### PR TITLE
Support for s3a/ s3n protocols when using mount point 

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -141,8 +141,18 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         tf_script = []
         cnt = 1
         for loc in missing_locations:
-            if loc.location.startswith("s3://"):
-                res_name = loc.location[5:].rstrip("/").replace("/", "_")
+            if loc.location.startswith(("s3://", "s3a://", "s3n://")):
+                # Determine the prefix length based on the starting substring
+                if loc.location.startswith("s3://"):
+                    prefix_length = 5
+                elif loc.location.startswith("s3a://"):
+                    prefix_length = 6
+                elif loc.location.startswith("s3n://"):
+                    prefix_length = 6
+                else:
+                    logger.warning(f"unsupported storage format {loc.location}")
+                    continue
+                res_name = loc.location[prefix_length:].rstrip("/").replace("/", "_")
             elif loc.location.startswith("gcs://"):
                 res_name = loc.location[6:].rstrip("/").replace("/", "_")
             elif loc.location.startswith("abfss://"):


### PR DESCRIPTION
…port for protocols like s3a and s3n

## Changes
![image](https://github.com/databrickslabs/ucx/assets/12300863/9a44e04a-87c7-4927-bbfd-a3e22dcb1623)

### Linked issues

Resolves #1722

External tables that uses s3a and s3n as protocolos when using mount points

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [X] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
rerun validate-external-location command and check both log files and generated terraform tf file
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
