### PR TITLE
Update UCX job cluster policy AWS zone_id to 'auto'

### DIFF
--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -113,6 +113,7 @@ class ClusterPolicyInstaller:
             policy_definition["aws_attributes.availability"] = self._policy_config(
                 compute.AwsAvailability.ON_DEMAND.value
             )
+            policy_definition["aws_attributes.zone_id"] = self._policy_config("auto")
         elif self._ws.config.is_azure:
             policy_definition["azure_attributes.availability"] = self._policy_config(
                 compute.AzureAvailability.ON_DEMAND_AZURE.value
@@ -127,6 +128,8 @@ class ClusterPolicyInstaller:
             policy_definition.pop("node_type_id")
             # 'availability' cannot be supplied when an instance pool ID is provided
             policy_definition.pop("aws_attributes.availability", "")
+            # 'zone_id' cannot be supplied when an instance pool ID is provided
+            policy_definition.pop("aws_attributes.zone_id", "")
             policy_definition.pop("azure_attributes.availability", "")
             policy_definition.pop("gcp_attributes.availability", "")
         return json.dumps(policy_definition)

--- a/tests/unit/installer/test_policy.py
+++ b/tests/unit/installer/test_policy.py
@@ -108,6 +108,7 @@ def test_cluster_policy_definition_aws_glue():
         "spark_conf.spark.databricks.hive.metastore.glueCatalog.enabled": {"type": "fixed", "value": "true"},
         "aws_attributes.instance_profile_arn": {"type": "fixed", "value": "role_arn_1"},
         "aws_attributes.availability": {"type": "fixed", "value": "ON_DEMAND"},
+        "aws_attributes.zone_id": {"type": "fixed", "value": "auto"},
     }
     assert policy_id == "foo1"
     assert instance_profile == "role_arn_1"
@@ -286,6 +287,7 @@ def test_cluster_policy_definition_aws_glue_warehouse():
         "spark_conf.spark.databricks.hive.metastore.glueCatalog.enabled": {"type": "fixed", "value": "true"},
         "aws_attributes.instance_profile_arn": {"type": "fixed", "value": "role_arn_1"},
         "aws_attributes.availability": {"type": "fixed", "value": "ON_DEMAND"},
+        "aws_attributes.zone_id": {"type": "fixed", "value": "auto"},
     }
     assert policy_id == "foo1"
     assert instance_profile == "role_arn_1"
@@ -380,6 +382,7 @@ def test_cluster_policy_definition_empty_config():
         "spark_version": {"type": "fixed", "value": "14.2.x-scala2.12"},
         "node_type_id": {"type": "fixed", "value": "Standard_F4s"},
         "aws_attributes.availability": {"type": "fixed", "value": "ON_DEMAND"},
+        "aws_attributes.zone_id": {"type": "fixed", "value": "auto"},
     }
     assert policy_id == "foo1"
 
@@ -422,6 +425,7 @@ def test_cluster_policy_instance_pool():
         "spark_version": {"type": "fixed", "value": "14.2.x-scala2.12"},
         "node_type_id": {"type": "fixed", "value": "Standard_F4s"},
         "aws_attributes.availability": {"type": "fixed", "value": "ON_DEMAND"},
+        "aws_attributes.zone_id": {"type": "fixed", "value": "auto"},
     }
     _, _, _, instance_pool_id = policy_installer.create('ucx')
     assert instance_pool_id is None


### PR DESCRIPTION
## Changes
Updated the UCX cluster policy used by the jobs to use auto-az instead of leaving ut empty (which lets Databricks make the choice based on a default value in the region)

### Linked issues
Resolves #533

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [x] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
