### PR TITLE
Init `RuntimeContext` from debug notebook to simplify interactive debugging flows

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -88,8 +88,9 @@ install_logger()
 with_user_agent_extra("cmd", "debug-notebook")
 logging.getLogger("databricks").setLevel("DEBUG")
 
-# ctx.<TAB> to see all available objects for you to use
-ctx = RuntimeContext({'config': "/Workspace{config_file}"})
+# ctx.<TAB> to see all available objects for you to
+named_parameters = dict(config="/Workspace{config_file}")
+ctx = RuntimeContext(named_parameters)
 
 print(__version__)
 """

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -78,17 +78,18 @@ dbutils.library.restartPython()
 
 import logging
 from pathlib import Path
+from databricks.sdk.config import with_user_agent_extra
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.logger import install_logger
 from databricks.labs.ucx.__about__ import __version__
-from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.sdk import WorkspaceClient
+from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 
 install_logger()
+with_user_agent_extra("cmd", "debug-notebook")
 logging.getLogger("databricks").setLevel("DEBUG")
 
-cfg = Installation.load_local(WorkspaceConfig, Path("/Workspace{config_file}"))
-ws = WorkspaceClient()
+# ctx.<TAB> to see all available objects for you to use
+ctx = RuntimeContext({'config': "/Workspace{config_file}"})
 
 print(__version__)
 """


### PR DESCRIPTION
UCX manages all object dependencies via subclasses of `GlobalContext`. All UCX workflows use `RuntimeContext` instance for any object lookup, so this PR simplifies debugging by pre-initializing `RuntimeContext` the correct way.
