### PR TITLE
fix bug when parsing unsupported magic syntax

### DIFF
--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -196,7 +196,7 @@ class RunCell(Cell):
         command = f'{LANGUAGE_PREFIX}{self.language.magic_name}'
         lines = self._original_code.split('\n')
         for idx, line in enumerate(lines):
-            start = line.index(command)
+            start = line.find(command)
             if start >= 0:
                 path = line[start + len(command) :]
                 path = path.strip().strip("'").strip('"')


### PR DESCRIPTION
## Changes
fix crasher when parsing unsupported magic syntax

### Linked issues
None

### Functionality
None

### Tests
- [x] manually tested

Was discovered when running `make solacc`. Fixes 1 of the 2 issues.
