### PR TITLE
Dashboard: N/A instead of NULL readiness while assessment job hasn't yet provided any data

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/00_0_compatibility.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/00_0_compatibility.sql
@@ -1,7 +1,7 @@
 -- viz type=counter, name=Workspace UC readiness, counter_label=UC readiness, value_column=readiness
 -- widget row=1, col=0, size_x=1, size_y=3
 WITH raw AS (
-  SELECT object_type, object_id, IF(failures == '[]', 1, 0) AS ready 
+  SELECT object_type, object_id, IF(failures == '[]', 1, 0) AS ready
   FROM $inventory.objects
 )
-SELECT CONCAT(ROUND(SUM(ready) / COUNT(*) * 100, 1), '%') AS readiness FROM raw
+SELECT COALESCE(CONCAT(ROUND(SUM(ready) / COUNT(*) * 100, 1), '%'), 'N/A') AS readiness FROM raw


### PR DESCRIPTION
## Changes

This PR modifies the dashboard to display N/A instead of NULL as the readiness during assessment startup when there isn't any data available yet.  

### Functionality 

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [X] modified existing workflow: `assessment`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [X] verified on staging environment (screenshot attached)

![image](https://github.com/databrickslabs/ucx/assets/401970/b3a57875-944e-4944-8048-fc86312314f8)
