### PR TITLE
Add support for skipping views when migrating tables and views

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -81,8 +81,7 @@ def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None
         return None
     ctx = WorkspaceContext(w)
     if table:
-        is_view = ctx.tables_crawler.is_view(schema, table)
-        return ctx.table_mapping.skip_table_or_view(schema, table, is_view)
+        return ctx.table_mapping.skip_table_or_view(schema, table, ctx.tables_crawler)
     return ctx.table_mapping.skip_schema(schema)
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -81,7 +81,8 @@ def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None
         return None
     ctx = WorkspaceContext(w)
     if table:
-        return ctx.table_mapping.skip_table(schema, table)
+        is_view = ctx.tables_crawler.is_view(schema, table)
+        return ctx.table_mapping.skip_table_or_view(schema, table, is_view)
     return ctx.table_mapping.skip_schema(schema)
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -81,7 +81,7 @@ def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None
         return None
     ctx = WorkspaceContext(w)
     if table:
-        return ctx.table_mapping.skip_table_or_view(schema, table, ctx.tables_crawler)
+        return ctx.table_mapping.skip_table_or_view(schema, table, ctx.tables_crawler.load_one)
     return ctx.table_mapping.skip_schema(schema)
 
 

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -116,10 +116,10 @@ class TableMapping:
             msg = "Please run: databricks labs ucx table-mapping"
             raise ValueError(msg) from None
 
-    def skip_table_or_view(self, schema: str, table: str, is_view: bool):
+    def skip_table_or_view(self, schema: str, table: str, crawler: TablesCrawler):
         # Marks a table to be skipped in the migration process by applying a table property
         try:
-            what = "VIEW" if is_view else "TABLE"
+            what = "VIEW" if crawler.is_view(schema, table) else "TABLE"
             self._sql_backend.execute(
                 f"ALTER {what} {escape_sql_identifier(schema)}.{escape_sql_identifier(table)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
             )

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from collections.abc import Collection
+from collections.abc import Collection, Callable
 from dataclasses import dataclass
 from functools import partial
 
@@ -116,20 +116,24 @@ class TableMapping:
             msg = "Please run: databricks labs ucx table-mapping"
             raise ValueError(msg) from None
 
-    def skip_table_or_view(self, schema: str, table: str, crawler: TablesCrawler):
+    def skip_table_or_view(self, schema_name: str, table_name: str, load_table: Callable[[str, str], Table | None]):
         # Marks a table to be skipped in the migration process by applying a table property
         try:
-            what = "VIEW" if crawler.is_view(schema, table) else "TABLE"
+            table = load_table(schema_name, table_name)
+            if table is None:
+                raise NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
             self._sql_backend.execute(
-                f"ALTER {what} {escape_sql_identifier(schema)}.{escape_sql_identifier(table)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
+                f"ALTER {table.kind} {escape_sql_identifier(schema_name)}.{escape_sql_identifier(table_name)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
             )
         except NotFound as err:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):
-                logger.error(f"Failed to apply skip marker for Table {schema}.{table}. Table not found.")
+                logger.error(f"Failed to apply skip marker for Table {schema_name}.{table_name}. Table not found.")
             else:
-                logger.error(f"Failed to apply skip marker for Table {schema}.{table}: {err!s}", exc_info=True)
+                logger.error(
+                    f"Failed to apply skip marker for Table {schema_name}.{table_name}: {err!s}", exc_info=True
+                )
         except BadRequest as err:
-            logger.error(f"Failed to apply skip marker for Table {schema}.{table}: {err!s}", exc_info=True)
+            logger.error(f"Failed to apply skip marker for Table {schema_name}.{table_name}: {err!s}", exc_info=True)
 
     def skip_schema(self, schema: str):
         # Marks a schema to be skipped in the migration process by applying a table property

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -116,11 +116,12 @@ class TableMapping:
             msg = "Please run: databricks labs ucx table-mapping"
             raise ValueError(msg) from None
 
-    def skip_table(self, schema: str, table: str):
+    def skip_table_or_view(self, schema: str, table: str, is_view: bool):
         # Marks a table to be skipped in the migration process by applying a table property
         try:
+            what = "VIEW" if is_view else "TABLE"
             self._sql_backend.execute(
-                f"ALTER TABLE {escape_sql_identifier(schema)}.{escape_sql_identifier(table)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
+                f"ALTER {what} {escape_sql_identifier(schema)}.{escape_sql_identifier(table)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
             )
         except NotFound as err:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -366,11 +366,7 @@ class TablesCrawler(CrawlerBase):
         """
         return self._snapshot(partial(self._try_load), partial(self._crawl))
 
-    def is_view(self, schema_name: str, table_name: str) -> bool:
-        table = self._try_load_one(schema_name, table_name)
-        return False if table is None else table.what == What.VIEW
-
-    def _try_load_one(self, schema_name: str, table_name: str) -> Table | None:
+    def load_one(self, schema_name: str, table_name: str) -> Table | None:
         query = f"SELECT * FROM {escape_sql_identifier(self.full_name)} WHERE database='{schema_name}' AND name='{table_name}' LIMIT 1"
         for row in self._fetch(query):
             return Table(*row)

--- a/tests/integration/hive_metastore/test_tables.py
+++ b/tests/integration/hive_metastore/test_tables.py
@@ -52,7 +52,7 @@ def test_describe_all_tables_in_databases(ws, sql_backend, inventory_schema, mak
     assert all_tables[view.full_name].object_type == "VIEW"
     assert all_tables[view.full_name].view_text == "SELECT 2+2 AS four"
     assert all_tables[view.full_name].what == What.VIEW
-    assert tables.is_view(view.schema_name, view.name)
+    assert tables.load_one(view.schema_name, view.name).what == What.VIEW
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/hive_metastore/test_tables.py
+++ b/tests/integration/hive_metastore/test_tables.py
@@ -52,6 +52,7 @@ def test_describe_all_tables_in_databases(ws, sql_backend, inventory_schema, mak
     assert all_tables[view.full_name].object_type == "VIEW"
     assert all_tables[view.full_name].view_text == "SELECT 2+2 AS four"
     assert all_tables[view.full_name].what == What.VIEW
+    assert tables.is_view(view.schema_name, view.name)
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -191,10 +191,12 @@ def test_skip_happy_path(caplog):
     sbe = create_autospec(SqlBackend)
     installation = MockInstallation()
     mapping = TableMapping(installation, ws, sbe)
-    mapping.skip_table_or_view(schema="schema", table="table", is_view=False)
+    crawler = create_autospec(TablesCrawler)
+    crawler.is_view.side_effect = lambda _, table: table == "view"
+    mapping.skip_table_or_view(schema="schema", table="table", crawler=crawler)
     ws.tables.get.assert_not_called()
     sbe.execute.assert_called_with(f"ALTER TABLE schema.table SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)")
-    mapping.skip_table_or_view(schema="schema", table="view", is_view=True)
+    mapping.skip_table_or_view(schema="schema", table="view", crawler=crawler)
     ws.tables.get.assert_not_called()
     sbe.execute.assert_called_with(f"ALTER VIEW schema.view SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)")
     assert len(caplog.records) == 0
@@ -220,7 +222,7 @@ def test_skip_missing_table(caplog):
     installation = MockInstallation()
     sbe.execute.side_effect = NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
     mapping = TableMapping(installation, ws, sbe)
-    mapping.skip_table_or_view('foo', table="table", is_view=False)
+    mapping.skip_table_or_view('foo', table="table", crawler=TablesCrawler(sbe, "schema"))
     ws.tables.get.assert_not_called()
     assert [rec.message for rec in caplog.records if "table not found" in rec.message.lower()]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -140,7 +140,7 @@ def test_skip_with_table(ws):
 
     ws.statement_execution.execute_statement.assert_called_with(
         warehouse_id='test',
-        statement="ALTER TABLE schema.table SET TBLPROPERTIES('databricks.labs.ucx.skip' = true)",
+        statement="SELECT * FROM hive_metastore.ucx.tables WHERE database='schema' AND name='table' LIMIT 1",
         byte_limit=None,
         catalog=None,
         schema=None,


### PR DESCRIPTION
## Changes
Add support for skipping views when migrating tables and views

### Linked issues
Resolves #1937 

### Functionality
- [ ] modified existing command: `databricks labs ucx skip`

### Tests
- [x] added unit tests
- [x] evolved integration tests
