### PR TITLE
Filter out missing import problems for imports within a try-except clause with ImportError

### DIFF
--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.graph import DependencyProblem, DependencyGraph, Dependency
+from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyProblem
 from databricks.labs.ucx.source_code.linters.files import FileLoader
 
 from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter, ImportSource, SysPathChange


### PR DESCRIPTION
## Changes
Filter out missing import problems for imports within a try-except clause with ImportError 

### Linked issues
Resolves #1705 

### Functionality
None

### Tests
- [x] added unit tests
