### PR TITLE
Add linters to check for spark logging and configuration access

### DIFF
--- a/tests/unit/source_code/test_spark_connect.py
+++ b/tests/unit/source_code/test_spark_connect.py
@@ -143,6 +143,32 @@ rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
     ] == list(linter.lint(code))
 
 
+def test_rdd_map_partitions():
+    linter = SparkConnectLinter(is_serverless=False)
+    code = """
+df = spark.createDataFrame([])
+df.rdd.mapPartitions(myUdf)
+    """
+    assert [
+        Failure(
+            code="rdd-in-shared-clusters",
+            message='RDD APIs are not supported on UC Shared Clusters. Use mapInArrow() or Pandas UDFs instead',
+            start_line=3,
+            start_col=0,
+            end_line=3,
+            end_col=27,
+        ),
+        Failure(
+            code="rdd-in-shared-clusters",
+            message='RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API',
+            start_line=3,
+            start_col=0,
+            end_line=3,
+            end_col=6,
+        ),
+    ] == list(linter.lint(code))
+
+
 def test_conf_shared():
     linter = SparkConnectLinter(is_serverless=False)
     code = """df.sparkContext.getConf().get('spark.my.conf')"""

--- a/tests/unit/source_code/test_spark_connect.py
+++ b/tests/unit/source_code/test_spark_connect.py
@@ -143,6 +143,36 @@ rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
     ] == list(linter.lint(code))
 
 
+def test_conf_shared():
+    linter = SparkConnectLinter(is_serverless=False)
+    code = """df.sparkContext.getConf().get('spark.my.conf')"""
+    assert [
+        Failure(
+            code='legacy-context-in-shared-clusters',
+            message='sparkContext and getConf are not supported on UC Shared Clusters. Rewrite it using spark.conf',
+            start_line=1,
+            start_col=0,
+            end_line=1,
+            end_col=23,
+        ),
+    ] == list(linter.lint(code))
+
+
+def test_conf_serverless():
+    linter = SparkConnectLinter(is_serverless=True)
+    code = """sc._conf().get('spark.my.conf')"""
+    assert [
+        Failure(
+            code='legacy-context-in-shared-clusters',
+            message='sc and _conf are not supported on Serverless Compute. Rewrite it using spark.conf',
+            start_line=1,
+            start_col=0,
+            end_line=1,
+            end_col=8,
+        ),
+    ] == list(linter.lint(code))
+
+
 def test_logging_shared():
     logging_matcher = LoggingMatcher(is_serverless=False)
     code = """

--- a/tests/unit/source_code/test_spark_connect.py
+++ b/tests/unit/source_code/test_spark_connect.py
@@ -1,5 +1,8 @@
+import ast
+from itertools import chain
+
 from databricks.labs.ucx.source_code.base import Failure
-from databricks.labs.ucx.source_code.spark_connect import SparkConnectLinter
+from databricks.labs.ucx.source_code.spark_connect import LoggingMatcher, SparkConnectLinter
 
 
 def test_jvm_access_match_shared():
@@ -138,6 +141,76 @@ rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
             end_col=40,
         ),
     ] == list(linter.lint(code))
+
+
+def test_logging_shared():
+    logging_matcher = LoggingMatcher(is_serverless=False)
+    code = """
+sc.setLogLevel("INFO")
+setLogLevel("WARN")
+
+log4jLogger = sc._jvm.org.apache.log4j
+LOGGER = log4jLogger.LogManager.getLogger(__name__)
+sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
+
+    """
+
+    assert [
+        Failure(
+            code='spark-logging-in-shared-clusters',
+            message='Cannot set Spark log level directly from code on UC Shared Clusters. '
+            'Remove the call and set the cluster spark conf \'spark.log.level\' instead',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=22,
+        ),
+        Failure(
+            code='spark-logging-in-shared-clusters',
+            message='Cannot access Spark Driver JVM logger on UC Shared Clusters. ' 'Use logging.getLogger() instead',
+            start_line=5,
+            start_col=14,
+            end_line=5,
+            end_col=38,
+        ),
+        Failure(
+            code='spark-logging-in-shared-clusters',
+            message='Cannot access Spark Driver JVM logger on UC Shared Clusters. ' 'Use logging.getLogger() instead',
+            start_line=7,
+            start_col=0,
+            end_line=7,
+            end_col=24,
+        ),
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in ast.walk(ast.parse(code))]))
+
+
+def test_logging_serverless():
+    logging_matcher = LoggingMatcher(is_serverless=True)
+    code = """
+sc.setLogLevel("INFO")
+log4jLogger = sc._jvm.org.apache.log4j
+
+    """
+
+    assert [
+        Failure(
+            code='spark-logging-in-shared-clusters',
+            message='Cannot set Spark log level directly from code on Serverless Compute. '
+            'Remove the call and set the cluster spark conf \'spark.log.level\' instead',
+            start_line=2,
+            start_col=0,
+            end_line=2,
+            end_col=22,
+        ),
+        Failure(
+            code='spark-logging-in-shared-clusters',
+            message='Cannot access Spark Driver JVM logger on Serverless Compute. ' 'Use logging.getLogger() instead',
+            start_line=3,
+            start_col=14,
+            end_line=3,
+            end_col=38,
+        ),
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in ast.walk(ast.parse(code))]))
 
 
 def test_valid_code():


### PR DESCRIPTION
## Changes
Add new linters to check for uses of spark logging, `sc.conf` access and `rdd.mapPartitions` 

### Linked issues
Resolves [#1805](https://github.com/databrickslabs/ucx/issues/1805), enhances [#1603](https://github.com/databrickslabs/ucx/issues/1603), [#1604](https://github.com/databrickslabs/ucx/issues/1604)

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
