### PR TITLE
Job integration tests: remove unused fixtures

### DIFF
--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -58,7 +58,7 @@ def test_linter_from_context(simple_ctx, make_job, make_notebook):
     assert result['count'] > 0
 
 
-def test_job_linter_no_problems(simple_ctx, ws, make_job):
+def test_job_linter_no_problems(simple_ctx, make_job):
     j = make_job()
 
     problems = simple_ctx.workflow_linter.lint_job(j.job_id)
@@ -67,7 +67,7 @@ def test_job_linter_no_problems(simple_ctx, ws, make_job):
 
 
 def test_job_task_linter_library_not_installed_cluster(
-    simple_ctx, ws, make_job, make_random, make_cluster, make_notebook, make_directory
+    simple_ctx, make_job, make_random, make_cluster, make_notebook, make_directory
 ):
     created_cluster = make_cluster(single_node=True)
     entrypoint = make_directory()
@@ -203,9 +203,7 @@ def test_workflow_linter_lints_job_with_requirements_dependency(
     ws,
     make_job,
     make_notebook,
-    make_random,
     make_directory,
-    tmp_path,
 ):
     expected_problem_message = "Could not locate import: yaml"
 
@@ -252,14 +250,7 @@ def test_workflow_linter_lints_job_with_egg_dependency(
     assert len([problem for problem in problems if problem.message == expected_problem_message]) == 0
 
 
-def test_workflow_linter_lints_job_with_missing_library(
-    simple_ctx,
-    ws,
-    make_job,
-    make_notebook,
-    make_random,
-    make_directory,
-):
+def test_workflow_linter_lints_job_with_missing_library(simple_ctx, make_job, make_notebook, make_directory):
     expected_problem_message = "Could not locate import: databricks.labs.ucx"
     allow_list = create_autospec(KnownList)  # databricks is in default list
     allow_list.module_compatibility.return_value = UNKNOWN
@@ -278,14 +269,7 @@ def test_workflow_linter_lints_job_with_missing_library(
     allow_list.module_compatibility.assert_called_once_with("databricks.labs.ucx")
 
 
-def test_workflow_linter_lints_job_with_wheel_dependency(
-    simple_ctx,
-    ws,
-    make_job,
-    make_notebook,
-    make_random,
-    make_directory,
-):
+def test_workflow_linter_lints_job_with_wheel_dependency(simple_ctx, make_job, make_notebook, make_directory):
     expected_problem_message = "Could not locate import: databricks.labs.ucx"
 
     simple_ctx = simple_ctx.replace(
@@ -307,7 +291,6 @@ def test_workflow_linter_lints_job_with_wheel_dependency(
 
 def test_job_spark_python_task_linter_happy_path(
     simple_ctx,
-    ws,
     make_job,
     make_random,
     make_cluster,
@@ -334,7 +317,7 @@ def test_job_spark_python_task_linter_happy_path(
 
 
 def test_job_spark_python_task_linter_unhappy_path(
-    simple_ctx, ws, make_job, make_random, make_cluster, make_notebook, make_directory
+    simple_ctx, make_job, make_random, make_cluster, make_notebook, make_directory
 ):
     entrypoint = make_directory()
 
@@ -391,10 +374,8 @@ def test_workflow_linter_lints_python_wheel_task(simple_ctx, ws, make_job, make_
 
 def test_job_dlt_task_linter_unhappy_path(
     simple_ctx,
-    ws,
     make_job,
     make_random,
-    make_cluster,
     make_notebook,
     make_directory,
     make_pipeline,
@@ -417,10 +398,8 @@ def test_job_dlt_task_linter_unhappy_path(
 
 def test_job_dlt_task_linter_happy_path(
     simple_ctx,
-    ws,
     make_job,
     make_random,
-    make_cluster,
     make_notebook,
     make_directory,
     make_pipeline,
@@ -442,9 +421,7 @@ def test_job_dlt_task_linter_happy_path(
     assert len([problem for problem in problems if problem.message == "Could not locate import: greenlet"]) == 0
 
 
-def test_job_dependency_problem_egg_dbr14plus(
-    make_cluster, make_job, make_directory, make_notebook, make_random, simple_ctx, ws
-):
+def test_job_dependency_problem_egg_dbr14plus(make_job, make_directory, make_notebook, make_random, simple_ctx, ws):
     egg_file = Path(__file__).parent / "../../unit/source_code/samples/distribution/dist/thingy-0.0.1-py3.10.egg"
     task_spark_conf = None
     entrypoint = make_directory()


### PR DESCRIPTION
## Changes

Some of the integration tests for jobs request fixtures that they don't use; this PR removes them.