### PR TITLE
Include findings on `DENY` grants during assessment

### DIFF
--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -271,6 +271,12 @@ The final row includes "Incompatible Delta Live Tables" and "Incompatible Global
 
 [[back to top](#migration-assessment-report)]
 
+## Incompatible Object Privileges
+
+These are permissions on objects that are not supported by Unit Catalog.
+
+[[back to top](#migration-assessment-report)]
+
 ## Incompatible Delta Live Tables
 
 These are Delta Live Table jobs that may be incompatible with Unity Catalog.

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -448,6 +448,12 @@ CREATE TABLE [IF NOT EXISTS] table_name
 
 [[back to top](#migration-assessment-report)]
 
+### AF222 - Explicitly DENYing privileges is not supported in UC
+
+Unity Catalog does not support `DENY` permissions on securable objects. These permissions will be updated during group migration, but won't be transferred during catalog migration.
+
+[[back to top](#migration-assessment-report)]
+
 ## AF300 - AF399
 The 300 series findings relate to [Compute Access mode limitations for Unity Catalog](https://docs.databricks.com/en/compute/access-mode-limitations.html#spark-api-limitations-for-unity-catalog-shared-access-mode)
 

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -207,7 +207,7 @@ This is a summary count of Hive Metastore tables, per storage type (DBFS Root, D
 
 ## Table counts by schema and format
 
-This is a summary count by Hive Metastore (HMS) table formats (Delta and Non Delta) for each HMS schema    
+This is a summary count by Hive Metastore (HMS) table formats (Delta and Non Delta) for each HMS schema
 
 The third row continues with "Database Summary"
 <img width="1220" alt="image" src="https://github.com/databrickslabs/ucx/assets/1122251/28742e33-d3e3-4eb8-832f-1edd34999fa2">
@@ -232,7 +232,7 @@ Tables were scanned for `LOCATION` attributes and that list was distilled down t
 
 ## Mount Points
 
-Mount points are popular means to provide access to external buckets / storage accounts. A more secure form in Unity Catalog are EXTERNAL LOCATIONs and VOLUMES. EXTERNAL LOCATIONs are the basis for EXTERNAL Tables, Schemas, Catalogs and VOLUMES. VOLUMES are the basis for managing files. 
+Mount points are popular means to provide access to external buckets / storage accounts. A more secure form in Unity Catalog are EXTERNAL LOCATIONs and VOLUMES. EXTERNAL LOCATIONs are the basis for EXTERNAL Tables, Schemas, Catalogs and VOLUMES. VOLUMES are the basis for managing files.
 The recommendation is to migrate Mountpoints to Either EXTERNAL LOCATIONS or VOLUMEs. The Unity Catalog Create External Location UI will prompt for mount points to assist in creating EXTERNAL LOCATIONS.
 
 Unfortunately, as of January 2024, cross cloud external locations are not supported. Databricks to Databricks delta sharing may assist in upgrading cross cloud mounts.
@@ -296,7 +296,7 @@ The assessment finding index is grouped by:
 ### AF101 - not supported DBR: ##.#.x-scala2.12
 
 Short description: The compute runtime does not meet the requirements to use Unity Catalog.
-Explanation: Unity Catalog capabilities are fully enabled on Databricks Runtime 13.3 LTS. This is the current recommended runtime for production interactive clusters and jobs. This finding is noting the cluster or job compute configuration does not meet this threshold. 
+Explanation: Unity Catalog capabilities are fully enabled on Databricks Runtime 13.3 LTS. This is the current recommended runtime for production interactive clusters and jobs. This finding is noting the cluster or job compute configuration does not meet this threshold.
 recommendation: Upgrade the DBR version to 13.3 LTS or later.
 
 [[back to top](#migration-assessment-report)]
@@ -376,10 +376,10 @@ How: Run the SYNC command on the table or schema.  If the tables (or source data
 ### AF202 - Asset Replication Required
 
 We found that the table or database needs to have the data copied into a Unity Catalog managed location or table.
-Recommendation: Perform a 'deep clone' operation on the table to copy the files 
+Recommendation: Perform a 'deep clone' operation on the table to copy the files
 ```sql
 CREATE TABLE [IF NOT EXISTS] table_name
-   [SHALLOW | DEEP] CLONE source_table_name [TBLPROPERTIES clause] [LOCATION path]   
+   [SHALLOW | DEEP] CLONE source_table_name [TBLPROPERTIES clause] [LOCATION path]
 ```
 
 [[back to top](#migration-assessment-report)]
@@ -437,7 +437,7 @@ where storage type can be any of `adl://`, `wasb://`, or `wasbs://`.
 ADLS Gen 2 (`abfss://`) is the only Azure native storage type supported. Use a Deep Clone process to copy the table data.
 ```sql
 CREATE TABLE [IF NOT EXISTS] table_name
-   [SHALLOW | DEEP] CLONE source_table_name [TBLPROPERTIES clause] [LOCATION path]   
+   [SHALLOW | DEEP] CLONE source_table_name [TBLPROPERTIES clause] [LOCATION path]
 ```
 
 [[back to top](#migration-assessment-report)]
@@ -595,7 +595,7 @@ The `boto3` library is used.
 Instance profiles (AWS) are not supported from the Python/Scala REPL or UDFs, e.g. using boto3 or s3fs, Instance profiles are only set from init scripts and (internally) from Spark. To access S3 objects the recommendation is to use EXTERNAL VOLUMES mapped to the fixed s3 storage location.
 
 **Workarounds**
-For accessing cloud storage (S3), use storage credentials and external locations. 
+For accessing cloud storage (S3), use storage credentials and external locations.
 
 (AWS) Consider other ways to authenticate with boto3, e.g., by passing credentials from Databricks secrets directly to boto3 as a parameter, or loading them as environment variables. This page contains more information. Please note that unlike instance profiles, those methods do not provide short-lived credentials out of the box, and customers are responsible for rotating secrets according to their security needs.
 
@@ -640,7 +640,7 @@ The `dbutils.credentials.` is used for credential passthrough. This is not suppo
 
 ## AF311.x - dbutils (`dbutils`)
 
-DBUtils and other clients that directly read the data from cloud storage are not supported. 
+DBUtils and other clients that directly read the data from cloud storage are not supported.
 Use [Volumes](https://docs.databricks.com/en/connect/unity-catalog/volumes.html) or use Assigned clusters.
 
 ### AF311.1 - dbutils.fs (`dbutils.fs.`)
@@ -711,7 +711,7 @@ The `from pyspark.sql import SQLContext` and `import org.apache.spark.sql.SQLCon
 
 ### AF313.3 - SparkContext (`.binaryFiles`)
 
-The `.binaryFiles` pattern was found, this is not supported by Unity Catalog. 
+The `.binaryFiles` pattern was found, this is not supported by Unity Catalog.
 Instead, please consider using `spark.read.format('binaryFiles')`.
 
 [[back to top](#migration-assessment-report)]
@@ -793,7 +793,7 @@ display(df)
 use:
 ```python
 from pyspark.sql import Row
-import json 
+import json
 # Sample JSON data as a list of dictionaries (similar to JSON objects)
 json_data_str = response.text
 json_data = [json.loads(json_data_str)]
@@ -976,7 +976,7 @@ The `mapInPandas` pattern was found. Use "Assigned" access mode compute.
 
 
 ## AF330.x - Streaming
-Streaming limitations for Unity Catalog shared access mode [documentation](https://docs.databricks.com/en/compute/access-mode-limitations.html#streaming-limitations-for-unity-catalog-shared-access-mode) should be consulted for more details. 
+Streaming limitations for Unity Catalog shared access mode [documentation](https://docs.databricks.com/en/compute/access-mode-limitations.html#streaming-limitations-for-unity-catalog-shared-access-mode) should be consulted for more details.
 
 See also [Streaming limitations for Unity Catalog single user access mode](https://docs.databricks.com/en/compute/access-mode-limitations.html#streaming-single) and [Streaming limitations for Unity Catalog shared access mode](https://docs.databricks.com/en/compute/access-mode-limitations.html#streaming-shared).
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -110,8 +110,8 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
             functools.partial(table, "recon_results", ReconResult),
         ],
     )
-    deployer.deploy_view("objects", "queries/views/objects.sql")
     deployer.deploy_view("grant_detail", "queries/views/grant_detail.sql")
+    deployer.deploy_view("objects", "queries/views/objects.sql")
     deployer.deploy_view("table_estimates", "queries/views/table_estimates.sql")
     deployer.deploy_view("misc_patterns", "queries/views/misc_patterns.sql")
     deployer.deploy_view("code_patterns", "queries/views/code_patterns.sql")

--- a/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
@@ -1,10 +1,8 @@
--- viz type=table, name=Grants, columns=finding, principal,action_type,catalog,database,object_type,object_id,principal
+-- viz type=table, name=Grants, columns=finding, principal,action_type,object_type,object_id,principal
 -- widget title=Incompatible Object Privileges, row=41, col=0, size_x=6, size_y=8
 SELECT
     EXPLODE(FROM_JSON(failures, 'array<string>')) AS finding,
     action_type,
-    catalog,
-    database,
     object_type,
     object_id,
     principal,
@@ -12,4 +10,4 @@ SELECT
 FROM $inventory.grant_detail
 WHERE startswith(action_type, 'DENIED_')
 ORDER BY
-    catalog, database, object_id, object_type, action_type, principal, principal_type
+    object_id, object_type, action_type, principal, principal_type

--- a/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
@@ -1,4 +1,4 @@
--- viz type=table, name=Grants, columns=finding, principal,action_type,object_type,object_id,principal
+-- viz type=table, name=Grants, columns=finding,action_type,object_type,object_id,principal,principal_type
 -- widget title=Incompatible Object Privileges, row=41, col=0, size_x=6, size_y=8
 SELECT
     EXPLODE(FROM_JSON(failures, 'array<string>')) AS finding,

--- a/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/35_0_grants.sql
@@ -1,0 +1,15 @@
+-- viz type=table, name=Grants, columns=finding, principal,action_type,catalog,database,object_type,object_id,principal
+-- widget title=Incompatible Object Privileges, row=41, col=0, size_x=6, size_y=8
+SELECT
+    EXPLODE(FROM_JSON(failures, 'array<string>')) AS finding,
+    action_type,
+    catalog,
+    database,
+    object_type,
+    object_id,
+    principal,
+    principal_type
+FROM $inventory.grant_detail
+WHERE startswith(action_type, 'DENIED_')
+ORDER BY
+    catalog, database, object_id, object_type, action_type, principal, principal_type

--- a/src/databricks/labs/ucx/queries/assessment/main/40___last_summary.md
+++ b/src/databricks/labs/ucx/queries/assessment/main/40___last_summary.md
@@ -1,6 +1,7 @@
 -- widget title=Assessment overview, row=40, col=2, size_x=8, size_y=3
 
 ## Other
+- Object permissions
 - Delta Live Tables
 - Global Init Scripts
 - Warning messages

--- a/src/databricks/labs/ucx/queries/views/objects.sql
+++ b/src/databricks/labs/ucx/queries/views/objects.sql
@@ -9,7 +9,7 @@ UNION ALL
 SELECT "pipelines" AS object_type, pipeline_id AS object_id, failures FROM $inventory.pipelines
 UNION ALL
 SELECT object_type, object_id, failures FROM (
-  SELECT "tables" as object_type, CONCAT(t.catalog, '.', t.database, '.', t.name) AS object_id, 
+  SELECT "tables" as object_type, CONCAT(t.catalog, '.', t.database, '.', t.name) AS object_id,
   TO_JSON(
     FILTER(ARRAY(
       IF(NOT STARTSWITH(t.table_format, "DELTA"), CONCAT("Non-DELTA format: ", t.table_format), NULL),

--- a/src/databricks/labs/ucx/queries/views/objects.sql
+++ b/src/databricks/labs/ucx/queries/views/objects.sql
@@ -31,3 +31,5 @@ SELECT object_type, object_id, failures FROM (
 UNION ALL
 SELECT "databases" AS object_type, CONCAT(catalog, '.', database) AS object_id, TO_JSON(ARRAY(error)) AS failures
 FROM $inventory.table_failures WHERE name IS NULL
+UNION ALL
+SELECT "permissions" AS object_type, object_id, failures FROM $inventory.grant_detail

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -472,7 +472,7 @@ class TestRuntimeContext(CommonUtils, RuntimeContext):
 
 
 @pytest.fixture
-def runtime_ctx(ws, sql_backend, make_table, make_schema, make_udf, make_group, env_or_skip):
+def runtime_ctx(ws, sql_backend, make_table, make_schema, make_udf, make_group, env_or_skip) -> TestRuntimeContext:
     ctx = TestRuntimeContext(make_table, make_schema, make_udf, make_group, env_or_skip, ws)
     return ctx.replace(workspace_client=ws, sql_backend=sql_backend)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -277,22 +277,22 @@ class TestRuntimeContext(CommonUtils, RuntimeContext):
     def with_workspace_info(self, workspace_info):
         self.installation.save(workspace_info, filename=AccountWorkspaces.SYNC_FILE_NAME)
 
-    def make_schema(self, **kwargs):
+    def make_schema(self, **kwargs) -> SchemaInfo:
         schema_info = self._make_schema(**kwargs)
         self._schemas.append(schema_info)
         return schema_info
 
-    def make_group(self, **kwargs):
+    def make_group(self, **kwargs) -> Group:
         group_info = self._make_group(**kwargs)
         self._groups.append(group_info)
         return group_info
 
-    def make_table(self, **kwargs):
+    def make_table(self, **kwargs) -> TableInfo:
         table_info = self._make_table(**kwargs)
         self._tables.append(table_info)
         return table_info
 
-    def make_udf(self, **kwargs):
+    def make_udf(self, **kwargs) -> FunctionInfo:
         udf_info = self._make_udf(**kwargs)
         self._udfs.append(udf_info)
         return udf_info
@@ -310,7 +310,7 @@ class TestRuntimeContext(CommonUtils, RuntimeContext):
         udf: str | None = None,
         any_file: bool = False,
         anonymous_function: bool = False,
-    ):
+    ) -> Grant:
         if table_info:
             catalog = table_info.catalog_name
             database = table_info.schema_name

--- a/tests/integration/hive_metastore/test_grant_detail.py
+++ b/tests/integration/hive_metastore/test_grant_detail.py
@@ -1,0 +1,60 @@
+import json
+import logging
+import datetime as dt
+
+import pytest
+from databricks.sdk.errors import NotFound
+from databricks.sdk.retries import retried
+
+from databricks.labs.lsql.backends import StatementExecutionBackend
+from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
+from databricks.labs.ucx.install import deploy_schema
+
+from ..conftest import TestRuntimeContext
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def _deployed_schema(runtime_ctx) -> None:
+    """Ensure that the schemas (and views) are initialized."""
+    # Takes ~11 seconds.
+    deploy_schema(runtime_ctx.sql_backend, runtime_ctx.inventory_database)
+
+
+@retried(on=[NotFound, TimeoutError], timeout=dt.timedelta(minutes=3))
+def test_grant_findings(
+    runtime_ctx: TestRuntimeContext, sql_backend: StatementExecutionBackend, _deployed_schema: None
+) -> None:
+    """Test that findings are reported for a grant."""
+
+    # Fixture: two objects, one with a grant that is okay and the other with a grant that is not okay.
+    group = runtime_ctx.make_group()
+    schema = runtime_ctx.make_schema()
+    table_a = runtime_ctx.make_table(schema_name=schema.name)
+    table_b = runtime_ctx.make_table(schema_name=schema.name)
+    sql_backend.execute(f"GRANT SELECT ON TABLE {table_a.full_name} TO `{group.display_name}`")
+    sql_backend.execute(f"DENY SELECT ON TABLE {table_b.full_name} TO `{group.display_name}`")
+
+    # Ensure the view is populated (it's based on the crawled grants) and fetch the content.
+    GrantsCrawler(runtime_ctx.tables_crawler, runtime_ctx.udfs_crawler).snapshot()
+
+    rows = sql_backend.fetch(
+        f"""
+        SELECT object_type, object_id, success, failures
+        FROM {runtime_ctx.inventory_database}.grant_detail
+        WHERE catalog='{schema.catalog_name}' AND database='{schema.name}'
+          AND principal_type='group' AND principal='{group.display_name}'
+        """
+    )
+    grants = {
+        (row.object_type, row.object_id): (row.success, json.loads(row.failures) if row.failures is not None else None)
+        for row in rows
+    }
+
+    # Check the findings on our objects.
+    expected_grants = {
+        ("TABLE", table_a.full_name): (1, []),
+        ("TABLE", table_b.full_name): (0, ["Explicitly DENYing privileges is not supported in UC."]),
+    }
+    assert grants == expected_grants


### PR DESCRIPTION
## Changes

This PR adds support for flagging DENY permissions on objects, which cannot be migrated to UC.

It also adds some new integration tests for existing grant-scanning.

### Linked issues

Resolves #1869, supersedes #1890.

### Functionality 

- [x] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [X] modified existing workflow: `assessment`
- [ ] added a new table
- [ ] modified existing table: `...`
- [x] modified existing view: `grant_detail`

### Tests

- [x] manually tested
- [ ] added unit tests
- [X] added integration tests
- [x] verified on staging environment (screenshot attached)
