### PR TITLE
Skip running certain integration tests when no relevant packages modified

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 5 * * *'
 
 permissions:
   id-token: write
@@ -38,7 +38,7 @@ jobs:
         uses: databrickslabs/sandbox/acceptance@acceptance/v0.2.2
         with:
           vault_uri: ${{ secrets.VAULT_URI }}
-          timeout: 45m
+          timeout: 55m
           create_issues: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import BinaryIO
 
 import pytest
+from databricks.labs.blueprint.entrypoint import is_in_debug
+from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.lsql.backends import StatementExecutionBackend
 from databricks.labs.blueprint.commands import CommandExecutor
 from databricks.sdk import AccountClient, WorkspaceClient
@@ -51,6 +53,7 @@ from databricks.sdk.service.sql import (
 )
 from databricks.sdk.service.workspace import ImportFormat, Language
 
+from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 
 # this file will get to databricks-labs-pytester project and be maintained/refactored there
@@ -1397,3 +1400,33 @@ def get_test_purge_time() -> str:
 def get_purge_suffix() -> str:
     """HEX-encoded purge time suffix for test objects."""
     return f'ra{int(get_test_purge_time()):x}'
+
+
+@pytest.fixture
+def modified_or_skip():
+    product_info = ProductInfo.from_class(WorkspaceConfig)
+    checkout_root = product_info.checkout_root()
+
+    def run_command(command: str) -> str:
+        with subprocess.Popen(
+            command.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=checkout_root,
+        ) as process:
+            output, error = process.communicate()
+            if process.returncode != 0:
+                pytest.fail(f"Command failed: {command}\n{error.decode('utf-8')}", pytrace=False)
+            return output.decode("utf-8").strip()
+
+    def inner(package: str):
+        if is_in_debug():
+            return  # not skipping, as we're debugging
+        if 'TEST_NIGHTLY' in os.environ:
+            return  # or during nightly runs
+        current_branch = run_command("git branch --show-current")
+        changed_files = run_command(f"git diff origin/main..{current_branch} --name-only")
+        if package not in changed_files:
+            pytest.skip(f"Skipping long test as {package} was not modified in branch {current_branch}")
+
+    return inner

--- a/tests/integration/hive_metastore/test_grants.py
+++ b/tests/integration/hive_metastore/test_grants.py
@@ -6,7 +6,6 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 
 from databricks.labs.lsql.backends import StatementExecutionBackend
-from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
 from ..conftest import MockRuntimeContext
 
 logger = logging.getLogger(__name__)
@@ -36,11 +35,8 @@ def test_all_grants_in_databases(runtime_ctx, sql_backend, make_group):
     sql_backend.execute(f"GRANT MODIFY ON VIEW {view_c.full_name} TO `{group_b.display_name}`")
     sql_backend.execute(f"DENY MODIFY ON TABLE {view_d.full_name} TO `{group_b.display_name}`")
 
-    # 20 seconds less than TablesCrawler(sql_backend, inventory_schema)
-    grants = GrantsCrawler(runtime_ctx.tables_crawler, runtime_ctx.udfs_crawler)
-
     all_grants = {}
-    for grant in list(grants.snapshot()):
+    for grant in list(runtime_ctx.grants_crawler.snapshot()):
         logging.info(f"grant:\n{grant}\n  hive: {grant.hive_grant_sql()}\n  uc: {grant.uc_grant_sql()}")
         object_type, object_key = grant.this_type_and_key()
         all_grants[f"{grant.principal}.{object_type}.{object_key}"] = grant.action_type
@@ -71,9 +67,7 @@ def test_all_grants_for_udfs_in_databases(runtime_ctx, sql_backend, make_group):
     sql_backend.execute(f"GRANT ALL PRIVILEGES ON FUNCTION {udf_b.full_name} TO `{group_a.display_name}`")
     sql_backend.execute(f"DENY READ_METADATA ON FUNCTION {udf_b.full_name} to `{group_b.display_name}`")
 
-    grants = GrantsCrawler(runtime_ctx.tables_crawler, runtime_ctx.udfs_crawler)
-
-    crawler_snapshot = list(grants.snapshot())
+    crawler_snapshot = list(runtime_ctx.grants_crawler.snapshot())
     actual_grants = defaultdict(set)
     for grant in crawler_snapshot:
         object_type, object_key = grant.this_type_and_key()
@@ -99,8 +93,8 @@ def test_all_grants_for_other_objects(
     sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{group_c.display_name}`")
     sql_backend.execute(f"DENY SELECT ON ANONYMOUS FUNCTION TO `{group_d.display_name}`")
 
-    crawler = GrantsCrawler(runtime_ctx.tables_crawler, runtime_ctx.udfs_crawler)
-    all_found_grants = list(crawler.snapshot())
+    runtime_ctx.make_schema()  # optimization to avoid crawling all databases
+    all_found_grants = list(runtime_ctx.grants_crawler.snapshot())
 
     found_any_file_grants = defaultdict(set)
     found_anonymous_function_grants = defaultdict(set)

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -15,8 +15,15 @@ from databricks.sdk.retries import retried
     ],
     indirect=("prepare_tables_for_migration",),
 )
-def test_table_migration_job_refreshes_migration_status(ws, installation_ctx, prepare_tables_for_migration, workflow):
+def test_table_migration_job_refreshes_migration_status(
+    ws,
+    installation_ctx,
+    prepare_tables_for_migration,
+    workflow,
+    modified_or_skip,
+):
     """The migration status should be refreshed after the migration job."""
+    modified_or_skip("hive_metastore")
     tables, _ = prepare_tables_for_migration
     ctx = installation_ctx.replace(
         extend_prompts={

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -23,8 +23,9 @@ from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.sdk.service import jobs, compute, pipelines
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=10))
-def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_directory, make_job):
+@retried(on=[NotFound], timeout=timedelta(minutes=5))
+def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_directory, make_job, modified_or_skip):
+    modified_or_skip("source_code")
     # Deprecated file system path in call to: /mnt/things/e/f/g
     lint_problem = b"display(spark.read.csv('/mnt/things/e/f/g'))"
     notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=lint_problem)

--- a/tests/integration/test_ext_hms.py
+++ b/tests/integration/test_ext_hms.py
@@ -95,7 +95,8 @@ def sql_backend(ws, env_or_skip) -> SqlBackend:
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
 @pytest.mark.parametrize('prepare_tables_for_migration', ['regular'], indirect=True)
-def test_migration_job_ext_hms(ws, installation_ctx, prepare_tables_for_migration, env_or_skip):
+def test_migration_job_ext_hms(ws, installation_ctx, prepare_tables_for_migration, env_or_skip, modified_or_skip):
+    modified_or_skip("hive_metastore")
     # this test spins up clusters using ext hms cluster policy, which will have a startup time of ~ 7-10m
     # skip this test if not in nightly test job or debug mode
     if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
@@ -143,13 +144,14 @@ def test_migration_job_ext_hms(ws, installation_ctx, prepare_tables_for_migratio
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
 def test_running_real_assessment_job_ext_hms(
-    ws, installation_ctx, env_or_skip, make_cluster_policy, make_cluster_policy_permissions
+    ws,
+    installation_ctx,
+    env_or_skip,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+    modified_or_skip,
 ):
-    # this test spins up clusters using ext hms cluster policy, which will have a startup time of ~ 7-10m
-    # skip this test if not in nightly test job or debug mode
-    if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        env_or_skip("TEST_NIGHTLY")
-
+    modified_or_skip("assessment")
     ext_hms_ctx = installation_ctx.replace(
         skip_dashboards=True,
         config_transform=lambda wc: dataclasses.replace(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,8 +1,6 @@
 import dataclasses
 import json
 import logging
-import os.path
-import sys
 from dataclasses import replace
 from datetime import timedelta
 
@@ -96,7 +94,9 @@ def test_experimental_permissions_migration_for_group_with_same_name(
     installation_ctx,
     make_cluster_policy,
     make_cluster_policy_permissions,
+    modified_or_skip,
 ):
+    modified_or_skip("workspace_access")
     ws_group, acc_group = installation_ctx.make_ucx_group()
     migrated_group = MigratedGroup.partial_info(ws_group, acc_group)
     cluster_policy = make_cluster_policy()
@@ -174,7 +174,8 @@ def test_job_cluster_policy(ws, installation_ctx):
 
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
-def test_running_real_remove_backup_groups_job(ws, installation_ctx):
+def test_running_real_remove_backup_groups_job(ws, installation_ctx, modified_or_skip):
+    modified_or_skip("workspace_access")
     ws_group_a, _ = installation_ctx.make_ucx_group()
 
     installation_ctx.__dict__['include_group_names'] = [ws_group_a.display_name]
@@ -367,10 +368,9 @@ def test_table_migration_job(
     installation_ctx,
     env_or_skip,
     prepare_tables_for_migration,
+    modified_or_skip,
 ):
-    # skip this test if not in nightly test job or debug mode
-    if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        env_or_skip("TEST_NIGHTLY")
+    modified_or_skip("hive_metastore")
 
     ctx = installation_ctx.replace(
         config_transform=lambda wc: replace(wc, override_clusters=None),
@@ -413,7 +413,9 @@ def test_table_migration_job_cluster_override(
     installation_ctx,
     prepare_tables_for_migration,
     env_or_skip,
+    modified_or_skip,
 ):
+    modified_or_skip("hive_metastore")
     tables, dst_schema = prepare_tables_for_migration
     ctx = installation_ctx.replace(
         extend_prompts={

--- a/tests/integration/test_runtime.py
+++ b/tests/integration/test_runtime.py
@@ -16,7 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=8))
-def test_running_real_assessment_job(ws, installation_ctx, make_cluster_policy, make_cluster_policy_permissions):
+def test_running_real_assessment_job(
+    ws,
+    installation_ctx,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+    modified_or_skip,
+):
+    modified_or_skip("assessment")
     ctx = installation_ctx.replace(skip_dashboards=False)
     ws_group_a, _ = ctx.make_ucx_group()
 
@@ -43,7 +50,9 @@ def test_running_real_migrate_groups_job(
     make_cluster_policy_permissions,
     make_secret_scope,
     make_secret_scope_acl,
+    modified_or_skip,
 ):
+    modified_or_skip("workspace_access")
     ws_group_a, acc_group_a = installation_ctx.make_ucx_group()
 
     cluster_policy = make_cluster_policy()
@@ -85,7 +94,9 @@ def test_running_real_validate_groups_permissions_job(
     make_cluster_policy_permissions,
     make_secret_scope,
     make_secret_scope_acl,
+    modified_or_skip,
 ):
+    modified_or_skip("workspace_access")
     ws_group_a, _ = installation_ctx.make_ucx_group()
 
     query = make_query()
@@ -124,8 +135,13 @@ def test_running_real_validate_groups_permissions_job(
 
 @retried(on=[NotFound], timeout=timedelta(minutes=8))
 def test_running_real_validate_groups_permissions_job_fails(
-    ws, installation_ctx, make_cluster_policy, make_cluster_policy_permissions
+    ws,
+    installation_ctx,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+    modified_or_skip,
 ):
+    modified_or_skip("workspace_access")
     ws_group_a, _ = installation_ctx.make_ucx_group()
 
     cluster_policy = make_cluster_policy()
@@ -135,7 +151,9 @@ def test_running_real_validate_groups_permissions_job_fails(
         group_name=ws_group_a.display_name,
     )
 
+    installation_ctx.make_schema()  # optimization to skip listing all schemas
     installation_ctx.__dict__['include_group_names'] = [ws_group_a.display_name]
+    installation_ctx.__dict__['include_object_permissions'] = [f'cluster-policies:{cluster_policy.policy_id}']
     installation_ctx.workspace_installation.run()
     installation_ctx.permission_manager.inventorize_permissions()
 
@@ -154,8 +172,9 @@ def test_hiveserde_table_in_place_migration_job(
     ws,
     installation_ctx,
     prepare_tables_for_migration,
-    env_or_skip,
+    modified_or_skip,
 ):
+    modified_or_skip("hive_metastore")
     tables, dst_schema = prepare_tables_for_migration
     ctx = installation_ctx.replace(
         extend_prompts={
@@ -180,8 +199,9 @@ def test_hiveserde_table_ctas_migration_job(
     ws,
     installation_ctx,
     prepare_tables_for_migration,
-    env_or_skip,
+    modified_or_skip,
 ):
+    modified_or_skip("hive_metastore")
     tables, dst_schema = prepare_tables_for_migration
     ctx = installation_ctx.replace(
         extend_prompts={

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -136,7 +136,7 @@ def test_tables_returning_error_when_show_tables(caplog):
     tables_crawler = TablesCrawler(backend, "default")
     results = tables_crawler.snapshot()
     assert len(results) == 0
-    assert "Schema hive_metastore.database no longer existed" in caplog.text
+    assert "Schema hive_metastore.database no longer exists" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds ability to skip running tests with `modified_or_skip` fixture when none of the three conditions are met:
1. Debugger is running
2. `TEST_NIGHTLY` environment variable is present
3. `git diff` on current branch doesn't have a relevant file changed.

Use with care.