### PR TITLE
Exclude VIEW from "Non-DELTA format: UNKNOWN" findings in assessment summary chart

### DIFF
--- a/src/databricks/labs/ucx/queries/views/objects.sql
+++ b/src/databricks/labs/ucx/queries/views/objects.sql
@@ -12,7 +12,7 @@ SELECT object_type, object_id, failures FROM (
   SELECT "tables" as object_type, CONCAT(t.catalog, '.', t.database, '.', t.name) AS object_id,
   TO_JSON(
     FILTER(ARRAY(
-      IF(NOT STARTSWITH(t.table_format, "DELTA"), CONCAT("Non-DELTA format: ", t.table_format), NULL),
+      IF(NOT STARTSWITH(t.table_format, "DELTA") AND t.object_type != "VIEW", CONCAT("Non-DELTA format: ", t.table_format), NULL),
       IF(STARTSWITH(t.location, "wasb"), "Unsupported Storage Type: wasb://", NULL),
       IF(STARTSWITH(t.location, "adl"), "Unsupported Storage Type: adl://", NULL),
       CASE


### PR DESCRIPTION
## Changes
The count of views is included in `Non-DELTA format: UNKNOWN` finding in the `Assessment Summary` chart in the assessment main dashboard. The customers were confused as they cannot find any unknown format tables but eventually find they are all views.
This PR will exclude views from `Non-DELTA format: UNKNOWN` finding.
<img width="934" alt="image" src="https://github.com/databrickslabs/ucx/assets/91635877/60e0a4a3-9fd8-4d30-b0ea-d810ba07a79f">
