### PR TITLE
Expose code linters as a LSP plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,16 @@ dependencies = ["databricks-sdk>=0.27,<0.29",
                 "sqlglot>=23.9,<25.2",
                 "astroid>=3.2.2"]
 
+[project.optional-dependencies]
+pylsp = [
+    "python-lsp-server>=1.9.0"
+]
+
 [project.entry-points.databricks]
 runtime = "databricks.labs.ucx.runtime:main"
+
+[project.entry-points.pylsp]
+plugin = "databricks.labs.ucx.source_code.lsp_plugin"
 
 [project.urls]
 Issues = "https://github.com/databricks/ucx/issues"
@@ -74,6 +82,7 @@ dependencies = [
     "pytest-mock~=3.14.0",
     "pytest-timeout~=2.3.1",
     "pytest-xdist~=3.5.0",
+    "python-lsp-server>=1.9.0",
     "ruff~=0.3.4",
     "types-PyYAML~=6.0.12",
     "types-requests~=2.31.0",

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -113,11 +113,11 @@ class Advisory(Advice):
     """A warning that does not prevent the code from running."""
 
 
-class Failure(Advisory):
+class Failure(Advice):
     """An error that prevents the code from running."""
 
 
-class Deprecation(Advisory):
+class Deprecation(Advice):
     """An advisory that suggests to replace the code with a newer version."""
 
 

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -12,26 +12,36 @@ from databricks.labs.ucx.source_code.queries import FromTable
 
 
 class LinterContext:
-    def __init__(self, index: MigrationIndex, session_state: CurrentSessionState | None = None):
+    def __init__(self, index: MigrationIndex | None, session_state: CurrentSessionState | None = None):
         self._index = index
         session_state = CurrentSessionState() if not session_state else session_state
-        from_table = FromTable(index, session_state=session_state)
-        dbfs_from_folder = FromDbfsFolder()
+
+        python_linters: list[Linter] = [
+            DBFSUsageLinter(session_state),
+            DBRv8d0Linter(dbr_version=None),
+            SparkConnectLinter(is_serverless=False),
+            DbutilsLinter(session_state),
+        ]
+        python_fixers: list[Fixer] = []
+
+        sql_linters: list[Linter] = [FromDbfsFolder()]
+        sql_fixers: list[Fixer] = []
+
+        if index is not None:
+            from_table = FromTable(index, session_state=session_state)
+            python_linters.append(SparkSql(from_table, index, session_state))
+            python_fixers.append(SparkSql(from_table, index, session_state))
+
+            sql_linters.append(from_table)
+            sql_fixers.append(from_table)
+
         self._linters = {
-            Language.PYTHON: SequentialLinter(
-                [
-                    SparkSql(from_table, index, session_state),
-                    DBFSUsageLinter(session_state),
-                    DBRv8d0Linter(dbr_version=None),
-                    SparkConnectLinter(is_serverless=False),
-                    DbutilsLinter(session_state),
-                ]
-            ),
-            Language.SQL: SequentialLinter([from_table, dbfs_from_folder]),
+            Language.PYTHON: SequentialLinter(python_linters),
+            Language.SQL: SequentialLinter(sql_linters),
         }
         self._fixers: dict[Language, list[Fixer]] = {
-            Language.PYTHON: [SparkSql(from_table, index, session_state)],
-            Language.SQL: [from_table],
+            Language.PYTHON: python_fixers,
+            Language.SQL: sql_fixers,
         }
 
     def is_supported(self, language: Language) -> bool:

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -12,19 +12,14 @@ from databricks.labs.ucx.source_code.queries import FromTable
 
 
 class LinterContext:
-    def __init__(self, index: MigrationIndex | None, session_state: CurrentSessionState | None = None):
+    def __init__(self, index: MigrationIndex | None = None, session_state: CurrentSessionState | None = None):
         self._index = index
         session_state = CurrentSessionState() if not session_state else session_state
 
-        python_linters: list[Linter] = [
-            DBFSUsageLinter(session_state),
-            DBRv8d0Linter(dbr_version=None),
-            SparkConnectLinter(is_serverless=False),
-            DbutilsLinter(session_state),
-        ]
+        python_linters: list[Linter] = []
         python_fixers: list[Fixer] = []
 
-        sql_linters: list[Linter] = [FromDbfsFolder()]
+        sql_linters: list[Linter] = []
         sql_fixers: list[Fixer] = []
 
         if index is not None:
@@ -34,6 +29,14 @@ class LinterContext:
 
             sql_linters.append(from_table)
             sql_fixers.append(from_table)
+
+        python_linters += [
+            DBFSUsageLinter(session_state),
+            DBRv8d0Linter(dbr_version=None),
+            SparkConnectLinter(is_serverless=False),
+            DbutilsLinter(session_state),
+        ]
+        sql_linters.append(FromDbfsFolder())
 
         self._linters = {
             Language.PYTHON: SequentialLinter(python_linters),

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -5,12 +5,11 @@ from databricks.sdk.service.workspace import Language
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.lsp import Diagnostic
 
-# TODO: initialize migration index and session state from config / env variables
-languages = LinterContext(index=None, session_state=None)
-
 
 @hookimpl
 def pylsp_lint(workspace: Workspace, document: Document) -> list[dict]:
+    # TODO: initialize migration index and session state from config / env variables
+    languages = LinterContext(index=None, session_state=None)
     analyser = languages.linter(Language.PYTHON)
     code = document.source
     diagnostics = [Diagnostic.from_advice(_) for _ in analyser.lint(code)]

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -7,7 +7,7 @@ from databricks.labs.ucx.source_code.lsp import Diagnostic
 
 
 @hookimpl
-def pylsp_lint(workspace: Workspace, document: Document) -> list[dict]:
+def pylsp_lint(workspace: Workspace, document: Document) -> list[dict]:  # pylint: disable=unused-argument
     # TODO: initialize migration index and session state from config / env variables
     languages = LinterContext(index=None, session_state=None)
     analyser = languages.linter(Language.PYTHON)

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -1,0 +1,17 @@
+from pylsp import hookimpl  # type: ignore
+from pylsp.workspace import Document, Workspace  # type: ignore
+from databricks.sdk.service.workspace import Language
+
+from databricks.labs.ucx.source_code.linters.context import LinterContext
+from databricks.labs.ucx.source_code.lsp import Diagnostic
+
+# TODO: initialize migration index and session state from config / env variables
+languages = LinterContext(index=None, session_state=None)
+
+
+@hookimpl
+def pylsp_lint(workspace: Workspace, document: Document) -> list[dict]:
+    analyser = languages.linter(Language.PYTHON)
+    code = document.source
+    diagnostics = [Diagnostic.from_advice(_) for _ in analyser.lint(code)]
+    return [d.as_dict() for d in diagnostics]

--- a/tests/unit/source_code/linters/test_dbfs.py
+++ b/tests/unit/source_code/linters/test_dbfs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from databricks.labs.ucx.source_code.base import Deprecation, Advisory, CurrentSessionState, Failure
+from databricks.labs.ucx.source_code.base import Deprecation, Advice, CurrentSessionState, Failure
 from databricks.labs.ucx.source_code.linters.dbfs import DBFSUsageLinter, FromDbfsFolder
 
 
@@ -20,7 +20,7 @@ class TestDetectDBFS:
         linter = DBFSUsageLinter(CurrentSessionState())
         advices = list(linter.lint(code))
         for advice in advices:
-            assert isinstance(advice, Advisory)
+            assert isinstance(advice, Advice)
         assert len(advices) == expected
 
     @pytest.mark.parametrize(

--- a/tests/unit/source_code/test_lsp_plugin.py
+++ b/tests/unit/source_code/test_lsp_plugin.py
@@ -10,19 +10,19 @@ from pylsp.config.config import Config  # type: ignore
 from databricks.labs.ucx.source_code import lsp_plugin
 
 
-@pytest.fixture()
-def workspace(tmp_path):
+@pytest.fixture
+def workspace(tmp_path) -> Workspace:
     uri = tmp_path.absolute().as_uri()
     config = Config(uri, {}, 0, {})
     ws = Workspace(uri, Mock(), config=config)
     return ws
 
 
-def temp_document(doc_text, workspace):
-    with tempfile.NamedTemporaryFile(mode="w", dir=workspace.root_path, delete=False) as temp_file:
+def temp_document(doc_text, ws):
+    with tempfile.NamedTemporaryFile(mode="w", dir=ws.root_path, delete=False) as temp_file:
         name = temp_file.name
         temp_file.write(doc_text)
-    doc = Document(uris.from_fs_path(name), workspace)
+    doc = Document(uris.from_fs_path(name), ws)
     return name, doc
 
 

--- a/tests/unit/source_code/test_lsp_plugin.py
+++ b/tests/unit/source_code/test_lsp_plugin.py
@@ -1,0 +1,50 @@
+import tempfile
+from unittest.mock import Mock
+
+import pytest
+
+from pylsp import uris  # type: ignore
+from pylsp.workspace import Document, Workspace  # type: ignore
+from pylsp.config.config import Config  # type: ignore
+
+from databricks.labs.ucx.source_code import lsp_plugin
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    uri = tmp_path.absolute().as_uri()
+    config = Config(uri, {}, 0, {})
+    ws = Workspace(uri, Mock(), config=config)
+    return ws
+
+
+def temp_document(doc_text, workspace):
+    with tempfile.NamedTemporaryFile(mode="w", dir=workspace.root_path, delete=False) as temp_file:
+        name = temp_file.name
+        temp_file.write(doc_text)
+    doc = Document(uris.from_fs_path(name), workspace)
+    return name, doc
+
+
+def test_pylsp_lint(workspace):
+    code = 'sc.emptyRDD()'
+    _, doc = temp_document(code, workspace)
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace, doc), key=lambda d: d['code'])
+    assert diagnostics == [
+        {
+            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 11}},
+            'code': 'legacy-context-in-shared-clusters',
+            'source': 'databricks.labs.ucx',
+            'message': 'sc is not supported on UC Shared Clusters. Rewrite it using spark',
+            'severity': 1,
+            'tags': [],
+        },
+        {
+            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 13}},
+            'code': 'rdd-in-shared-clusters',
+            'source': 'databricks.labs.ucx',
+            'message': 'RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API',
+            'severity': 1,
+            'tags': [],
+        },
+    ]


### PR DESCRIPTION
## Changes
Add a PyLSP plugin entrypoint for UCX code linters. When a user has `python-lsp-server` installed, UCX will automatically register an LSP plugin on installation. 

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
