### PR TITLE
improve no-cheat CI check

### DIFF
--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Verify no additional disabled lint in the new code
         run: |
           DIFFS=$(git diff origin/main..$(git branch --show-current))
+          echo $DIFFS
           RESULTS=$(python tests/unit/no_cheat.py ${DIFFS})
-          if [ "${#RESULTS}" -gt 0 ]; then
+          echo ${RESULTS}
+          if [ ${#RESULTS} -gt 0 ]; then
             echo ${RESULTS}
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          git diff origin/main..$(git branch --show-current) >> diff_data.txt
+          git diff origin/main...$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
           COUNT=$(cat cheats.txt | wc -c)
           if [ ${COUNT} -gt 0 ]; then

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           git diff origin/main..$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
+          cat cheats.txt
           COUNT=$(wc -c cheats.txt)
           if [ ${COUNT} -gt 0 ]; then
             cat cheats.txt

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Verify no additional disabled lint in the new code
         run: |
           DIFFS=$(git diff origin/main..$(git branch --show-current))
-          echo $DIFFS
-          RESULTS=$(python tests/unit/no_cheat.py ${DIFFS})
+          python tests/unit/no_cheat.py ${DIFFS} >> no_cheats.txt
+          RESULTS=$(cat no_cheats.txt)
           echo ${RESULTS}
           if [ ${#RESULTS} -gt 0 ]; then
             echo ${RESULTS}

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,12 +22,12 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          OLD_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^-')
-          OLD_CHEATS=$(echo "${OLD_CODE}" | grep -c '# pylint: disable'
-          NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          NEW_CHEATS=$(echo "${NEW_CODE}" | grep -c '# pylint: disable'
-          CHEATS=$((NEW_CHEATS-OLD_CHEATS))
-          if [ "${CHEATS}" -ne 0 ]; then
-            echo "Do not cheat the linter: ${CHEATS} new '# pylint: disable ...'"
+          MAIN_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^-')
+          MAIN_CHEATS=$(echo "${MAIN_CODE}" | grep -c '# pylint: disable')
+          BRANCH_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
+          BRANCH_CHEATS=$(echo "${BRANCH_CODE}" | grep -c '# pylint: disable')
+          NEW_CHEATS=$((BRANCH_CHEATS-MAIN_CHEATS))
+          if [ "${NEW_CHEATS}" -gt 0 ]; then
+            echo "Do not cheat the linter: ${NEW_CHEATS} new '# pylint: disable ...'"
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,7 +22,11 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          git diff origin/main...$(git branch --show-current) >> diff_data.txt
+          echo "Using base ref: ${GITHUB_BASE_REF}"
+          echo "Using head ref: ${$GITHUB_HEAD_REF}"
+          git fetch origin/$GITHUB_BASE_REF
+          git fetch origin/$GITHUB_HEAD_REF
+          git diff $GITHUB_BASE_REF...$GITHUB_HEAD_REF >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
           COUNT=$(cat cheats.txt | wc -c)
           if [ ${COUNT} -gt 0 ]; then

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Verify no additional disabled lint in the new code
         run: |
           git diff origin/main..$(git branch --show-current) >> diff_data.txt
-          RESULTS=$(python tests/unit/no_cheat.py diff_data.txt)
-          if [ ${#RESULTS} -gt 0 ]; then
-            echo ${RESULTS}
+          python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
+          COUNT=$(wc -c cheats.txt)
+          if [ ${COUNT} -gt 0 ]; then
+            cat cheats.txt
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           git diff origin/main..$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
-          cat cheats.txt
-          COUNT=$(wc -c cheats.txt)
+          COUNT=$(cat cheats.txt | wc -c)
           if [ ${COUNT} -gt 0 ]; then
             cat cheats.txt
             exit 1

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Verify no additional disabled lint in the new code
         run: |
           echo "Using base ref: ${GITHUB_BASE_REF}"
-          echo "Using head ref: ${$GITHUB_HEAD_REF}"
+          echo "Using head ref: ${GITHUB_HEAD_REF}"
           git fetch origin/$GITHUB_BASE_REF
           git fetch origin/$GITHUB_HEAD_REF
           git diff $GITHUB_BASE_REF...$GITHUB_HEAD_REF >> diff_data.txt

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,11 +22,8 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          echo "Using base ref: ${GITHUB_BASE_REF}"
-          echo "Using head ref: ${GITHUB_HEAD_REF}"
-          git fetch origin/$GITHUB_BASE_REF
-          git fetch origin/$GITHUB_HEAD_REF
-          git diff $GITHUB_BASE_REF...$GITHUB_HEAD_REF >> diff_data.txt
+          git fetch origin:$GITHUB_BASE_REF
+          git diff $GITHUB_BASE_REF...$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
           COUNT=$(cat cheats.txt | wc -c)
           if [ ${COUNT} -gt 0 ]; then

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -20,11 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify no lint is disabled in the new code
+      - name: Verify no additional disabled lint in the new code
         run: |
+          OLD_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^-')
+          OLD_CHEATS=$(echo "${OLD_CODE}" | grep -c '# pylint: disable'
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable' | grep -v "CHEAT" | wc -c)
-          if [ "${CHEAT}" -ne 0 ]; then
-            echo "Do not cheat the linter: ${CHEAT}"
+          NEW_CHEATS=$(echo "${NEW_CODE}" | grep -c '# pylint: disable'
+          CHEATS=$((NEW_CHEATS-OLD_CHEATS))
+          if [ "${CHEATS}" -ne 0 ]; then
+            echo "Do not cheat the linter: ${CHEATS} new '# pylint: disable ...'"
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -26,7 +26,7 @@ jobs:
           git diff $GITHUB_BASE_REF...$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
           COUNT=$(cat cheats.txt | wc -c)
-          if [ ${COUNT} -gt 0 ]; then
+          if [ ${COUNT} -gt 1 ]; then
             cat cheats.txt
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,12 +22,9 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          MAIN_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^-')
-          MAIN_CHEATS=$(echo "${MAIN_CODE}" | grep -c '# pylint: disable')
-          BRANCH_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          BRANCH_CHEATS=$(echo "${BRANCH_CODE}" | grep -c '# pylint: disable')
-          NEW_CHEATS=$((BRANCH_CHEATS-MAIN_CHEATS))
-          if [ "${NEW_CHEATS}" -gt 0 ]; then
-            echo "Do not cheat the linter: ${NEW_CHEATS} new '# pylint: disable ...'"
+          DIFFS=$(git diff origin/main..$(git branch --show-current))
+          RESULTS=$(python tests/unit/no_cheat.py ${DIFFS})
+          if [ "${#RESULTS}" -gt 0 ]; then
+            echo ${RESULTS}
             exit 1
           fi

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          git fetch origin:$GITHUB_BASE_REF
+          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
           git diff $GITHUB_BASE_REF...$(git branch --show-current) >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
           COUNT=$(cat cheats.txt | wc -c)

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -22,10 +22,8 @@ jobs:
 
       - name: Verify no additional disabled lint in the new code
         run: |
-          DIFFS=$(git diff origin/main..$(git branch --show-current))
-          python tests/unit/no_cheat.py ${DIFFS} >> no_cheats.txt
-          RESULTS=$(cat no_cheats.txt)
-          echo ${RESULTS}
+          git diff origin/main..$(git branch --show-current) >> diff_data.txt
+          RESULTS=$(python tests/unit/no_cheat.py diff_data.txt)
           if [ ${#RESULTS} -gt 0 ]; then
             echo ${RESULTS}
             exit 1

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 DISABLE_TAG = '# pylint: disable='
 
@@ -30,4 +31,7 @@ def no_cheat(diff_text: str) -> str:
 
 if __name__ == "__main__":
     diff_data = sys.argv[1]
+    path = Path(diff_data)
+    if path.exists():
+        diff_data = path.read_text()
     print(no_cheat(diff_data))

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -33,5 +33,5 @@ if __name__ == "__main__":
     diff_data = sys.argv[1]
     path = Path(diff_data)
     if path.exists():
-        diff_data = path.read_text()
+        diff_data = path.read_text("utf-8")
     print(no_cheat(diff_data))

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -1,0 +1,33 @@
+import sys
+
+DISABLE_TAG = '# pylint: disable='
+
+
+def no_cheat(diff_text: str) -> str:
+    lines = diff_text.split('\n')
+    removed: dict[str, int] = {}
+    added: dict[str, int] = {}
+    for line in lines:
+        if not (line.startswith("-") or line.startswith("+")):
+            continue
+        idx = line.find(DISABLE_TAG)
+        if idx < 0:
+            continue
+        codes = line[idx + len(DISABLE_TAG) :].split(',')
+        for code in codes:
+            code = code.strip()
+            if line.startswith("-"):
+                removed[code] = removed.get(code, 0) + 1
+                continue
+            added[code] = added.get(code, 0) + 1
+    results: list[str] = []
+    for code, count in added.items():
+        count -= removed.get(code, 0)
+        if count > 0:
+            results.append(f"Do not cheat the linter: found {count} additional {DISABLE_TAG}{code}")
+    return '\n'.join(results)
+
+
+if __name__ == "__main__":
+    diff_data = sys.argv[1]
+    print(no_cheat(diff_data))

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -16,7 +16,7 @@ def no_cheat(diff_text: str) -> str:
             continue
         codes = line[idx + len(DISABLE_TAG) :].split(',')
         for code in codes:
-            code = code.strip()
+            code = code.strip().strip('\n').strip('"').strip("'")
             if line.startswith("-"):
                 removed[code] = removed.get(code, 0) + 1
                 continue

--- a/tests/unit/test_no_cheat.py
+++ b/tests/unit/test_no_cheat.py
@@ -1,0 +1,78 @@
+from tests.unit.no_cheat import no_cheat
+
+
+def test_no_cheat_returns_empty_string_for_empty_diff():
+    diff_data = ""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_no_cheat_diff():
+    diff_data = """
++some code
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_removed_cheat():
+    diff_data = """
++some code
+-some other code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_replaced_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_message_for_single_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == "Do not cheat the linter: found 1 additional # pylint: disable=some-rule"
+
+
+def test_no_cheat_returns_message_for_multiple_same_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
++some code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert result == "Do not cheat the linter: found 2 additional # pylint: disable=some-rule"
+
+
+def test_no_cheat_returns_message_for_multiple_cheats_in_different_lines():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
++some code # pylint: disable=some-other-rule
+"""
+    result = no_cheat(diff_data)
+    assert result == (
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule\n"
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+    )
+
+
+def test_no_cheat_returns_message_for_multiple_cheats_in_same_lines():
+    diff_data = """
++some code # pylint: disable=some-rule, some-other-rule
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == (
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule\n"
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+    )


### PR DESCRIPTION
## Changes
improve no-cheat CI check

Currently we get blocked when we change a line of code that already contains a cheat. 
For example, changing from:
`some_function("abc") # pylint: disable=some-code`
to:
`some_function("xyz") # pylint: disable=some-code`
triggers a no-cheat erroneously.
We want to avoid that, and also get better feedback on the new cheats.

The current script diffs the incoming branch with main, not the target branch. 
This PR changes that by using `$GITHUB_BASE_REF`.

The logic is too complex for bash, so delegating the analysis to python.

### Linked issues
None

### Functionality
None

### Tests
- [x] manually tested
