### PR TITLE
Group migration: improve robustness while deleting workspace groups

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -672,7 +672,6 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         # a strategy of enumerating the bare minimum and request full attributes for each group individually.
         attributes = scim_attributes.split(",")
         if "members" in attributes:
-            attributes.remove("members")
             retry_on_internal_error = retried(on=[InternalError], timeout=self._verify_timeout)
             get_group = retry_on_internal_error(self._get_group)
             # Limit to the attributes we need for determining if the group is out of scope; the rest are fetched later.

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -543,9 +543,6 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         waiting_tasks = []
         deleted_groups = []
         for migrated_group in migrated_groups:
-            if migrated_group.temporary_name not in workspace_groups_in_workspace:
-                logger.info(f"Skipping {migrated_group.name_in_workspace}: no longer in workspace")
-                continue
             if migrated_group.name_in_account not in account_groups_in_workspace:
                 logger.warning(
                     f"Not deleting group {migrated_group.temporary_name}(id={migrated_group.id_in_workspace}) (originally {migrated_group.name_in_workspace}): its migrated account group ({migrated_group.name_in_account}) cannot be found."

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -100,15 +100,20 @@ def sql_fetch_all(sql_backend):
 
 @pytest.fixture
 def make_ucx_group(make_random, make_group, make_acc_group, make_user):
-    def inner(workspace_group_name=None, account_group_name=None):
+    def inner(workspace_group_name=None, account_group_name=None, **kwargs):
         if not workspace_group_name:
             workspace_group_name = f"ucx_G{make_random(4)}"
         if not account_group_name:
             account_group_name = workspace_group_name
         user = make_user()
         members = [user.id]
-        ws_group = make_group(display_name=workspace_group_name, members=members, entitlements=["allow-cluster-create"])
-        acc_group = make_acc_group(display_name=account_group_name, members=members)
+        ws_group = make_group(
+            display_name=workspace_group_name,
+            members=members,
+            entitlements=["allow-cluster-create"],
+            **kwargs,
+        )
+        acc_group = make_acc_group(display_name=account_group_name, members=members, **kwargs)
         return ws_group, acc_group
 
     return inner

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 import logging
 from datetime import timedelta
+from typing import NoReturn
 
 import pytest
 
@@ -186,8 +187,8 @@ def test_running_real_remove_backup_groups_job(ws: WorkspaceClient, installation
     # happened.
     # Note: If you are adjusting this, also look at: test_running_real_remove_backup_groups_job
     @retried(on=[KeyError], timeout=timedelta(seconds=90))
-    def get_group(group_id: str):
-        ws.groups.get(group_id)
+    def get_group(group_id: str) -> NoReturn:
+        _ = ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
     with pytest.raises(NotFound, match=f"Group with id {ws_group_a.id} not found."):

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import timedelta
+from typing import NoReturn
 
 import pytest
 from databricks.sdk.errors import NotFound, ResourceConflict
@@ -110,8 +111,8 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     # happened.
     # Note: If you are adjusting this, also look at: test_running_real_remove_backup_groups_job
     @retried(on=[KeyError], timeout=timedelta(seconds=90))
-    def get_group(group_id: str):
-        ws.groups.get(group_id)
+    def get_group(group_id: str) -> NoReturn:
+        _ = ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
     with pytest.raises(NotFound, match=f"Group with id {ws_group.id} not found."):

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -93,7 +93,7 @@ def test_reflect_account_groups_on_workspace(ws, make_ucx_group, sql_backend, in
 def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     ws, make_ucx_group, sql_backend, inventory_schema
 ):
-    ws_group, _ = make_ucx_group()
+    ws_group, _ = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(
         sql_backend,


### PR DESCRIPTION
## Changes

This PR updates the group manager so that deleting workspace groups is more reliable. Changes include:

 - We no longer skip deletion of groups that don't appear to be present. Due to eventual consistency issues this was occurring with groups that had recently been renamed (to their temporary name).
 - Deletion now waits for the effects of deletion to be visible by double-checking that a group can no longer be directly retrieved from the API, and that it no longer appears in the list of groups during enumeration. (Due to API limitations this is not a guarantee that the groups are no longer visible, but it does decrease the likelihood of anything noticed afterwards.)
 - Improved logging.

A subsequent PR will update group renaming to use a similar approach to that here.

### Linked issues

Resolves #2227.

### Functionality

- modified existing workflow: `remove-workspace-local-backup-groups`

### Tests

- updated unit tests
- updated integration tests
