### PR TITLE
Fix substituting regex with empty string

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -281,11 +281,12 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
 class RegexSubStrategy(GroupMigrationStrategy):
     def __init__(
         self,
-        workspace_groups_in_workspace,
-        account_groups_in_account,
-        /,
-        renamed_groups_prefix,
-        include_group_names=None,
+        workspace_groups_in_workspace: dict[str, Group],
+        account_groups_in_account: dict[str, Group],
+        *,
+        # TODO: Check if hints below could be non optional
+        renamed_groups_prefix: str | None,
+        include_group_names: list[str] | None = None,
         workspace_group_regex: str | None = None,
         workspace_group_replace: str | None = None,
     ):

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -716,6 +716,7 @@ class ConfigureGroups:
     def __init__(self, prompts: Prompts):
         self._prompts = prompts
         self._ask_for_group = functools.partial(self._prompts.question, validate=self._is_valid_group_str)
+        self._ask_for_substitute = functools.partial(self._prompts.question, validate=self._is_valid_substitute_str)
         self._ask_for_regex = functools.partial(self._prompts.question, validate=self._validate_regex)
 
     def run(self):
@@ -755,7 +756,7 @@ class ConfigureGroups:
         match_value = self._ask_for_regex("Enter a regular expression for substitution")
         if not match_value:
             return False
-        sub_value = self._ask_for_group("Enter the substitution value")
+        sub_value = self._ask_for_substitute("Enter the substitution value")
         if sub_value is None:
             return False
         self.workspace_group_regex = match_value
@@ -787,9 +788,12 @@ class ConfigureGroups:
         self.group_match_by_external_id = True
         return True
 
+    def _is_valid_group_str(self, group_str: str) -> bool:
+        return len(group_str) > 0 and self._is_valid_substitute_str(group_str)
+
     @staticmethod
-    def _is_valid_group_str(group_str: str | None) -> bool:
-        return group_str is not None and not re.search(r"[\s#,+ \\<>;]", group_str)
+    def _is_valid_substitute_str(substitute: str) -> bool:
+        return not re.search(r"[\s#,+ \\<>;]", substitute)
 
     @staticmethod
     def _validate_regex(regex_input: str) -> bool:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -721,6 +721,8 @@ class ConfigureGroups:
     group_match_by_external_id = None
     include_group_names = None
 
+    _valid_substitute_pattern = re.compile(r"[\s#,+ \\<>;]")
+
     def __init__(self, prompts: Prompts):
         self._prompts = prompts
         self._ask_for_group = functools.partial(self._prompts.question, validate=self._is_valid_group_str)
@@ -799,9 +801,8 @@ class ConfigureGroups:
     def _is_valid_group_str(self, group_str: str) -> bool:
         return len(group_str) > 0 and self._is_valid_substitute_str(group_str)
 
-    @staticmethod
-    def _is_valid_substitute_str(substitute: str) -> bool:
-        return not re.search(r"[\s#,+ \\<>;]", substitute)
+    def _is_valid_substitute_str(self, substitute: str) -> bool:
+        return not self._valid_substitute_pattern.search(substitute)
 
     @staticmethod
     def _validate_regex(regex_input: str) -> bool:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -296,8 +296,8 @@ class RegexSubStrategy(GroupMigrationStrategy):
             include_group_names=include_group_names,
             renamed_groups_prefix=renamed_groups_prefix,
         )
-        self.workspace_group_replace = workspace_group_replace
         self.workspace_group_regex = workspace_group_regex
+        self.workspace_group_replace = workspace_group_replace
 
     def generate_migrated_groups(self):
         workspace_groups = self.get_filtered_groups()

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -756,7 +756,7 @@ class ConfigureGroups:
         if not match_value:
             return False
         sub_value = self._ask_for_group("Enter the substitution value")
-        if not sub_value:
+        if sub_value is None:
             return False
         self.workspace_group_regex = match_value
         self.workspace_group_replace = sub_value
@@ -788,8 +788,8 @@ class ConfigureGroups:
         return True
 
     @staticmethod
-    def _is_valid_group_str(group_str: str):
-        return group_str and not re.search(r"[\s#,+ \\<>;]", group_str)
+    def _is_valid_group_str(group_str: str | None) -> bool:
+        return group_str is not None and not re.search(r"[\s#,+ \\<>;]", group_str)
 
     @staticmethod
     def _validate_regex(regex_input: str) -> bool:

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -299,7 +299,7 @@ class RegexSubStrategy(GroupMigrationStrategy):
         self.workspace_group_regex = workspace_group_regex
         self.workspace_group_replace = workspace_group_replace
 
-    def generate_migrated_groups(self):
+    def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         workspace_groups = self.get_filtered_groups()
         for group in workspace_groups.values():
             name_in_account = self._safe_sub(

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -673,7 +673,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
     def _get_strategy(
         self, workspace_groups_in_workspace: dict[str, Group], account_groups_in_account: dict[str, Group]
     ) -> GroupMigrationStrategy:
-        if self._workspace_group_regex and self._workspace_group_replace:
+        if self._workspace_group_regex is not None and self._workspace_group_replace is not None:
             return RegexSubStrategy(
                 workspace_groups_in_workspace,
                 account_groups_in_account,
@@ -682,7 +682,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
                 workspace_group_regex=self._workspace_group_regex,
                 workspace_group_replace=self._workspace_group_replace,
             )
-        if self._workspace_group_regex and self._account_group_regex:
+        if self._workspace_group_regex is not None and self._account_group_regex is not None:
             return RegexMatchStrategy(
                 workspace_groups_in_workspace,
                 account_groups_in_account,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -302,7 +302,6 @@ class RegexSubStrategy(GroupMigrationStrategy):
     def generate_migrated_groups(self):
         workspace_groups = self.get_filtered_groups()
         for group in workspace_groups.values():
-            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             name_in_account = self._safe_sub(
                 group.display_name, self.workspace_group_regex, self.workspace_group_replace
             )
@@ -312,6 +311,7 @@ class RegexSubStrategy(GroupMigrationStrategy):
                     f"Couldn't find a matching account group for {group.display_name} group with regex substitution"
                 )
                 continue
+            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             yield MigratedGroup(
                 id_in_workspace=group.id,
                 name_in_workspace=group.display_name,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -222,13 +222,13 @@ class MatchingNamesStrategy(GroupMigrationStrategy):
     def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         workspace_groups = self.get_filtered_groups()
         for group in workspace_groups.values():
-            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             account_group = self.account_groups_in_account.get(group.display_name)
             if not account_group:
                 logger.info(
                     f"Couldn't find a matching account group for {group.display_name} group using name matching"
                 )
                 continue
+            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             yield MigratedGroup(
                 id_in_workspace=group.id,
                 name_in_workspace=group.display_name,
@@ -261,11 +261,11 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
         workspace_groups = self.get_filtered_groups()
         account_groups_by_id = {group.external_id: group for group in self.account_groups_in_account.values()}
         for group in workspace_groups.values():
-            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             account_group = account_groups_by_id.get(group.external_id)
             if not account_group:
                 logger.info(f"Couldn't find a matching account group for {group.display_name} group with external_id")
                 continue
+            temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
             yield MigratedGroup(
                 id_in_workspace=group.id,
                 name_in_workspace=group.display_name,
@@ -353,13 +353,13 @@ class RegexMatchStrategy(GroupMigrationStrategy):
             for group_name, group in self.account_groups_in_account.items()
         }
         for group_match, ws_group in workspace_groups_by_match.items():
-            temporary_name = f"{self.renamed_groups_prefix}{ws_group.display_name}"
             account_group = account_groups_by_match.get(group_match)
             if not account_group:
                 logger.info(
                     f"Couldn't find a matching account group for {ws_group.display_name} group with regex matching"
                 )
                 continue
+            temporary_name = f"{self.renamed_groups_prefix}{ws_group.display_name}"
             yield MigratedGroup(
                 id_in_workspace=ws_group.id,
                 name_in_workspace=ws_group.display_name,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -208,9 +208,9 @@ class MatchingNamesStrategy(GroupMigrationStrategy):
         self,
         workspace_groups_in_workspace,
         account_groups_in_account,
-        /,
-        renamed_groups_prefix,
-        include_group_names=None,
+        *,
+        renamed_groups_prefix: str,
+        include_group_names: list[str] | None,
     ):
         super().__init__(
             workspace_groups_in_workspace,
@@ -246,9 +246,9 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
         self,
         workspace_groups_in_workspace,
         account_groups_in_account,
-        /,
-        renamed_groups_prefix,
-        include_group_names=None,
+        *,
+        renamed_groups_prefix: str,
+        include_group_names: list[str] | None,
     ):
         super().__init__(
             workspace_groups_in_workspace,
@@ -284,11 +284,10 @@ class RegexSubStrategy(GroupMigrationStrategy):
         workspace_groups_in_workspace: dict[str, Group],
         account_groups_in_account: dict[str, Group],
         *,
-        # TODO: Check if hints below could be non optional
-        renamed_groups_prefix: str | None,
-        include_group_names: list[str] | None = None,
-        workspace_group_regex: str | None = None,
-        workspace_group_replace: str | None = None,
+        renamed_groups_prefix: str,
+        include_group_names: list[str] | None,
+        workspace_group_regex: str,
+        workspace_group_replace: str,
     ):
         super().__init__(
             workspace_groups_in_workspace,
@@ -329,11 +328,11 @@ class RegexMatchStrategy(GroupMigrationStrategy):
         self,
         workspace_groups_in_workspace,
         account_groups_in_account,
-        /,
-        renamed_groups_prefix,
-        include_group_names=None,
-        workspace_group_regex: str | None = None,
-        account_group_regex: str | None = None,
+        *,
+        renamed_groups_prefix: str,
+        include_group_names: list[str] | None,
+        workspace_group_regex: str,
+        account_group_regex: str,
     ):
         super().__init__(
             workspace_groups_in_workspace,

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -167,7 +167,7 @@ class GroupMigrationStrategy:
         self.include_group_names = include_group_names
 
     @abstractmethod
-    def generate_migrated_groups(self):
+    def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         raise NotImplementedError
 
     def get_filtered_groups(self):
@@ -219,7 +219,7 @@ class MatchingNamesStrategy(GroupMigrationStrategy):
             renamed_groups_prefix=renamed_groups_prefix,
         )
 
-    def generate_migrated_groups(self):
+    def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         workspace_groups = self.get_filtered_groups()
         for group in workspace_groups.values():
             temporary_name = f"{self.renamed_groups_prefix}{group.display_name}"
@@ -257,7 +257,7 @@ class MatchByExternalIdStrategy(GroupMigrationStrategy):
             renamed_groups_prefix=renamed_groups_prefix,
         )
 
-    def generate_migrated_groups(self):
+    def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         workspace_groups = self.get_filtered_groups()
         account_groups_by_id = {group.external_id: group for group in self.account_groups_in_account.values()}
         for group in workspace_groups.values():
@@ -343,7 +343,7 @@ class RegexMatchStrategy(GroupMigrationStrategy):
         self.account_group_regex = account_group_regex
         self.workspace_group_regex = workspace_group_regex
 
-    def generate_migrated_groups(self):
+    def generate_migrated_groups(self) -> Iterable[MigratedGroup]:
         workspace_groups_by_match = {
             self._safe_match(group_name, self.workspace_group_regex): group
             for group_name, group in self.get_filtered_groups().items()

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -766,11 +766,11 @@ class ConfigureGroups:
         match_value = self._ask_for_regex("Enter a regular expression for substitution")
         if not match_value:
             return False
-        sub_value = self._ask_for_substitute("Enter the substitution value")
-        if sub_value is None:
+        substitute = self._ask_for_substitute("Enter the substitution value")
+        if substitute is None:
             return False
         self.workspace_group_regex = match_value
-        self.workspace_group_replace = sub_value
+        self.workspace_group_replace = substitute
         return True
 
     def _configure_matching(self):

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -16,6 +16,7 @@ from databricks.labs.ucx.workspace_access.groups import (
     GroupManager,
     MigratedGroup,
     MigrationState,
+    RegexSubStrategy,
 )
 
 
@@ -1108,3 +1109,23 @@ def test_migration_state_with_filtered_group():
             roles='',
         )
     ]
+
+
+def test_regex_sub_strategy_replaces_with_empty_replace():
+    workspace_groups = {"group_old": Group("group_old")}
+    account_groups = {"group": Group("group")}
+    strategy = RegexSubStrategy(
+        workspace_groups,
+        account_groups,
+        renamed_groups_prefix="ucx-renamed-",
+        include_group_names=["group_old"],
+        workspace_group_regex="_old",
+        workspace_group_replace="",
+    )
+
+    migrated_group = next(strategy.generate_migrated_groups(), None)
+
+    assert migrated_group is not None
+    assert migrated_group.name_in_workspace == "group_old"
+    assert migrated_group.name_in_account == "group"
+    assert migrated_group.temporary_name == "ucx-renamed-group_old"

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -145,7 +145,6 @@ def test_snapshot_should_consider_groups_defined_in_conf():
     wsclient = create_autospec(WorkspaceClient)
     group1 = Group(id="1", display_name="de", meta=ResourceMeta(resource_type="WorkspaceGroup"))
     group2 = Group(id="2", display_name="ds", meta=ResourceMeta(resource_type="WorkspaceGroup"))
-    wsclient.groups.list.return_value = [group1, group2]
     acc_group_1 = Group(id="11", display_name="de", external_id="1234")
     acc_group_2 = Group(id="12", display_name="ds", external_id="1235")
     wsclient.api_client.do.return_value = {

--- a/tests/unit/workspace_access/test_groups.py
+++ b/tests/unit/workspace_access/test_groups.py
@@ -856,21 +856,22 @@ def test_configure_external_id():
     assert configure_groups.group_match_by_external_id
 
 
-def test_configure_substitute():
+@pytest.mark.parametrize("substitution_value", ["business", ""])
+def test_configure_substitute(substitution_value):
     configure_groups = ConfigureGroups(
         MockPrompts(
             {
                 "Backup prefix": "",
                 r"Choose how to map the workspace groups.*": "4",  # substitute
                 r".*for substitution": "biz",
-                r".*substitution value": "business",
+                r".*substitution value": substitution_value,
                 ".*": "",
             }
         )
     )
     configure_groups.run()
     assert configure_groups.workspace_group_regex == "biz"
-    assert configure_groups.workspace_group_replace == "business"
+    assert configure_groups.workspace_group_replace == substitution_value
 
 
 def test_configure_match():


### PR DESCRIPTION
## Changes
Fix substituting regex with empty string

### Linked issues
Resolves #1922

### Functionality 

- [x] modified existing workflow: `assesment.crawl_groups` and `migrate-groups`

### Tests

- [x] manually tested
- [x] added unit tests
