### PR TITLE
Make job resources clickable in migration dashboard with linted workflows

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import sqlglot
 from databricks.sdk.core import Config
 
 __all__ = ["WorkspaceConfig"]
@@ -67,16 +66,6 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None
-
-    def transform_inventory_database(self, node: sqlglot.Expression) -> sqlglot.Expression:
-        """Replace the inventory database in a query."""
-        if (
-            isinstance(node, sqlglot.exp.Table)
-            and node.args.get("db") is not None
-            and getattr(node.args.get("db"), "this", "") == "inventory"
-        ):
-            node.args["db"].set("this", f"hive_metastore.{self.inventory_database}")
-        return node
 
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from functools import cached_property
 from typing import Any
 
-import databricks.sdk.errors
 import sqlglot
 from databricks.labs.blueprint.entrypoint import get_logger, is_in_debug
 from databricks.labs.blueprint.installation import Installation, SerdeError
@@ -30,6 +29,7 @@ from databricks.sdk.errors import (
     BadRequest,
     InvalidParameterValue,
     NotFound,
+    NotImplemented,
     PermissionDenied,
     ResourceDoesNotExist,
 )
@@ -266,7 +266,7 @@ class WorkspaceInstaller(WorkspaceContext):
             # Logic for forced global over user install
             # Migration logic will go here
             # verify complains without full path, asks to raise NotImplementedError builtin
-            raise databricks.sdk.errors.NotImplemented("Migration needed. Not implemented yet.")
+            raise NotImplemented("Migration needed. Not implemented yet.")
         if self.installation.is_global() and self._force_install == "user":
             # Logic for forced user install over global install
             self.replace(

--- a/src/databricks/labs/ucx/queries/migration/main/02_1_code_compatibility_problems.sql
+++ b/src/databricks/labs/ucx/queries/migration/main/02_1_code_compatibility_problems.sql
@@ -1,4 +1,17 @@
--- --title 'Workflow migration problems'
+/*
+--title 'Workflow migration problems'
+--overrides '{"spec": {"encodings": {"columns": [
+    {"fieldName": "path", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "path"},
+    {"fieldName": "code", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "code"},
+    {"fieldName": "message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "message"},
+    {"fieldName": "workflow_id", "booleanValues": ["false", "true"], "linkUrlTemplate": "$DATABRICKS_HOST/jobs/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "integer", "displayAs": "link", "title": "workflow_id"},
+    {"fieldName": "workflow_name", "booleanValues": ["false", "true"], "linkUrlTemplate": "$DATABRICKS_HOST/jobs/{{ workflow_id }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "workflow_name"},
+    {"fieldName": "task_key", "booleanValues": ["false", "true"], "imageUrlTemplate": "{{ @ }}", "linkUrlTemplate": "$DATABRICKS_HOST/jobs/{{ workflow_id }}/tasks/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "task_key"},
+    {"fieldName": "start_line", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "start_line"},
+    {"fieldName": "start_col", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "start_col"},
+    {"fieldName": "end_line", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "end_line"},
+    {"fieldName": "end_col", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "end_col"}]}}}'
+*/
 SELECT
     path,
     code,

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -30,7 +30,7 @@ def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_
     notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=lint_problem)
     make_job(notebook_path=notebook)
 
-    ctx = installation_ctx
+    ctx = installation_ctx.replace(skip_dashboards=False)
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow("experimental-workflow-linter")
     ctx.deployed_workflows.validate_step("experimental-workflow-linter")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,3 @@
-import sqlglot
 from databricks.labs.blueprint.installation import MockInstallation
 
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -29,19 +28,3 @@ def test_v1_migrate_some_conf():
 
     assert workspace_config.renamed_group_prefix == 'some-'
     assert workspace_config.include_group_names == ['foo', 'bar']
-
-
-def test_workspace_config_transforms_inventory_database_in_query():
-    installation = MockInstallation({"config.yml": {"inventory_database": "test"}})
-    workspace_config = installation.load(WorkspaceConfig)
-
-    query_transformed_expected = "SELECT a, b FROM hive_metastore.test.table"
-    query = sqlglot.parse_one("SELECT a, b FROM inventory.table")
-
-    query_transformed = (
-        query
-        .transform(workspace_config.transform_inventory_database)
-        .sql(dialect=sqlglot.dialects.Databricks)
-    )
-
-    assert query_transformed == query_transformed_expected

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,4 @@
+import sqlglot
 from databricks.labs.blueprint.installation import MockInstallation
 
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -28,3 +29,19 @@ def test_v1_migrate_some_conf():
 
     assert workspace_config.renamed_group_prefix == 'some-'
     assert workspace_config.include_group_names == ['foo', 'bar']
+
+
+def test_workspace_config_transforms_inventory_database_in_query():
+    installation = MockInstallation({"config.yml": {"inventory_database": "test"}})
+    workspace_config = installation.load(WorkspaceConfig)
+
+    query_transformed_expected = "SELECT a, b FROM hive_metastore.test.table"
+    query = sqlglot.parse_one("SELECT a, b FROM inventory.table")
+
+    query_transformed = (
+        query
+        .transform(workspace_config.transform_inventory_database)
+        .sql(dialect=sqlglot.dialects.Databricks)
+    )
+
+    assert query_transformed == query_transformed_expected

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1933,7 +1933,9 @@ def test_upload_dependencies(ws, mock_installation):
 @pytest.mark.parametrize(
     "query, query_transformed_expected",
     [
+        ("SELECT a FROM table", "SELECT a FROM table"),
         ("SELECT a, b FROM inventory.table", "SELECT a, b FROM hive_metastore.test.table"),
+        ("SELECT '$DATABRICKS_HOST' FROM table", "SELECT '$DATABRICKS_HOST' FROM table"),
         ("/* $DATABRICKS_HOST */ SELECT 1", "/* https://adb-0123456789.2.azuredatabricks.net */ SELECT 1"),
     ],
 )


### PR DESCRIPTION
## Changes
Make job resources clickable in migration dashboard with linted workflows

### Linked issues
Partially resolves #1740 

### Functionality 

- [x] modified dashboard : UCX migration

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] existing integration tests
- [x] verified on staging environment (screenshot attached)
