### PR TITLE
Change order of Library installation when upload_dependencies flag is True

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -536,8 +536,10 @@ class WorkflowsDeployment(InstallationMixin):
                 return 0
             case library if 'blueprint' in library:
                 return 1
-            case _:
+            case library if 'sqlglot' in library:
                 return 2
+            case _:
+                return 3
 
     def _upload_wheel(self):
         wheel_paths = []

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1913,6 +1913,8 @@ def test_upload_dependencies(ws, mock_installation):
     wheels.upload_wheel_dependencies.return_value = [
         'databricks_labs_blueprint-0.6.2-py3-none-any.whl',
         'databricks_sdk-0.28.0-py3-none-any.whl',
+        'sqlglot-24.0.2-py3-none-any.whl',
+        'databricks_labs_lsql-0.4.3-py3-none-any.whl',
         'databricks_labs_ucx-0.23.2+4920240527095658-py3-none-any.whl',
     ]
     workspace_installation = WorkspaceInstaller(ws).replace(


### PR DESCRIPTION
## Changes
This PR fixes the issue when the upload_dependencies flag is set to True.
Currently the order of the library installation in each workflow task is
sdk-->blueprint-->lsql-->sqlglot-->ucx. 
Since lsql is dependent on sqlglot its failing in no internet workspaces.
This PR changes the order to below
sdk-->blueprint-->sqlglot-->lsql-->ucx. 


Resolves #1795 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [X] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
