### PR TITLE
relay logs when test_experimental_permissions_migration_for_group_with_same_name fails

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -115,8 +115,16 @@ def test_experimental_permissions_migration_for_group_with_same_name(
     )
     new_schema_grants = installation_ctx.grants_crawler.for_schema_info(schema_a)
 
-    assert {"USAGE", "OWN"} == new_schema_grants[migrated_group.name_in_account]
-    assert object_permissions[migrated_group.name_in_account] == PermissionLevel.CAN_USE
+    if {"USAGE", "OWN"} != new_schema_grants[migrated_group.name_in_account] or object_permissions[
+        migrated_group.name_in_account
+    ] != PermissionLevel.CAN_USE:
+        installation_ctx.deployed_workflows.relay_logs("migrate-groups-experimental")
+    assert {"USAGE", "OWN"} == new_schema_grants[
+        migrated_group.name_in_account
+    ], "Incorrect schema grants for migrated group"
+    assert (
+        object_permissions[migrated_group.name_in_account] == PermissionLevel.CAN_USE
+    ), "Incorrect permissions for migrated group"
 
 
 @retried(on=[NotFound, TimeoutError], timeout=timedelta(minutes=3))


### PR DESCRIPTION
## Changes
relay logs when test_experimental_permissions_migration_for_group_with_same_name fails

### Linked issues
#1719

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
