### PR TITLE
Lint child dependencies recursively

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -139,15 +139,16 @@ class LocalCodeLinter:
         self, dependency: Dependency, graph: DependencyGraph, linted: set[Dependency]
     ) -> Iterable[LocatedAdvice]:
         if dependency in linted:
-            return []
+            yield from []
         linted.add(dependency)
         if dependency.path.is_dir():
-            return []
+            yield from []
         ctx = self._new_linter_context()
         linter = FileLinter(ctx, self._path_lookup, self._session_state, dependency.path)
         for advice in linter.lint():
             yield advice.for_path(dependency.path)
         maybe_graph = graph.locate_dependency(dependency.path)
+        # problems have already been reported while building the graph
         if maybe_graph.graph:
             child_graph = maybe_graph.graph
             for child_dependency in child_graph.local_dependencies:

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -139,10 +139,10 @@ class LocalCodeLinter:
         self, dependency: Dependency, graph: DependencyGraph, linted: set[Dependency]
     ) -> Iterable[LocatedAdvice]:
         if dependency in linted:
-            yield from []
+            return
         linted.add(dependency)
         if dependency.path.is_dir():
-            yield from []
+            return
         ctx = self._new_linter_context()
         linter = FileLinter(ctx, self._path_lookup, self._session_state, dependency.path)
         for advice in linter.lint():

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -198,7 +198,7 @@ def test_lint_local_code(simple_ctx):
         light_ctx.dependency_resolver,
         lambda: linter_context,
     )
-    problems = linter.lint(Prompts(), path_to_scan, StringIO())
+    problems = linter.lint(Prompts(), set(), path_to_scan, StringIO())
     assert len(problems) > 0
 
 

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -122,7 +122,9 @@ def test_linter_walks_directory(mock_path_lookup, migration_index):
     linter = LocalCodeLinter(
         file_loader, folder_loader, mock_path_lookup, session_state, resolver, lambda: LinterContext(migration_index)
     )
-    advices = linter.lint(prompts, None)
+    paths: set[Path] = set()
+    advices = linter.lint(prompts, paths, None)
+    assert len(paths) > 10
     assert not advices
 
 
@@ -181,6 +183,7 @@ def test_known_issues(path: Path, migration_index):
         resolver,
         lambda: LinterContext(migration_index, session_state),
     )
-    advices = linter.lint(MockPrompts({}), path)
+    linted: set[Path] = set()
+    advices = linter.lint(MockPrompts({}), linted, path)
     for advice in advices:
         print(repr(advice))


### PR DESCRIPTION
## Changes
The current code lints local files without considering parent/child relationships (where a given 'parent' file imports or runs a 'child' file).
This makes it impossible to lint files in context, where a child file uses variables inherited from a parent file.
This PR is progress towards that, by linting child dependencies recursively.

### Linked issues
Progresses #2155 
Progresses #2156

### Functionality
- [x] modified existing command: `databricks labs ucx lint-local-code`

### Tests
- [x] checked integration tests
