### PR TITLE
Added table property for upgrade errors.

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -82,6 +82,8 @@ class TableToMigrate:
 class TableMapping:
     FILENAME = 'mapping.csv'
     UCX_SKIP_PROPERTY = "databricks.labs.ucx.skip"
+    UCX_MIGRATE_ERROR_PROPERTY = "databricks.labs.ucx.upgrade_error"
+    UCX_ACL_ERROR_PROPERTY = "databricks.labs.ucx.acl_error"
 
     def __init__(
         self,


### PR DESCRIPTION
closes #1754
Mark tables that failed to upgrade in using table migrate with the migration error.
Display the upgrade error on the migration dashboard.