### PR TITLE
Remove redundant state setting in test

### DIFF
--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1302,7 +1302,6 @@ def test_triggering_assessment_wf_w_job(ws, mocker, mock_installation):
 def test_runs_upgrades_on_too_old_version(ws, any_prompt):
     existing_installation = MockInstallation(
         {
-            'state.json': {'resources': {'dashboards': {'assessment_main': 'abc'}}},
             'config.yml': {
                 'inventory_database': 'x',
                 'warehouse_id': 'abc',


### PR DESCRIPTION
## Changes
Remove redundant state setting in test

### Tests

- [x] manually tested
- [x] modified unit test: `test_runs_upgrades_on_too_old_version`
