### PR TITLE
Handle legacy ACL `DENY` permission in group migration

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -137,6 +137,7 @@ class Grant:
     def _apply_grant_sql(self, action_type, object_type, object_key):
         if "DENIED" in action_type:
             action_type = action_type.replace("DENIED_", "")
+            # need to wrap the action type in backticks to avoid syntax errors with DENY SELECT
             return f"DENY `{action_type}` ON {object_type} {escape_sql_identifier(object_key)} TO `{self.principal}`"
         return f"GRANT {action_type} ON {object_type} {escape_sql_identifier(object_key)} TO `{self.principal}`"
 

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -135,6 +135,9 @@ class Grant:
         return f"ALTER {object_type} {escape_sql_identifier(object_key)} OWNER TO `{self.principal}`"
 
     def _apply_grant_sql(self, action_type, object_type, object_key):
+        if "DENIED" in action_type:
+            action_type = action_type.replace("DENIED_", "")
+            return f"DENY `{action_type}` ON {object_type} {escape_sql_identifier(object_key)} TO `{self.principal}`"
         return f"GRANT {action_type} ON {object_type} {escape_sql_identifier(object_key)} TO `{self.principal}`"
 
     def _uc_action(self, action_type):

--- a/tests/integration/hive_metastore/test_grants.py
+++ b/tests/integration/hive_metastore/test_grants.py
@@ -33,7 +33,7 @@ def test_all_grants_in_databases(runtime_ctx, sql_backend, make_group):
     sql_backend.execute(f"GRANT MODIFY ON SCHEMA {schema_b.full_name} TO `{group_b.display_name}`")
     sql_backend.execute(f"GRANT MODIFY ON SCHEMA {empty_schema.full_name} TO `{group_b.display_name}`")
     sql_backend.execute(f"GRANT MODIFY ON VIEW {view_c.full_name} TO `{group_b.display_name}`")
-    sql_backend.execute(f"GRANT MODIFY ON TABLE {view_d.full_name} TO `{group_b.display_name}`")
+    sql_backend.execute(f"DENY MODIFY ON TABLE {view_d.full_name} TO `{group_b.display_name}`")
 
     # 20 seconds less than TablesCrawler(sql_backend, inventory_schema)
     grants = GrantsCrawler(runtime_ctx.tables_crawler, runtime_ctx.udfs_crawler)
@@ -51,7 +51,7 @@ def test_all_grants_in_databases(runtime_ctx, sql_backend, make_group):
     assert all_grants[f"{group_b.display_name}.{schema_b.full_name}"] == "MODIFY"
     assert all_grants[f"{group_b.display_name}.{empty_schema.full_name}"] == "MODIFY"
     assert all_grants[f"{group_b.display_name}.{view_c.full_name}"] == "MODIFY"
-    assert all_grants[f"{group_b.display_name}.{view_d.full_name}"] == "MODIFY"
+    assert all_grants[f"{group_b.display_name}.{view_d.full_name}"] == "DENIED_MODIFY"
     assert all_grants[f"{group_b.display_name}.{table_e.full_name}"] == "MODIFY"
 
 

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -105,6 +105,13 @@ def test_hive_revoke_sql():
     assert grant.hive_revoke_sql() == "REVOKE SELECT ON TABLE hive_metastore.mydb.mytable FROM `user`"
 
 
+def test_hive_deny_sql():
+    grant = Grant(
+        principal="user", action_type="DENIED_SELECT", catalog="hive_metastore", database="mydb", table="mytable"
+    )
+    assert grant.hive_grant_sql() == ["DENY `SELECT` ON TABLE hive_metastore.mydb.mytable TO `user`"]
+
+
 @pytest.mark.parametrize(
     "grant,query",
     [


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
- In our legacy table ACLs, there are DENY operations. These permissions are shown with `DENIED` prefix. Apply them correctly when applying permissions for group migrations

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1803

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
- [x] verified on staging environment (screenshot attached)
