### PR TITLE
Added support for DBFS when building the dependency graph for tasks

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -170,7 +170,7 @@ class WorkflowTaskContainer(SourceContainer):
         self._named_parameters = self._task.notebook_task.base_parameters
         notebook_path = self._task.notebook_task.notebook_path
         logger.info(f'Discovering {self._task.task_key} entrypoint: {notebook_path}')
-        # TODO: Support DBFS here.
+        # Notebooks can't be on DBFS.
         path = WorkspacePath(self._ws, notebook_path)
         return graph.register_notebook(path)
 
@@ -246,7 +246,7 @@ class WorkflowTaskContainer(SourceContainer):
                 return
             if library.notebook.path:
                 notebook_path = library.notebook.path
-                # TODO: Support DBFS here.
+                # Notebooks can't be on DBFS.
                 path = WorkspacePath(self._ws, notebook_path)
                 yield from graph.register_notebook(path)
             if library.jar:

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -156,6 +156,7 @@ class WorkflowTaskContainer(SourceContainer):
             requirements_path = self._as_path(library.requirements)
             with requirements_path.open() as requirements:
                 for requirement in requirements:
+                    requirement = requirement.rstrip()
                     clean_requirement = requirement.replace(" ", "")  # requirements.txt may contain spaces
                     if clean_requirement.startswith("-r"):
                         logger.warning(f"References to other requirements file is not supported: {requirement}")

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -125,12 +125,14 @@ class WorkflowTaskContainer(SourceContainer):
                 yield from problems
         if library.egg:
             logger.info(f"Registering library from {library.egg}")
+            # TODO: Support DBFS here.
             with self._ws.workspace.download(library.egg, format=ExportFormat.AUTO) as remote_file:
                 with tempfile.TemporaryDirectory() as directory:
                     local_file = Path(directory) / Path(library.egg).name
                     local_file.write_bytes(remote_file.read())
                     yield from graph.register_library(local_file.as_posix())
         if library.whl:
+            # TODO: Support DBFS here.
             with self._ws.workspace.download(library.whl, format=ExportFormat.AUTO) as remote_file:
                 with tempfile.TemporaryDirectory() as directory:
                     local_file = Path(directory) / Path(library.whl).name
@@ -138,6 +140,7 @@ class WorkflowTaskContainer(SourceContainer):
                     yield from graph.register_library(local_file.as_posix())
         if library.requirements:  # https://pip.pypa.io/en/stable/reference/requirements-file-format/
             logger.info(f"Registering libraries from {library.requirements}")
+            # TODO: Support DBFS here.
             with self._ws.workspace.download(library.requirements, format=ExportFormat.AUTO) as remote_file:
                 contents = remote_file.read().decode()
                 for requirement in contents.splitlines():
@@ -159,6 +162,7 @@ class WorkflowTaskContainer(SourceContainer):
         self._named_parameters = self._task.notebook_task.base_parameters
         notebook_path = self._task.notebook_task.notebook_path
         logger.info(f'Discovering {self._task.task_key} entrypoint: {notebook_path}')
+        # TODO: Support DBFS here.
         path = WorkspacePath(self._ws, notebook_path)
         return graph.register_notebook(path)
 
@@ -168,6 +172,7 @@ class WorkflowTaskContainer(SourceContainer):
         self._parameters = self._task.spark_python_task.parameters
         notebook_path = self._task.spark_python_task.python_file
         logger.info(f'Discovering {self._task.task_key} entrypoint: {notebook_path}')
+        # TODO: Support DBFS here.
         path = WorkspacePath(self._ws, notebook_path)
         return graph.register_notebook(path)
 
@@ -233,6 +238,7 @@ class WorkflowTaskContainer(SourceContainer):
                 return
             if library.notebook.path:
                 notebook_path = library.notebook.path
+                # TODO: Support DBFS here.
                 path = WorkspacePath(self._ws, notebook_path)
                 yield from graph.register_notebook(path)
             if library.jar:

--- a/src/databricks/labs/ucx/source_code/path_lookup.py
+++ b/src/databricks/labs/ucx/source_code/path_lookup.py
@@ -95,7 +95,7 @@ class PathLookup:
 
     @property
     def library_roots(self) -> list[Path]:
-        # we may return a combination of WorkspacePath and PosixPath here
+        # we may return a combination of DBFSPath, WorkspacePath and PosixPath here
         library_roots = []
         for library_root in [self._cwd] + self._sys_paths:
             try:

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -249,7 +249,7 @@ def test_workflow_linter_lints_job_with_egg_dependency(
 
     problems = simple_ctx.workflow_linter.lint_job(job_with_egg_dependency.job_id)
 
-    assert len([problem for problem in problems if problem.message == expected_problem_message]) == 0
+    assert not [problem for problem in problems if problem.message == expected_problem_message]
 
 
 def test_workflow_linter_lints_job_with_missing_library(

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -1,11 +1,11 @@
 import io
 import logging
 import shutil
+from collections.abc import Callable
 from dataclasses import replace
 from datetime import timedelta
 from io import StringIO
 from pathlib import Path
-from typing import Callable
 from unittest.mock import create_autospec
 
 import pytest

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -153,7 +153,9 @@ class TestWorkflowTaskContainerDependencyGraphForLibraries:
         _ = workflow_task_container.build_dependency_graph(dep_graph)
 
         dep_graph.register_library.assert_called_once()
-        registered_libraries = [library for args in dep_graph.register_library.call_args_list for library in args[0]]
+        registered_libraries = tuple(
+            library for args in dep_graph.register_library.call_args_list for library in args[0]
+        )
         registered_names = tuple(Path(library).name for library in registered_libraries)
         assert registered_names == (expected_name,)
 
@@ -204,9 +206,10 @@ class TestWorkflowTaskContainerDependencyGraphForLibraries:
         workflow_task_container = WorkflowTaskContainer(ws, task, Job())
         _ = workflow_task_container.build_dependency_graph(dep_graph)
 
-        registered_libraries = [library for args in dep_graph.register_library.call_args_list for library in args[0]]
-        registered_names = tuple(Path(library).name for library in registered_libraries)
-        assert registered_names == expected_dependencies
+        registered_libraries = tuple(
+            library for args in dep_graph.register_library.call_args_list for library in args[0]
+        )
+        assert registered_libraries == expected_dependencies
 
 
 def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_lookup, empty_index, caplog):


### PR DESCRIPTION
## Changes

This PR updates the way we track the tasks dependencies when assessing workflows; DBFS-located paths are now supported for:

 - Wheels and eggs that a task depends on.
 - The location of `requirements.txt` files that specify task dependencies.
 - The location of PySpark jobs.

### Linked issues

Resolves #1558.

### Functionality

- modified existing workflow: `assessment`

### Tests

- added unit tests
