### PR TITLE
Group migration: change error logging format

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -119,9 +119,7 @@ class MigrationState:
                 total_permissions += group_permissions
                 success_groups += 1
             except IOError as e:
-                logger.exception(
-                    f"Migration of group permissions failed: {name_in_workspace} (workspace) -> {name_in_account} (account)"
-                )
+                logger.error(f"failed-group-migration: {name_in_workspace} -> {name_in_account}: {e}")
                 errors.append(e)
         logger.info(f"Migrated {total_permissions} permissions for {success_groups}/{len(self)} groups successfully.")
         if errors:

--- a/tests/unit/workspace_access/test_workflows.py
+++ b/tests/unit/workspace_access/test_workflows.py
@@ -133,8 +133,8 @@ def test_migrate_permissions_continue_on_error(run_workflow, caplog) -> None:
     assert len(raised_exception.errs) == 2
     expected_exceptions = {"simulate group failure: immediately", "simulate group failure: midway"}
     assert {str(e) for e in raised_exception.errs} == expected_exceptions
-    assert "Migration of group permissions failed: temp_1" in caplog.text
-    assert "Migration of group permissions failed: temp_2" in caplog.text
+    assert "failed-group-migration: temp_1 -> account_group_1: simulate group failure: immediately" in caplog.text
+    assert "failed-group-migration: temp_2 -> account_group_2: simulate group failure: midway" in caplog.text
     assert "Migrated 50 permissions for 1/3 groups successfully." in caplog.messages
     assert "Migrating permissions failed for 2/3 groups." in caplog.messages
 


### PR DESCRIPTION
## Changes

This PR updates the format of the logged messages when permissions migration fails during the experimental group migration workflow.

The new format is as-suggested [here](https://github.com/databrickslabs/ucx/issues/1914#issuecomment-2233315439), although both the source and destination account names are mentioned (because they can be different).

### Linked issues

Progresses #1914.

### Functionality

- modified existing workflow: `group-migration-experimental`

### Tests

- added unit tests
