### PR TITLE
fix failing solacc

### DIFF
--- a/tests/integration/source_code/solacc.py
+++ b/tests/integration/source_code/solacc.py
@@ -70,7 +70,7 @@ def print_advices(advices: list[LocatedAdvice], file: Path):
 
 def lint_one(file: Path, ctx: LocalCheckoutContext, unparsed: Path | None) -> tuple[set[str], int, int]:
     try:
-        advices = list(ctx.local_code_linter.lint_path(file))
+        advices = list(ctx.local_code_linter.lint_path(file, set()))
         missing_imports = collect_missing_imports(advices)
         not_computed = collect_not_computed(advices)
         print_advices(advices, file)


### PR DESCRIPTION
## Changes
Fix failing solacc

### Linked issues
None

### Functionality
None

### Tests
- [x] manually tested

`make solacc` output:
INFO [verify-accelerators] Skipped: 9, parseable: 100% (1155/1155), missing imports: 213, not computed: 757
