### PR TITLE
Infer simple f-string values when computing values during linting

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/dbfs.py
+++ b/src/databricks/labs/ucx/source_code/linters/dbfs.py
@@ -6,8 +6,7 @@ import sqlglot
 from sqlglot.expressions import Table
 
 from databricks.labs.ucx.source_code.base import Advice, Linter, Deprecation
-from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeVisitor
-
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeVisitor, InferredValue
 
 logger = logging.getLogger(__file__)
 
@@ -29,30 +28,34 @@ class DetectDbfsVisitor(TreeVisitor):
 
     def _visit_arg(self, arg: NodeNG):
         try:
-            for inferred in arg.inferred():
-                if isinstance(inferred, Const) and isinstance(inferred.value, str):
-                    self._check_str_constant(arg, inferred)
+            for inferred in Tree(arg).infer_values():
+                if not inferred.is_inferred():
+                    logger.debug(f"Could not infer value of {arg.as_string()}")
+                    continue
+                self._check_str_constant(arg, inferred)
         except InferenceError as e:
             logger.debug(f"Could not infer value of {arg.as_string()}", exc_info=e)
 
     def visit_const(self, node: Const):
         # Constant strings yield Advisories
         if isinstance(node.value, str):
-            self._check_str_constant(node, node)
+            self._check_str_constant(node, InferredValue([node]))
 
-    def _check_str_constant(self, source_node, const_node: Const):
-        if self._already_reported(source_node, const_node):
+    def _check_str_constant(self, source_node, inferred: InferredValue):
+        if self._already_reported(source_node, inferred):
             return
-        value = const_node.value
+        value = inferred.as_string()
         if any(value.startswith(prefix) for prefix in self._fs_prefixes):
             advisory = Deprecation.from_node(
                 code='dbfs-usage', message=f"Deprecated file system path: {value}", node=source_node
             )
             self._advices.append(advisory)
 
-    def _already_reported(self, *nodes: NodeNG):
-        reported = any((node.lineno, node.col_offset) in self._reported_locations for node in nodes)
-        for node in nodes:
+    def _already_reported(self, source_node: NodeNG, inferred: InferredValue):
+        all_nodes = [source_node]
+        all_nodes.extend(inferred.nodes())
+        reported = any((node.lineno, node.col_offset) in self._reported_locations for node in all_nodes)
+        for node in all_nodes:
             self._reported_locations.add((node.lineno, node.col_offset))
         return reported
 

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.source_code.base import (
     Linter,
 )
 from databricks.labs.ucx.source_code.queries import FromTable
-from databricks.labs.ucx.source_code.linters.python_ast import Tree
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, InferredValue
 
 
 @dataclass
@@ -69,21 +69,22 @@ class QueryMatcher(Matcher):
 
     def lint(self, from_table: FromTable, index: MigrationIndex, node: Call) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
-        try:
-            for inferred in table_arg.inferred():
-                yield from self._lint_table_arg(from_table, node, inferred)
-        except InferenceError:
-            yield Advisory.from_node(
-                code='table-migrate',
-                message=f"Can't migrate table_name argument in '{node.as_string()}' because its value cannot be computed",
-                node=node,
-            )
+        if table_arg:
+            try:
+                for inferred in Tree(table_arg).infer_values():
+                    yield from self._lint_table_arg(from_table, node, inferred)
+            except InferenceError:
+                yield Advisory.from_node(
+                    code='table-migrate',
+                    message=f"Can't migrate table_name argument in '{node.as_string()}' because its value cannot be computed",
+                    node=node,
+                )
 
     @classmethod
-    def _lint_table_arg(cls, from_table: FromTable, call_node: NodeNG, inferred: NodeNG):
-        if isinstance(inferred, Const):
-            for advice in from_table.lint(inferred.value):
-                yield advice.replace_from_node(inferred)
+    def _lint_table_arg(cls, from_table: FromTable, call_node: NodeNG, inferred: InferredValue):
+        if inferred.is_inferred():
+            for advice in from_table.lint(inferred.as_string()):
+                yield advice.replace_from_node(call_node)
         else:
             yield Advisory.from_node(
                 code='table-migrate',

--- a/src/databricks/labs/ucx/source_code/linters/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/linters/python_ast.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Iterable
 from typing import TypeVar
 
-from astroid import Attribute, Call, Name, parse, Module, NodeNG, Const, Import, ImportFrom  # type: ignore
+from astroid import Assign, Attribute, Call, Name, parse, Module, NodeNG, Const, Import, ImportFrom  # type: ignore
 
 logger = logging.getLogger(__file__)
 
@@ -161,6 +161,11 @@ class MatchingVisitor(TreeVisitor):
     @property
     def matched_nodes(self):
         return self._matched_nodes
+
+    def visit_assign(self, node: Assign):
+        if self._node_type is not Assign:
+            return
+        self._matched_nodes.append(node)
 
     def visit_call(self, node: Call):
         if self._node_type is not Call:

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -51,9 +51,9 @@ for i in range(10):
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
             start_line=3,
-            start_col=23,
+            start_col=13,
             end_line=3,
-            end_col=49,
+            end_col=50,
         ),
     ]
 
@@ -81,9 +81,9 @@ for i in range(10):
             code='table-migrate',
             message='Table old.things is migrated to brand.new.stuff in Unity Catalog',
             start_line=3,
-            start_col=44,
+            start_col=13,
             end_line=3,
-            end_col=70,
+            end_col=71,
         ),
     ]
 

--- a/tests/unit/source_code/linters/test_python_ast.py
+++ b/tests/unit/source_code/linters/test_python_ast.py
@@ -1,8 +1,5 @@
-from collections.abc import Iterator, Iterable
-from typing import cast
-
 import pytest
-from astroid import Assign, Attribute, Call, Const, Expr, FormattedValue, JoinedStr, Name, NodeNG  # type: ignore
+from astroid import Assign, Attribute, Call, Const, Expr  # type: ignore
 
 from databricks.labs.ucx.source_code.linters.python_ast import Tree
 
@@ -88,6 +85,30 @@ def test_tree_walks_nodes_once():
     assert len(nodes) == count
 
 
+def test_infers_empty_list():
+    tree = Tree.parse("a=[]")
+    nodes = tree.locate(Assign, [])
+    tree = Tree(nodes[0].value)
+    values = list(tree.infer_values())
+    assert not values
+
+
+def test_infers_empty_tuple():
+    tree = Tree.parse("a=tuple()")
+    nodes = tree.locate(Assign, [])
+    tree = Tree(nodes[0].value)
+    values = list(tree.infer_values())
+    assert not values
+
+
+def test_infers_empty_set():
+    tree = Tree.parse("a={}")
+    nodes = tree.locate(Assign, [])
+    tree = Tree(nodes[0].value)
+    values = list(tree.infer_values())
+    assert not values
+
+
 def test_infers_fstring_value():
     source = """
 value = "abc"
@@ -95,11 +116,11 @@ fstring = f"Hello {value}!"
 """
     tree = Tree.parse(source)
     nodes = tree.locate(Assign, [])
-    tree = Tree(nodes[1].value) # value of fstring = ...
-    unresolved, values = tree.infer_values()
-    assert not unresolved
-    joined = Tree.string_from_consts(values[0])
-    assert joined == "Hello abc!"
+    tree = Tree(nodes[1].value)  # value of fstring = ...
+    values = list(tree.infer_values())
+    assert all(value.is_inferred() for value in values)
+    strings = list(value.as_string() for value in values)
+    assert strings == ["Hello abc!"]
 
 
 def test_infers_fstring_values():
@@ -113,16 +134,14 @@ for value1 in values_1:
     tree = Tree.parse(source)
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[2].value)  # value of fstring = ...
-    unresolved, values = tree.infer_values()
-    assert not unresolved
-    strings: list[str] = []
-    for value in values:
-        joined = Tree.string_from_consts(value)
-        strings.append(joined)
+    values = list(tree.infer_values())
+    assert all(value.is_inferred() for value in values)
+    strings = list(value.as_string() for value in values)
     assert strings == ["Hello abc, ghi!", "Hello abc, jkl!", "Hello def, ghi!", "Hello def, jkl!"]
 
 
 def test_fails_to_infer_cascading_fstring_values():
+    # The purpose of this test s to detect a change in astroid support for f-strings
     source = """
     value1 = "John"
     value2 = f"Hello {value1}"
@@ -131,7 +150,7 @@ def test_fails_to_infer_cascading_fstring_values():
     tree = Tree.parse(source)
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[2].value)  # value of value3 = ...
-    unresolved, values = tree.infer_values()
-    assert unresolved
-    joined = Tree.string_from_consts(values[0])
-    # assert joined == "Hello John, how are you today?"
+    values = list(tree.infer_values())
+    # for now, we simply check failure to infer!
+    assert any(not value.is_inferred() for value in values)
+    # the expected value would be ["Hello John, how are you today?"]

--- a/tests/unit/source_code/samples/functional/file-access/direct-fs2.py
+++ b/tests/unit/source_code/samples/functional/file-access/direct-fs2.py
@@ -1,13 +1,16 @@
 # ucx[direct-filesystem-access:+1:0:+1:34] The use of direct filesystem references is deprecated: s3://bucket/path
 spark.read.csv("s3://bucket/path")
 for i in range(10):
-    # ucx[table-migrate:+1:23:+1:49] Table old.things is migrated to brand.new.stuff in Unity Catalog
+    # ucx[table-migrate:+1:13:+1:50] Table old.things is migrated to brand.new.stuff in Unity Catalog
     result = spark.sql("SELECT * FROM old.things").collect()
     print(len(result))
-# ucx[table-migrate:+2:0:+2:41] Can't migrate table_name argument in 'spark.sql(f'SELECT * FROM table_{index}')' because its value cannot be computed
 index = 10
 spark.sql(f"SELECT * FROM table_{index}").collect()
-# ucx[table-migrate:+2:14:+2:40] Table old.things is migrated to brand.new.stuff in Unity Catalog
-# ucx[table-migrate:+2:4:+2:20] Can't migrate table_name argument in 'spark.sql(query)' because its value cannot be computed
-for query in ["SELECT * FROM old.things", f"SELECT * FROM table_{index}"]:
+# ucx[table-migrate:+2:0:+2:40] Can't migrate table_name argument in 'spark.sql(f'SELECT * FROM {table_name}')' because its value cannot be computed
+table_name = f"table_{index}"
+spark.sql(f"SELECT * FROM {table_name}").collect()
+# ucx[table-migrate:+4:4:+4:20] Table old.things is migrated to brand.new.stuff in Unity Catalog
+# ucx[table-migrate:+3:4:+3:20] Can't migrate table_name argument in 'spark.sql(query)' because its value cannot be computed
+table_name = f"table_{index}"
+for query in ["SELECT * FROM old.things", f"SELECT * FROM {table_name}"]:
     spark.sql(query).collect()

--- a/tests/unit/source_code/samples/sys-path-with-fstring.py
+++ b/tests/unit/source_code/samples/sys-path-with-fstring.py
@@ -1,6 +1,7 @@
 import sys
 name_1 = "whatever"
-sys.path.append(f"{name_1}")
-names = [ f"{name_1}", name_1 ]
+name_2 = f"{name_1}"
+sys.path.append(f"{name_2}")
+names = [ f"{name_2}", name_2 ]
 for name in names:
     sys.path.append(name)

--- a/tests/unit/source_code/test_dependencies.py
+++ b/tests/unit/source_code/test_dependencies.py
@@ -195,20 +195,20 @@ def test_dependency_resolver_raises_problem_for_non_inferable_sys_path(simple_de
     assert list(maybe.problems) == [
         DependencyProblem(
             code='sys-path-cannot-compute',
-            message="Can't update sys.path from f'{name_1}' because the expression cannot be computed",
+            message="Can't update sys.path from f'{name_2}' because the expression cannot be computed",
             source_path=Path('sys-path-with-fstring.py'),
-            start_line=2,
+            start_line=3,
             start_col=16,
-            end_line=2,
+            end_line=3,
             end_col=27,
         ),
         DependencyProblem(
             code='sys-path-cannot-compute',
             message="Can't update sys.path from name because the expression cannot be computed",
             source_path=Path('sys-path-with-fstring.py'),
-            start_line=5,
+            start_line=6,
             start_col=20,
-            end_line=5,
+            end_line=6,
             end_col=24,
         ),
     ]


### PR DESCRIPTION
## Changes
Add support for f-strings not natively supported by astroid
Adjust existing linters accordingly

Works for simple f-strings such as:
```
a = "value"
some_function(f"some {a}")

```
but not for f-strings of f-strings such as:

```
a = "value"
b = f"some {a}"
some_function(f"{b} is better than none")

```

### Linked issues
Resolves #1871 
Progresses #1205

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
