### PR TITLE
Rename `GraphBuilderContext` to `DependencyGraphContext` for clarity

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -196,15 +196,15 @@ class DependencyGraph:
                 return True
         return False
 
-    def new_graph_builder_context(self):
-        return GraphBuilderContext(parent=self, path_lookup=self._path_lookup, session_state=self._session_state)
+    def new_dependency_graph_context(self):
+        return DependencyGraphContext(parent=self, path_lookup=self._path_lookup, session_state=self._session_state)
 
     def __repr__(self):
         return f"<DependencyGraph {self.path}>"
 
 
 @dataclass
-class GraphBuilderContext:
+class DependencyGraphContext:
     parent: DependencyGraph
     path_lookup: PathLookup
     session_state: CurrentSessionState

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -40,7 +40,7 @@ class LocalFile(SourceContainer):
 
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
         if self._language is CellLanguage.PYTHON:
-            context = parent.new_graph_builder_context()
+            context = parent.new_dependency_graph_context()
             analyser = PythonCodeAnalyzer(context, self._original_code)
             return analyser.build_graph()
         # supported language that does not generate dependencies

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -16,7 +16,7 @@ from sqlglot import parse as parse_sql, ParseError as SQLParseError
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.graph import DependencyGraph, DependencyProblem, GraphBuilderContext
+from databricks.labs.ucx.source_code.graph import DependencyGraph, DependencyProblem, DependencyGraphContext
 from databricks.labs.ucx.source_code.linters.imports import (
     SysPathChange,
     DbutilsLinter,
@@ -103,7 +103,7 @@ class PythonCell(Cell):
             return True
 
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
-        context = parent.new_graph_builder_context()
+        context = parent.new_dependency_graph_context()
         analyzer = PythonCodeAnalyzer(context, self._original_code)
         python_dependency_problems = analyzer.build_graph()
         # Position information for the Python code is within the code and needs to be mapped to the location within the parent nodebook.
@@ -394,7 +394,7 @@ class CellLanguage(Enum):
 
 class PythonCodeAnalyzer:
 
-    def __init__(self, context: GraphBuilderContext, python_code: str):
+    def __init__(self, context: DependencyGraphContext, python_code: str):
         self._context = context
         self._python_code = python_code
 

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -182,8 +182,7 @@ def test_graph_builder_parse_error(
     # Fixture.
     dependency = Dependency(FileLoader(), Path(""))
     graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
-    graph.new_graph_builder_context()
-    analyser = PythonCodeAnalyzer(graph.new_graph_builder_context(), "this is not valid python")
+    analyser = PythonCodeAnalyzer(graph.new_dependency_graph_context(), "this is not valid python")
 
     # Run the test.
     problems = analyser.build_graph()


### PR DESCRIPTION
## Changes
Rename `GraphBuilderContext` to `DependencyGraphContext` for clarity
This is in preparation of https://github.com/databrickslabs/ucx/pull/2236

### Linked issues
Progresses https://github.com/databrickslabs/ucx/issues/2155
Progresses https://github.com/databrickslabs/ucx/issues/2156

### Functionality
None

### Tests
- [x] ran unit tests
