### PR TITLE
Group migration: continue permission migration even if one or more groups fails

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -114,7 +114,7 @@ class MigrationState:
         return True
 
     @staticmethod
-    def _migrate_group_permissions_paginated(ws: WorkspaceClient, name_in_workspace: str, name_in_account: str):
+    def _migrate_group_permissions_paginated(ws: WorkspaceClient, name_in_workspace: str, name_in_account: str) -> int:
         batch_size = 1000
         logger.info(f"Migrating permissions: {name_in_workspace} (workspace) -> {name_in_account} (account)")
         permissions_migrated = 0

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -137,11 +137,13 @@ class MigrationState:
                 name_in_account,
                 size=batch_size,
             )
+            permissions_migrated += result.permissions_migrated or 0
+            logger.info(
+                f"Permission migration progress: {name_in_workspace} -> {name_in_account} {permissions_migrated}(+{result.permissions_migrated})"
+            )
             if not result.permissions_migrated:
                 logger.info("No more permissions to migrate.")
                 return permissions_migrated
-            permissions_migrated += result.permissions_migrated
-            logger.info(f"Migrated {result.permissions_migrated} permissions to {name_in_account} account group")
 
 
 class GroupMigrationStrategy:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -132,7 +132,7 @@ class MigrationState:
     @staticmethod
     def _migrate_group_permissions_paginated(ws: WorkspaceClient, name_in_workspace: str, name_in_account: str) -> int:
         batch_size = 1000
-        logger.info(f"Migrating permissions: {name_in_workspace} (workspace) -> {name_in_account} (account)")
+        logger.info(f"Migrating permissions: {name_in_workspace} (workspace) -> {name_in_account} (account) starting")
         permissions_migrated = 0
         while True:
             result = ws.permission_migration.migrate_permissions(
@@ -150,9 +150,6 @@ class MigrationState:
             logger.info(
                 f"Migrating permissions: {name_in_workspace} (workspace) -> {name_in_account} (account) progress={permissions_migrated}(+{result.permissions_migrated})"
             )
-            if not result.permissions_migrated:
-                logger.info("No more permissions to migrate.")
-                return permissions_migrated
 
 
 class GroupMigrationStrategy:

--- a/src/databricks/labs/ucx/workspace_access/workflows.py
+++ b/src/databricks/labs/ucx/workspace_access/workflows.py
@@ -95,7 +95,7 @@ class PermissionsMigrationAPI(Workflow):
         elif migration_state.apply_to_renamed_groups(ctx.workspace_client):
             logger.info("Group permission migration completed successfully.")
         else:
-            msg = "Group migration failed; reason unknown."
+            msg = "Permission migration for groups failed; reason unknown."
             raise RuntimeError(msg)
 
 

--- a/src/databricks/labs/ucx/workspace_access/workflows.py
+++ b/src/databricks/labs/ucx/workspace_access/workflows.py
@@ -92,8 +92,11 @@ class PermissionsMigrationAPI(Workflow):
         migration_state = ctx.group_manager.get_migration_state()
         if len(migration_state.groups) == 0:
             logger.info("Skipping group migration as no groups were found.")
-            return
-        migration_state.apply_to_renamed_groups(ctx.workspace_client)
+        elif migration_state.apply_to_renamed_groups(ctx.workspace_client):
+            logger.info("Group permission migration completed successfully.")
+        else:
+            msg = "Group migration failed; reason unknown."
+            raise RuntimeError(msg)
 
 
 class ValidateGroupPermissions(Workflow):

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -183,7 +183,7 @@ dbutils.notebook.run(name)
         ),
     ],
 )
-def test_infers_dbutils_notebook_run_dynamic_value(code, expected):
+def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
     tree = Tree.parse(code)
     calls = DbutilsLinter.list_dbutils_notebook_run_calls(tree)
     all_paths: list[str] = []

--- a/tests/unit/workspace_access/test_workflows.py
+++ b/tests/unit/workspace_access/test_workflows.py
@@ -1,8 +1,11 @@
+import logging
 from unittest.mock import create_autospec, call
 
 import pytest
+from databricks.labs.blueprint.parallel import ManyError
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import DatabricksError
 from databricks.sdk.service.iam import PermissionMigrationResponse
 
 from databricks.labs.ucx.workspace_access.workflows import (
@@ -97,3 +100,39 @@ def test_migrate_permissions_experimental_error(run_workflow):
     ws.permission_migration.migrate_permissions.side_effect = NotImplementedError("api not enabled")
     with pytest.raises(NotImplementedError):
         run_workflow(PermissionsMigrationAPI.apply_permissions, sql_backend=sql_backend, workspace_client=ws)
+
+
+def test_migrate_permissions_continue_on_error(run_workflow, caplog) -> None:
+    """Check that permission migration continues for other groups even if it fails for a single group."""
+    rows = {
+        'SELECT \\* FROM hive_metastore.ucx.groups': GROUPS[
+            ("", "workspace_group_1", "account_group_1", "temp_1", "", "", "", ""),  # Will fail immediately.
+            ("", "workspace_group_2", "account_group_2", "temp_2", "", "", "", ""),  # Will fail midway.
+            ("", "workspace_group_3", "account_group_3", "temp_3", "", "", "", ""),  # Will succeed.
+        ],
+    }
+    sql_backend = MockBackend(rows=rows)
+    ws = create_autospec(WorkspaceClient)
+    ws.get_workspace_id.return_value = "12345678"
+    ws.permission_migration.migrate_permissions.side_effect = [
+        # First group: fails immediately.
+        DatabricksError("simulate group failure: immediately"),
+        # Second group; fails mid-migration.
+        PermissionMigrationResponse(permissions_migrated=10),
+        DatabricksError("simulate group failure: midway"),
+        # Third group.
+        PermissionMigrationResponse(permissions_migrated=50),
+        PermissionMigrationResponse(permissions_migrated=0),
+    ]
+
+    with pytest.raises(ManyError) as exc_info, caplog.at_level(logging.INFO):
+        run_workflow(PermissionsMigrationAPI.apply_permissions, sql_backend=sql_backend, workspace_client=ws)
+
+    raised_exception = exc_info.value
+    assert len(raised_exception.errs) == 2
+    expected_exceptions = {"simulate group failure: immediately", "simulate group failure: midway"}
+    assert {str(e) for e in raised_exception.errs} == expected_exceptions
+    assert "Migration of group permissions failed: temp_1" in caplog.text
+    assert "Migration of group permissions failed: temp_2" in caplog.text
+    assert "Migrated 50 permissions for 1/3 groups successfully." in caplog.messages
+    assert "Migrating permissions failed for 2/3 groups." in caplog.messages

--- a/tests/unit/workspace_access/test_workflows.py
+++ b/tests/unit/workspace_access/test_workflows.py
@@ -16,27 +16,27 @@ from databricks.labs.ucx.workspace_access.workflows import (
 from tests.unit import GROUPS, PERMISSIONS
 
 
-def test_runtime_delete_backup_groups(run_workflow):
+def test_runtime_delete_backup_groups(run_workflow) -> None:
     ctx = run_workflow(RemoveWorkspaceLocalGroups.delete_backup_groups)
     assert 'SELECT * FROM hive_metastore.ucx.groups' in ctx.sql_backend.queries
 
 
-def test_runtime_apply_permissions_to_account_groups(run_workflow):
+def test_runtime_apply_permissions_to_account_groups(run_workflow) -> None:
     ctx = run_workflow(GroupMigration.apply_permissions_to_account_groups)
     assert 'SELECT * FROM hive_metastore.ucx.groups' in ctx.sql_backend.queries
 
 
-def test_rename_workspace_local_group(run_workflow):
+def test_rename_workspace_local_group(run_workflow) -> None:
     ctx = run_workflow(GroupMigration.rename_workspace_local_groups)
     assert 'SELECT * FROM hive_metastore.ucx.groups' in ctx.sql_backend.queries
 
 
-def test_reflect_account_groups_on_workspace(run_workflow):
+def test_reflect_account_groups_on_workspace(run_workflow) -> None:
     ctx = run_workflow(PermissionsMigrationAPI.reflect_account_groups_on_workspace)
     assert 'SELECT * FROM hive_metastore.ucx.groups' in ctx.sql_backend.queries
 
 
-def test_migrate_permissions_experimental(run_workflow):
+def test_migrate_permissions_experimental(run_workflow) -> None:
     rows = {
         'SELECT \\* FROM hive_metastore.ucx.groups': GROUPS[
             ("", "workspace_group_1", "account_group_1", "temp_1", "", "", "", ""),
@@ -60,7 +60,7 @@ def test_migrate_permissions_experimental(run_workflow):
     ws.permission_migration.migrate_permissions.assert_has_calls(calls, any_order=True)
 
 
-def test_migrate_permissions_experimental_paginated(run_workflow):
+def test_migrate_permissions_experimental_paginated(run_workflow) -> None:
     rows = {
         'SELECT \\* FROM hive_metastore.ucx.groups': GROUPS[
             ("", "workspace_group_1", "account_group_1", "temp_1", "", "", "", ""),
@@ -86,7 +86,7 @@ def test_migrate_permissions_experimental_paginated(run_workflow):
     ws.permission_migration.migrate_permissions.assert_has_calls(calls, any_order=True)
 
 
-def test_migrate_permissions_experimental_error(run_workflow):
+def test_migrate_permissions_not_enabled_error(run_workflow) -> None:
     rows = {
         'SELECT \\* FROM hive_metastore.ucx.groups': GROUPS[
             ("", "workspace_group_1", "account_group_1", "temp_1", "", "", "", ""),


### PR DESCRIPTION
## Changes

This PR updates permission migration so that if an error occurs while migrating the permissions for a group it moves onto the next group instead of stopping immediately. Any errors are raised at the end instead.

At present the information about which groups succeeded and failed is logged but not persisted in any other way.

### Linked issues

Progresses #1914.

### Functionality 

- [X] modified existing workflow: `group-migration`

### Tests

- [X] added unit tests
