### PR TITLE
Improve group migration error reporting

### DIFF
--- a/src/databricks/labs/ucx/queries/migration/groups/00_0_migration_overview.md
+++ b/src/databricks/labs/ucx/queries/migration/groups/00_0_migration_overview.md
@@ -10,7 +10,7 @@ Workspace Group Migration
 Prerequisites for group migration are:
 
  - The assessment workflow has completed.
- - For each workspace group a corresponding account-level group must exist.
+ - For each workspace group a corresponding account-level group must exist. (Refer to the documentation for details about the different strategies that can be configured for associating workspace groups with their corresponding account-level group.)
 
 Group migration performs the following steps:
 

--- a/src/databricks/labs/ucx/queries/migration/groups/00_0_migration_overview.md
+++ b/src/databricks/labs/ucx/queries/migration/groups/00_0_migration_overview.md
@@ -18,7 +18,7 @@ Group migration performs the following steps:
 2. The account-level groups are then provisioned into the workspace.
 3. Permissions assigned to the workspace groups are replicated on the account-level groups.
 
-These steps are performed by either the `migrate-groups` or the `migrate-groups-experimental` workflows. (The latter uses a faster, but experimental, method to replicate group permissions.)
+These steps are performed by either the `migrate-groups` or the `migrate-groups-experimental` [workflows](/jobs). (The latter uses a faster, but experimental, method to replicate group permissions.)
 
 Once group migration has taken place:
 

--- a/src/databricks/labs/ucx/queries/migration/groups/01_0_group_migration_failures.md
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_0_group_migration_failures.md
@@ -1,11 +1,9 @@
 ---
 height: 4
-width: 2
+width: 1
 ---
 
 Group Migration Failures
 ------------------------
 
 When migrating groups, errors may occur during the migration of a particular group. Any errors that occurred while migrating groups are displayed here.
-
-The errors for all workflow runs are shown; to clear (old) errors the job run can be deleted.

--- a/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
@@ -13,9 +13,9 @@
         {"fieldName": "error_message", "title": "Error Message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"}
       ]},
     "invisibleColumns": [
-        {"fieldName": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
-        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true}
-      ]
+      {"name": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
+      {"name": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true}
+    ]
    }}'
 */
 WITH latest_job_runs AS (

--- a/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
@@ -2,19 +2,21 @@
 --title 'Group Migration Failures'
 --height 4
 --width 5
---overrides '{"spec":
-    {"encodings":{"columns": [
+--overrides '{"spec":{
+    "encodings":{
+      "columns": [
         {"fieldName": "timestamp", "title": "Time of Failure", "booleanValues": ["false", "true"], "type": "datetime", "displayAs": "datetime", "dateTimeFormat": "ll LTS (z)"},
-        {"fieldName": "job_run_id", "title": "Workflow/Task", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}/runs/{{ job_run_id }}", "linkTextTemplate": "{{ workflow_name }}/{{ task_name }}", "linkTitleTemplate": "Job Run: {{ job_run_id }}", "useMonospaceFont": true},
+        {"fieldName": "task_name", "title": "Workflow/Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}/{{ @ }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "linkOpenInNewTab": true, "useMonospaceFont": true},
+        {"fieldName": "job_run_id", "title": "Run ID", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}/runs/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "Job Run: {{ @ }}", "linkOpenInNewTab": true},
         {"fieldName": "workspace_group", "title": "Workspace Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
         {"fieldName": "account_group", "title": "Account Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
         {"fieldName": "error_message", "title": "Error Message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"}
-    ]}},
+      ]},
     "invisibleColumns": [
         {"fieldName": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
-        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
-        {"fieldName": "task_name", "title": "Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}/{{ task_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true}
-    ]}'
+        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true}
+      ]
+   }}'
 */
 WITH latest_job_runs AS (
   SELECT

--- a/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
@@ -1,15 +1,36 @@
-/* --title 'Group Migration Failures' --height 4 --width 4 */ /*
- *
+/*
+--title 'Group Migration Failures'
+--height 4
+--width 4
+--overrides '{"spec":
+    {"encodings":{"columns": [
+        {"fieldName": "timestamp", "title": "Time of Failure", "booleanValues": ["false", "true"], "type": "datetime", "displayAs": "datetime", "dateTimeFormat": "ll LTS (z)"},
+        {"fieldName": "job_run_id", "title": "Workflow/Task", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}/runs/{{ job_run_id }}", "linkTextTemplate": "{{workflow_name}}/{{task_name}}", "linkTitleTemplate": "Job Run: {{ job_run_id }}", "useMonospaceFont": true},
+        {"fieldName": "workspace_group", "title": "Workspace Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
+        {"fieldName": "account_group", "title": "Account Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
+        {"fieldName": "error_message", "title": "Error Message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"}
+    ]}},
+    "invisibleColumns": [
+        {"fieldName": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true},
+        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true},
+        {"fieldName": "task_name", "title": "Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}/{{task_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true}
+    ]}'
+*/
+/*
  * Messages that we're looking for are of the form:
  *   failed-group-migration: {name_in_workspace} -> {name_in_account}: {reason}
  */
 SELECT
-  FROM_UNIXTIME(timestamp) AS timestamp,
+  CAST(timestamp AS TIMESTAMP) AS timestamp,
   job_run_id,
-  level,
-  message
+  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 1) AS workspace_group,
+  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 2) AS account_group,
+  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 3) AS error_message,
+  job_id,
+  workflow_name,
+  task_name
 FROM inventory.logs
 WHERE
-  workflow_name IN ('migrate-groups', 'migrate-groups-experimental') AND STARTSWITH(message, 'failed-group-migration:')
+  workflow_name IN ('migrate-groups', 'migrate-groups-experimental') AND STARTSWITH(message, 'failed-group-migration: ')
 ORDER BY
-  1
+  1 DESC

--- a/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
@@ -5,15 +5,15 @@
 --overrides '{"spec":
     {"encodings":{"columns": [
         {"fieldName": "timestamp", "title": "Time of Failure", "booleanValues": ["false", "true"], "type": "datetime", "displayAs": "datetime", "dateTimeFormat": "ll LTS (z)"},
-        {"fieldName": "job_run_id", "title": "Workflow/Task", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}/runs/{{ job_run_id }}", "linkTextTemplate": "{{workflow_name}}/{{task_name}}", "linkTitleTemplate": "Job Run: {{ job_run_id }}", "useMonospaceFont": true},
+        {"fieldName": "job_run_id", "title": "Workflow/Task", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}/runs/{{ job_run_id }}", "linkTextTemplate": "{{ workflow_name }}/{{ task_name }}", "linkTitleTemplate": "Job Run: {{ job_run_id }}", "useMonospaceFont": true},
         {"fieldName": "workspace_group", "title": "Workspace Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
         {"fieldName": "account_group", "title": "Account Group", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"},
         {"fieldName": "error_message", "title": "Error Message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string"}
     ]}},
     "invisibleColumns": [
-        {"fieldName": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true},
-        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true},
-        {"fieldName": "task_name", "title": "Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}/{{task_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true}
+        {"fieldName": "job_id", "title": "Workflow", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
+        {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true},
+        {"fieldName": "task_name", "title": "Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{ workflow_name }}/{{ task_name }}", "linkTitleTemplate": "{{ workflow_name }} (ID: {{ job_id }})", "useMonospaceFont": true}
     ]}'
 */ /*
  * Messages that we're looking for are of the form:

--- a/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
+++ b/src/databricks/labs/ucx/queries/migration/groups/01_1_group_migration_failures.sql
@@ -1,7 +1,7 @@
 /*
 --title 'Group Migration Failures'
 --height 4
---width 4
+--width 5
 --overrides '{"spec":
     {"encodings":{"columns": [
         {"fieldName": "timestamp", "title": "Time of Failure", "booleanValues": ["false", "true"], "type": "datetime", "displayAs": "datetime", "dateTimeFormat": "ll LTS (z)"},
@@ -15,17 +15,16 @@
         {"fieldName": "workflow_name", "title": "Workflow", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true},
         {"fieldName": "task_name", "title": "Task", "booleanValues": ["false", "true"], "type": "string", "displayAs": "link", "linkUrlTemplate": "/jobs/{{ job_id }}", "linkTextTemplate": "{{workflow_name}}/{{task_name}}", "linkTitleTemplate": "{{workflow_name}} (ID: {{job_id}})", "useMonospaceFont": true}
     ]}'
-*/
-/*
+*/ /*
  * Messages that we're looking for are of the form:
  *   failed-group-migration: {name_in_workspace} -> {name_in_account}: {reason}
  */
 SELECT
   CAST(timestamp AS TIMESTAMP) AS timestamp,
   job_run_id,
-  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 1) AS workspace_group,
-  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 2) AS account_group,
-  REGEXP_EXTRACT(message, r'^failed-group-migration: (.+?) -> (.+?): (.+?)$', 3) AS error_message,
+  REGEXP_EXTRACT(message, '^failed-group-migration: (.+?) -> (.+?): (.+)$', 1) AS workspace_group,
+  REGEXP_EXTRACT(message, '^failed-group-migration: (.+?) -> (.+?): (.+)$', 2) AS account_group,
+  REGEXP_EXTRACT(message, '^failed-group-migration: (.+?) -> (.+?): (.+)$', 3) AS error_message,
   job_id,
   workflow_name,
   task_name


### PR DESCRIPTION
## Changes

This PR updates the dashboard for group migration:

 - The documentation widgets have been adjusted.
 - The failed-migration widget now displays formatted information about the failure, and links to the failed job run.
 - Only failures from the latest workflow run (with logs) are displayed.

### Linked issues

Improves upon #2333.
Relates to #1914.

### Functionality

 - Updated dashboard: _UCX Migration (Groups)_

### Tests

 - [x] manually tested
 - [x] verified on staging environment (screenshot attached)
