### PR TITLE
Fix dashboard queries fail when default catalog is not `hive_metastore`

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import sqlglot
 from databricks.sdk.core import Config
 
 __all__ = ["WorkspaceConfig"]
@@ -70,16 +69,6 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None
-
-    def transform_inventory_database(self, node: sqlglot.Expression) -> sqlglot.Expression:
-        """Replace the inventory database in a query."""
-        if (
-            isinstance(node, sqlglot.exp.Table)
-            and node.args.get("db") is not None
-            and getattr(node.args.get("db"), "this", "") == "inventory"
-        ):
-            node.args["db"].set("this", f"hive_metastore.{self.inventory_database}")
-        return node
 
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -598,8 +598,7 @@ class WorkspaceInstallation(InstallationMixin):
         """Create a lakeview dashboard from the SQL queries in the folder"""
         logger.info(f"Creating dashboard in {folder}...")
         metadata = DashboardMetadata.from_path(folder).replace_database(
-            catalog="hive_metastore",
-            database=self._config.inventory_database,
+            database=f"hive_metastore.{self._config.inventory_database}",
             database_to_replace="inventory",
         )
         metadata.display_name = f"{self._name('UCX ')} {folder.parent.stem.title()} ({folder.stem.title()})"

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -598,7 +598,9 @@ class WorkspaceInstallation(InstallationMixin):
         """Create a lakeview dashboard from the SQL queries in the folder"""
         logger.info(f"Creating dashboard in {folder}...")
         metadata = DashboardMetadata.from_path(folder).replace_database(
-            database=self._config.inventory_database, database_to_replace="inventory"
+            catalog="hive_metastore",
+            database=self._config.inventory_database,
+            database_to_replace="inventory",
         )
         metadata.display_name = f"{self._name('UCX ')} {folder.parent.stem.title()} ({folder.stem.title()})"
         reference = f"{folder.parent.stem}_{folder.stem}".lower()

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -501,7 +501,7 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
     install_state = InstallState.from_installation(mock_installation)
     wheels = create_autospec(WheelsV2)
     workflows_installer = WorkflowsDeployment(
-        WorkspaceConfig(inventory_database="...", policy_id='123'),
+        WorkspaceConfig(inventory_database="ucx", policy_id='123'),
         mock_installation,
         install_state,
         ws,
@@ -511,7 +511,7 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
         [],
     )
     workspace_installation = WorkspaceInstallation(
-        WorkspaceConfig(inventory_database="...", policy_id='123'),
+        WorkspaceConfig(inventory_database="ucx", policy_id='123'),
         mock_installation,
         install_state,
         sql_backend,


### PR DESCRIPTION
## Changes
Fix dashboard queries fail when default catalog is not `hive_metastore` by always adding the `hive_metastore` namespace to the dashboard queries.

### Linked issues

Resolves #2277

### Functionality

- [x] modified existing command: `databricks labs ucx install`

### Tests

- [x] manually tested
- [x] verified on staging environment (screenshot attached)
