### PR TITLE
Rewrite `PipResolver._locate_dist_info` to use `Path`

### DIFF
--- a/src/databricks/labs/ucx/source_code/python_libraries.py
+++ b/src/databricks/labs/ucx/source_code/python_libraries.py
@@ -59,15 +59,11 @@ class PipResolver(BaseLibraryResolver):
     def _locate_dist_info(self, library_path: Path, library: Path) -> Path | None:
         if not library_path.parent.exists():
             return None
-        packages = library_path.parent.iterdir()
-        dist_info_dir = next(
-            (
-                package
-                for package in packages
-                if package.name.startswith(library.name) and package.name.endswith(".dist-info")
-            ),
-            None,
-        )
+        dist_info_dir = None
+        for package in library_path.parent.iterdir():
+            if package.name.startswith(library.name) and package.name.endswith(".dist-info"):
+                dist_info_dir = package
+                break  # TODO: Matching multiple .dist-info's, https://github.com/databrickslabs/ucx/issues/1751
         if dist_info_dir is not None:
             return dist_info_dir
         # maybe the name needs tweaking

--- a/src/databricks/labs/ucx/source_code/python_libraries.py
+++ b/src/databricks/labs/ucx/source_code/python_libraries.py
@@ -57,13 +57,19 @@ class PipResolver(BaseLibraryResolver):
         return None
 
     def _locate_dist_info(self, library_path: Path, library: Path) -> Path | None:
-        packages = os.listdir(library_path.parent.as_posix())
+        if not library_path.parent.exists():
+            return None
+        packages = library_path.parent.iterdir()
         dist_info_dir = next(
-            (package for package in packages if package.startswith(library.name) and package.endswith(".dist-info")),
+            (
+                package
+                for package in packages
+                if package.name.startswith(library.name) and package.name.endswith(".dist-info")
+            ),
             None,
         )
         if dist_info_dir is not None:
-            return Path(library_path.parent, Path(dist_info_dir))
+            return dist_info_dir
         # maybe the name needs tweaking
         if "-" in library.name:
             name = library.name.replace("-", "_")

--- a/tests/unit/source_code/test_python_libraries.py
+++ b/tests/unit/source_code/test_python_libraries.py
@@ -25,6 +25,13 @@ def test_pip_resolver_does_not_resolve_unknown_library(mock_path_lookup):
     assert mock_path_lookup.resolve(Path("unknown-library-name")) is None
 
 
+def test_pip_resolver_locates_dist_info_without_parent(mock_path_lookup):
+    pip_resolver = PipResolver(FileLoader(), Whitelist())
+    path = pip_resolver._locate_dist_info(Path("/non/existing/path/to/library"), Path("library"))
+
+    assert path is None
+
+
 def test_dist_info_package_parses_installed_package_with_toplevel():
     site_packages_path = locate_site_packages()
     astroid_path = Path(site_packages_path, "astroid-3.1.0.dist-info")

--- a/tests/unit/source_code/test_python_libraries.py
+++ b/tests/unit/source_code/test_python_libraries.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from unittest.mock import create_autospec
 
 from databricks.labs.ucx.source_code.files import FileLoader
+from databricks.labs.ucx.source_code.graph import DependencyProblem
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.python_libraries import DistInfoPackage, PipResolver
 from databricks.labs.ucx.source_code.whitelist import Whitelist
@@ -25,11 +27,16 @@ def test_pip_resolver_does_not_resolve_unknown_library(mock_path_lookup):
     assert mock_path_lookup.resolve(Path("unknown-library-name")) is None
 
 
-def test_pip_resolver_locates_dist_info_without_parent(mock_path_lookup):
-    pip_resolver = PipResolver(FileLoader(), Whitelist())
-    path = pip_resolver._locate_dist_info(Path("/non/existing/path/to/library"), Path("library"))
+def test_pip_resolver_locates_dist_info_without_parent():
+    mock_path_lookup = create_autospec(PathLookup)
+    mock_path_lookup.resolve.return_value = Path("/non/existing/path/")
 
-    assert path is None
+    pip_resolver = PipResolver(FileLoader(), Whitelist())
+    maybe = pip_resolver.resolve_library(mock_path_lookup, Path("library"))
+
+    assert len(maybe.problems) == 1
+    assert maybe.problems[0] == DependencyProblem("no-dist-info", "No dist-info found for library")
+    mock_path_lookup.resolve.assert_called_once()
 
 
 def test_dist_info_package_parses_installed_package_with_toplevel():


### PR DESCRIPTION
## Changes
Rewrite `PipResolver._locate_dist_info` to use `Path`

### Linked issues
Resolves #1750

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
