### PR TITLE
Install state misses `dashboards` fields

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -508,6 +508,7 @@ class WorkspaceInstallation(InstallationMixin):
         if self.config.trigger_job:
             logger.info("Triggering the assessment workflow")
             self._trigger_workflow("assessment")
+        self._install_state.save()
         return True
 
     def _create_database_and_dashboards(self) -> None:

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -8,6 +8,7 @@ import pytest
 
 import databricks
 from databricks.labs.blueprint.installation import Installation
+from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.parallel import ManyError
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.blueprint.wheels import ProductInfo
@@ -246,6 +247,17 @@ def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx, dashboa
     installation_ctx.workspace_installation.run()
     new_dashboard_id = installation_ctx.install_state.dashboards[dashboard_key]
     assert dashboard_id != new_dashboard_id, "Dashboard id is not updated"
+
+
+def test_installation_stores_install_state_keys(ws, installation_ctx):
+    """The installation should store the keys in the installation state."""
+    expected_keys = "jobs", "dashboards"
+    installation_ctx.workspace_installation.run()
+    # Refresh the installation state, the installation context uses `@cached_property`
+    install_state = InstallState.from_installation(installation_ctx.installation)
+    for key in expected_keys:
+        assert hasattr(install_state, key), f"Missing key in install state: {key}"
+        assert getattr(install_state, key), f"Installation state is empty: {key}"
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))


### PR DESCRIPTION
## Changes
Save installation at the end of the `WorkspaceInstallation.run`.

This bug was silently introduced in #2229, where the installation is parallelized. The installation state was saved [in the `WorkflowsDeployment`](https://github.com/databrickslabs/ucx/blob/58607092f49b470b7f34577afda9b641dddb97cc/src/databricks/labs/ucx/installer/workflows.py#L449), which happened after dashboard deployment before parralelization.

### Linked issues
Resolves #2273

### Functionality

- [ ] modified existing command: `databricks labs install ucx`

### Tests

- [ ] added integration tests
