### PR TITLE
Group renaming: wait for consistency before completing task

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -436,7 +436,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
             logger.info(f"Renaming: {migrated_group.name_in_workspace} -> {migrated_group.temporary_name}")
             tasks.append(
                 functools.partial(
-                    self._rename_group_and_wait,
+                    self._rename_group_and_wait_for_rename,
                     migrated_group.id_in_workspace,
                     migrated_group.name_in_workspace,
                     migrated_group.temporary_name,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -449,7 +449,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         # present.
         self._wait_for_renamed_groups(renamed_groups)
 
-    def _rename_group_and_wait(self, group_id: str, old_group_name, new_group_name: str) -> tuple[str, str]:
+    def _rename_group_and_wait_for_rename(self, group_id: str, old_group_name, new_group_name: str) -> tuple[str, str]:
         logger.debug(f"Renaming group {group_id}: {old_group_name} -> {new_group_name}")
         self._rename_group(group_id, new_group_name)
         logger.debug(f"Waiting for group {group_id} rename to take effect: {old_group_name} -> {new_group_name}")

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -450,9 +450,8 @@ def test_rename_groups_should_fail_if_error_is_thrown():
     }
     wsclient.groups.patch.side_effect = RuntimeError("Something bad")
     group_manager = GroupManager(backend, wsclient, inventory_database="inv", renamed_group_prefix="test-group-")
-    with pytest.raises(ManyError) as e:
+    with pytest.raises(RuntimeError, match="Something bad"):
         group_manager.rename_groups()
-    assert e.value.args[0] == "Detected 1 failures: RuntimeError: Something bad"
 
 
 def test_reflect_account_groups_on_workspace_should_be_called_for_eligible_groups():


### PR DESCRIPTION
## Changes

Renaming groups is eventually consistent. This PR updates the task that renames workspace groups so that it does not complete until the renaming is visible via direct get on the group and via group enumeration.

The integration tests already dealt with the eventual consistency problem, but downstream tasks in the workflow might also run into problems and this wasn't being handled. Ensuring that renaming has completed before the task prevents this from being an issue.

### Functionality 

- [X] modified existing workflow: `group-migration`

### Tests

- [X] added unit tests
