### PR TITLE
Handle corrupted dashboard state in installation process

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -572,6 +572,12 @@ class WorkspaceInstallation(InstallationMixin):
                     dashboard_id = None  # Recreate the dashboard if it is trashed (manually)
             except (NotFound, InvalidParameterValue):
                 logger.info(f"Recovering invalid dashboard reference: {dashboard_id}")
+                dashboard_path = f"{parent_path}/{metadata.display_name}.lvdash.json"
+                try:
+                    self._ws.workspace.delete(dashboard_path)  # Cannot recreate dashboard if file still exists
+                    logger.debug(f"Deleted dangling dashboard: {dashboard_path}")
+                except NotFound:
+                    pass
                 dashboard_id = None  # Recreate the dashboard if it's reference is corrupted (manually)
         if dashboard_id is not None and "-" in dashboard_id:
             logger.info(f"Upgrading dashboard to Lakeview: {metadata.display_name}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -570,25 +570,25 @@ class WorkspaceInstallation(InstallationMixin):
         if dashboard_id is None:
             return None  # Create the dashboard if it does not exist yet
         if dashboard_id is not None and "-" in dashboard_id:
-            logger.info(f"Upgrading dashboard to Lakeview: {display_name}")
+            logger.info(f"Upgrading dashboard to Lakeview: {display_name} ({dashboard_id})")
             try:
                 self._ws.dashboards.delete(dashboard_id=dashboard_id)
             except BadRequest as e:
-                logger.warning(f"Cannot delete dashboard: {e}")
+                logger.warning(f"Cannot delete dashboard {display_name} ({dashboard_id}): {e}")
             return None  # Recreate the dashboard if upgrading from Redash
         try:
             dashboard = self._ws.lakeview.get(dashboard_id)
             if dashboard.lifecycle_state is None:
-                raise NotFound(f"Dashboard life cycle state: {dashboard_id}")
+                raise NotFound(f"Dashboard life cycle state: {display_name} ({dashboard_id})")
             if dashboard.lifecycle_state == LifecycleState.TRASHED:
-                logger.info(f"Recreating trashed dashboard: {dashboard_id}")
+                logger.info(f"Recreating trashed dashboard: {display_name} ({dashboard_id})")
                 return None  # Recreate the dashboard if it is trashed (manually)
         except (NotFound, InvalidParameterValue):
-            logger.info(f"Recovering invalid dashboard: {dashboard_id}")
+            logger.info(f"Recovering invalid dashboard: {display_name} ({dashboard_id})")
             try:
                 dashboard_path = f"{parent_path}/{display_name}.lvdash.json"
                 self._ws.workspace.delete(dashboard_path)  # Cannot recreate dashboard if file still exists
-                logger.debug(f"Deleted dangling dashboard: {dashboard_path}")
+                logger.debug(f"Deleted dangling dashboard {display_name} ({dashboard_id}): {dashboard_path}")
             except NotFound:
                 pass
             return None  # Recreate the dashboard if it's reference is corrupted (manually)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -577,7 +577,7 @@ class WorkspaceInstallation(InstallationMixin):
                 logger.warning(f"Cannot delete dashboard {display_name} ({dashboard_id}): {e}")
             return None  # Recreate the dashboard if upgrading from Redash
         try:
-            dashboard = self._ws.lakeview.get(dashboard_id)
+            dashboard = self._ws.lakeview.get(dashboard_id or "")
             if dashboard.lifecycle_state is None:
                 raise NotFound(f"Dashboard life cycle state: {display_name} ({dashboard_id})")
             if dashboard.lifecycle_state == LifecycleState.TRASHED:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -567,6 +567,8 @@ class WorkspaceInstallation(InstallationMixin):
         if dashboard_id is not None:
             try:
                 dashboard = self._ws.lakeview.get(dashboard_id)
+                if dashboard.lifecycle_state is None:
+                    raise NotFound(f"Dashboard life cycle state: {dashboard_id}")
                 if dashboard.lifecycle_state == LifecycleState.TRASHED:
                     logger.info(f"Recreating trashed dashboard: {dashboard_id}")
                     dashboard_id = None  # Recreate the dashboard if it is trashed (manually)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -573,7 +573,7 @@ class WorkspaceInstallation(InstallationMixin):
                 logger.warning(f"Cannot delete dashboard: {display_name} ({dashboard_id})")
             return None  # Recreate the dashboard if upgrading from Redash
         try:
-            dashboard = self._ws.lakeview.get(dashboard_id or "")
+            dashboard = self._ws.lakeview.get(dashboard_id)
             if dashboard.lifecycle_state is None:
                 raise NotFound(f"Dashboard life cycle state: {display_name} ({dashboard_id})")
             if dashboard.lifecycle_state == LifecycleState.TRASHED:

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -219,6 +219,18 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
         assert False, "Installation failed when dashboard was trashed"
 
 
+def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx):
+    """A dashboard reference might be invalid (after manual changes), the upgrade should handle this."""
+    installation_ctx.workspace_installation.run()
+    dashboard_key = list(installation_ctx.install_state.dashboards.keys())[0]
+    installation_ctx.install_state.dashboards[dashboard_key] = "01ef4d7b294112968fa07ffae17dd55f"
+    try:
+        installation_ctx.workspace_installation.run()
+        assert True, "Installation succeeded when dashboard reference was invalid"
+    except NotFound:
+        assert False, "Installation failed when dashboard reference was invalid"
+
+
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_uninstallation(ws, sql_backend, installation_ctx):
     installation_ctx.workspace_installation.run()

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -252,14 +252,14 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
 )
 def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx, dashboard_id, exception):
     """A dashboard reference might be invalid (after manual changes), the upgrade should handle this."""
-    installation_ctx.workspace_installation.run()
-    dashboard_key = list(installation_ctx.install_state.dashboards.keys())[0]
+    dashboard_key = "assessment_main"
     installation_ctx.install_state.dashboards[dashboard_key] = dashboard_id
     try:
         installation_ctx.workspace_installation.run()
-        assert True, "Installation succeeded when dashboard reference was invalid"
     except exception:
         assert False, "Installation failed when dashboard reference was invalid"
+    new_dashboard_id = installation_ctx.install_state.dashboards[dashboard_key]
+    assert dashboard_id != new_dashboard_id, "Dashboard id is not updated"
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -219,15 +219,23 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
         assert False, "Installation failed when dashboard was trashed"
 
 
-def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx):
+@pytest.mark.parametrize(
+    "dashboard_id, exception",
+    [
+        ("01ef4d7b294112968fa07ffae17dd55f", NotFound),
+        ("invalid-dashboard-id", InvalidParameterValue),
+        ("", NotFound),
+    ],
+)
+def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx, dashboard_id, exception):
     """A dashboard reference might be invalid (after manual changes), the upgrade should handle this."""
     installation_ctx.workspace_installation.run()
     dashboard_key = list(installation_ctx.install_state.dashboards.keys())[0]
-    installation_ctx.install_state.dashboards[dashboard_key] = "01ef4d7b294112968fa07ffae17dd55f"
+    installation_ctx.install_state.dashboards[dashboard_key] = dashboard_id
     try:
         installation_ctx.workspace_installation.run()
         assert True, "Installation succeeded when dashboard reference was invalid"
-    except NotFound:
+    except exception:
         assert False, "Installation failed when dashboard reference was invalid"
 
 

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -207,6 +207,14 @@ def test_repair_run_workflow_job(installation_ctx, mocker):
     assert installation_ctx.deployed_workflows.validate_step("failing")
 
 
+def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
+    """A dashboard might be trashed (manually), the upgrade should handle this."""
+    installation_ctx.workspace_installation.run()
+    dashboard_id = list(installation_ctx.install_state.dashboards.values())[0]
+    ws.lakeview.trash(dashboard_id)
+    installation_ctx.workspace_installation.run()
+
+
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_uninstallation(ws, sql_backend, installation_ctx):
     installation_ctx.workspace_installation.run()

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -220,14 +220,13 @@ def test_installation_when_upgrading_from_redash(ws, installation_ctx, make_dash
     installation_ctx.install_state.dashboards["assessment_main"] = dashboard.id
     try:
         installation_ctx.workspace_installation.run()
-        assert True, "Installation succeeded when upgrading from redash"
     except BadRequest:
         assert False, "Installation failed when upgrading from redash"
     try:
         check_dashboard_is_archived(dashboard.id)
-        assert True, "Lakeview dashboard was deleted"
     except TimeoutError:
         assert False, "Lakeview dashboard was not deleted"
+    assert True, "Lakeview dashboard was deleted"
 
 
 def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
@@ -237,9 +236,9 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
     ws.lakeview.trash(dashboard_id)
     try:
         installation_ctx.workspace_installation.run()
-        assert True, "Installation succeeded when dashboard was trashed"
     except NotFound:
         assert False, "Installation failed when dashboard was trashed"
+    assert True, "Installation succeeded when dashboard was trashed"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -15,7 +15,6 @@ from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.labs.lsql.backends import StatementExecutionBackend
 from databricks.sdk.errors import (
     AlreadyExists,
-    BadRequest,
     InvalidParameterValue,
     NotFound,
     ResourceConflict,

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -212,7 +212,11 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
     installation_ctx.workspace_installation.run()
     dashboard_id = list(installation_ctx.install_state.dashboards.values())[0]
     ws.lakeview.trash(dashboard_id)
-    installation_ctx.workspace_installation.run()
+    try:
+        installation_ctx.workspace_installation.run()
+        assert True, "Installation succeeded when dashboard was trashed"
+    except NotFound:
+        assert False, "Installation failed when dashboard was trashed"
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -209,7 +209,7 @@ def test_repair_run_workflow_job(installation_ctx, mocker):
 
 
 def test_installation_when_upgrading_from_redash(ws, installation_ctx, make_dashboard):
-    """The installation should handle upgrading Dashboards from redash."""
+    """The installation should handle upgrading dashboards from redash."""
 
     @retried(on=[ValueError], timeout=timedelta(minutes=2))
     def check_dashboard_is_archived(dashboard_id: str):

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -210,6 +210,7 @@ def test_repair_run_workflow_job(installation_ctx, mocker):
 
 def test_installation_when_upgrading_from_redash(ws, installation_ctx, make_dashboard):
     """The installation should handle upgrading Dashboards from redash."""
+
     @retried(on=[ValueError], timeout=timedelta(minutes=2))
     def check_dashboard_is_archived(dashboard_id: str):
         dashboard = ws.dashboards.get(dashboard_id)

--- a/tests/unit/install/conftest.py
+++ b/tests/unit/install/conftest.py
@@ -1,0 +1,102 @@
+import io
+from unittest.mock import create_autospec
+
+import pytest
+import yaml
+from databricks.labs.blueprint.tui import MockPrompts
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.compute import ClusterDetails, CreatePolicyResponse, DataSecurityMode, State
+from databricks.sdk.errors import NotFound
+from databricks.sdk.service import iam, jobs
+from databricks.sdk.service.sql import (
+    Dashboard,
+    DataSource,
+    EndpointInfo,
+    EndpointInfoWarehouseType,
+    Query,
+    Visualization,
+    Widget,
+)
+from databricks.sdk.service.workspace import ObjectInfo
+
+
+@pytest.fixture
+def any_prompt():
+    return MockPrompts({".*": ""})
+
+
+@pytest.fixture
+def clusters() -> list[ClusterDetails]:
+    return [
+        ClusterDetails(
+            spark_version="13.3.x-dbrxxx",
+            cluster_name="zero",
+            data_security_mode=DataSecurityMode.USER_ISOLATION,
+            state=State.RUNNING,
+            cluster_id="1111-999999-userisol",
+        ),
+        ClusterDetails(
+            spark_version="13.3.x-dbrxxx",
+            cluster_name="one",
+            data_security_mode=DataSecurityMode.NONE,
+            state=State.RUNNING,
+            cluster_id='2222-999999-nosecuri',
+        ),
+        ClusterDetails(
+            spark_version="13.3.x-dbrxxx",
+            cluster_name="two",
+            data_security_mode=DataSecurityMode.LEGACY_TABLE_ACL,
+            state=State.RUNNING,
+            cluster_id='3333-999999-legacytc',
+        ),
+    ]
+
+
+@pytest.fixture
+def ws(clusters):
+    state = {
+        "/Applications/ucx/config.yml": yaml.dump(
+            {
+                'version': 1,
+                'inventory_database': 'ucx_exists',
+                'connect': {
+                    'host': '...',
+                    'token': '...',
+                },
+            }
+        ),
+    }
+
+    def download(path: str) -> io.StringIO | io.BytesIO:
+        if path not in state:
+            raise NotFound(path)
+        if ".csv" in path:
+            return io.BytesIO(state[path].encode('utf-8'))
+        return io.StringIO(state[path])
+
+    workspace_client = create_autospec(WorkspaceClient)
+
+    workspace_client.current_user.me = lambda: iam.User(
+        user_name="me@example.com", groups=[iam.ComplexValue(display="admins")]
+    )
+    workspace_client.config.host = "https://foo"
+    workspace_client.config.is_aws = True
+    workspace_client.config.is_azure = False
+    workspace_client.config.is_gcp = False
+    workspace_client.workspace.get_status = lambda _: ObjectInfo(object_id=123)
+    workspace_client.data_sources.list = lambda: [DataSource(id="bcd", warehouse_id="abc")]
+    workspace_client.warehouses.list = lambda **_: [
+        EndpointInfo(name="abc", id="abc", warehouse_type=EndpointInfoWarehouseType.PRO, state=State.RUNNING)
+    ]
+    workspace_client.dashboards.create.return_value = Dashboard(id="abc")
+    workspace_client.jobs.create.return_value = jobs.CreateResponse(job_id=123)
+    workspace_client.queries.create.return_value = Query(id="abc")
+    workspace_client.query_visualizations.create.return_value = Visualization(id="abc")
+    workspace_client.dashboard_widgets.create.return_value = Widget(id="abc")
+    workspace_client.clusters.list.return_value = clusters
+    workspace_client.cluster_policies.create.return_value = CreatePolicyResponse(policy_id="foo")
+    workspace_client.clusters.select_spark_version = lambda **_: "14.2.x-scala2.12"
+    workspace_client.clusters.select_node_type = lambda **_: "Standard_F4s"
+    workspace_client.workspace.download = download
+
+    return workspace_client

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -25,16 +25,16 @@ def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
     install_state = InstallState.from_installation(mock_installation)
     wheels = WheelsV2(mock_installation, PRODUCT_INFO)
     workflows_installation = WorkflowsDeployment(
-        WorkspaceConfig(inventory_database="...", policy_id='123'),
+        WorkspaceConfig(inventory_database="..."),
         mock_installation,
         install_state,
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
+        timedelta(seconds=10),
         [],
     )
-    workspace_installation = WorkspaceInstallation(
+    return WorkspaceInstallation(
         WorkspaceConfig(inventory_database='ucx'),
         mock_installation,
         install_state,
@@ -44,7 +44,6 @@ def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
         any_prompt,
         PRODUCT_INFO,
     )
-    return workspace_installation
 
 
 def test_installation_creates_dashboard(ws, workspace_installation):

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -1,0 +1,175 @@
+import logging
+from datetime import timedelta
+
+import pytest
+from databricks.labs.blueprint.installation import MockInstallation
+from databricks.labs.blueprint.installer import InstallState
+from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2, find_project_root
+from databricks.labs.lsql.backends import MockBackend
+from databricks.labs.lsql.dashboards import DashboardMetadata
+from databricks.sdk.errors.platform import BadRequest
+from databricks.sdk.service.dashboards import Dashboard as LakeviewDashboard, LifecycleState
+from databricks.sdk.errors import NotFound, InvalidParameterValue
+
+from databricks.labs.ucx.config import WorkspaceConfig
+from databricks.labs.ucx.install import WorkspaceInstallation
+from databricks.labs.ucx.installer.workflows import WorkflowsDeployment
+
+
+PRODUCT_INFO = ProductInfo.from_class(WorkspaceConfig)
+
+
+@pytest.fixture
+def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
+    mock_installation = request.param if hasattr(request, "param") else MockInstallation()
+    install_state = InstallState.from_installation(mock_installation)
+    wheels = WheelsV2(mock_installation, PRODUCT_INFO)
+    workflows_installation = WorkflowsDeployment(
+        WorkspaceConfig(inventory_database="...", policy_id='123'),
+        mock_installation,
+        install_state,
+        ws,
+        wheels,
+        PRODUCT_INFO,
+        timedelta(seconds=1),
+        [],
+    )
+    workspace_installation = WorkspaceInstallation(
+        WorkspaceConfig(inventory_database='ucx'),
+        mock_installation,
+        install_state,
+        MockBackend(),
+        ws,
+        workflows_installation,
+        any_prompt,
+        PRODUCT_INFO,
+    )
+    return workspace_installation
+
+
+def test_installation_creates_dashboard(ws, workspace_installation):
+    workspace_installation.run()
+    ws.lakeview.create.assert_called()
+
+
+def test_installation_updates_dashboard(ws, workspace_installation):
+    workspace_installation.run()
+    ws.lakeview.update.assert_not_called()
+    workspace_installation.run()
+    ws.lakeview.update.assert_called()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "redash-id"}}}})],
+    indirect=True,
+)
+def test_installation_upgrades_redash_dashboard(caplog, ws, workspace_installation):
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Upgrading dashboard to Lakeview" in caplog.text
+    ws.dashboards.delete.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "redash-id"}}}})],
+    indirect=True,
+)
+def test_installation_upgrades_non_existing_redash_dashboard(caplog, ws, workspace_installation):
+    ws.dashboards.delete.side_effect = BadRequest
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Upgrading dashboard to Lakeview" in caplog.text
+    assert "Cannot delete dashboard" in caplog.text
+    ws.dashboards.delete.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+def test_installation_updates_existing_lakeview_dashboard(ws, workspace_installation):
+    ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=LifecycleState.ACTIVE)
+    workspace_installation.run()
+    ws.lakeview.get.assert_called_with("lakeview_id")
+    ws.lakeview.update.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+def test_installation_recreates_lakeview_dashboard_without_lifecycle_state(caplog, ws, workspace_installation):
+    ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=None)
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Recovering invalid dashboard" in caplog.text
+    ws.lakeview.create.assert_called()
+    ws.lakeview.update.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+def test_installation_recreates_trashed_lakeview_dashboard(caplog, ws, workspace_installation):
+    ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=LifecycleState.TRASHED)
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Recreating trashed dashboard" in caplog.text
+    ws.lakeview.create.assert_called()
+    ws.lakeview.update.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+@pytest.mark.parametrize("exception", [NotFound, InvalidParameterValue])
+def test_installation_recovers_invalid_dashboard(caplog, ws, workspace_installation, exception):
+    ws.lakeview.get.side_effect = exception
+    with caplog.at_level(logging.DEBUG, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Recovering invalid dashboard" in caplog.text
+    assert "Deleted dangling dashboard" in caplog.text
+    ws.workspace.delete.assert_called_once()
+    ws.lakeview.create.assert_called()
+    ws.lakeview.update.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+def test_installation_recovers_invalid_deleted_dashboard(caplog, ws, workspace_installation):
+    ws.lakeview.get.side_effect = NotFound
+    ws.workspace.delete.side_effect = NotFound
+    with caplog.at_level(logging.DEBUG, logger="databricks.labs.ucx.install"):
+        workspace_installation.run()
+    assert "Recovering invalid dashboard" in caplog.text
+    assert "Deleted dangling dashboard" not in caplog.text
+    ws.workspace.delete.assert_called_once()
+    ws.lakeview.create.assert_called()
+    ws.lakeview.update.assert_not_called()
+
+
+def test_validate_dashboards(ws):
+    queries_path = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
+    for step_folder in queries_path.iterdir():
+        if not step_folder.is_dir():
+            continue
+        for dashboard_folder in step_folder.iterdir():
+            if not dashboard_folder.is_dir():
+                continue
+            try:
+                DashboardMetadata.from_path(dashboard_folder).validate()
+            except ValueError as e:
+                assert False, f"Invalid dashboard in {dashboard_folder}: {e}"
+            else:
+                assert True, f"Valid dashboard in {dashboard_folder}"

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -129,14 +129,14 @@ def test_installation_recreates_trashed_lakeview_dashboard(caplog, ws, workspace
     [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
     indirect=True,
 )
-@pytest.mark.parametrize("exception", [NotFound, InvalidParameterValue])
+@pytest.mark.parametrize("exception", [InvalidParameterValue, NotFound])
 def test_installation_recovers_invalid_dashboard(caplog, ws, workspace_installation, exception):
     ws.lakeview.get.side_effect = exception
     with caplog.at_level(logging.DEBUG, logger="databricks.labs.ucx.install"):
         workspace_installation.run()
     assert "Recovering invalid dashboard" in caplog.text
     assert "Deleted dangling dashboard" in caplog.text
-    ws.workspace.delete.assert_called_once()
+    ws.workspace.delete.assert_called()
     ws.lakeview.create.assert_called()
     ws.lakeview.update.assert_not_called()
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -672,6 +672,20 @@ def test_installation_upgrades_redash_dashboard(caplog, ws, new_workspace_instal
     ws.dashboards.delete.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "new_workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview-id"}}}})],
+    indirect=True,
+)
+def test_installation_upgrades_non_existing_redash_dashboard(caplog, ws, new_workspace_installation):
+    ws.dashboards.delete.side_effect = BadRequest
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        new_workspace_installation.run()
+    assert "Upgrading dashboard to Lakeview:" in caplog.text
+    assert "Cannot delete dashboard" in caplog.text
+    ws.dashboards.delete.assert_called_once()
+
+
 def test_validate_dashboards(ws):
     queries_path = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     for step_folder in queries_path.iterdir():

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -669,7 +669,7 @@ def test_installation_updates_dashboard(ws, new_workspace_installation):
 def test_installation_upgrades_redash_dashboard(caplog, ws, new_workspace_installation):
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
         new_workspace_installation.run()
-    assert "Upgrading dashboard to Lakeview:" in caplog.text
+    assert "Upgrading dashboard to Lakeview" in caplog.text
     ws.dashboards.delete.assert_called_once()
 
 
@@ -682,7 +682,7 @@ def test_installation_upgrades_non_existing_redash_dashboard(caplog, ws, new_wor
     ws.dashboards.delete.side_effect = BadRequest
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
         new_workspace_installation.run()
-    assert "Upgrading dashboard to Lakeview:" in caplog.text
+    assert "Upgrading dashboard to Lakeview" in caplog.text
     assert "Cannot delete dashboard" in caplog.text
     ws.dashboards.delete.assert_called_once()
 
@@ -708,7 +708,7 @@ def test_installation_recreates_lakeview_dashboard_without_lifecycle_state(caplo
     ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=None)
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
         new_workspace_installation.run()
-    assert "Recovering invalid dashboard: " in caplog.text
+    assert "Recovering invalid dashboard" in caplog.text
     ws.lakeview.create.assert_called()
     ws.lakeview.update.assert_not_called()
 
@@ -722,7 +722,7 @@ def test_installation_recreates_trashed_lakeview_dashboard(caplog, ws, new_works
     ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=LifecycleState.TRASHED)
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
         new_workspace_installation.run()
-    assert "Recreating trashed dashboard: " in caplog.text
+    assert "Recreating trashed dashboard" in caplog.text
     ws.lakeview.create.assert_called()
     ws.lakeview.update.assert_not_called()
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -699,6 +699,20 @@ def test_installation_updates_existing_lakeview_dashboard(ws, new_workspace_inst
     ws.lakeview.update.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "new_workspace_installation",
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview_id"}}}})],
+    indirect=True,
+)
+def test_installation_recreates_lakeview_dashboard_without_lifecycle_state(caplog, ws, new_workspace_installation):
+    ws.lakeview.get.return_value = LakeviewDashboard(lifecycle_state=None)
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.install"):
+        new_workspace_installation.run()
+    assert "Recovering invalid dashboard: " in caplog.text
+    ws.lakeview.create.assert_called()
+    ws.lakeview.update.assert_not_called()
+
+
 def test_validate_dashboards(ws):
     queries_path = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     for step_folder in queries_path.iterdir():

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -662,7 +662,7 @@ def test_installation_updates_dashboard(ws, new_workspace_installation):
 
 @pytest.mark.parametrize(
     "new_workspace_installation",
-    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview-id"}}}})],
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "redash-id"}}}})],
     indirect=True,
 )
 def test_installation_upgrades_redash_dashboard(caplog, ws, new_workspace_installation):
@@ -674,7 +674,7 @@ def test_installation_upgrades_redash_dashboard(caplog, ws, new_workspace_instal
 
 @pytest.mark.parametrize(
     "new_workspace_installation",
-    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "lakeview-id"}}}})],
+    [MockInstallation({'state.json': {'resources': {'dashboards': {"assessment_main": "redash-id"}}}})],
     indirect=True,
 )
 def test_installation_upgrades_non_existing_redash_dashboard(caplog, ws, new_workspace_installation):

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -625,7 +625,7 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
 def new_workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
     mock_installation = request.param if hasattr(request, "param") else MockInstallation()
     install_state = InstallState.from_installation(mock_installation)
-    wheels = create_autospec(WheelsV2)
+    wheels = WheelsV2(mock_installation, PRODUCT_INFO)
     workflows_installation = WorkflowsDeployment(
         WorkspaceConfig(inventory_database="...", policy_id='123'),
         mock_installation,

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -620,6 +620,35 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
     wheels.upload_to_dbfs.assert_not_called()
 
 
+def test_installation_creates_dashboard(ws, caplog, mock_installation, any_prompt):
+    install_state = InstallState.from_installation(mock_installation)
+    wheels = create_autospec(WheelsV2)
+    workflows_installation = WorkflowsDeployment(
+        WorkspaceConfig(inventory_database="...", policy_id='123'),
+        mock_installation,
+        install_state,
+        ws,
+        wheels,
+        PRODUCT_INFO,
+        timedelta(seconds=1),
+        [],
+    )
+    workspace_installation = WorkspaceInstallation(
+        WorkspaceConfig(inventory_database='ucx'),
+        mock_installation,
+        install_state,
+        MockBackend(),
+        ws,
+        workflows_installation,
+        any_prompt,
+        PRODUCT_INFO,
+    )
+
+    workspace_installation.run()
+    ws.lakeview.create.assert_called()
+    wheels.assert_not_called()
+
+
 def test_validate_dashboards(ws):
     queries_path = find_project_root(__file__) / "src/databricks/labs/ucx/queries"
     for step_folder in queries_path.iterdir():


### PR DESCRIPTION
## Changes
Handle corrupted dashboard state in installation process. See linked issue for more details

### Linked issues
Resolves #2261

### Functionality

- [x] modified existing command: `databricks labs install ucx`

### Tests

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
