### PR TITLE
Update purge suffix so that resources are preserved for _at least_ as long as the configured timeout.

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -51,10 +51,11 @@ from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.installer.logs import PartialLogRecord, parse_logs
 from databricks.labs.ucx.installer.mixins import InstallationMixin
 
+from ..mixins.fixtures import get_test_purge_time
+
 logger = logging.getLogger(__name__)
 
-TEST_JOBS_PURGE_TIMEOUT = timedelta(hours=1, minutes=15)
-TEST_NIGHTLY_CI_JOBS_PURGE_TIMEOUT = timedelta(hours=3)  # Buffer for debugging nightly integration test runs
+TEST_NIGHTLY_CI_RESOURCES_PURGE_TIMEOUT = timedelta(hours=3)  # Buffer for debugging nightly integration test runs
 EXTRA_TASK_PARAMS = {
     "job_id": "{{job_id}}",
     "run_id": "{{run_id}}",
@@ -461,8 +462,9 @@ class WorkflowsDeployment(InstallationMixin):
         return ci_env is not None and ci_env.lower() == "true"
 
     def _get_test_purge_time(self) -> str:
-        timeout = TEST_NIGHTLY_CI_JOBS_PURGE_TIMEOUT if self._is_nightly() else TEST_JOBS_PURGE_TIMEOUT
-        return (datetime.utcnow() + timeout).strftime("%Y%m%d%H")
+        if self._is_nightly():
+            return get_test_purge_time(TEST_NIGHTLY_CI_RESOURCES_PURGE_TIMEOUT)
+        return get_test_purge_time()
 
     def _create_readme(self) -> None:
         debug_notebook_link = self._installation.workspace_markdown_link('debug notebook', 'DEBUG.py')

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -8,7 +8,7 @@ import string
 import subprocess
 import sys
 from collections.abc import Callable, Generator, MutableMapping
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, UTC
 from pathlib import Path
 from typing import BinaryIO
 
@@ -1464,7 +1464,9 @@ def make_lakeview_dashboard(ws, make_random, env_or_skip):
 
 
 def get_test_purge_time(timeout: timedelta = TEST_RESOURCE_PURGE_TIMEOUT) -> str:
-    return (datetime.utcnow() + timeout).strftime("%Y%m%d%H")
+    now = datetime.now(UTC)
+    purge_deadline = now + timeout
+    return purge_deadline.strftime("%Y%m%d%H")
 
 
 def get_purge_suffix() -> str:

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -1466,7 +1466,9 @@ def make_lakeview_dashboard(ws, make_random, env_or_skip):
 def get_test_purge_time(timeout: timedelta = TEST_RESOURCE_PURGE_TIMEOUT) -> str:
     now = datetime.now(UTC)
     purge_deadline = now + timeout
-    return purge_deadline.strftime("%Y%m%d%H")
+    # Round UP to the next hour boundary: that is when resources will be deleted.
+    purge_hour = purge_deadline + (datetime.min.replace(tzinfo=UTC) - purge_deadline) % timedelta(hours=1)
+    return purge_hour.strftime("%Y%m%d%H")
 
 
 def get_purge_suffix() -> str:

--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -58,7 +58,9 @@ from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 # pylint: disable=redefined-outer-name,too-many-try-statements,import-outside-toplevel,unnecessary-lambda,too-complex,invalid-name
 
 logger = logging.getLogger(__name__)
-TEST_JOBS_PURGE_TIMEOUT = timedelta(hours=1, minutes=15)  # 15 minutes grace for jobs starting at the end of the hour
+
+"""Preserve resources created during tests for at least this long."""
+TEST_RESOURCE_PURGE_TIMEOUT = timedelta(hours=1)
 
 
 def factory(name, create, remove):
@@ -1461,8 +1463,8 @@ def make_lakeview_dashboard(ws, make_random, env_or_skip):
     yield from factory("dashboard", create, delete)
 
 
-def get_test_purge_time() -> str:
-    return (datetime.utcnow() + TEST_JOBS_PURGE_TIMEOUT).strftime("%Y%m%d%H")
+def get_test_purge_time(timeout: timedelta = TEST_RESOURCE_PURGE_TIMEOUT) -> str:
+    return (datetime.utcnow() + timeout).strftime("%Y%m%d%H")
 
 
 def get_purge_suffix() -> str:


### PR DESCRIPTION
## Changes

This PR updates the purge suffix used by integration tests so that resources are marked for preservation _at least_ as long as the configured timeout. The situation is that:

 - Many resources can be marked with a tag (or a special suffix in the name) to ensure they are preserved until a specific time.
 - The timestamp refers to a UTC-based hour, such as: `2024072915`. This means that resources can be deleted at any moment after 3 p.m. (UTC).
 - Prior to this change, resources created as late as 2:44:59 p.m. would be tagged for deletion with `2024072915` meaning deletion as of 3 p.m. This is 0:15 later instead of the intended 1:15.

The default timeout for tests was 1:15 in an attempt to deal with resources being deleted when the test started near the hour boundary. This PR also updates the default timeout to 1:00 because the extra 0:15 isn't needed to ensure this.