### PR TITLE
Tentatively fix failure when running assessment without a hive_metastore

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -127,8 +127,11 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
             yield table_migration_status
 
     def _try_fetch(self) -> Iterable[MigrationStatus]:
-        for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
-            yield MigrationStatus(*row)
+        try:
+            for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
+                yield MigrationStatus(*row)
+        except NotFound:
+            logger.warning(f"Table {self._schema}.{self._table} does not exist. Skipping loading of migration status.")
 
     def _iter_schemas(self):
         for catalog in self._ws.catalogs.list():

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -127,11 +127,8 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
             yield table_migration_status
 
     def _try_fetch(self) -> Iterable[MigrationStatus]:
-        try:
-            for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
-                yield MigrationStatus(*row)
-        except NotFound:
-            logger.warning(f"Table {self._schema}.{self._table} does not exist. Skipping loading of migration status.")
+        for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
+            yield MigrationStatus(*row)
 
     def _iter_schemas(self):
         for catalog in self._ws.catalogs.list():


### PR DESCRIPTION
## Changes
Don't fatally fail when loading data from `hive_metastore.migration_status` fails

### Linked issues
Resolves #2221 

### Functionality
None

### Tests
Not tested
