### PR TITLE
enhance python abstract syntax tree API

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -238,7 +238,7 @@ class PythonSequentialLinter(Linter):
             # error already reported when linting enclosing notebook
             logger.warning(f"Failed to parse Python cell: {code}", exc_info=e)
 
-    def _make_tree(self):
+    def _make_tree(self) -> Tree:
         if self._tree is None:
             self._tree = Tree.new_module()
         return self._tree

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -196,15 +196,15 @@ class DependencyGraph:
                 return True
         return False
 
-    def new_graph_builder_context(self):
-        return GraphBuilderContext(parent=self, path_lookup=self._path_lookup, session_state=self._session_state)
+    def new_dependency_graph_context(self):
+        return DependencyGraphContext(parent=self, path_lookup=self._path_lookup, session_state=self._session_state)
 
     def __repr__(self):
         return f"<DependencyGraph {self.path}>"
 
 
 @dataclass
-class GraphBuilderContext:
+class DependencyGraphContext:
     parent: DependencyGraph
     path_lookup: PathLookup
     session_state: CurrentSessionState

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -14,7 +14,7 @@ from databricks.sdk.service.workspace import Language
 from databricks.labs.blueprint.tui import Prompts
 
 from databricks.labs.ucx.source_code.linters.context import LinterContext
-from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage, GraphBuilder
+from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage, PythonCodeAnalyzer
 from databricks.labs.ucx.source_code.graph import (
     BaseImportResolver,
     BaseFileResolver,
@@ -40,9 +40,9 @@ class LocalFile(SourceContainer):
 
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
         if self._language is CellLanguage.PYTHON:
-            context = parent.new_graph_builder_context()
-            builder = GraphBuilder(context)
-            return builder.build_graph_from_python_source(self._original_code)
+            context = parent.new_dependency_graph_context()
+            analyser = PythonCodeAnalyzer(context, self._original_code)
+            return analyser.build_graph()
         # supported language that does not generate dependencies
         if self._language is CellLanguage.SQL:
             return []

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -14,7 +14,7 @@ from databricks.labs.ucx.source_code.base import (
 )
 from databricks.labs.ucx.source_code.linters.python_infer import InferredValue
 from databricks.labs.ucx.source_code.queries import FromTable
-from databricks.labs.ucx.source_code.linters.python_ast import Tree
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 
 
 @dataclass
@@ -61,7 +61,7 @@ class Matcher(ABC):
     def _check_call_context(self, node: Call) -> bool:
         assert isinstance(node.func, Attribute)  # Avoid linter warning
         func_name = node.func.attrname
-        qualified_name = Tree.get_full_function_name(node)
+        qualified_name = TreeHelper.get_full_function_name(node)
 
         # Check if the call_context is None as that means all calls are checked
         if self.call_context is None:

--- a/src/databricks/labs/ucx/source_code/linters/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/linters/python_ast.py
@@ -84,6 +84,11 @@ class Tree:
                 in_multi_line_comment = not in_multi_line_comment
         return "\n".join(lines)
 
+    @classmethod
+    def new_module(cls):
+        node = Module("root")
+        return Tree(node)
+
     def __init__(self, node: NodeNG):
         self._node: NodeNG = node
 
@@ -117,6 +122,140 @@ class Tree:
             if len(self._node.body) > 0:
                 return self._node.body[0]
         return None
+
+    def __repr__(self):
+        truncate_after = 32
+        code = repr(self._node)
+        if len(code) > truncate_after:
+            code = code[0:truncate_after] + "..."
+        return f"<Tree: {code}>"
+
+    def append_tree(self, tree: Tree) -> Tree:
+        """returns the appended tree, not the consolidated one!"""
+        if not isinstance(tree.node, Module):
+            raise NotImplementedError(f"Can't append tree from {type(tree.node).__name__}")
+        tree_module: Module = cast(Module, tree.node)
+        self.append_nodes(tree_module.body)
+        self.append_globals(tree_module.globals)
+        # the following may seem strange but it's actually ok to use the original module as tree root
+        # because each node points to the correct parent (practically, the tree is now only a list of statements)
+        return tree
+
+    def append_globals(self, globs: dict):
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't append globals to {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        for name, values in globs.items():
+            statements: list[Expr] = self_module.globals.get(name, None)
+            if statements is None:
+                self_module.globals[name] = list(values)  # clone the source list to avoid side-effects
+                continue
+            statements.extend(values)
+
+    def append_nodes(self, nodes: list[NodeNG]):
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        for node in nodes:
+            node.parent = self_module
+            self_module.body.append(node)
+
+    def is_from_module(self, module_name: str):
+        # if this is the call's root node, check it against the required module
+        if isinstance(self._node, Name):
+            if self._node.name == module_name:
+                return True
+            root = self.root
+            if not isinstance(root, Module):
+                return False
+            for value in root.globals.get(self._node.name, []):
+                if not isinstance(value, AssignName) or not isinstance(value.parent, Assign):
+                    continue
+                if Tree(value.parent.value).is_from_module(module_name):
+                    return True
+            return False
+        # walk up intermediate calls such as spark.range(...)
+        if isinstance(self._node, Call):
+            return isinstance(self._node.func, Attribute) and Tree(self._node.func.expr).is_from_module(module_name)
+        if isinstance(self._node, Attribute):
+            return Tree(self._node.expr).is_from_module(module_name)
+        return False
+
+    def has_global(self, name: str) -> bool:
+        if not isinstance(self.node, Module):
+            return False
+        self_module: Module = cast(Module, self.node)
+        return self_module.globals.get(name, None) is not None
+
+    def nodes_between(self, first_line: int, last_line: int) -> list[NodeNG]:
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't extract nodes from {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        nodes: list[NodeNG] = []
+        for node in self_module.body:
+            if node.lineno < first_line:
+                continue
+            if node.lineno > last_line:
+                break
+            nodes.append(node)
+        return nodes
+
+    def globals_between(self, first_line: int, last_line: int) -> dict[str, list[NodeNG]]:
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't extract globals from {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        globs: dict[str, list[NodeNG]] = {}
+        for key, nodes in self_module.globals.items():
+            nodes_in_scope: list[NodeNG] = []
+            for node in nodes:
+                if node.lineno < first_line or node.lineno > last_line:
+                    continue
+                nodes_in_scope.append(node)
+            if len(nodes_in_scope) > 0:
+                globs[key] = nodes_in_scope
+        return globs
+
+    def line_count(self):
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't count lines from {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        nodes_count = len(self_module.body)
+        if nodes_count == 0:
+            return 0
+        return 1 + self_module.body[nodes_count - 1].lineno - self_module.body[0].lineno
+
+    def renumber(self, start: int) -> Tree:
+        assert start != 0
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't renumber {type(self.node).__name__}")
+        root: Module = self.node
+        # for now renumber in place to avoid the complexity of rebuilding the tree with clones
+
+        def renumber_node(node: NodeNG, offset: int):
+            for child in node.get_children():
+                renumber_node(child, offset + child.lineno - node.lineno)
+            if node.end_lineno:
+                node.end_lineno = node.end_lineno + offset
+                node.lineno = node.lineno + offset
+
+        nodes = root.body
+        if start > 0:
+            for node in nodes:
+                offset = start - node.lineno
+                renumber_node(node, offset)
+                num_lines = 1 + (node.end_lineno - node.lineno if node.end_lineno else 0)
+                start = start + num_lines
+        else:
+            for node in reversed(nodes):
+                offset = start - node.lineno
+                renumber_node(node, offset)
+                num_lines = 1 + (node.end_lineno - node.lineno if node.end_lineno else 0)
+                start = start - num_lines
+
+        return self
+
+
+class TreeHelper(ABC):
 
     @classmethod
     def extract_call_by_name(cls, call: Call, name: str) -> Call | None:
@@ -163,13 +302,6 @@ class Tree:
             return False
         return node.value is None
 
-    def __repr__(self):
-        truncate_after = 32
-        code = repr(self._node)
-        if len(code) > truncate_after:
-            code = code[0:truncate_after] + "..."
-        return f"<Tree: {code}>"
-
     @classmethod
     def get_full_attribute_name(cls, node: Attribute) -> str:
         return cls._get_attribute_value(node)
@@ -209,55 +341,6 @@ class Tree:
             missing_handlers.add(name)
             logger.debug(f"Missing handler for {name}")
         return None
-
-    def append_tree(self, tree: Tree) -> Tree:
-        if not isinstance(tree.node, Module):
-            raise NotImplementedError(f"Can't append tree from {type(tree.node).__name__}")
-        tree_module: Module = cast(Module, tree.node)
-        self.append_nodes(tree_module.body)
-        self.append_globals(tree_module.globals)
-        # the following may seem strange but it's actually ok to use the original module as tree root
-        return tree
-
-    def append_globals(self, globs: dict):
-        if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Can't append globals to {type(self.node).__name__}")
-        self_module: Module = cast(Module, self.node)
-        for name, value in globs.items():
-            statements: list[Expr] = self_module.globals.get(name, None)
-            if statements is None:
-                self_module.globals[name] = list(value)  # clone the source list to avoid side-effects
-                continue
-            statements.extend(value)
-
-    def append_nodes(self, nodes: list[NodeNG]):
-        if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
-        self_module: Module = cast(Module, self.node)
-        for node in nodes:
-            node.parent = self_module
-            self_module.body.append(node)
-
-    def is_from_module(self, module_name: str):
-        # if this is the call's root node, check it against the required module
-        if isinstance(self._node, Name):
-            if self._node.name == module_name:
-                return True
-            root = self.root
-            if not isinstance(root, Module):
-                return False
-            for value in root.globals.get(self._node.name, []):
-                if not isinstance(value, AssignName) or not isinstance(value.parent, Assign):
-                    continue
-                if Tree(value.parent.value).is_from_module(module_name):
-                    return True
-            return False
-        # walk up intermediate calls such as spark.range(...)
-        if isinstance(self._node, Call):
-            return isinstance(self._node.func, Attribute) and Tree(self._node.func.expr).is_from_module(module_name)
-        if isinstance(self._node, Attribute):
-            return Tree(self._node.expr).is_from_module(module_name)
-        return False
 
 
 class TreeVisitor:

--- a/src/databricks/labs/ucx/source_code/linters/table_creation.py
+++ b/src/databricks/labs/ucx/source_code/linters/table_creation.py
@@ -9,7 +9,7 @@ from databricks.labs.ucx.source_code.base import (
     Advice,
     PythonLinter,
 )
-from databricks.labs.ucx.source_code.linters.python_ast import Tree
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 
 
 @dataclass
@@ -46,7 +46,7 @@ class NoFormatPythonMatcher:
         # Check 2: check presence of the table-creating method call:
         if not isinstance(node.func, Attribute) or node.func.attrname != self.method_name:
             return None
-        call_args_count = Tree.args_count(node)
+        call_args_count = TreeHelper.args_count(node)
         if call_args_count < self.min_args or call_args_count > self.max_args:
             return None
 
@@ -57,13 +57,13 @@ class NoFormatPythonMatcher:
         # Check 4: check presence of the format specifier:
         #   Option A: format specifier may be given as a direct parameter to the table-creating call
         #   >>> df.saveToTable("c.db.table", format="csv")
-        format_arg = Tree.get_arg(node, self.format_arg_index, self.format_arg_name)
-        if format_arg is not None and not Tree.is_none(format_arg):
+        format_arg = TreeHelper.get_arg(node, self.format_arg_index, self.format_arg_name)
+        if format_arg is not None and not TreeHelper.is_none(format_arg):
             # i.e., found an explicit "format" argument, and its value is not None.
             return None
         #   Option B. format specifier may be a separate ".format(...)" call in this callchain
         #   >>> df.format("csv").saveToTable("c.db.table")
-        format_call = Tree.extract_call_by_name(node, "format")
+        format_call = TreeHelper.extract_call_by_name(node, "format")
         if format_call is not None:
             # i.e., found an explicit ".format(...)" call in this chain.
             return None

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -544,14 +544,6 @@ class MagicCommand(ABC):
 
 class RunCommand(MagicCommand):
 
-    @property
-    def notebook_path(self) -> Path | None:
-        start = self._code.find(' ')
-        if start < 0:
-            return None
-        path = self._code[start + 1 :].strip().strip('"').strip("'")
-        return Path(path)
-
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
         path = self.notebook_path
         if path is not None:
@@ -559,6 +551,14 @@ class RunCommand(MagicCommand):
             return [problem.from_node(problem.code, problem.message, self._node) for problem in problems]
         problem = DependencyProblem.from_node('invalid-run-cell', "Missing notebook path in %run command", self._node)
         return [problem]
+
+    @property
+    def notebook_path(self) -> Path | None:
+        start = self._code.find(' ')
+        if start < 0:
+            return None
+        path = self._code[start + 1 :].strip().strip('"').strip("'")
+        return Path(path)
 
 
 class PipCommand(MagicCommand):

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -3,7 +3,7 @@ import pytest
 from astroid import Call, Const, Expr  # type: ignore
 
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState
-from databricks.labs.ucx.source_code.linters.python_ast import Tree
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 from databricks.labs.ucx.source_code.linters.pyspark import TableNameMatcher, SparkSql
 from databricks.labs.ucx.source_code.queries import FromTable
 
@@ -573,7 +573,7 @@ def test_get_full_function_name_for_member_function():
     node = tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
-    assert Tree.get_full_function_name(node.value) == 'value.attr'
+    assert TreeHelper.get_full_function_name(node.value) == 'value.attr'
 
 
 def test_get_full_function_name_for_member_member_function():
@@ -581,7 +581,7 @@ def test_get_full_function_name_for_member_member_function():
     node = tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
-    assert Tree.get_full_function_name(node.value) == 'value1.value2.attr'
+    assert TreeHelper.get_full_function_name(node.value) == 'value1.value2.attr'
 
 
 def test_get_full_function_name_for_chained_function():
@@ -589,7 +589,7 @@ def test_get_full_function_name_for_chained_function():
     node = tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
-    assert Tree.get_full_function_name(node.value) == 'value.attr1.attr2'
+    assert TreeHelper.get_full_function_name(node.value) == 'value.attr1.attr2'
 
 
 def test_get_full_function_name_for_global_function():
@@ -597,14 +597,14 @@ def test_get_full_function_name_for_global_function():
     node = tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
-    assert Tree.get_full_function_name(node.value) == 'name'
+    assert TreeHelper.get_full_function_name(node.value) == 'name'
 
 
 def test_get_full_function_name_for_non_method():
     tree = Tree.parse("not_a_function")
     node = tree.first_statement()
     assert isinstance(node, Expr)
-    assert Tree.get_full_function_name(node.value) is None
+    assert TreeHelper.get_full_function_name(node.value) is None
 
 
 def test_apply_table_name_matcher_with_missing_constant(migration_index):

--- a/tests/unit/source_code/linters/test_python_ast.py
+++ b/tests/unit/source_code/linters/test_python_ast.py
@@ -1,7 +1,7 @@
 import pytest
 from astroid import Assign, AstroidSyntaxError, Attribute, Call, Const, Expr, Name  # type: ignore
 
-from databricks.labs.ucx.source_code.linters.python_ast import Tree
+from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 from databricks.labs.ucx.source_code.linters.python_infer import InferredValue
 
 
@@ -23,7 +23,7 @@ def test_extract_call_by_name():
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
-    act = Tree.extract_call_by_name(stmt.value, "m2")
+    act = TreeHelper.extract_call_by_name(stmt.value, "m2")
     assert isinstance(act, Call)
     assert isinstance(act.func, Attribute)
     assert act.func.attrname == "m2"
@@ -34,7 +34,7 @@ def test_extract_call_by_name_none():
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
-    act = Tree.extract_call_by_name(stmt.value, "m5000")
+    act = TreeHelper.extract_call_by_name(stmt.value, "m5000")
     assert act is None
 
 
@@ -60,7 +60,7 @@ def test_linter_gets_arg(code, arg_index, arg_name, expected):
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
-    act = Tree.get_arg(stmt.value, arg_index, arg_name)
+    act = TreeHelper.get_arg(stmt.value, arg_index, arg_name)
     if expected is None:
         assert act is None
     else:
@@ -85,7 +85,7 @@ def test_args_count(code, expected):
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
-    act = Tree.args_count(stmt.value)
+    act = TreeHelper.args_count(stmt.value)
     assert act == expected
 
 
@@ -177,3 +177,47 @@ def test_supports_recursive_refs_when_checking_module():
     main_tree.append_tree(tree)
     assign = tree.locate(Assign, [])[0]
     assert Tree(assign.value).is_from_module("spark")
+
+
+def test_renumbers_positively():
+    source = """df = spark.read.csv("hi")
+df.write.format("delta").saveAsTable("old.things")
+"""
+    tree = Tree.normalize_and_parse(source)
+    nodes = list(tree.node.get_children())
+    assert len(nodes) == 2
+    assert nodes[0].lineno == 1
+    assert nodes[1].lineno == 2
+    tree = tree.renumber(5)
+    nodes = list(tree.node.get_children())
+    assert len(nodes) == 2
+    assert nodes[0].lineno == 5
+    assert nodes[1].lineno == 6
+
+
+def test_renumbers_negatively():
+    source = """df = spark.read.csv("hi")
+df.write.format("delta").saveAsTable("old.things")
+"""
+    tree = Tree.normalize_and_parse(source)
+    nodes = list(tree.node.get_children())
+    assert len(nodes) == 2
+    assert nodes[0].lineno == 1
+    assert nodes[1].lineno == 2
+    tree = tree.renumber(-1)
+    nodes = list(tree.node.get_children())
+    assert len(nodes) == 2
+    assert nodes[0].lineno == -2
+    assert nodes[1].lineno == -1
+
+
+@pytest.mark.parametrize(
+    "source, line_count",
+    [
+        ("""df = spark.read.csv("hi")""", 1),
+        ("""df = spark.read.csv("hi")\ndf.write.format("delta").saveAsTable("old.things")""", 2),
+    ],
+)
+def test_counts_lines(source: str, line_count: int):
+    tree = Tree.normalize_and_parse(source)
+    assert tree.line_count() == line_count

--- a/tests/unit/source_code/linters/test_python_ast.py
+++ b/tests/unit/source_code/linters/test_python_ast.py
@@ -215,7 +215,9 @@ df.write.format("delta").saveAsTable("old.things")
     "source, line_count",
     [
         ("""df = spark.read.csv("hi")""", 1),
+        ("""# comment\ndf = spark.read.csv("hi")\n# comment""", 1),
         ("""df = spark.read.csv("hi")\ndf.write.format("delta").saveAsTable("old.things")""", 2),
+        ("""df = spark.read.csv("hi")\n# comment\ndf.write.format("delta").saveAsTable("old.things")""", 3),
     ],
 )
 def test_counts_lines(source: str, line_count: int):

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -12,9 +12,9 @@ from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.cells import (
     CellLanguage,
     PipCell,
-    GraphBuilder,
     PythonCell,
     PipCommand,
+    PythonCodeAnalyzer,
 )
 from databricks.labs.ucx.source_code.notebooks.cells import MagicLine
 from databricks.labs.ucx.source_code.notebooks.loaders import (
@@ -182,11 +182,10 @@ def test_graph_builder_parse_error(
     # Fixture.
     dependency = Dependency(FileLoader(), Path(""))
     graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
-    graph.new_graph_builder_context()
-    builder = GraphBuilder(graph.new_graph_builder_context())
+    analyser = PythonCodeAnalyzer(graph.new_dependency_graph_context(), "this is not valid python")
 
     # Run the test.
-    problems = builder.build_graph_from_python_source("this is not valid python")
+    problems = analyser.build_graph()
 
     # Check results.
     assert [


### PR DESCRIPTION
## Changes
Enhance python abstract syntax tree API in preparation of linting with inherited context
Move Tree static methods to TreeHelper class to avoid 'too many public methods' linting error

### Linked issues
Progresses #2155 
Progresses #2156 
 
### Functionality
None

### Tests
- [x] added unit tests
