### PR TITLE
Make ucx pylsp plugin configurable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ pylsp = [
 runtime = "databricks.labs.ucx.runtime:main"
 
 [project.entry-points.pylsp]
-plugin = "databricks.labs.ucx.source_code.lsp_plugin"
+pylsp_ucx = "databricks.labs.ucx.source_code.lsp_plugin"
 
 [project.urls]
 Issues = "https://github.com/databricks/ucx/issues"

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -26,6 +26,17 @@ class MigrationStatus:
     def destination(self):
         return f"{self.dst_catalog}.{self.dst_schema}.{self.dst_table}".lower()
 
+    @classmethod
+    def from_json(cls, json: dict):
+        return cls(
+            src_schema=json['src_schema'],
+            src_table=json['src_table'],
+            dst_catalog=json.get('dst_catalog', None),
+            dst_schema=json.get('dst_schema', None),
+            dst_table=json.get('dst_table', None),
+            update_ts=json.get('update_ts', None),
+        )
+
 
 @dataclass(frozen=True)
 class TableView:

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -27,14 +27,14 @@ class MigrationStatus:
         return f"{self.dst_catalog}.{self.dst_schema}.{self.dst_table}".lower()
 
     @classmethod
-    def from_json(cls, json: dict):
+    def from_json(cls, raw: dict[str, str]) -> "MigrationStatus":
         return cls(
-            src_schema=json['src_schema'],
-            src_table=json['src_table'],
-            dst_catalog=json.get('dst_catalog', None),
-            dst_schema=json.get('dst_schema', None),
-            dst_table=json.get('dst_table', None),
-            update_ts=json.get('update_ts', None),
+            src_schema=raw['src_schema'],
+            src_table=raw['src_table'],
+            dst_catalog=raw.get('dst_catalog', None),
+            dst_schema=raw.get('dst_schema', None),
+            dst_table=raw.get('dst_table', None),
+            update_ts=raw.get('update_ts', None),
         )
 
 

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -183,13 +183,13 @@ class CurrentSessionState:
             catalog=json.get('catalog', DEFAULT_CATALOG),
             spark_conf=json.get('spark_conf', None),
             named_parameters=json.get('named_parameters', None),
-            data_security_mode=CurrentSessionState._parse_security_mode(json.get('data_security_mode', None)),
+            data_security_mode=cls.parse_security_mode(json.get('data_security_mode', None)),
             is_serverless=json.get('is_serverless', False),
             dbr_version=tuple(json['dbr_version']) if 'dbr_version' in json else None,
         )
 
     @staticmethod
-    def _parse_security_mode(mode_str: str | None) -> compute.DataSecurityMode | None:
+    def parse_security_mode(mode_str: str | None) -> compute.DataSecurityMode | None:
         try:
             return compute.DataSecurityMode(mode_str) if mode_str else None
         except ValueError:

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -178,21 +178,23 @@ class CurrentSessionState:
 
     @classmethod
     def from_json(cls, json: dict) -> CurrentSessionState:
-        mode_str = json.get('data_security_mode', None)
-        try:
-            data_security_mode = compute.DataSecurityMode(mode_str) if mode_str else None
-        except ValueError:
-            logger.error(f'Unknown data_security_mode {mode_str}')
-            data_security_mode = None
         return cls(
             schema=json.get('schema', DEFAULT_SCHEMA),
             catalog=json.get('catalog', DEFAULT_CATALOG),
             spark_conf=json.get('spark_conf', None),
             named_parameters=json.get('named_parameters', None),
-            data_security_mode=data_security_mode,
+            data_security_mode=CurrentSessionState._parse_security_mode(json.get('data_security_mode', None)),
             is_serverless=json.get('is_serverless', False),
             dbr_version=tuple(json['dbr_version']) if 'dbr_version' in json else None,
         )
+
+    @staticmethod
+    def _parse_security_mode(mode_str: str | None) -> compute.DataSecurityMode | None:
+        try:
+            return compute.DataSecurityMode(mode_str) if mode_str else None
+        except ValueError:
+            logger.warning(f'Unknown data_security_mode {mode_str}')
+            return None
 
 
 class SequentialLinter(Linter):

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -179,12 +179,17 @@ class CurrentSessionState:
     @classmethod
     def from_json(cls, json: dict) -> CurrentSessionState:
         mode_str = json.get('data_security_mode', None)
+        try:
+            data_security_mode = compute.DataSecurityMode(mode_str) if mode_str else None
+        except ValueError:
+            logger.error(f'Unknown data_security_mode {mode_str}')
+            data_security_mode = None
         return cls(
             schema=json.get('schema', DEFAULT_SCHEMA),
             catalog=json.get('catalog', DEFAULT_CATALOG),
             spark_conf=json.get('spark_conf', None),
             named_parameters=json.get('named_parameters', None),
-            data_security_mode=compute.DataSecurityMode(mode_str) if mode_str else None,
+            data_security_mode=data_security_mode,
             is_serverless=json.get('is_serverless', False),
             dbr_version=tuple(json['dbr_version']) if 'dbr_version' in json else None,
         )

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -178,12 +178,13 @@ class CurrentSessionState:
 
     @classmethod
     def from_json(cls, json: dict) -> CurrentSessionState:
+        mode_str = json.get('data_security_mode', None)
         return cls(
             schema=json.get('schema', DEFAULT_SCHEMA),
             catalog=json.get('catalog', DEFAULT_CATALOG),
             spark_conf=json.get('spark_conf', None),
             named_parameters=json.get('named_parameters', None),
-            data_security_mode=json.get('data_security_mode', None),
+            data_security_mode=compute.DataSecurityMode(mode_str) if mode_str else None,
             is_serverless=json.get('is_serverless', False),
             dbr_version=tuple(json['dbr_version']) if 'dbr_version' in json else None,
         )

--- a/src/databricks/labs/ucx/source_code/linters/spark_connect.py
+++ b/src/databricks/labs/ucx/source_code/linters/spark_connect.py
@@ -9,6 +9,8 @@ from databricks.labs.ucx.source_code.base import (
     PythonLinter,
     CurrentSessionState,
 )
+from databricks.sdk.service.compute import DataSecurityMode
+
 from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 
 
@@ -238,6 +240,10 @@ class CommandContextMatcher(SharedClusterMatcher):
 
 class SparkConnectLinter(PythonLinter):
     def __init__(self, session_state: CurrentSessionState):
+        if session_state.data_security_mode != DataSecurityMode.USER_ISOLATION:
+            self._matchers = []
+            return
+
         self._matchers = [
             JvmAccessMatcher(session_state=session_state),
             RDDApiMatcher(session_state=session_state),

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -1,10 +1,12 @@
 import logging
+from packaging import version
 
 from pylsp import hookimpl  # type: ignore
 from pylsp.config.config import Config  # type: ignore
 from pylsp.workspace import Document  # type: ignore
 from databricks.sdk.service.workspace import Language
 
+from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, MigrationStatus
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.lsp import Diagnostic
@@ -18,29 +20,37 @@ logger = logging.getLogger(__name__)
 def pylsp_lint(config: Config, document: Document) -> list[dict]:
     cfg = config.plugin_settings('pylsp_ucx', document_path=document.uri)
 
+    migration_index_list = cfg.get('migration_index', None)
+    migration_index = (
+        None
+        if not migration_index_list
+        else MigrationIndex([MigrationStatus.from_json(st) for st in migration_index_list])
+    )
+
     session_state = CurrentSessionState(
         data_security_mode=parse_data_security_mode(cfg.get('dataSecurityMode', None)),
         dbr_version=parse_dbr_version(cfg.get('dbrVersion', None)),
         is_serverless=bool(cfg.get('isServerless', False)),
     )
-    languages = LinterContext(index=None, session_state=session_state)
+    languages = LinterContext(index=migration_index, session_state=session_state)
     analyser = languages.linter(Language.PYTHON)
     code = document.source
     diagnostics = [Diagnostic.from_advice(_) for _ in analyser.lint(code)]
     return [d.as_dict() for d in diagnostics]
 
 
-def parse_dbr_version(version: str | None) -> tuple[int, int] | None:
-    if not version:
+def parse_dbr_version(version_str: str | None) -> tuple[int, int] | None:
+    if not version_str:
         return None
-    version_parts = [int(i) for i in version.split('.') if i.isnumeric()]
-    if len(version_parts) < 2:
-        logger.error(f'Incorrect DBR version string: {version}')
+    try:
+        release_version = version.parse(version_str).release
+        return release_version[0], release_version[1]
+    except version.InvalidVersion:
+        logger.error(f'Incorrect DBR version string: {version_str}')
         return None
-    return version_parts[0], version_parts[1]
 
 
-def parse_data_security_mode(mode_str: str | None):
+def parse_data_security_mode(mode_str: str | None) -> DataSecurityMode | None:
     if not mode_str:
         return None
     try:

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -46,7 +46,7 @@ def parse_dbr_version(version_str: str | None) -> tuple[int, int] | None:
         release_version = version.parse(version_str).release
         return release_version[0], release_version[1]
     except version.InvalidVersion:
-        logger.error(f'Incorrect DBR version string: {version_str}')
+        logger.warning(f'Incorrect DBR version string: {version_str}')
         return None
 
 
@@ -56,5 +56,5 @@ def parse_data_security_mode(mode_str: str | None) -> DataSecurityMode | None:
     try:
         return DataSecurityMode(mode_str)
     except ValueError as _:
-        logger.error(f'Unknown data_security_mode: {mode_str}')
+        logger.warning(f'Unknown data_security_mode: {mode_str}')
         return None

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -1,16 +1,50 @@
+import logging
+
 from pylsp import hookimpl  # type: ignore
-from pylsp.workspace import Document, Workspace  # type: ignore
+from pylsp.config.config import Config  # type: ignore
+from pylsp.workspace import Document  # type: ignore
 from databricks.sdk.service.workspace import Language
 
+from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.lsp import Diagnostic
+from databricks.sdk.service.compute import DataSecurityMode
+
+
+logger = logging.getLogger(__name__)
 
 
 @hookimpl
-def pylsp_lint(workspace: Workspace, document: Document) -> list[dict]:  # pylint: disable=unused-argument
-    # TODO: initialize migration index and session state from config / env variables
-    languages = LinterContext(index=None, session_state=None)
+def pylsp_lint(config: Config, document: Document) -> list[dict]:
+    cfg = config.plugin_settings('pylsp_ucx', document_path=document.uri)
+
+    session_state = CurrentSessionState(
+        data_security_mode=parse_data_security_mode(cfg.get('dataSecurityMode', None)),
+        dbr_version=parse_dbr_version(cfg.get('dbrVersion', None)),
+        is_serverless=bool(cfg.get('isServerless', False)),
+    )
+    languages = LinterContext(index=None, session_state=session_state)
     analyser = languages.linter(Language.PYTHON)
     code = document.source
     diagnostics = [Diagnostic.from_advice(_) for _ in analyser.lint(code)]
     return [d.as_dict() for d in diagnostics]
+
+
+def parse_dbr_version(version: str | None) -> tuple[int, int] | None:
+    if not version:
+        return None
+    version_parts = [int(i) for i in version.split('.') if i.isnumeric()]
+    if len(version_parts) < 2:
+        logger.error(f'Incorrect DBR version string: {version}')
+        return None
+    return version_parts[0], version_parts[1]
+
+
+def parse_data_security_mode(mode_str: str | None):
+    if not mode_str:
+        return None
+    try:
+        return DataSecurityMode(mode_str)
+    except ValueError as _:
+        logger.error(f'Unknown data_security_mode: {mode_str}')
+        return None

--- a/tests/unit/source_code/samples/functional/spark-connect/catalog-api_13_3.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/catalog-api_13_3.py
@@ -1,4 +1,4 @@
-# ucx[session-state] {"dbr_version": [13, 3]}
+# ucx[session-state] {"dbr_version": [13, 3], "data_security_mode": "USER_ISOLATION"}
 # ucx[catalog-api-in-shared-clusters:+1:0:+1:13] spark.catalog functions require DBR 14.3 LTS or above on UC Shared Clusters
 spark.catalog.tableExists("table")
 # ucx[catalog-api-in-shared-clusters:+1:0:+1:13] spark.catalog functions require DBR 14.3 LTS or above on UC Shared Clusters

--- a/tests/unit/source_code/samples/functional/spark-connect/catalog-api_14_3.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/catalog-api_14_3.py
@@ -1,4 +1,4 @@
-# ucx[session-state] {"dbr_version": [14, 3]}
+# ucx[session-state] {"dbr_version": [14, 3], "data_security_mode": "USER_ISOLATION"}
 spark.catalog.tableExists("table")
 spark.catalog.listDatabases()
 

--- a/tests/unit/source_code/samples/functional/spark-connect/command-context.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/command-context.py
@@ -1,3 +1,4 @@
+# ucx[session-state] {"data_security_mode": "USER_ISOLATION"}
 # ucx[to-json-in-shared-clusters:+1:6:+1:80] toJson() is not available on UC Shared Clusters. Use toSafeJson() on DBR 13.3 LTS or above to get a subset of command context information.
 print(dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson())
 dbutils.notebook.entry_point.getDbutils().notebook().getContext().toSafeJson()

--- a/tests/unit/source_code/samples/functional/spark-connect/jvm-access.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/jvm-access.py
@@ -1,3 +1,4 @@
+# ucx[session-state] {"data_security_mode": "USER_ISOLATION"}
 spark.range(10).collect()
 # ucx[jvm-access-in-shared-clusters:+1:0:+1:18] Cannot access Spark Driver JVM on UC Shared Clusters
 spark._jspark._jvm.com.my.custom.Name()

--- a/tests/unit/source_code/samples/functional/spark-connect/python-udfs_13_3.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/python-udfs_13_3.py
@@ -1,4 +1,4 @@
-# ucx[session-state] {"dbr_version": [13, 3]}
+# ucx[session-state] {"dbr_version": [13, 3], "data_security_mode": "USER_ISOLATION"}
 from pyspark.sql.functions import udf, udtf, lit
 import pandas as pd
 

--- a/tests/unit/source_code/samples/functional/spark-connect/python-udfs_14_3.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/python-udfs_14_3.py
@@ -1,4 +1,4 @@
-# ucx[session-state] {"dbr_version": [14, 3]}
+# ucx[session-state] {"dbr_version": [14, 3], "data_security_mode": "USER_ISOLATION"}
 from pyspark.sql.functions import udf, udtf, lit
 import pandas as pd
 

--- a/tests/unit/source_code/samples/functional/spark-connect/rdd-apis.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/rdd-apis.py
@@ -1,3 +1,4 @@
+# ucx[session-state] {"data_security_mode": "USER_ISOLATION"}
 df = spark.createDataFrame([])
 # ucx[rdd-in-shared-clusters:+1:0:+1:27] RDD APIs are not supported on UC Shared Clusters. Use mapInArrow() or Pandas UDFs instead
 df.rdd.mapPartitions(myUdf)

--- a/tests/unit/source_code/samples/functional/spark-connect/spark-logging.py
+++ b/tests/unit/source_code/samples/functional/spark-connect/spark-logging.py
@@ -1,3 +1,4 @@
+# ucx[session-state] {"data_security_mode": "USER_ISOLATION"}
 # ucx[legacy-context-in-shared-clusters:+2:0:+2:14] sc is not supported on UC Shared Clusters. Rewrite it using spark
 # ucx[spark-logging-in-shared-clusters:+1:0:+1:22] Cannot set Spark log level directly from code on UC Shared Clusters. Remove the call and set the cluster spark conf 'spark.log.level' instead
 sc.setLogLevel("INFO")

--- a/tests/unit/source_code/test_lsp_plugin.py
+++ b/tests/unit/source_code/test_lsp_plugin.py
@@ -27,9 +27,67 @@ def temp_document(doc_text, ws):
 
 
 def test_pylsp_lint(workspace):
-    code = 'sc.emptyRDD()'
+    code = 'sc.emptyRDD()\ndf.groupby("id").applyInPandas(udf)'
     _, doc = temp_document(code, workspace)
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace, doc), key=lambda d: d['code'])
+
+    workspace.update_config(
+        {
+            'pylsp': {
+                'plugins': {
+                    'pylsp_ucx': {
+                        'enabled': True,
+                        'dbrVersion': '14.2',
+                        'isServerless': False,
+                        'dataSecurityMode': 'USER_ISOLATION',
+                    },
+                }
+            }
+        }
+    )
+
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    assert diagnostics == [
+        {
+            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 11}},
+            'code': 'legacy-context-in-shared-clusters',
+            'source': 'databricks.labs.ucx',
+            'message': 'sc is not supported on UC Shared Clusters. Rewrite it using spark',
+            'severity': 1,
+            'tags': [],
+        },
+        {
+            'range': {'end': {'character': 35, 'line': 1}, 'start': {'character': 0, 'line': 1}},
+            'code': 'python-udf-in-shared-clusters',
+            'message': 'applyInPandas require DBR 14.3 LTS or above on UC Shared Clusters',
+            'severity': 1,
+            'source': 'databricks.labs.ucx',
+            'tags': [],
+        },
+        {
+            'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 13}},
+            'code': 'rdd-in-shared-clusters',
+            'source': 'databricks.labs.ucx',
+            'message': 'RDD APIs are not supported on UC Shared Clusters. Rewrite it using DataFrame API',
+            'severity': 1,
+            'tags': [],
+        },
+    ]
+
+
+def test_pylsp_lint_no_dbr_version(workspace):
+    code = 'sc.emptyRDD()\ndf.groupby("id").applyInPandas(udf)'
+    _, doc = temp_document(code, workspace)
+    workspace.update_config(
+        {
+            'pylsp': {
+                'plugins': {
+                    'pylsp_ucx': {'enabled': True, 'isServerless': False, 'dataSecurityMode': 'USER_ISOLATION'},
+                }
+            }
+        }
+    )
+
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
     assert diagnostics == [
         {
             'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 11}},
@@ -48,3 +106,56 @@ def test_pylsp_lint(workspace):
             'tags': [],
         },
     ]
+
+
+def test_pylsp_no_config(workspace):
+    code = 'sc.emptyRDD()'
+    _, doc = temp_document(code, workspace)
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    assert diagnostics == []
+
+
+def test_pylsp_invalid_config(workspace):
+    code = 'sc.emptyRDD()\ndf.groupby("id").applyInPandas(udf)'
+    _, doc = temp_document(code, workspace)
+
+    workspace.update_config(
+        {
+            'pylsp': {
+                'plugins': {
+                    'pylsp_ucx': {
+                        'enabled': True,
+                        'dbrVersion': 'invalid-version',
+                        'isServerless': False,
+                        'dataSecurityMode': 'unknown',
+                    },
+                }
+            }
+        }
+    )
+
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    assert diagnostics == []
+
+
+def test_pylsp_lint_single_user_cluster(workspace):
+    code = 'sc.emptyRDD()'
+    _, doc = temp_document(code, workspace)
+
+    workspace.update_config(
+        {
+            'pylsp': {
+                'plugins': {
+                    'pylsp_ucx': {
+                        'enabled': True,
+                        'dbrVersion': '14.3',
+                        'isServerless': False,
+                        'dataSecurityMode': 'SINGLE_USER',
+                    },
+                }
+            }
+        }
+    )
+
+    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    assert diagnostics == []

--- a/tests/unit/source_code/test_lsp_plugin.py
+++ b/tests/unit/source_code/test_lsp_plugin.py
@@ -87,7 +87,7 @@ def test_pylsp_lint_no_dbr_version(workspace, config):
         }
     )
 
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    diagnostics = sorted(lsp_plugin.pylsp_lint(config, doc), key=lambda d: d['code'])
     assert diagnostics == [
         {
             'range': {'start': {'line': 0, 'character': 0}, 'end': {'line': 0, 'character': 11}},
@@ -108,10 +108,10 @@ def test_pylsp_lint_no_dbr_version(workspace, config):
     ]
 
 
-def test_pylsp_no_config(workspace):
+def test_pylsp_no_config(workspace, config):
     code = 'sc.emptyRDD()'
     _, doc = temp_document(code, workspace)
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    diagnostics = sorted(lsp_plugin.pylsp_lint(config, doc), key=lambda d: d['code'])
     assert diagnostics == []
 
 
@@ -132,7 +132,7 @@ def test_pylsp_invalid_config(workspace, config):
         }
     )
 
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    diagnostics = sorted(lsp_plugin.pylsp_lint(config, doc), key=lambda d: d['code'])
     assert diagnostics == []
 
 
@@ -153,7 +153,7 @@ def test_pylsp_lint_single_user_cluster(workspace, config):
         }
     )
 
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    diagnostics = sorted(lsp_plugin.pylsp_lint(config, doc), key=lambda d: d['code'])
     assert diagnostics == []
 
 
@@ -172,7 +172,7 @@ def test_with_migration_index(workspace, config):
         }
     )
 
-    diagnostics = sorted(lsp_plugin.pylsp_lint(workspace._config, doc), key=lambda d: d['code'])
+    diagnostics = sorted(lsp_plugin.pylsp_lint(config, doc), key=lambda d: d['code'])
     assert diagnostics == [
         {
             'range': {'end': {'character': 67, 'line': 0}, 'start': {'character': 9, 'line': 0}},


### PR DESCRIPTION
## Changes
Make LSP linter plugin configurable with cluster information. This config can be provided either in a file or by a client and its provisioning is handled by pylsp infrastructure.
Spark Connect linter is now applied only to UC Shared clusters, as Single-User clusters are running in Spark Classic mode.

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
