### PR TITLE
Remove DuckdbDB lint message from `known.json`

### DIFF
--- a/src/databricks/labs/ucx/source_code/known.json
+++ b/src/databricks/labs/ucx/source_code/known.json
@@ -3213,12 +3213,7 @@
     "duckdb.experimental.spark.sql.functions": [],
     "duckdb.experimental.spark.sql.group": [],
     "duckdb.experimental.spark.sql.readwriter": [],
-    "duckdb.experimental.spark.sql.session": [
-      {
-        "code": "table-migrate",
-        "message": "The default format changed in Databricks Runtime 8.0, from Parquet to Delta"
-      }
-    ],
+    "duckdb.experimental.spark.sql.session": [],
     "duckdb.experimental.spark.sql.streaming": [],
     "duckdb.experimental.spark.sql.type_utils": [],
     "duckdb.experimental.spark.sql.types": [],


### PR DESCRIPTION
Remove the lint message for DuckDB from `knownd.json` as it does not use Spark, nor does it change behavior based on the Databricks runtime. See [this comment](https://github.com/databrickslabs/ucx/pull/2134#discussion_r1674006987) for more context
