### PR TITLE
[internal] Add RemoveAfter tag/property to additional testing artifacts

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -45,7 +45,7 @@ from databricks.sdk.service.sql import (
     Query,
     Dashboard,
     WidgetOptions,
-    WidgetPosition,
+    WidgetPosition, EndpointTagPair, EndpointTags,
 )
 from databricks.sdk.service.workspace import ImportFormat, Language
 
@@ -725,6 +725,7 @@ def make_cluster(ws, make_random):
             cluster_name=cluster_name,
             spark_version=spark_version,
             autotermination_minutes=autotermination_minutes,
+            custom_tags={"RemoveAfter": get_test_purge_time()},
             **kwargs,
         )
 
@@ -761,7 +762,8 @@ def make_instance_pool(ws, make_random):
             instance_pool_name = f"sdk-{make_random(4)}"
         if node_type_id is None:
             node_type_id = ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
-        return ws.instance_pools.create(instance_pool_name, node_type_id, **kwargs)
+        return ws.instance_pools.create(instance_pool_name, node_type_id,
+                                        custom_tags={"RemoveAfter": get_test_purge_time()}, **kwargs)
 
     yield from factory("instance pool", create, lambda item: ws.instance_pools.delete(item.instance_pool_id))
 
@@ -812,9 +814,6 @@ def make_job(ws, make_random, make_notebook):
         job = ws.jobs.create(**kwargs)
         logger.info(f"Job: {ws.config.host}#job/{job.job_id}")
         return job
-
-    def get_test_purge_time() -> str:
-        return (datetime.utcnow() + TEST_JOBS_PURGE_TIMEOUT).strftime("%Y%m%d%H")
 
     yield from factory("job", create, lambda item: ws.jobs.delete(item.job_id))
 
@@ -877,12 +876,14 @@ def make_warehouse(ws, make_random):
         if cluster_size is None:
             cluster_size = "2X-Small"
 
+        remove_after_tags = EndpointTags(custom_tags=[EndpointTagPair(key="RemoveAfter", value=get_test_purge_time())])
         return ws.warehouses.create(
             name=warehouse_name,
             cluster_size=cluster_size,
             warehouse_type=warehouse_type,
             max_num_clusters=max_num_clusters,
             enable_serverless_compute=enable_serverless_compute,
+            tags=remove_after_tags,
             **kwargs,
         )
 
@@ -1340,3 +1341,6 @@ def make_dashboard(ws, make_random, make_query):
             logger.info(f"Can't delete dashboard {e}")
 
     yield from factory("dashboard", create, remove)
+
+def get_test_purge_time() -> str:
+    return (datetime.utcnow() + TEST_JOBS_PURGE_TIMEOUT).strftime("%Y%m%d%H")

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -721,11 +721,14 @@ def make_cluster(ws, make_random):
         if "instance_pool_id" not in kwargs:
             kwargs["node_type_id"] = ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
 
+        if "custom_tags" not in kwargs:
+            kwargs["custom_tags"] = {"RemoveAfter": get_test_purge_time()}
+        else:
+            kwargs["custom_tags"]["RemoveAfter"] = get_test_purge_time()
         return ws.clusters.create(
             cluster_name=cluster_name,
             spark_version=spark_version,
             autotermination_minutes=autotermination_minutes,
-            custom_tags={"RemoveAfter": get_test_purge_time()},
             **kwargs,
         )
 

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -45,7 +45,9 @@ from databricks.sdk.service.sql import (
     Query,
     Dashboard,
     WidgetOptions,
-    WidgetPosition, EndpointTagPair, EndpointTags,
+    WidgetPosition,
+    EndpointTagPair,
+    EndpointTags,
 )
 from databricks.sdk.service.workspace import ImportFormat, Language
 
@@ -765,8 +767,9 @@ def make_instance_pool(ws, make_random):
             instance_pool_name = f"sdk-{make_random(4)}"
         if node_type_id is None:
             node_type_id = ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
-        return ws.instance_pools.create(instance_pool_name, node_type_id,
-                                        custom_tags={"RemoveAfter": get_test_purge_time()}, **kwargs)
+        return ws.instance_pools.create(
+            instance_pool_name, node_type_id, custom_tags={"RemoveAfter": get_test_purge_time()}, **kwargs
+        )
 
     yield from factory("instance pool", create, lambda item: ws.instance_pools.delete(item.instance_pool_id))
 
@@ -1344,6 +1347,7 @@ def make_dashboard(ws, make_random, make_query):
             logger.info(f"Can't delete dashboard {e}")
 
     yield from factory("dashboard", create, remove)
+
 
 def get_test_purge_time() -> str:
     return (datetime.utcnow() + TEST_JOBS_PURGE_TIMEOUT).strftime("%Y%m%d%H")

--- a/tests/integration/framework/test_fixtures.py
+++ b/tests/integration/framework/test_fixtures.py
@@ -120,7 +120,6 @@ def test_remove_after_tag_clusters(ws, env_or_skip, make_cluster):
     new_cluster = make_cluster(single_node=True, instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'))
     created_cluster = ws.clusters.get(new_cluster.cluster_id)
     assert "RemoveAfter" in created_cluster.custom_tags
-
     purge_time = datetime.strptime(created_cluster.custom_tags.get("RemoveAfter"), "%Y%m%d%H")
     assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)
 
@@ -131,4 +130,12 @@ def test_remove_after_tag_warehouse(ws, env_or_skip, make_warehouse):
     custom_tags = created_warehouse.tags.as_dict()
     assert 'RemoveAfter' in custom_tags.get("custom_tags")[0]["key"]
     purge_time = datetime.strptime(custom_tags.get("custom_tags")[0]["value"], "%Y%m%d%H")
+    assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)
+
+
+def test_remove_after_tag_instance_pool(ws, make_instance_pool):
+    new_instance_pool = make_instance_pool()
+    created_instance_pool = ws.instance_pools.get(new_instance_pool.instance_pool_id)
+    assert "RemoveAfter" in created_instance_pool.custom_tags
+    purge_time = datetime.strptime(created_instance_pool.custom_tags.get("RemoveAfter"), "%Y%m%d%H")
     assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)

--- a/tests/integration/framework/test_fixtures.py
+++ b/tests/integration/framework/test_fixtures.py
@@ -107,10 +107,28 @@ def test_dbfs_fixture(make_mounted_location):
     logger.info(f"Created new dbfs data copy:{make_mounted_location}")
 
 
-def test_removeafter_tag(ws, env_or_skip, make_job):
+def test_remove_after_tag_jobs(ws, env_or_skip, make_job):
     new_job = make_job(spark_conf=_SPARK_CONF)
     created_job = ws.jobs.get(new_job.job_id)
     assert "RemoveAfter" in created_job.settings.tags
 
     purge_time = datetime.strptime(created_job.settings.tags.get("RemoveAfter"), "%Y%m%d%H")
+    assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)
+
+
+def test_remove_after_tag_clusters(ws, env_or_skip, make_cluster):
+    new_cluster = make_cluster(single_node=True, instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'))
+    created_cluster = ws.clusters.get(new_cluster.cluster_id)
+    assert "RemoveAfter" in created_cluster.custom_tags
+
+    purge_time = datetime.strptime(created_cluster.custom_tags.get("RemoveAfter"), "%Y%m%d%H")
+    assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)
+
+
+def test_remove_after_tag_warehouse(ws, env_or_skip, make_warehouse):
+    new_warehouse = make_warehouse()
+    created_warehouse = ws.warehouses.get(new_warehouse.response.id)
+    custom_tags = created_warehouse.tags.as_dict()
+    assert 'RemoveAfter' in custom_tags.get("custom_tags")[0]["key"]
+    purge_time = datetime.strptime(custom_tags.get("custom_tags")[0]["value"], "%Y%m%d%H")
     assert purge_time - datetime.utcnow() < timedelta(hours=1, minutes=15)


### PR DESCRIPTION
## Changes
Add RemoveAfter tag to additional artifacts

Add it as tag to:

- clusters
- instance pools
- sql warehouse

Add it a property to:

- schemas
- tables

### Linked issues
Introduces #977 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
