### PR TITLE
Adjust type hints in credentials handling for Azure API client

### DIFF
--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -8,6 +8,7 @@ from databricks.sdk.core import (
     ApiClient,
     AzureCliTokenSource,
     Config,
+    CredentialsProvider,
     CredentialsStrategy,
     credentials_strategy,
 )
@@ -231,18 +232,16 @@ class AzureAPIClient:
     @staticmethod
     def _strategy_for(endpoint: str) -> CredentialsStrategy:
         @credentials_strategy("azure-cli", ["host"])
-        def _credentials(_: Config) -> CredentialsStrategy:
+        def _credentials(_: Config) -> CredentialsProvider:
             token_source = AzureCliTokenSource(endpoint)
 
             def inner() -> dict[str, str]:
                 token = token_source.token()
                 return {"Authorization": f"{token.token_type} {token.access_token}"}
 
-            # The type hints are off but according to the sdk:
-            # https://github.com/databricks/databricks-sdk-py/blob/f7d920e1f912b204669b826ed76e026607c59797/databricks/sdk/credentials_provider.py#L116
-            return inner  # type: ignore
+            return inner
 
-        return _credentials  # type: ignore
+        return _credentials
 
     def get(self, path: str, api_version: str | None = None, query: dict[str, str] | None = None):
         headers = {"Accept": "application/json"}


### PR DESCRIPTION
## Changes

This PR is stacked on #1943; it is stacked to verify the type hinting changes via the CI environment.

The situation is:

 - The Databricks SDK has partially implemented type hints for the credentials handlers.
 - The `CredentialsProvider` is the fundamental type for a callable factory that can be used to obtain credentials.
 - The `CredentialsStrategy` is the type that can be used for a function that can be used to obtain a provider, given the `Config`.
 - The `@credentials_strategy` decorator is used to fuse the two:

   1. It decorates a function that, given a `Config`, returns a `CredentialsProvider`.
   2. The decorated function that it returns is a `CredentialsStrategy`.

 - The type upstream type hinting for the `@credentials_strategy` decorator is incomplete: the return type is omitted. This confuses IntelliJ/PyCharm a little but not Mypy. 
