### PR TITLE
Added `codecov.yml` and set threshold to 0.5%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
## Changes
- Allow the coverage to drop by 0.5% to avoid failures for small fixes.
- Per https://docs.codecov.com/docs/codecovyml-reference#coveragestatus and https://docs.codecov.com/docs/commit-status

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1727
