### PR TITLE
Added tracking for UCX workflows and as-library usage

### DIFF
--- a/src/databricks/labs/ucx/__init__.py
+++ b/src/databricks/labs/ucx/__init__.py
@@ -1,7 +1,11 @@
-from databricks.sdk.core import with_user_agent_extra
+from databricks.sdk.core import with_user_agent_extra, with_product
 from databricks.labs.blueprint.logger import install_logger
 from databricks.labs.ucx.__about__ import __version__
 
 install_logger()
 
+# Add ucx/<version> for projects depending on ucx as a library
 with_user_agent_extra("ucx", __version__)
+
+# Add ucx/<version> for re-packaging of ucx, where product name is omitted
+with_product("ucx", __version__)

--- a/src/databricks/labs/ucx/__init__.py
+++ b/src/databricks/labs/ucx/__init__.py
@@ -1,3 +1,7 @@
+from databricks.sdk.core import with_user_agent_extra
 from databricks.labs.blueprint.logger import install_logger
+from databricks.labs.ucx.__about__ import __version__
 
 install_logger()
+
+with_user_agent_extra("ucx", __version__)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -24,6 +24,7 @@ from databricks.labs.blueprint.wheels import (
 from databricks.labs.lsql.backends import SqlBackend, StatementExecutionBackend
 from databricks.labs.lsql.deployment import SchemaDeployer
 from databricks.sdk import WorkspaceClient, AccountClient
+from databricks.sdk.core import with_user_agent_extra
 from databricks.sdk.errors import (
     AlreadyExists,
     BadRequest,
@@ -74,6 +75,7 @@ WAREHOUSE_PREFIX = "Unity Catalog Migration"
 NUM_USER_ATTEMPTS = 10  # number of attempts user gets at answering a question
 
 logger = logging.getLogger(__name__)
+with_user_agent_extra("cmd", "install")
 
 
 def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+from databricks.sdk.config import with_user_agent_extra
+
 from databricks.labs.ucx.__about__ import __version__
 from databricks.labs.ucx.assessment.workflows import Assessment, Failing
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
@@ -78,6 +80,8 @@ class Workflows:
         workflow = self._workflows[workflow_name]
         if task_name == "parse_logs":
             return ctx.task_run_warning_recorder.snapshot()
+        # both CLI commands and workflow names appear in telemetry under `cmd`
+        with_user_agent_extra("cmd", workflow_name)
         # `{{parent_run_id}}` is the run of entire workflow, whereas `{{run_id}}` is the run of a task
         workflow_run_id = named_parameters.get("parent_run_id", "unknown_run_id")
         job_id = named_parameters.get("job_id", "unknown_job_id")

--- a/tests/unit/test_useragent.py
+++ b/tests/unit/test_useragent.py
@@ -1,0 +1,82 @@
+import contextlib
+import functools
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+
+import yaml
+
+from databricks.labs.ucx.__about__ import __version__
+from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
+from databricks.labs.ucx.framework.tasks import Workflow, job_task
+from databricks.labs.ucx.runtime import Workflows
+
+
+@contextlib.contextmanager
+def http_fixture_server(handler: Callable[[BaseHTTPRequestHandler], None]):
+
+    class _handler(BaseHTTPRequestHandler):
+        def __init__(self, handler: Callable[[BaseHTTPRequestHandler], None], *args):
+            self._handler = handler
+            super().__init__(*args)
+
+        def __getattr__(self, item):
+            if item[0:3] != "do_":
+                raise AttributeError(f"method {item} not found")
+            return functools.partial(self._handler, self)
+
+    handler_factory = functools.partial(_handler, handler)
+    srv = HTTPServer(("localhost", 0), handler_factory)
+    srv_thread = Thread(target=srv.serve_forever)
+    try:
+        srv_thread.daemon = True
+        srv_thread.start()
+        yield "http://{0}:{1}".format(*srv.server_address)  # pylint: disable=consider-using-f-string
+    finally:
+        srv.shutdown()
+
+
+def test_user_agent_is_propagated(tmp_path):
+    user_agent = {}
+
+    def inner(handler: BaseHTTPRequestHandler):
+        for pair in handler.headers["User-Agent"].split(" "):
+            if "/" not in pair:
+                continue
+            key, value = pair.split("/")
+            user_agent[key] = value
+        handler.send_response(200)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        handler.wfile.write(b"{}")
+        handler.wfile.flush()
+
+    class Dummy(Workflow):
+        def __init__(self):
+            super().__init__('dummy')
+
+        @job_task
+        def something(self, ctx: RuntimeContext):
+            """Some comment"""
+            ctx.workspace_client.current_user.me()
+
+    workflows = Workflows([Dummy()])
+    with http_fixture_server(inner) as host:
+        cfg = Path(tmp_path, "config.yml")
+        cfg.write_text(
+            yaml.safe_dump(
+                {
+                    'version': 2,
+                    'inventory_database': '_',
+                    'connect': {"host": host, "token": "_"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        workflows.trigger(f"--config={cfg.as_posix()}", "--workflow=dummy", "--task=something")
+
+    assert "ucx" in user_agent
+    assert "cmd" in user_agent
+    assert user_agent["ucx"] == __version__
+    assert user_agent["cmd"] == "dummy"


### PR DESCRIPTION
This PR adds `User-Agent` OtherInfo elements:
* `ucx/<version>` for all requests where UCX is imported as a library
* `cmd/install` for all installations/upgrades
* `cmd/<workflow>` for all managed job invocations

Relevant PRs:
- https://github.com/databrickslabs/lsql/pull/206
- https://github.com/databrickslabs/blueprint/pull/114