### PR TITLE
Fix linting or fixing non-utf8 encoded files

### DIFF
--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -170,7 +170,11 @@ class LocalFileMigrator:
         linter = languages.linter(language)
         # Open the file and read the code
         with path.open("r") as f:
-            code = f.read()
+            try:
+                code = f.read()
+            except UnicodeDecodeError as e:
+                logger.error(f"Could not decode file {path}: {e}")
+                return False
             applied = False
             # Lint the code and apply fixes
             for advice in linter.lint(code):

--- a/tests/unit/source_code/notebooks/test_sources.py
+++ b/tests/unit/source_code/notebooks/test_sources.py
@@ -1,3 +1,4 @@
+import locale
 from pathlib import Path
 
 import pytest
@@ -43,3 +44,15 @@ def test_file_linter_lints_ignorable_language(path, migration_index):
     linter = FileLinter(Languages(migration_index), Path(path), "")
     advices = list(linter.lint())
     assert not advices
+
+
+def test_file_linter_lints_non_ascii_encoded_file(migration_index):
+    preferred_encoding = locale.getpreferredencoding(False)
+    non_ascii_encoded_file = Path(__file__).parent.parent / "samples" / "nonascii.py"
+    linter = FileLinter(Languages(migration_index), non_ascii_encoded_file)
+
+    advices = list(linter.lint())
+
+    assert len(advices) == 1
+    assert advices[0].code == "unsupported-file-encoding"
+    assert advices[0].message == f"File without {preferred_encoding} encoding is not supported {non_ascii_encoded_file}"

--- a/tests/unit/source_code/samples/nonascii.py
+++ b/tests/unit/source_code/samples/nonascii.py
@@ -1,0 +1,4 @@
+# coding: iso-8859-5
+# (Unlikely to be the default encoding for most testers.)
+# ±¶ÿאבגדהוזחטיךכלםמן <- Cyrillic characters
+u = "®גנÄ"


### PR DESCRIPTION
## Changes
Fix linting non-utf8 encoded files. The linter and fixer would fail with non-utf8 encoded file


### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
