### PR TITLE
Fix flaky test test_instance_pools

### DIFF
--- a/tests/integration/workspace_access/test_generic.py
+++ b/tests/integration/workspace_access/test_generic.py
@@ -26,7 +26,7 @@ from . import apply_tasks
 
 
 @pytest.mark.parametrize("is_experimental", [True, False])
-@retried(on=[NotFound], timeout=timedelta(minutes=3))
+@retried(on=[NotFound, TimeoutError], timeout=timedelta(minutes=3))
 def test_instance_pools(
     ws: WorkspaceClient,
     migrated_group,


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
The test did not fail with the timeout error in the original issue. Added a retry on timeout error to reduce flakiness.

### Linked issues
Adds retried to avoid #1829

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
