### PR TITLE
Fix mypy flags `import distutils` in Python 3.12

### DIFF
--- a/src/databricks/labs/ucx/source_code/python_libraries.py
+++ b/src/databricks/labs/ucx/source_code/python_libraries.py
@@ -128,7 +128,8 @@ class PythonLibraryResolver(LibraryResolver):
             from setuptools import setup  # type: ignore
         except (ImportError, AssertionError):
             try:
-                from distutils.core import setup  # pylint: disable=deprecated-module
+                # pylint: disable-next=deprecated-module
+                from distutils.core import setup  # type: ignore
             except ImportError:
                 logger.warning("Could not import setup.")
                 setup = None


### PR DESCRIPTION
## Changes
Fix mypy flags `import distutils` in python 3.12. Local `make lint` fails with Python 3.12.