### PR TITLE
raise warning instead of error to allow assessment in regions that do not support certain features

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -59,7 +59,7 @@ class Listing:
             for item in self._func():
                 yield GenericPermissionsInfo(getattr(item, self._id_attribute), self._object_type)
         except NotFound as e:
-            logger.error(f"Listing {self._object_type} failed: {e}")
+            logger.warning(f"Listing {self._object_type} failed: {e}")
         since = datetime.datetime.now() - started
         logger.info(f"Listed {self._object_type} in {since}")
 

--- a/tests/unit/workspace_access/test_generic.py
+++ b/tests/unit/workspace_access/test_generic.py
@@ -918,11 +918,11 @@ def test_models_page_listing():
         assert item.object_type == "registered-models"
 
 
-def test_serving_endpoints_not_enabled(caplog):
+def test_serving_endpoints_not_enabled_raises_warning(caplog):
     ws = create_autospec(WorkspaceClient)
     ws.serving_endpoints.list.side_effect = NotFound("Model serving is not enabled for your shard")
 
     sup = GenericPermissionsSupport(ws=ws, listings=[Listing(ws.serving_endpoints.list, "id", "serving-endpoints")])
-    with caplog.at_level('ERROR'):
+    with caplog.at_level('WARNING'):
         list(sup.get_crawler_tasks())
     assert "Listing serving-endpoints failed: Model serving is not enabled for your shard" in caplog.text


### PR DESCRIPTION
## Changes
raise warning instead of error to allow assessment in regions that do not support certain features

### Linked issues
Resolves #2082 

### Functionality
None

### Tests
- [x] added unit tests
