### PR TITLE
Fix test failure `test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only`

### DIFF
--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -190,7 +190,7 @@ def test_running_real_remove_backup_groups_job(ws, installation_ctx):
         ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
-    with pytest.raises(NotFound):
+    with pytest.raises(NotFound, match=f"Group with id {ws_group_a.id} not found."):
         get_group(ws_group_a.id)
 
 

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -94,7 +94,13 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
 ):
     ws_group, _ = make_ucx_group()
 
-    group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
+    group_manager = GroupManager(
+        sql_backend,
+        ws,
+        inventory_schema,
+        [ws_group.display_name],
+        "ucx-temp-",
+    )
     group_manager.rename_groups()
     group_manager.reflect_account_groups_on_workspace()
     group_manager.delete_original_workspace_groups()

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -111,7 +111,7 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
         ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
-    with pytest.raises(NotFound):
+    with pytest.raises(NotFound, match=f"Group with id {ws_group.id} not found."):
         get_group(ws_group.id)
 
 


### PR DESCRIPTION
## Changes
Fix test failure `test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only`

### Linked issues
Resolves #1830
Resolves #1841 

### Tests

- [x] manually tested
- [x] modified integration tests
