### PR TITLE
Explain unused variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1311,3 +1311,4 @@ By default, it will revert all the clusters present in the backup folder
 Please note that all projects in the databrickslabs GitHub account are provided for your exploration only, and are not formally supported by Databricks with Service Level Agreements (SLAs).  They are provided AS-IS, and we do not make any guarantees of any kind.  Please do not submit a support ticket relating to any issues arising from the use of these projects.
 
 Any issues discovered through the use of this project should be filed as GitHub Issues on the Repo.  They will be reviewed as time permits, but there are no formal SLAs for support.
+

--- a/README.md
+++ b/README.md
@@ -1311,4 +1311,3 @@ By default, it will revert all the clusters present in the backup folder
 Please note that all projects in the databrickslabs GitHub account are provided for your exploration only, and are not formally supported by Databricks with Service Level Agreements (SLAs).  They are provided AS-IS, and we do not make any guarantees of any kind.  Please do not submit a support ticket relating to any issues arising from the use of these projects.
 
 Any issues discovered through the use of this project should be filed as GitHub Issues on the Repo.  They will be reviewed as time permits, but there are no formal SLAs for support.
-

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1277,7 +1277,7 @@ def make_feature_table(ws, make_random):
 
 
 @pytest.fixture
-def make_dbfs_data_copy(ws, make_cluster, env_or_skip):
+def make_dbfs_data_copy(ws, env_or_skip):
     if ws.config.is_aws:
         cmd_exec = CommandExecutor(ws.clusters, ws.command_execution, lambda: env_or_skip("TEST_WILDCARD_CLUSTER_ID"))
 

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1277,7 +1277,8 @@ def make_feature_table(ws, make_random):
 
 
 @pytest.fixture
-def make_dbfs_data_copy(ws, env_or_skip):
+def make_dbfs_data_copy(ws, make_cluster, env_or_skip):
+    _ = make_cluster  # Need cluster to copy data
     if ws.config.is_aws:
         cmd_exec = CommandExecutor(ws.clusters, ws.command_execution, lambda: env_or_skip("TEST_WILDCARD_CLUSTER_ID"))
 


### PR DESCRIPTION
`make fmt` was picking this up. I don know why it just came up now, the change dates back to 16th of April