### PR TITLE
Deduplicate errors emitted by Spark Connect linter

### DIFF
--- a/tests/unit/source_code/linters/test_spark_connect.py
+++ b/tests/unit/source_code/linters/test_spark_connect.py
@@ -21,14 +21,6 @@ spark._jspark._jvm.com.my.custom.Name()
             end_line=3,
             end_col=18,
         ),
-        Failure(
-            code="jvm-access-in-shared-clusters",
-            message='Cannot access Spark Driver JVM on UC Shared Clusters',
-            start_line=3,
-            start_col=0,
-            end_line=3,
-            end_col=13,
-        ),
     ] == list(linter.lint(code))
 
 
@@ -47,14 +39,6 @@ spark._jspark._jvm.com.my.custom.Name()
             start_col=0,
             end_line=3,
             end_col=18,
-        ),
-        Failure(
-            code="jvm-access-in-shared-clusters",
-            message='Cannot access Spark Driver JVM on Serverless Compute',
-            start_line=3,
-            start_col=0,
-            end_line=3,
-            end_col=13,
         ),
     ] == list(linter.lint(code))
 
@@ -75,20 +59,20 @@ rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
             end_col=32,
         ),
         Failure(
-            code='legacy-context-in-shared-clusters',
-            message='sc is not supported on UC Shared Clusters. Rewrite it using spark',
-            start_line=2,
-            start_col=7,
-            end_line=2,
-            end_col=21,
-        ),
-        Failure(
             code="rdd-in-shared-clusters",
             message='RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API',
             start_line=3,
             start_col=29,
             end_line=3,
             end_col=42,
+        ),
+        Failure(
+            code='legacy-context-in-shared-clusters',
+            message='sc is not supported on UC Shared Clusters. Rewrite it using spark',
+            start_line=2,
+            start_col=7,
+            end_line=2,
+            end_col=21,
         ),
         Failure(
             code="legacy-context-in-shared-clusters",
@@ -117,20 +101,20 @@ rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
             end_col=32,
         ),
         Failure(
-            code='legacy-context-in-shared-clusters',
-            message='sc is not supported on Serverless Compute. Rewrite it using spark',
-            start_line=2,
-            start_col=7,
-            end_line=2,
-            end_col=21,
-        ),
-        Failure(
             code="rdd-in-shared-clusters",
             message='RDD APIs are not supported on Serverless Compute. Rewrite it using DataFrame API',
             start_line=3,
             start_col=29,
             end_line=3,
             end_col=42,
+        ),
+        Failure(
+            code='legacy-context-in-shared-clusters',
+            message='sc is not supported on Serverless Compute. Rewrite it using spark',
+            start_line=2,
+            start_col=7,
+            end_line=2,
+            end_col=21,
         ),
         Failure(
             code="legacy-context-in-shared-clusters",
@@ -157,14 +141,6 @@ df.rdd.mapPartitions(myUdf)
             start_col=0,
             end_line=3,
             end_col=27,
-        ),
-        Failure(
-            code="rdd-in-shared-clusters",
-            message='RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API',
-            start_line=3,
-            start_col=0,
-            end_line=3,
-            end_col=6,
         ),
     ] == list(linter.lint(code))
 

--- a/tests/unit/source_code/samples/functional/jvm-access.py
+++ b/tests/unit/source_code/samples/functional/jvm-access.py
@@ -1,9 +1,6 @@
 spark.range(10).collect()
-# TODO: looks like a bug in linter, because we are hitting the same issue twice
-# ucx[jvm-access-in-shared-clusters:+2:0:+2:18] Cannot access Spark Driver JVM on UC Shared Clusters
 # ucx[jvm-access-in-shared-clusters:+1:0:+1:18] Cannot access Spark Driver JVM on UC Shared Clusters
 spark._jspark._jvm.com.my.custom.Name()
 
-# ucx[jvm-access-in-shared-clusters:+2:0:+2:18] Cannot access Spark Driver JVM on UC Shared Clusters
 # ucx[jvm-access-in-shared-clusters:+1:0:+1:18] Cannot access Spark Driver JVM on UC Shared Clusters
 spark._jspark._jvm.com.my.custom.Name()

--- a/tests/unit/source_code/samples/functional/rdd-apis.py
+++ b/tests/unit/source_code/samples/functional/rdd-apis.py
@@ -1,0 +1,12 @@
+df = spark.createDataFrame([])
+# ucx[rdd-in-shared-clusters:+1:0:+1:27] RDD APIs are not supported on UC Shared Clusters. Use mapInArrow() or Pandas UDFs instead
+df.rdd.mapPartitions(myUdf)
+
+# ucx[rdd-in-shared-clusters:+1:7:+1:32] RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API
+# ucx[legacy-context-in-shared-clusters:+1:7:+1:21] sc is not supported on UC Shared Clusters. Rewrite it using spark
+rdd1 = sc.parallelize([1, 2, 3])
+
+# ucx[rdd-in-shared-clusters:+1:29:+1:42] RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API
+# ucx[legacy-context-in-shared-clusters:+1:29:+1:40] sc is not supported on UC Shared Clusters. Rewrite it using spark
+rdd2 = spark.createDataFrame(sc.emptyRDD(), schema)
+

--- a/tests/unit/source_code/samples/functional/spark-logging.py
+++ b/tests/unit/source_code/samples/functional/spark-logging.py
@@ -1,0 +1,15 @@
+# ucx[legacy-context-in-shared-clusters:+1:0:+1:14] sc is not supported on UC Shared Clusters. Rewrite it using spark
+# ucx[spark-logging-in-shared-clusters:+1:0:+1:22] Cannot set Spark log level directly from code on UC Shared Clusters. Remove the call and set the cluster spark conf 'spark.log.level' instead
+sc.setLogLevel("INFO")
+setLogLevel("WARN")
+
+# ucx[jvm-access-in-shared-clusters:+1:14:+1:21] Cannot access Spark Driver JVM on UC Shared Clusters
+# ucx[legacy-context-in-shared-clusters:+1:14:+1:21] sc is not supported on UC Shared Clusters. Rewrite it using spark
+# ucx[spark-logging-in-shared-clusters:+1:14:+1:38] Cannot access Spark Driver JVM logger on UC Shared Clusters. Use logging.getLogger() instead
+log4jLogger = sc._jvm.org.apache.log4j
+LOGGER = log4jLogger.LogManager.getLogger(__name__)
+
+# ucx[jvm-access-in-shared-clusters:+1:0:+1:7] Cannot access Spark Driver JVM on UC Shared Clusters
+# ucx[legacy-context-in-shared-clusters:+1:0:+1:7] sc is not supported on UC Shared Clusters. Rewrite it using spark
+# ucx[spark-logging-in-shared-clusters:+1:12:+1:24] Cannot access Spark Driver JVM logger on UC Shared Clusters. Use logging.getLogger() instead
+sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")

--- a/tests/unit/source_code/test_functional.py
+++ b/tests/unit/source_code/test_functional.py
@@ -47,7 +47,7 @@ class Functional:
 
     def verify(self):
         expected_problems = list(self._expected_problems())
-        actual_problems = list(self._lint())
+        actual_problems = sorted(list(self._lint()), key=lambda a: (a.start_line, a.start_col))
         high_level_expected = [f'{p.code}:{p.message}' for p in expected_problems]
         high_level_actual = [f'{p.code}:{p.message}' for p in actual_problems]
         assert high_level_expected == high_level_actual


### PR DESCRIPTION
## Changes
This PR adds deduplication of errors emitted by Spark Connect linter. It also adds more functional tests using the new framework

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
