### PR TITLE
added doc to clarify that principal-prefix-access for azure will only list abfss storage accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,8 @@ on each storage account. The command is used to identify Azure Service Principal
 `Storage Blob Data Reader`, `Storage Blob Data Owner` roles, or custom read/write roles on ADLS Gen2 locations that are being
 used in Databricks. This requires Azure CLI to be installed and configured via `az login`. It outputs azure_storage_account_info.csv
 which will be later used by migrate-credentials command to create UC storage credentials.
+Note: This cmd only lists azure storage account gen2, storage format wasb:// or adl:// are not supported in UC and those storage info
+will be skipped.
 
 Once done, proceed to the [`migrate-credentials` command](#migrate-credentials-command).
 


### PR DESCRIPTION

## Changes
This PR updates the documentation to clarify that principal-prefix-access cli cmd for azure will only list abfss://  storage account. storage account used as adl:// or wasb:// will not be listed as those will not be used for credential migration

### Linked issues
#1065 

Resolves #1552 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
