### PR TITLE
adding astroid in the upload_dependencies

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -564,7 +564,7 @@ class WorkflowsDeployment(InstallationMixin):
         wheel_paths = []
         with self._wheels:
             if self._config.upload_dependencies:
-                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot"])
+                wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "astroid"])
             wheel_paths.sort(key=WorkflowsDeployment._library_dep_order)
             wheel_paths.append(self._wheels.upload_to_wsfs())
             wheel_paths = [f"/Workspace{wheel}" for wheel in wheel_paths]


### PR DESCRIPTION
## Changes
Recently, Astroid was added as a dependent library for UCX, but this was not included in upload_wheel_dependencies due to this assessment not running in a blocked workspace. This changes adds astroid to the dependent library


Resolves #2257 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested: Ran the assessment job on a internet blocked workspace and confirmed working
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
