### PR TITLE
Add new widget to get table count

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/01_3_count_table_by_type_location_format.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/01_3_count_table_by_type_location_format.sql
@@ -1,0 +1,29 @@
+/* --title 'Table counts by type, location and format' --width 4 --height 4 */
+SELECT object_type AS SOURCE_TABLE_TYPE,
+table_format AS FORMAT, LOCATION, count(*) AS COUNT
+FROM
+(SELECT object_type,
+table_format,
+  CASE
+    WHEN STARTSWITH(location, 'dbfs:/mnt')
+    THEN 'DBFS MOUNT'
+    WHEN STARTSWITH(location, '/dbfs/mnt')
+    THEN 'DBFS MOUNT'
+    WHEN STARTSWITH(location, 'dbfs:/databricks-datasets')
+    THEN 'Databricks Demo Dataset'
+    WHEN STARTSWITH(location, '/dbfs/databricks-datasets')
+    THEN 'Databricks Demo Dataset'
+    WHEN STARTSWITH(location, 'dbfs:/')
+    THEN 'DBFS ROOT'
+    WHEN STARTSWITH(location, '/dbfs/')
+    THEN 'DBFS ROOT'
+    WHEN STARTSWITH(location, 'wasb')
+    THEN 'UNSUPPORTED'
+    WHEN STARTSWITH(location, 'adl')
+    THEN 'UNSUPPORTED'
+    ELSE 'EXTERNAL'
+  END AS LOCATION
+  FROM inventory.tables
+WHERE object_type NOT IN ('VIEW'))
+GROUP BY ALL
+ORDER BY SOURCE_TABLE_TYPE

--- a/src/databricks/labs/ucx/queries/assessment/main/01_3_count_table_by_type_location_format.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/01_3_count_table_by_type_location_format.sql
@@ -1,29 +1,36 @@
 /* --title 'Table counts by type, location and format' --width 4 --height 4 */
-SELECT object_type AS SOURCE_TABLE_TYPE,
-table_format AS FORMAT, LOCATION, count(*) AS COUNT
-FROM
-(SELECT object_type,
-table_format,
-  CASE
-    WHEN STARTSWITH(location, 'dbfs:/mnt')
-    THEN 'DBFS MOUNT'
-    WHEN STARTSWITH(location, '/dbfs/mnt')
-    THEN 'DBFS MOUNT'
-    WHEN STARTSWITH(location, 'dbfs:/databricks-datasets')
-    THEN 'Databricks Demo Dataset'
-    WHEN STARTSWITH(location, '/dbfs/databricks-datasets')
-    THEN 'Databricks Demo Dataset'
-    WHEN STARTSWITH(location, 'dbfs:/')
-    THEN 'DBFS ROOT'
-    WHEN STARTSWITH(location, '/dbfs/')
-    THEN 'DBFS ROOT'
-    WHEN STARTSWITH(location, 'wasb')
-    THEN 'UNSUPPORTED'
-    WHEN STARTSWITH(location, 'adl')
-    THEN 'UNSUPPORTED'
-    ELSE 'EXTERNAL'
-  END AS LOCATION
+SELECT
+  object_type AS source_table_type,
+  table_format AS format,
+  location,
+  COUNT(*) AS count
+FROM (
+  SELECT
+    object_type,
+    table_format,
+    CASE
+      WHEN STARTSWITH(location, 'dbfs:/mnt')
+      THEN 'DBFS MOUNT'
+      WHEN STARTSWITH(location, '/dbfs/mnt')
+      THEN 'DBFS MOUNT'
+      WHEN STARTSWITH(location, 'dbfs:/databricks-datasets')
+      THEN 'Databricks Demo Dataset'
+      WHEN STARTSWITH(location, '/dbfs/databricks-datasets')
+      THEN 'Databricks Demo Dataset'
+      WHEN STARTSWITH(location, 'dbfs:/')
+      THEN 'DBFS ROOT'
+      WHEN STARTSWITH(location, '/dbfs/')
+      THEN 'DBFS ROOT'
+      WHEN STARTSWITH(location, 'wasb')
+      THEN 'UNSUPPORTED'
+      WHEN STARTSWITH(location, 'adl')
+      THEN 'UNSUPPORTED'
+      ELSE 'EXTERNAL'
+    END AS location
   FROM inventory.tables
-WHERE object_type NOT IN ('VIEW'))
+  WHERE
+    NOT object_type IN ('VIEW')
+)
 GROUP BY ALL
-ORDER BY SOURCE_TABLE_TYPE
+ORDER BY
+  source_table_type


### PR DESCRIPTION
## Changes
New widgets gives table counts summary by type (external/managed), location (dbfs root/mount/cloud) and format (delta, parquet etc).

### Linked issues
Introduces #1916 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
