### PR TITLE
Integration tests: mark cluster policy fixtures with a purge-suffix

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -694,7 +694,7 @@ def migrated_group(acc, ws, make_group, make_acc_group):
 def make_cluster_policy(ws, make_random):
     def create(*, name: str | None = None, **kwargs):
         if name is None:
-            name = f"sdk-{make_random(4)}"
+            name = f"sdk-{make_random(4)}-{get_purge_suffix()}"
         if "definition" not in kwargs:
             kwargs["definition"] = json.dumps(
                 {


### PR DESCRIPTION
## Changes

This PR updates the cluster-policy fixtures created during integration tests so that they have the purge-time encoded as a suffix in their name. This will prevent the fixture from being removed while the test runs and causing spurious integration test failures.

### Linked issues

Progresses: #2353

### Tests

- integration tests
