### PR TITLE
Code Compatibility Dashboard: Fix broken links

### DIFF
--- a/src/databricks/labs/ucx/queries/migration/main/02_0_code_compatibility_problems.md
+++ b/src/databricks/labs/ucx/queries/migration/main/02_0_code_compatibility_problems.md
@@ -6,4 +6,4 @@ problem code and workflow name. The table:
 - Explains the problem with a human-readable message and a code.
 
 The code compatibility problems are updated after running
-[Jobs Static Code Analysis Workflow](https://github.com/databrickslabs/ucx/blob/main/README.md#workflow-linter-workflow).
+[Jobs Static Code Analysis Workflow](https://github.com/databrickslabs/ucx/blob/main/README.md#jobs-static-code-analysis-workflow).

--- a/src/databricks/labs/ucx/queries/migration/main/02_1_code_compatibility_problems.sql
+++ b/src/databricks/labs/ucx/queries/migration/main/02_1_code_compatibility_problems.sql
@@ -1,8 +1,9 @@
 /*
 --title 'Workflow migration problems'
 --width 6
---overrides '{"spec":
-    {"encodings": {"columns": [
+--overrides '{"spec":{
+    "encodings":{
+      "columns": [
         {"fieldName": "path", "booleanValues": ["false", "true"], "linkUrlTemplate": "/#workspace/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "path"},
         {"fieldName": "code", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "code"},
         {"fieldName": "message", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "message"},
@@ -12,10 +13,11 @@
         {"fieldName": "start_col", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "start_col"},
         {"fieldName": "end_line", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "end_line"},
         {"fieldName": "end_col", "booleanValues": ["false", "true"], "type": "integer", "displayAs": "number", "title": "end_col"}
-    ]}},
+      ]},
     "invisibleColumns": [
-        {"fieldName": "workflow_id", "booleanValues": ["false", "true"], "linkUrlTemplate": "/jobs/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "workflow_id"}
-    ]}'
+      {"name": "workflow_id", "booleanValues": ["false", "true"], "linkUrlTemplate": "/jobs/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "workflow_id"}
+    ]
+  }}'
 */
 SELECT
   path,


### PR DESCRIPTION
## Changes

In our Code Compatibility dashboard, this PR fixes two problems:

 - The link to the workflow in the Markdown panel didn't have the correct #anchor; now it does.
 - The links in the table widget to the workflow and task definitions was not being rendered correctly and therefore didn't work. Now they do.

### Functionality

- modified dashboard: _UCX Migration (Main)_

### Tests

- [X] manually tested
- [X] verified on staging environment (screenshot attached)

### Screenshots

Before:
![Dashboard with broken URL](https://github.com/user-attachments/assets/9645a864-5279-4b81-83ff-f722bf56fbda)

After:
![Dashboard with correct (and working) URL](https://github.com/user-attachments/assets/3e14ebb5-8981-4198-b32f-fca817bd404a)
