### PR TITLE
Handle missing permission to read file

### DIFF
--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -52,7 +52,7 @@ class NotebookLoader(DependencyLoader, abc.ABC):
             return None
         try:
             content = absolute_path.read_text("utf-8")
-        except NotFound:
+        except (NotFound, PermissionError):
             logger.warning(f"Could not read notebook from workspace: {absolute_path}")
             return None
         language = self._detect_language(absolute_path, content)

--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -52,8 +52,10 @@ class NotebookLoader(DependencyLoader, abc.ABC):
             return None
         try:
             content = absolute_path.read_text("utf-8")
-        except (NotFound, PermissionError):
-            logger.warning(f"Could not read notebook from workspace: {absolute_path}")
+        except NotFound:
+            logger.warning(f"Path not found trying to read notebook from workspace: {absolute_path}")
+        except PermissionError as e:
+            logger.warning(f"Permissions error ({e}) while reading notebook from workspace: {absolute_path}")
             return None
         language = self._detect_language(absolute_path, content)
         if not language:

--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -54,8 +54,12 @@ class NotebookLoader(DependencyLoader, abc.ABC):
             content = absolute_path.read_text("utf-8")
         except NotFound:
             logger.warning(f"Path not found trying to read notebook from workspace: {absolute_path}")
-        except PermissionError as e:
-            logger.warning(f"Permissions error ({e}) while reading notebook from workspace: {absolute_path}")
+            return None
+        except PermissionError:
+            logger.warning(
+                f"Permission error while reading notebook from workspace: {absolute_path}",
+                exc_info=True,
+            )
             return None
         language = self._detect_language(absolute_path, content)
         if not language:

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -187,6 +187,10 @@ class FileLinter:
             failure_message = f"File without {encoding} encoding is not supported {self._path}"
             yield Failure("unsupported-file-encoding", failure_message, 0, 0, 1, 1)
             return
+        except PermissionError:
+            failure_message = f"Missing permission to read {self._path}"
+            yield Failure("file-permission", failure_message, 0, 0, 1, 1)
+            return
 
         if is_notebook:
             yield from self._lint_notebook()
@@ -208,9 +212,8 @@ class FileLinter:
                 linter = self._ctx.linter(language)
                 yield from linter.lint(self._source_code)
             except ValueError as err:
-                yield Failure(
-                    "unsupported-content", f"Error while parsing content of {self._path.as_posix()}: {err}", 0, 0, 1, 1
-                )
+                failure_message = f"Error while parsing content of {self._path.as_posix()}: {err}"
+                yield Failure("unsupported-content", failure_message, 0, 0, 1, 1)
 
     def _lint_notebook(self):
         notebook = Notebook.parse(self._path, self._source_code, self._file_language())

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -188,7 +188,7 @@ class FileLinter:
             yield Failure("unsupported-file-encoding", failure_message, 0, 0, 1, 1)
             return
         except PermissionError:
-            failure_message = f"Missing permission to read {self._path}"
+            failure_message = f"Missing read permission for {self._path}"
             yield Failure("file-permission", failure_message, 0, 0, 1, 1)
             return
 

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -183,6 +183,10 @@ class FileLinter:
         encoding = locale.getpreferredencoding(False)
         try:
             is_notebook = self._is_notebook()
+        except FileNotFoundError:
+            failure_message = f"File not found: {self._path}"
+            yield Failure("file-not-found", failure_message, 0, 0, 1, 1)
+            return
         except UnicodeDecodeError:
             failure_message = f"File without {encoding} encoding is not supported {self._path}"
             yield Failure("unsupported-file-encoding", failure_message, 0, 0, 1, 1)

--- a/tests/unit/source_code/notebooks/test_loader.py
+++ b/tests/unit/source_code/notebooks/test_loader.py
@@ -35,5 +35,5 @@ def test_notebook_loader_loads_dependency_with_permission_error(caplog):
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.source_code.notebooks.loaders"):
         found = NotebookLoader().load_dependency(path_lookup, dependency)
 
-    assert f"Could not read notebook from workspace: {path}" in caplog.text
+    assert f"Permission error while reading notebook from workspace: {path}" in caplog.text
     assert found is None

--- a/tests/unit/source_code/notebooks/test_loader.py
+++ b/tests/unit/source_code/notebooks/test_loader.py
@@ -1,7 +1,12 @@
+import logging
 from pathlib import Path
+from unittest.mock import create_autospec
 
-from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader
 from databricks.sdk.service.workspace import Language
+
+from databricks.labs.ucx.source_code.graph import Dependency
+from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader
+from databricks.labs.ucx.source_code.path_lookup import PathLookup
 
 
 def test_detects_language():
@@ -17,3 +22,18 @@ def test_detects_language():
     assert NotebookLoaderForTesting.detect_language(Path("hi"), "# Databricks notebook source") == Language.PYTHON
     assert NotebookLoaderForTesting.detect_language(Path("hi"), "-- Databricks notebook source") == Language.SQL
     assert not NotebookLoaderForTesting.detect_language(Path("hi"), "stuff")
+
+
+def test_notebook_loader_loads_dependency_with_permission_error(caplog):
+    path = create_autospec(Path)
+    path.read_text.side_effect = PermissionError("Permission denied")
+    path_lookup = create_autospec(PathLookup)
+    path_lookup.resolve.return_value = path
+    dependency = create_autospec(Dependency)
+    dependency.path.return_value = path
+
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.source_code.notebooks.loaders"):
+        found = NotebookLoader().load_dependency(path_lookup, dependency)
+
+    assert f"Could not read notebook from workspace: {path}" in caplog.text
+    assert found is None

--- a/tests/unit/source_code/notebooks/test_sources.py
+++ b/tests/unit/source_code/notebooks/test_sources.py
@@ -1,5 +1,6 @@
 import locale
 from pathlib import Path
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -56,3 +57,16 @@ def test_file_linter_lints_non_ascii_encoded_file(migration_index):
     assert len(advices) == 1
     assert advices[0].code == "unsupported-file-encoding"
     assert advices[0].message == f"File without {preferred_encoding} encoding is not supported {non_ascii_encoded_file}"
+
+
+def test_file_linter_lints_file_with_missing_read_permission(migration_index):
+    path = create_autospec(Path)
+    path.suffix = ".py"
+    path.read_text.side_effect = PermissionError("Permission denied")
+    linter = FileLinter(LinterContext(migration_index), path)
+
+    advices = list(linter.lint())
+
+    assert len(advices) == 1
+    assert advices[0].code == "file-permission"
+    assert advices[0].message == f"Missing read permission for {path}"

--- a/tests/unit/source_code/notebooks/test_sources.py
+++ b/tests/unit/source_code/notebooks/test_sources.py
@@ -59,6 +59,19 @@ def test_file_linter_lints_non_ascii_encoded_file(migration_index):
     assert advices[0].message == f"File without {preferred_encoding} encoding is not supported {non_ascii_encoded_file}"
 
 
+def test_file_linter_lints_file_with_missing_file(migration_index):
+    path = create_autospec(Path)
+    path.suffix = ".py"
+    path.read_text.side_effect = FileNotFoundError("No such file or directory: 'test.py'")
+    linter = FileLinter(LinterContext(migration_index), path)
+
+    advices = list(linter.lint())
+
+    assert len(advices) == 1
+    assert advices[0].code == "file-not-found"
+    assert advices[0].message == f"File not found: {path}"
+
+
 def test_file_linter_lints_file_with_missing_read_permission(migration_index):
     path = create_autospec(Path)
     path.suffix = ".py"


### PR DESCRIPTION
Handle missing permissions when reading files during linting

### Linked issues
Resolves #1942
Partially resolves #1952
