### PR TITLE
Further fix for DENY permissions

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -120,11 +120,15 @@ class Grant:
         # See https://docs.databricks.com/en/sql/language-manual/security-grant.html
         statements = []
         actions = self.action_type.split(", ")
-        if "OWN" in actions:
-            actions.remove("OWN")
+        deny_actions = [action for action in actions if "DENIED" in action]
+        grant_actions = [action for action in actions if "DENIED" not in action]
+        if "OWN" in grant_actions:
+            grant_actions.remove("OWN")
             statements.append(self._set_owner_sql(object_type, object_key))
-        if actions:
-            statements.append(self._apply_grant_sql(", ".join(actions), object_type, object_key))
+        if grant_actions:
+            statements.append(self._apply_grant_sql(", ".join(grant_actions), object_type, object_key))
+        if deny_actions:
+            statements.append(self._apply_grant_sql(", ".join(deny_actions), object_type, object_key))
         return statements
 
     def hive_revoke_sql(self) -> str:


### PR DESCRIPTION
## Changes
- Legacy TACL migration logic currently grouped all permissions in a single `GRANT` statement. Split this into 2 separate statements, one for `DENY` and one for `GRANT`
- Added more unit tests, and added integration tests

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
