### PR TITLE
Remove false warning on DataFrame.insertInto() about the default format changing from parquet to delta

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -131,7 +131,7 @@ class WorkflowTaskContainer(SourceContainer):
         path = WorkspacePath(self._ws, notebook_path)
         return graph.register_notebook(path)
 
-    def _register_spark_python_task(self, graph: DependencyGraph):  # pylint: disable=unused-argument
+    def _register_spark_python_task(self, graph: DependencyGraph):
         if not self._task.spark_python_task:
             return []
         notebook_path = self._task.spark_python_task.python_file

--- a/src/databricks/labs/ucx/source_code/linters/table_creation.py
+++ b/src/databricks/labs/ucx/source_code/linters/table_creation.py
@@ -107,7 +107,6 @@ class DBRv8d0Linter(Linter):
             [
                 NoFormatPythonMatcher("writeTo", 1, 1),
                 NoFormatPythonMatcher("table", 1, 1),
-                NoFormatPythonMatcher("insertInto", 1, 2),
                 NoFormatPythonMatcher("saveAsTable", 1, 4, 2, "format"),
             ]
         )

--- a/tests/unit/source_code/linters/test_table_creation.py
+++ b/tests/unit/source_code/linters/test_table_creation.py
@@ -9,7 +9,6 @@ from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0Linter
 METHOD_NAMES = [
     "writeTo",
     "table",
-    "insertInto",
     "saveAsTable",
 ]
 ASSIGN = [True, False]


### PR DESCRIPTION
## Changes

This pull request removes a spurious incompatible-format warning for `DataFrameWriter.insertInto()`. The `.insertInto()` operation uses the existing format of the underlying table; any specified format is ignored. As such use of this operation be flagged as a potential problem due to the change of the default format from `parquet` to `delta`.

Incidental changes included in this PR:

 - Removed an unnecessary linting suppression.

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
