### PR TITLE
Drop pyspark 'register' lint matcher

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -274,11 +274,6 @@ class SparkMatchers:
         # nothing to migrate in DataFrameWriterV2, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriterV2.html
         # nothing to migrate in UDFRegistration, see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDFRegistration.html
 
-        # see https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.UDTFRegistration.html
-        spark_udtfregistration_matchers = [
-            TableNameMatcher("register", 1, 2, 0, "name"),
-        ]
-
         direct_fs_access_matchers = [
             DirectFilesystemAccessMatcher("ls", 1, 1, 0, call_context={"ls": {"dbutils.fs.ls"}}),
             DirectFilesystemAccessMatcher("cp", 1, 2, 0, call_context={"cp": {"dbutils.fs.cp"}}),
@@ -319,7 +314,6 @@ class SparkMatchers:
             + spark_dataframe_matchers
             + spark_dataframereader_matchers
             + spark_dataframewriter_matchers
-            + spark_udtfregistration_matchers
             + direct_fs_access_matchers
         ):
             self._matchers[matcher.method_name] = matcher

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -101,7 +101,6 @@ METHOD_NAMES = [
     "table",
     "insertInto",
     "saveAsTable",
-    "register",
 ]
 
 


### PR DESCRIPTION
## Changes

This PR drops the 'register' lint matcher on the Spark context. This is being dropped because:

 - The method is not on the Spark session, but is accessed via the `spark.udf`.
 - The name argument is not the name of a table; rather it's the name of a (local) table function which doesn't pose a problem for migration.

### Linked issues

Resolves #1779 

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
