### PR TITLE
Mock WheelsV2 in unit-tests to avoid lengthy wheel-building.

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ from databricks.labs.blueprint.entrypoint import is_in_debug
 from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
+from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.service.catalog import FunctionInfo, SchemaInfo, TableInfo

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ from databricks.labs.blueprint.entrypoint import is_in_debug
 from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.labs.blueprint.wheels import ProductInfo
+from databricks.labs.blueprint.wheels import ProductInfo, WheelsV2
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.service.catalog import FunctionInfo, SchemaInfo, TableInfo

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from databricks.labs.blueprint.installation import MockInstallation
@@ -23,7 +24,7 @@ PRODUCT_INFO = ProductInfo.from_class(WorkspaceConfig)
 def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
     mock_installation = request.param if hasattr(request, "param") else MockInstallation()
     install_state = InstallState.from_installation(mock_installation)
-    wheels = WheelsV2(mock_installation, PRODUCT_INFO)
+    wheels = mock.create_autospec(WheelsV2)
     workflows_installation = WorkflowsDeployment(
         WorkspaceConfig(inventory_database="..."),
         mock_installation,


### PR DESCRIPTION
## Changes

This PR updates some of the unit-testing fixtures to mock `WheelsV2` where this is referenced instead of the real thing; this avoids lengthy wheel-building during unit tests.

(Wheel-building can easily exceed the 30s unit-testing deadline, especially on developer laptops with the solacc dataset present.) 