### PR TITLE
Fix invalid JSON (`known.json`)

### DIFF
--- a/src/databricks/labs/ucx/source_code/known.json
+++ b/src/databricks/labs/ucx/source_code/known.json
@@ -1281,7 +1281,7 @@
       }
     ],
     "arc.utils": [],
-    "arc.utils.utils": [],
+    "arc.utils.utils": []
   },
   "databricks-feature-engineering": {
     "databricks": [],


### PR DESCRIPTION
## Changes

This PR fixes our `known.json` file to make it valid JSON: at present it won't load because of the presence of a trailing comma that renders it invalid JSON. (This was accidentally introduced by PR #2099.)
