### PR TITLE
Disable the builtin pip version check when running pip commands

### DIFF
--- a/src/databricks/labs/ucx/source_code/python_libraries.py
+++ b/src/databricks/labs/ucx/source_code/python_libraries.py
@@ -71,7 +71,9 @@ class PythonLibraryResolver(LibraryResolver):
         return libs
 
     def _install_pip(self, *libraries: str) -> list[DependencyProblem]:
-        install_command = f"pip install {shlex.join(libraries)} -t {self._temporary_virtual_environment}"
+        install_command = (
+            f"pip --disable-pip-version-check install {shlex.join(libraries)} -t {self._temporary_virtual_environment}"
+        )
         return_code, stdout, stderr = self._runner(install_command)
         logger.debug(f"pip output:\n{stdout}\n{stderr}")
         if return_code != 0:

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -138,7 +138,7 @@ def test_pip_cell_build_dependency_graph_reports_unknown_library(mock_path_looku
 
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
-    assert problems[0].message.startswith("'pip install unknown-library-name")
+    assert problems[0].message.startswith("'pip --disable-pip-version-check install unknown-library-name")
 
 
 def test_pip_cell_build_dependency_graph_resolves_installed_library(mock_path_lookup):

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -100,7 +100,7 @@ def test_workflow_task_container_builds_dependency_graph_unknown_pypi_library(mo
 
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
-    assert problems[0].message.startswith("'pip install unknown-library-name")
+    assert problems[0].message.startswith("'pip --disable-pip-version-check install unknown-library-name")
     assert mock_path_lookup.resolve(Path("unknown-library-name")) is None
     ws.assert_not_called()
 
@@ -228,7 +228,7 @@ def test_workflow_task_container_builds_dependency_graph_spark_python_task(
 
 
 def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_lookup, empty_index, caplog):
-    expected_message = "Found job problems:\nUNKNOWN:-1 [library-install-failed] 'pip install unknown-library"
+    expected_message = "Found job problems:\nUNKNOWN:-1 [library-install-failed] 'pip --disable-pip-version-check install unknown-library"
 
     ws = create_autospec(WorkspaceClient)
     linter = WorkflowLinter(ws, dependency_resolver, mock_path_lookup, empty_index)
@@ -258,7 +258,7 @@ def test_workflow_task_container_builds_dependency_graph_for_requirements_txt(mo
 
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
-    assert problems[0].message.startswith("'pip install test")
+    assert problems[0].message.startswith("'pip --disable-pip-version-check install test")
     assert mock_path_lookup.resolve(Path("test")) is None
     ws.assert_not_called()
 

--- a/tests/unit/source_code/test_python_libraries.py
+++ b/tests/unit/source_code/test_python_libraries.py
@@ -7,7 +7,7 @@ from databricks.labs.ucx.source_code.known import KnownList
 
 def test_python_library_resolver_resolves_library(mock_path_lookup):
     def mock_pip_install(command):
-        assert command.startswith("pip install anything -t")
+        assert command.startswith("pip --disable-pip-version-check install anything -t")
         return 0, "", ""
 
     python_library_resolver = PythonLibraryResolver(KnownList(), mock_pip_install)
@@ -25,7 +25,7 @@ def test_python_library_resolver_failing(mock_path_lookup):
 
     assert len(problems) == 1
     assert problems[0].code == "library-install-failed"
-    assert problems[0].message.startswith("'pip install anything")
+    assert problems[0].message.startswith("'pip --disable-pip-version-check install anything")
     assert problems[0].message.endswith("nope'")
 
 


### PR DESCRIPTION
## Changes

This PR disables Pip's built-in version check when using it to install dependencies. Pip itself is outside the control of UCX, and the version check often produces a lot of noise in the pip-related errors and finding messages.

### Functionality

- modified existing workflow: `...`

### Tests

- manually tested
- unit tests
