### PR TITLE
EditorConfig specification for the project and minor tooling improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# Top-most EditorConfig file.
+root = true
+
+# Universal settings.
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+indent_size = tab
+
+[*.{json,yml}]
+indent_size = 2
+
+[*.xml]
+indent_size = 2
+
+[*.scala]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,9 +17,3 @@ indent_size = tab
 
 [*.{json,yml}]
 indent_size = 2
-
-[*.xml]
-indent_size = 2
-
-[*.scala]
-indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,4 @@ integration:
 coverage:
 	hatch run coverage && open htmlcov/index.html
 
+.PHONY: all clean dev lint fmt test integration coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ fmt         = ["black . --extend-exclude 'tests/unit/source_code/samples/*'",
                "mypy --disable-error-code 'annotation-unchecked' --exclude 'tests/unit/source_code/samples/*' .",
                "pylint --output-format=colorized -j 0 src tests"]
 verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples/*'",
-               "ruff .",
+               "ruff check .",
                "mypy --exclude 'tests/unit/source_code/samples/*' .",
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]


### PR DESCRIPTION
## Changes

This PR includes some trivial repository updates:

 - An [EditorConfig](https://editorconfig.org) profile to set basic code formatting, set to match the files already in the repo. (IntelliJ/PyCharm should pick this up out of the box.)
 - A warning when running the `make verify` target is eliminated.
 - The `Makefile` targets are now marked as [phony](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html), which is more of a hygiene thing than anything else.

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
