### PR TITLE
[BUG]: UCX table migration workflow does not preserve column name case 

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1083,6 +1083,12 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Generator[Callable[
 
         str_properties = ",".join([f" '{k}' = '{v}' " for k, v in tbl_properties.items()])
 
+        if hiveserde_ddl:
+            ddl = hiveserde_ddl
+            data_source_format = None
+            table_type = TableType.EXTERNAL
+            storage_location = storage_override
+
         # table properties fails with CTAS statements
         alter_table_tbl_properties = ""
         if ctas or non_delta:
@@ -1091,12 +1097,6 @@ def make_table(ws, sql_backend, make_schema, make_random) -> Generator[Callable[
             )
         else:
             ddl = f"{ddl} TBLPROPERTIES ({str_properties})"
-
-        if hiveserde_ddl:
-            ddl = hiveserde_ddl
-            data_source_format = None
-            table_type = TableType.EXTERNAL
-            storage_location = storage_override
 
         sql_backend.execute(ddl)
 


### PR DESCRIPTION
## Changes
Test column case preservation during migration

### Linked issues
Resolves #2218

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
