### PR TITLE
Install pytest from https index url instead for http in integration test

### DIFF
--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -34,6 +34,15 @@ def test_build_notebook_dependency_graphs_installs_pytest_from_index_url(simple_
     assert not maybe.problems
 
 
+def test_build_notebook_dependency_graphs_installs_pypi_packages(simple_ctx):
+    ctx = simple_ctx.replace(path_lookup=MockPathLookup())
+    maybe = ctx.dependency_resolver.build_notebook_dependency_graph(Path("pip_install_multiple_packages"))
+    assert not maybe.problems
+    assert maybe.graph.path_lookup.resolve(Path("splink"))
+    assert maybe.graph.path_lookup.resolve(Path("mlflow"))
+    assert maybe.graph.path_lookup.resolve(Path("hyperopt"))
+
+
 @pytest.mark.xfail(reason="Spaces in path are not handled by subprocess when quoted")
 @pytest.mark.parametrize("notebook", ("pip_install_demo_wheel_with_spaces_in_target_directory",))
 def test_build_notebook_dependency_graphs_fails_installing_when_spaces(simple_ctx, notebook):

--- a/tests/unit/source_code/samples/pip_install_multiple_packages.py
+++ b/tests/unit/source_code/samples/pip_install_multiple_packages.py
@@ -1,0 +1,5 @@
+# Databricks notebook source
+
+# COMMAND ----------
+
+# MAGIC %pip install --quiet splink mlflow hyperopt

--- a/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
+++ b/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
@@ -2,7 +2,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install pytest --index-url http://pypi.python.org/simple
+# MAGIC %pip install pytest --index-url https://pypi.python.org/simple
 
 # COMMAND ----------
 


### PR DESCRIPTION
## Changes
Install pytest from https index url. Pip complained about the http link

### Tests

- [x] manually tested
- [x] modified integration tests `test_build_notebook_dependency_graphs_installs_pytest_from_index_url`
