### PR TITLE
Clean up left over uber principal resources for Azure

### DIFF
--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -419,11 +419,14 @@ class AzureResourcePermissions:
         for storage in self._azurerm.storage_accounts():
             if storage.name in used_storage_accounts:
                 storage_accounts.append(storage)
-        self._azurerm.delete_storage_permission(config.uber_spn_id, *storage_accounts, safe=True)
         try:
+            self._azurerm.delete_storage_permission(config.uber_spn_id, *storage_accounts, safe=True)
             self._azurerm.delete_service_principal(config.uber_spn_id, safe=True)
         except PermissionDenied:
-            logger.error(f"Missing permissions to delete service principal: {config.uber_spn_id}", exc_info=True)
+            logger.error(
+                f"Missing permissions to delete service principal and its permissions: {config.uber_spn_id}",
+                exc_info=True,
+            )
         secret_identifier = f"secrets/{config.inventory_database}/{self._UBER_PRINCIPAL_SECRET_KEY}"
         if config.policy_id is not None:
             try:

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -410,7 +410,7 @@ class AzureResourcePermissions:
             self._delete_uber_principal()  # Clean up dangling resources
             raise
 
-    def _delete_uber_principal(self):
+    def _delete_uber_principal(self) -> None:
         config = self._installation.load(WorkspaceConfig)
         if config.uber_spn_id is None:
             return

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -420,14 +420,7 @@ class AzureResourcePermissions:
             if storage.name in used_storage_accounts:
                 storage_accounts.append(storage)
         for storage_account in storage_accounts:
-            try:
-                self._azurerm.delete_storage_permission(config.uber_spn_id, storage_account)
-            except NotFound:
-                pass  # Already deleted
-            except PermissionDenied:
-                logger.error(
-                    f"Missing permissions to delete storage permission for {storage_account.id}", exc_info=True
-                )
+            self._azurerm.delete_storage_permission(config.uber_spn_id, storage_account, safe=True)
         try:
             self._azurerm.delete_service_principal(config.uber_spn_id)
         except NotFound:

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -210,8 +210,8 @@ class AzureResourcePermissions:
         principal_secret_identifier: str,
         storage_accounts: list[StorageAccount],
     ):
+        policy_definition = ""
         try:
-            policy_definition = ""
             cluster_policy = self._ws.cluster_policies.get(policy_id)
             self._installation.save(cluster_policy, filename="policy-backup.json")
             if cluster_policy.definition is not None:

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -23,7 +23,11 @@ from databricks.sdk.errors import (
 from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import Privilege
 from databricks.sdk.service.compute import Policy
-from databricks.sdk.service.sql import EndpointConfPair, GetWorkspaceWarehouseConfigResponse, SetWorkspaceWarehouseConfigRequestSecurityPolicy
+from databricks.sdk.service.sql import (
+    EndpointConfPair,
+    GetWorkspaceWarehouseConfigResponse,
+    SetWorkspaceWarehouseConfigRequestSecurityPolicy,
+)
 from databricks.sdk.service.workspace import GetSecretResponse
 
 from databricks.labs.ucx.azure.resources import (

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -536,7 +536,7 @@ class AzureResourcePermissions:
         self._ws.secrets.put_secret(scope, self._UBER_PRINCIPAL_SECRET_KEY, string_value=principal_secret.secret)
         return self._get_secret(scope, self._UBER_PRINCIPAL_SECRET_KEY)
 
-    @retried(on=[ResourceDoesNotExist], timeout=timedelta(minutes=2))
+    @retried(on=[ResourceDoesNotExist], timeout=timedelta(minutes=1))
     def _get_secret(self, scope: str, secret: str) -> GetSecretResponse:
         return self._ws.secrets.get_secret(scope, secret)
 

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -369,7 +369,7 @@ class AzureResourcePermissions:
             sql_dac_log_msg = "\n".join(f"{config_pair.key} {config_pair.value}" for config_pair in sql_dac)
             logger.error(
                 f'Adding uber principal to SQL warehouse Data Access Properties is failed using Python SDK with error "{error}". '
-                f'Please try applying the following configs manually in the worksapce admin UI:\n{sql_dac_log_msg}'
+                f'Please try applying the following configs manually in the workspace admin UI:\n{sql_dac_log_msg}'
             )
             raise error
 

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -415,7 +415,7 @@ class AzureResourcePermissions:
 
         message = "Missing permissions to load the configuration"
         config = log_permission_denied(self._installation.load, message=message)(WorkspaceConfig)
-        if config.uber_spn_id is None:
+        if config is None or config.uber_spn_id is None:
             return
 
         secret_identifier = f"secrets/{config.inventory_database}/{self._UBER_PRINCIPAL_SECRET_KEY}"

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -422,9 +422,7 @@ class AzureResourcePermissions:
         for storage_account in storage_accounts:
             self._azurerm.delete_storage_permission(config.uber_spn_id, storage_account, safe=True)
         try:
-            self._azurerm.delete_service_principal(config.uber_spn_id)
-        except NotFound:
-            pass  # Already deleted
+            self._azurerm.delete_service_principal(config.uber_spn_id, safe=True)
         except PermissionDenied:
             logger.error(f"Missing permissions to delete service principal: {config.uber_spn_id}", exc_info=True)
         secret_identifier = f"secrets/{config.inventory_database}/{self._UBER_PRINCIPAL_SECRET_KEY}"

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -419,8 +419,7 @@ class AzureResourcePermissions:
         for storage in self._azurerm.storage_accounts():
             if storage.name in used_storage_accounts:
                 storage_accounts.append(storage)
-        for storage_account in storage_accounts:
-            self._azurerm.delete_storage_permission(config.uber_spn_id, storage_account, safe=True)
+        self._azurerm.delete_storage_permission(config.uber_spn_id, *storage_accounts, safe=True)
         try:
             self._azurerm.delete_service_principal(config.uber_spn_id, safe=True)
         except PermissionDenied:

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -353,10 +353,25 @@ class AzureResourcePermissions:
                 if configuration_pair in sql_dac:
                     sql_dac.remove(configuration_pair)
 
-        self._ws.warehouses.set_workspace_warehouse_config(
-            data_access_config=sql_dac,
-            sql_configuration_parameters=warehouse_config.sql_configuration_parameters,
+        security_policy = (
+            SetWorkspaceWarehouseConfigRequestSecurityPolicy(warehouse_config.security_policy.value)
+            if warehouse_config.security_policy
+            else SetWorkspaceWarehouseConfigRequestSecurityPolicy.NONE
         )
+        try:
+            self._ws.warehouses.set_workspace_warehouse_config(
+                data_access_config=sql_dac,
+                sql_configuration_parameters=warehouse_config.sql_configuration_parameters,
+                security_policy=security_policy,
+            )
+        # TODO: Remove following try except once https://github.com/databricks/databricks-sdk-py/issues/305 is fixed
+        except InvalidParameterValue as error:
+            sql_dac_log_msg = "\n".join(f"{config_pair.key} {config_pair.value}" for config_pair in sql_dac)
+            logger.error(
+                f'Adding uber principal to SQL warehouse Data Access Properties is failed using Python SDK with error "{error}". '
+                f'Please try applying the following configs manually in the worksapce admin UI:\n{sql_dac_log_msg}'
+            )
+            raise error
 
     def create_uber_principal(self, prompts: Prompts):
         config = self._installation.load(WorkspaceConfig)

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -385,6 +385,8 @@ class AzureResourcePermissions:
             )
             return
         logger.info("Creating service principal")
+
+        secret_identifier = f"secrets/{inventory_database}/{self._UBER_PRINCIPAL_SECRET_KEY}"
         try:
             uber_principal = self._azurerm.create_service_principal(uber_principal_name)
             config.uber_spn_id = uber_principal.client.client_id
@@ -392,8 +394,7 @@ class AzureResourcePermissions:
             self._apply_storage_permission(
                 uber_principal.client.object_id, "STORAGE_BLOB_DATA_CONTRIBUTOR", *storage_accounts
             )
-            secret = self._create_and_get_secret_for_uber_principal(uber_principal, inventory_database)
-            secret_identifier = f"secrets/{inventory_database}/{secret.key}"
+            self._create_and_get_secret_for_uber_principal(uber_principal, inventory_database)
             self._add_service_principal_configuration_to_cluster_policy(
                 policy_id,
                 uber_principal.client.client_id,

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -423,16 +423,12 @@ class AzureResourcePermissions:
                 self._remove_service_principal_configuration_from_cluster_policy(
                     config.policy_id, config.uber_spn_id, secret_identifier, storage_accounts
                 )
-            except NotFound:
-                pass
             except PermissionDenied:
                 logger.error("Missing permissions to revert cluster policy", exc_info=True)
         try:
             self._remove_service_principal_configuration_from_workspace_warehouse_config(
                 config.uber_spn_id, secret_identifier, storage_accounts
             )
-        except NotFound:
-            pass
         except PermissionDenied:
             logger.error("Missing permissions to revert SQL warehouse config", exc_info=True)
         self._safe_delete_scope(config.inventory_database)

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -12,7 +12,14 @@ from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.parallel import ManyError, Threads
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import BadRequest, InvalidParameterValue, NotFound, PermissionDenied, ResourceAlreadyExists, ResourceDoesNotExist
+from databricks.sdk.errors import (
+    BadRequest,
+    InvalidParameterValue,
+    NotFound,
+    PermissionDenied,
+    ResourceAlreadyExists,
+    ResourceDoesNotExist,
+)
 from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import Privilege
 from databricks.sdk.service.compute import Policy
@@ -259,7 +266,7 @@ class AzureResourcePermissions:
         except NotFound:
             try:
                 policy = self._ws.cluster_policies.get(policy_id)
-            except NotFound:
+            except (InvalidParameterValue, NotFound):
                 return  # No policy to revert
         policy_definition = policy.definition
         if policy_definition is not None:

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -241,7 +241,7 @@ class AzureResourcePermissions:
             for key, _ in self._create_service_principal_cluster_policy_configuration_pairs(
                 principal_client_id, principal_secret_identifier, storage
             ):
-                if key in key:
+                if key in policy_dict:
                     del policy_dict[key]
         return json.dumps(policy_dict)
 
@@ -453,6 +453,8 @@ class AzureResourcePermissions:
         except PermissionDenied:
             logger.error("Missing permissions to revert SQL warehouse config", exc_info=True)
         self._safe_delete_scope(config.inventory_database)
+        config.uber_spn_id = None
+        self._installation.save(config)
 
     def _create_access_connector_for_storage_account(
         self, storage_account: StorageAccount, role_name: str = "STORAGE_BLOB_DATA_READER"

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -263,7 +263,7 @@ class AzureResourcePermissions:
         policy_definition = policy.definition
         if policy_definition is not None:
             policy_definition = self._remove_service_principal_configuration_from_cluster_policy_definition(
-                policy.definition,
+                policy_definition,
                 principal_client_id,
                 principal_secret_identifier,
                 storage_accounts,

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -340,7 +340,7 @@ class AzureResources:
         principal_id : str
             The principal id to delete.
         safe : bool, optional (default: True)
-            If True, do not raise a NotFound error when the principal is not found.
+            If True, will not raise an error if the service principal does not exists.
 
         Raises
         ------
@@ -502,7 +502,7 @@ class AzureResources:
         storage_accounts : StorageAccount
             The storage account(s) to delete permission for.
         safe : bool, optional (default: False)
-            If True, will not raise an exception if the no role assignment are found.
+            If True, will not raise an exception if no role assignment are found.
 
         Raises
         ------

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -332,13 +332,33 @@ class AzureResources:
         )
         return principal_secret
 
-    def delete_service_principal(self, principal_id: str):
+    def delete_service_principal(self, principal_id: str, *, safe: bool = False):
+        """Delete the service principal.
+
+        Parameters
+        ----------
+        principal_id : str
+            The principal id to delete.
+        safe : bool, optional (default: True)
+            If True, do not raise a NotFound error when the principal is not found.
+
+        Raises
+        ------
+        NotFound :
+            If the principal is not found.
+        PermissionDenied :
+            If missing permission to delete the service principal
+        """
         try:
             self._graph.delete(f"/v1.0/applications(appId='{principal_id}')")
         except PermissionDenied:
             msg = f"User doesnt have permission to delete application {principal_id}"
             logger.error(msg)
             raise PermissionDenied(msg) from None
+        except NotFound:
+            if safe:
+                return
+            raise
 
     def _log_permission_denied_error_for_storage_permission(self, path: str) -> None:
         logger.error(

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -328,7 +328,8 @@ class AzureResources:
             Principal(client_id, display_name, object_id, principal_type, directory_id), secret
         )
         logger.info(
-            f"Created service principal ({principal_secret.client.client_id}) with access to used storage accounts."
+            f"Created service principal ({principal_secret.client.client_id}) with access to used storage accounts: "
+            + principal_secret.client.display_name
         )
         return principal_secret
 

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -465,25 +465,10 @@ class AzureResources:
             self._log_permission_denied_error_for_storage_permission(path)
             raise
 
-    def delete_storage_permission(
+    def _delete_storage_permission(
         self, principal_id: str, storage_account: StorageAccount, *, safe: bool = False
     ) -> None:
-        """Delete storage permission(s) for a principal
-
-        Parameters
-        ----------
-        principal_id : str
-            The principal id to delete the role assignment(s) for.
-        storage_account : StorageAccount
-            The storage account to delete permission for.
-        safe : bool, optional (default: False)
-            If True, will not raise an exception if the no role assignment are found.
-
-        Raises
-        ------
-        PermissionDenied :
-            If user is missing permission to get the storage permission.
-        """
+        """See meth:delete_storage_permission"""
         try:
             storage_permissions = self._get_storage_permissions(principal_id, storage_account)
         except NotFound:
@@ -504,6 +489,28 @@ class AzureResources:
             raise PermissionDenied(
                 f"Permission denied for deleting role assignments: {', '.join(permission_denied_guids)}"
             )
+
+    def delete_storage_permission(
+        self, principal_id: str, *storage_accounts: StorageAccount, safe: bool = False
+    ) -> None:
+        """Delete storage permission(s) for a principal
+
+        Parameters
+        ----------
+        principal_id : str
+            The principal id to delete the role assignment(s) for.
+        storage_accounts : StorageAccount
+            The storage account(s) to delete permission for.
+        safe : bool, optional (default: False)
+            If True, will not raise an exception if the no role assignment are found.
+
+        Raises
+        ------
+        PermissionDenied :
+            If user is missing permission to get the storage permission.
+        """
+        for storage_account in storage_accounts:
+            self._delete_storage_permission(principal_id, storage_account, safe=safe)
 
     def tenant_id(self):
         token = self._mgmt.token()

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -472,7 +472,7 @@ class AzureResources:
     ) -> None:
         """See meth:delete_storage_permission"""
         try:
-            storage_permissions = self._get_storage_permissions(principal_id, storage_account)
+            storage_permissions = list(self._get_storage_permissions(principal_id, storage_account))
         except NotFound:
             if safe:
                 return

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -88,7 +88,9 @@ def test_create_global_spn(skip_if_not_in_debug, env_or_skip, az_cli_ctx, make_c
     az_cli_ctx.azure_resource_permissions.create_uber_principal(prompts)
 
     assert az_cli_ctx.config.uber_spn_id is not None
-    policy_definition = json.loads(az_cli_ctx.workspace_client.cluster_policies.get(policy_id=policy.policy_id).definition)
+    policy_definition = json.loads(
+        az_cli_ctx.workspace_client.cluster_policies.get(policy_id=policy.policy_id).definition
+    )
     role_assignments = az_cli_ctx.azure_resource_permissions.role_assignments(env_or_skip("TEST_STORAGE_RESOURCE"))
     global_spn_assignment = None
     for assignment in role_assignments:
@@ -117,7 +119,7 @@ def test_create_global_service_principal_clean_up_after_failure(
     az_cli_ctx,
     make_cluster_policy,
     clean_up_spn,
-):
+) -> None:
     storage_account_resource = AzureResource(env_or_skip("TEST_STORAGE_RESOURCE"))
 
     az_cli_ctx.workspace_client.api_client.do_original = az_cli_ctx.workspace_client.api_client.do
@@ -161,8 +163,8 @@ def test_create_global_service_principal_clean_up_after_failure(
     for key in missing_policy_keys:
         assert key not in policy_definition
 
-    warehouse_config = az_cli_ctx.workspace_client.warehouses.get_workspace_warehouse_config() or []
-    for config_pair in warehouse_config.data_access_config:
+    warehouse_config = az_cli_ctx.workspace_client.warehouses.get_workspace_warehouse_config()
+    for config_pair in warehouse_config.data_access_config or []:
         for key in missing_policy_keys:
             assert key != config_pair.key, f"Warehouse config still contains policy key: {key}"
 

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -80,7 +80,7 @@ def clean_up_spn(env_or_skip):
 
 def test_create_global_spn(skip_if_not_in_debug, env_or_skip, az_cli_ctx, make_cluster_policy, clean_up_spn) -> None:
     policy = make_cluster_policy()
-    az_cli_ctx.installation.save(dataclasses.replace(az_cli_ctx.config, policy_id=policy))
+    az_cli_ctx.installation.save(dataclasses.replace(az_cli_ctx.config, policy_id=policy.policy_id))
     tables = [ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1)]
     az_cli_ctx.sql_backend.save_table(f"{az_cli_ctx.inventory_database}.external_locations", tables, ExternalLocation)
     prompts = MockPrompts({"Enter a name for the uber service principal to be created*": "UCXServicePrincipal"})
@@ -132,7 +132,7 @@ def test_create_global_service_principal_clean_up_after_failure(
     az_cli_ctx.workspace_client.api_client.do = do_raise_permission_denied_on_put_warehouse_configuration
 
     policy = make_cluster_policy()
-    az_cli_ctx.installation.save(dataclasses.replace(az_cli_ctx.config, policy_id=policy))
+    az_cli_ctx.installation.save(dataclasses.replace(az_cli_ctx.config, policy_id=policy.policy_id))
     tables = [ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1)]
     az_cli_ctx.sql_backend.save_table(f"{az_cli_ctx.inventory_database}.external_locations", tables, ExternalLocation)
     prompts = MockPrompts({"Enter a name for the uber service principal to be created*": "UCXServicePrincipal"})

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -79,7 +79,7 @@ def clean_up_spn(env_or_skip):
             continue
 
 
-def test_create_global_spn(skip_if_not_in_debug, env_or_skip, az_cli_ctx, make_cluster_policy) -> None:
+def test_create_global_spn(skip_if_not_in_debug, env_or_skip, az_cli_ctx, make_cluster_policy, clean_up_spn) -> None:
     policy = make_cluster_policy()
     ctx = az_cli_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -153,7 +153,9 @@ def test_create_global_service_principal_clean_up_after_failure(
             break
     assert ucx_scope is None
 
-    policy_definition = json.loads(az_cli_ctx.workspace_client.cluster_policies.get(policy_id=policy.policy_id).definition)
+    policy_definition = json.loads(
+        az_cli_ctx.workspace_client.cluster_policies.get(policy_id=policy.policy_id).definition
+    )
     storage_account_name = storage_account_resource.storage_account
     missing_policy_keys = (
         f"spark_conf.fs.azure.account.oauth2.client.id.{storage_account_name}.dfs.core.windows.net",

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -20,10 +20,13 @@ from databricks.sdk.errors.platform import PermissionDenied
 logger = logging.getLogger(__name__)
 
 
-def test_azure_storage_accounts(ws, sql_backend, inventory_schema, make_random):
-    # skip this test if not in local mode
+@pytest.fixture
+def skip_if_not_in_debug() -> None:
     if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        return
+        pytest.skip("This test can only be run in debug mode")
+
+
+def test_azure_storage_accounts(skip_if_not_in_debug, ws, sql_backend, inventory_schema, make_random):
     tables = [
         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/folder1", 1),
     ]
@@ -42,10 +45,7 @@ def test_azure_storage_accounts(ws, sql_backend, inventory_schema, make_random):
     assert mapping[0].prefix == "abfss://things@labsazurethings.dfs.core.windows.net/"
 
 
-def test_save_spn_permissions_local(ws, sql_backend, inventory_schema, make_random):
-    # skip this test if not in local mode
-    if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        return
+def test_save_spn_permissions_local(skip_if_not_in_debug, ws, sql_backend, inventory_schema, make_random):
     tables = [
         ExternalLocation("abfss://things@labsazurethings.dfs.core.windows.net/folder1", 1),
     ]
@@ -79,11 +79,15 @@ def clean_up_spn(env_or_skip):
 
 
 def test_create_global_spn(
-    ws, sql_backend, inventory_schema, make_random, make_cluster_policy, env_or_skip, clean_up_spn
+    skip_if_not_in_debug,
+    ws,
+    sql_backend,
+    inventory_schema,
+    make_random,
+    make_cluster_policy,
+    env_or_skip,
+    clean_up_spn,
 ):
-    # skip this test if not in local mode
-    if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        return
     tables = [
         ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1),
     ]
@@ -129,11 +133,15 @@ def test_create_global_spn(
 
 
 def test_create_global_service_principal_clean_up_after_failure(
-    ws, sql_backend, inventory_schema, make_random, make_cluster_policy, env_or_skip, clean_up_spn
+    skip_if_not_in_debug,
+    ws,
+    sql_backend,
+    inventory_schema,
+    make_random,
+    make_cluster_policy,
+    env_or_skip,
+    clean_up_spn,
 ):
-    # skip this test if not in local mode
-    if os.path.basename(sys.argv[0]) not in {"_jb_pytest_runner.py", "testlauncher.py"}:
-        return
     storage_account_resource = AzureResource(env_or_skip("TEST_STORAGE_RESOURCE"))
     tables = [
         ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1),

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -5,14 +5,11 @@ import os
 import sys
 
 import pytest
-from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.tui import MockPrompts
 
-from databricks.labs.ucx.azure.access import AzureResourcePermissions
-from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResource, AzureResources
+from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResource
 from databricks.labs.ucx.hive_metastore.locations import (
     ExternalLocation,
-    ExternalLocations,
 )
 
 from databricks.sdk.errors.platform import PermissionDenied

--- a/tests/integration/azure/test_access.py
+++ b/tests/integration/azure/test_access.py
@@ -10,7 +10,6 @@ from databricks.labs.blueprint.tui import MockPrompts
 
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResource, AzureResources
-from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore.locations import (
     ExternalLocation,
     ExternalLocations,
@@ -120,57 +119,43 @@ def test_create_global_spn(skip_if_not_in_debug, env_or_skip, az_cli_ctx, make_c
 
 def test_create_global_service_principal_clean_up_after_failure(
     skip_if_not_in_debug,
-    ws,
-    sql_backend,
-    inventory_schema,
-    make_random,
-    make_cluster_policy,
     env_or_skip,
+    az_cli_ctx,
+    make_cluster_policy,
     clean_up_spn,
 ):
     storage_account_resource = AzureResource(env_or_skip("TEST_STORAGE_RESOURCE"))
-    tables = [
-        ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1),
-    ]
-    sql_backend.save_table(f"{inventory_schema}.external_locations", tables, ExternalLocation)
-    installation = Installation(ws, make_random(4))
-    policy = make_cluster_policy()
-    installation.save(WorkspaceConfig(inventory_database='ucx', policy_id=policy.policy_id))
-    azure_mgmt_client = AzureAPIClient(
-        ws.config.arm_environment.resource_manager_endpoint,
-        ws.config.arm_environment.service_management_endpoint,
-    )
-    graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
-    azure_resources = AzureResources(azure_mgmt_client, graph_client)
-    az_res_perm = AzureResourcePermissions(
-        installation, ws, azure_resources, ExternalLocations(ws, sql_backend, inventory_schema)
-    )
 
-    def do(method: str, path: str, *args, **kwargs):
+    ws = az_cli_ctx.workspace_client
+    ws.api_client.do_original = ws.api_client.do
+
+    def do_raise_permission_denied_on_put_warehouse_configuration(method: str, path: str, *args, **kwargs):
         if method == "PUT" and path == "/api/2.0/sql/config/warehouses":
             raise PermissionDenied("Cannot set warehouse configuration")
         return ws.api_client.do_original(method, path, *args, **kwargs)
 
-    ws.api_client.do_original = ws.api_client.do
-    ws.api_client.do = do  # Force a permission denied error
+    ws.api_client.do = do_raise_permission_denied_on_put_warehouse_configuration
+
+    ctx = az_cli_ctx.replace(_ws=ws)
+    policy = make_cluster_policy()
+    ctx.installation.save(dataclasses.replace(ctx.config, policy_id=policy))
+    tables = [ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1)]
+    ctx.sql_backend.save_table(f"{ctx.inventory_database}.external_locations", tables, ExternalLocation)
+    prompts = MockPrompts({"Enter a name for the uber service principal to be created*": "UCXServicePrincipal"})
 
     with pytest.raises(PermissionDenied):  # Raises the error again after cleaning up resources
-        az_res_perm.create_uber_principal(
-            MockPrompts({"Enter a name for the uber service principal to be created*": "UCXServicePrincipal"})
-        )
+        ctx.azure_resource_permissions.create_uber_principal(prompts)
 
-    config = installation.load(WorkspaceConfig)
-    assert config.uber_spn_id is None
+    assert ctx.config.uber_spn_id is None
 
-    scopes = ws.secrets.list_scopes()
     ucx_scope = None
-    for scope in scopes:
-        if scope.name == config.inventory_database:
+    for scope in ctx.workspace_client.secrets.list_scopes():
+        if scope.name == ctx.config.inventory_database:
             ucx_scope = scope
             break
     assert ucx_scope is None
 
-    policy_definition = json.loads(ws.cluster_policies.get(policy_id=policy.policy_id).definition)
+    policy_definition = json.loads(ctx.workspace_client.cluster_policies.get(policy_id=policy.policy_id).definition)
     storage_account_name = storage_account_resource.storage_account
     missing_policy_keys = (
         f"spark_conf.fs.azure.account.oauth2.client.id.{storage_account_name}.dfs.core.windows.net",
@@ -182,15 +167,10 @@ def test_create_global_service_principal_clean_up_after_failure(
     for key in missing_policy_keys:
         assert key not in policy_definition
 
-    warehouse_config = ws.warehouses.get_workspace_warehouse_config()
-    has_missing_policy_key = False
-    if warehouse_config.data_access_config is not None:
-        for config_pair in warehouse_config.data_access_config:
-            for key in missing_policy_keys:
-                if key == config_pair.key:
-                    has_missing_policy_key = True
-                    break
-    assert not has_missing_policy_key, f"Warehouse config still contains policy key: {key}"
+    warehouse_config = ctx.workspace_client.warehouses.get_workspace_warehouse_config() or []
+    for config_pair in warehouse_config.data_access_config:
+        for key in missing_policy_keys:
+            assert key != config_pair.key, f"Warehouse config still contains policy key: {key}"
 
     # TODO: Test Azure resources, service principal and its role assignments
     # REASON: Missing permissions to test Azure resources

--- a/tests/integration/azure/test_resources.py
+++ b/tests/integration/azure/test_resources.py
@@ -75,18 +75,18 @@ def access_connector(az_cli_ctx, make_random, test_storage_account: StorageAccou
     access_connector_name = f"test-{make_random()}"
     tomorrow = dt.datetime.now() + dt.timedelta(days=1)
     tags = {"RemoveAfter": str(tomorrow), "NoAutoRemove": "False"}
-    access_connector = az_cli_ctx.azure_resources.create_or_update_access_connector(
+    ac = az_cli_ctx.azure_resources.create_or_update_access_connector(
         test_storage_account.id.subscription_id,
         test_storage_account.id.resource_group,
         access_connector_name,
         test_storage_account.location,
         tags,
     )
-    yield access_connector
+    yield ac
     az_cli_ctx.azure_resources.delete_access_connector(
-        access_connector.id.subscription_id,
-        access_connector.id.resource_group,
-        access_connector.name,
+        ac.id.subscription_id,
+        ac.id.resource_group,
+        ac.name,
     )
 
 

--- a/tests/integration/azure/test_resources.py
+++ b/tests/integration/azure/test_resources.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import uuid
+from collections.abc import Iterator
 
 import pytest
 
@@ -70,7 +71,7 @@ def test_storage_account(az_cli_ctx, env_or_skip) -> StorageAccount:
 
 
 @pytest.fixture
-def access_connector(az_cli_ctx, make_random, test_storage_account: StorageAccount) -> AccessConnector:
+def access_connector(az_cli_ctx, make_random, test_storage_account: StorageAccount) -> Iterator[AccessConnector]:
     access_connector_name = f"test-{make_random()}"
     tomorrow = dt.datetime.now() + dt.timedelta(days=1)
     tags = {"RemoveAfter": str(tomorrow), "NoAutoRemove": "False"}

--- a/tests/integration/azure/test_resources.py
+++ b/tests/integration/azure/test_resources.py
@@ -94,7 +94,7 @@ def test_azure_resource_gets_applies_and_deletes_storage_permissions(
     az_cli_ctx,
     test_storage_account,
     access_connector,
-):
+) -> None:
     role_guid = str(uuid.uuid4())
     storage_permission = az_cli_ctx.azure_resources.get_storage_permission(test_storage_account, role_guid)
     assert storage_permission is None

--- a/tests/integration/azure/test_resources.py
+++ b/tests/integration/azure/test_resources.py
@@ -75,18 +75,18 @@ def access_connector(az_cli_ctx, make_random, test_storage_account: StorageAccou
     access_connector_name = f"test-{make_random()}"
     tomorrow = dt.datetime.now() + dt.timedelta(days=1)
     tags = {"RemoveAfter": str(tomorrow), "NoAutoRemove": "False"}
-    ac = az_cli_ctx.azure_resources.create_or_update_access_connector(
+    access_conn = az_cli_ctx.azure_resources.create_or_update_access_connector(
         test_storage_account.id.subscription_id,
         test_storage_account.id.resource_group,
         access_connector_name,
         test_storage_account.location,
         tags,
     )
-    yield ac
+    yield access_conn
     az_cli_ctx.azure_resources.delete_access_connector(
-        ac.id.subscription_id,
-        ac.id.resource_group,
-        ac.name,
+        access_conn.id.subscription_id,
+        access_conn.id.resource_group,
+        access_conn.name,
     )
 
 

--- a/tests/unit/azure/__init__.py
+++ b/tests/unit/azure/__init__.py
@@ -35,5 +35,5 @@ def azure_api_client():
         method.side_effect = get_az_api_mapping
         # Set attributes required for `functools.wraps`
         for attr in "__name__", "__qualname__", "__annotations__", "__type_params__":
-            setattr(method, attr, getattr(get_az_api_mapping, attr))
+            setattr(method, attr, getattr(get_az_api_mapping, attr, None))
     return api_client

--- a/tests/unit/azure/__init__.py
+++ b/tests/unit/azure/__init__.py
@@ -17,9 +17,11 @@ def _load_fixture(filename: str):
 
 def get_az_api_mapping(*args, **_):
     mapping = _load_fixture("azure/mappings.json")[0]
+    if len(args) == 0:
+        return {}
     if args[0] in mapping:
         return mapping[args[0]]
-    if args[1] in mapping:
+    if len(args) >= 2 and args[1] in mapping:
         return mapping[args[1]]
     return {}
 

--- a/tests/unit/azure/azure/mappings.json
+++ b/tests/unit/azure/azure/mappings.json
@@ -1,5 +1,11 @@
 [
   {
+    "/v1.0/directoryObjects/appIduser1": {
+      "appId": "appIduser1",
+      "displayName": "disNameuser1",
+      "id": "Iduser1",
+      "servicePrincipalType": "ManagedIdentity"
+    },
     "/v1.0/directoryObjects/user1": {
       "appId": "appIduser1",
       "displayName": "disNameuser1",

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -930,6 +930,7 @@ def test_delete_global_service_principal_after_creation(use_backup) -> None:
     w.warehouses.set_workspace_warehouse_config.assert_called_with(
         data_access_config=[EndpointConfPair(key="foo", value="bar")],
         sql_configuration_parameters=None,
+        security_policy=SetWorkspaceWarehouseConfigRequestSecurityPolicy.NONE,
     )
 
 

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -815,6 +815,40 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_ap
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_create_scope():
+    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    w.secrets.create_scope.side_effect = PermissionDenied
+
+    with pytest.raises(PermissionDenied):
+        azure_resource_permission.create_uber_principal(prompts)
+
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
+    calls = [
+        call("rol1", "2022-04-01"),
+        call("rol2", "2022-04-01"),
+        call("/v1.0/applications(appId='appIduser1')"),
+    ]
+    w.api_client.delete.assert_has_calls(calls)
+    w.secrets.delete_scope.assert_called_with("ucx")
+
+
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_put_secret():
+    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    w.secrets.put_secret.side_effect = PermissionDenied
+
+    with pytest.raises(PermissionDenied):
+        azure_resource_permission.create_uber_principal(prompts)
+
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
+    calls = [
+        call("rol1", "2022-04-01"),
+        call("rol2", "2022-04-01"),
+        call("/v1.0/applications(appId='appIduser1')"),
+    ]
+    w.api_client.delete.assert_has_calls(calls)
+    w.secrets.delete_scope.assert_called_with("ucx")
+
+
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config():
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.warehouses.set_workspace_warehouse_config.side_effect = PermissionDenied

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -786,7 +786,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cr
     with pytest.raises(PermissionDenied):
         azure_resource_permission.create_uber_principal(prompts)
 
-    w.secrets.delete_scope.assert_called_with("ucx")
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_save_config():
@@ -800,8 +800,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_sa
     with pytest.raises(PermissionDenied):
         azure_resource_permission.create_uber_principal(prompts)
 
-    w.api_client.delete.assert_called_with("/v1.0/applications(appId='appIduser1')")
-    w.secrets.delete_scope.assert_called_with("ucx")
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_apply_storage_permission():

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -849,6 +849,23 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_pu
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_cluster_policies_edit():
+    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    w.cluster_policies.edit.side_effect = PermissionDenied
+
+    with pytest.raises(PermissionDenied):
+        azure_resource_permission.create_uber_principal(prompts)
+
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
+    calls = [
+        call("rol1", "2022-04-01"),
+        call("rol2", "2022-04-01"),
+        call("/v1.0/applications(appId='appIduser1')"),
+    ]
+    w.api_client.delete.assert_has_calls(calls)
+    w.secrets.delete_scope.assert_called_with("ucx")
+
+
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config():
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.warehouses.set_workspace_warehouse_config.side_effect = PermissionDenied

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -792,7 +792,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cr
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_save_config():
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
 
-    def raise_permission_denied(*args, **kwargs):
+    def raise_permission_denied(*_, **__):
         raise PermissionDenied()
 
     installation.save = raise_permission_denied

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -663,7 +663,7 @@ def setup_create_uber_principal():
 
 
 def test_create_global_spn_cluster_policy_not_found() -> None:
-    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    w, _, prompts, azure_resource_permission = setup_create_uber_principal()
     w.cluster_policies.get.side_effect = NotFound()
 
     with pytest.raises(NotFound):
@@ -788,7 +788,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cr
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_save_config() -> None:
-    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    _, installation, prompts, azure_resource_permission = setup_create_uber_principal()
 
     def raise_permission_denied(*_, **__):
         raise PermissionDenied()
@@ -865,7 +865,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cl
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config() -> None:
-    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+    w, _, prompts, azure_resource_permission = setup_create_uber_principal()
     w.warehouses.set_workspace_warehouse_config.side_effect = PermissionDenied
 
     with pytest.raises(PermissionDenied):

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -127,6 +127,7 @@ def test_save_spn_permissions_valid_azure_storage_account():
     ]
     azure_resources.role_assignments.return_value = [
         AzureRoleAssignment(
+            id="rol1",
             resource=AzureResource(f'{containers}/container1'),
             scope=AzureResource(f'{containers}/container1'),
             principal=Principal('a', 'b', 'c', 'Application', '0000-0000'),
@@ -135,6 +136,7 @@ def test_save_spn_permissions_valid_azure_storage_account():
             role_permissions=[],
         ),
         AzureRoleAssignment(
+            id="rol2",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('d', 'e', 'f', 'Application', '0000-0000'),
@@ -210,6 +212,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
     ]
     azure_resources.role_assignments.return_value = [
         AzureRoleAssignment(
+            id="rol1",
             resource=AzureResource(f'{containers}/container1'),
             scope=AzureResource(f'{containers}/container1'),
             principal=Principal('a', 'b', 'c', 'Application', '0000-0000'),
@@ -224,6 +227,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol2",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('d', 'e', 'f', 'Application', '0000-0000'),
@@ -235,6 +239,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol3",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('d', 'e', 'f', 'Application', '0000-0000'),
@@ -243,6 +248,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             role_permissions=["Microsoft.Authorization/*"],
         ),
         AzureRoleAssignment(
+            id="rol4",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('g', 'h', 'i', 'Application', '0000-0000'),
@@ -253,6 +259,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol5",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('j', 'k', 'l', 'Application', '0000-0000'),
@@ -263,6 +270,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol6",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('j', 'k', 'l', 'Application', '0000-0000'),
@@ -273,6 +281,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol7",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('m', 'n', 'o', 'Application', '0000-0000'),
@@ -283,6 +292,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol8",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('v', 'w', 'x', 'Application', '0000-0000'),
@@ -293,6 +303,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol9",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('p', 'q', 'r', 'Application', '0000-0000'),
@@ -303,6 +314,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol10",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('s', 't', 'u', 'Application', '0000-0000'),
@@ -316,6 +328,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol11",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('a1', 'b1', 'c1', 'Application', '0000-0000'),
@@ -324,6 +337,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             role_permissions=[],
         ),
         AzureRoleAssignment(
+            id="rol12",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('a1', 'b1', 'c1', 'Application', '0000-0000'),
@@ -334,6 +348,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol13",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('a2', 'b2', 'c2', 'Application', '0000-0000'),
@@ -344,6 +359,7 @@ def test_save_spn_permissions_custom_role_valid_azure_storage_account():
             ],
         ),
         AzureRoleAssignment(
+            id="rol14",
             resource=AzureResource(f'{storage_accounts}/storage1'),
             scope=AzureResource(f'{storage_accounts}/storage1'),
             principal=Principal('a2', 'b2', 'c2', 'Application', '0000-0000'),

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -654,13 +654,13 @@ def test_create_global_spn_cluster_policy_not_found():
     azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, location)
     with pytest.raises(NotFound):
         azure_resource_permission.create_uber_principal(prompts)
-    w.cluster_policies.get.assert_called_once()
+    w.cluster_policies.get.assert_has_calls([call("foo1"), call("foo1")])
     w.secrets.get_secret.asser_called_with("ucx", "uber_principal_secret")
     w.secrets.create_scope.assert_called_with("ucx")
     w.secrets.put_secret.assert_called_with('ucx', 'uber_principal_secret', string_value='mypwd')
     w.cluster_policies.edit.assert_not_called()
     w.get_workspace_id.assert_called_once()
-    w.warehouses.set_workspace_warehouse_config.assert_not_called()
+    w.warehouses.set_workspace_warehouse_config.assert_called_once()
 
 
 def setup_create_uber_principal():

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -653,11 +653,6 @@ def setup_create_uber_principal():
     w.warehouses.get_workspace_warehouse_config.return_value = GetWorkspaceWarehouseConfigResponse(
         data_access_config=[EndpointConfPair(key="foo", value="bar")]
     )
-
-    def set_workspace_warehouse_config(data_access_config: list[EndpointConfPair], *_, **__) -> None:
-        global data_access_config_mock
-        data_access_config_mock = data_access_config
-    w.warehouses.set_workspace_warehouse_config.side_effect = set_workspace_warehouse_config
     rows = {
         "SELECT \\* FROM hive_metastore.ucx.external_locations": [
             ["abfss://container1@sto2.dfs.core.windows.net/folder1", "1"]

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -650,9 +650,8 @@ def setup_create_uber_principal():
     )
     w.cluster_policies.get.return_value = cluster_policy
     w.secrets.get_secret.return_value = GetSecretResponse("uber_principal_secret", "mypwd")
-    data_access_config_mock = [EndpointConfPair(key="foo", value="bar")]
     w.warehouses.get_workspace_warehouse_config.return_value = GetWorkspaceWarehouseConfigResponse(
-        data_access_config=data_access_config_mock
+        data_access_config=[EndpointConfPair(key="foo", value="bar")]
     )
 
     def set_workspace_warehouse_config(data_access_config: list[EndpointConfPair], *_, **__) -> None:
@@ -712,7 +711,7 @@ def test_create_global_spn() -> None:
     )
     installation.assert_file_written(
         'warehouse-config-backup.json',
-        GetWorkspaceWarehouseConfigResponse(data_access_config=[EndpointConfPair(key="foo", value="bar")]).as_dict()
+        GetWorkspaceWarehouseConfigResponse(data_access_config=[EndpointConfPair(key="foo", value="bar")]).as_dict(),
     )
     calls = [
         call("/v1.0/applications", {"displayName": "UCXServicePrincipal"}),

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -662,7 +662,7 @@ def setup_create_uber_principal():
     return w, installation, prompts, azure_resource_permission
 
 
-def test_create_global_spn_cluster_policy_not_found():
+def test_create_global_spn_cluster_policy_not_found() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.cluster_policies.get.side_effect = NotFound()
 
@@ -678,7 +678,7 @@ def test_create_global_spn_cluster_policy_not_found():
     w.warehouses.set_workspace_warehouse_config.assert_called_once()
 
 
-def test_create_global_spn():
+def test_create_global_spn() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     azure_resource_permission.create_uber_principal(prompts)
 
@@ -777,7 +777,7 @@ def test_create_global_spn_set_warehouse_config_security_policy(get_security_pol
     assert w.warehouses.set_workspace_warehouse_config.call_args.kwargs["security_policy"] == set_security_policy
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_create_service_principal():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_create_service_principal() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.api_client.post.side_effect = PermissionDenied
 
@@ -787,7 +787,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cr
     assert installation.load(WorkspaceConfig).uber_spn_id is None
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_save_config():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_save_config() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
 
     def raise_permission_denied(*_, **__):
@@ -801,7 +801,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_sa
     assert installation.load(WorkspaceConfig).uber_spn_id is None
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_apply_storage_permission():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_apply_storage_permission() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.api_client.put.side_effect = PermissionDenied
 
@@ -813,7 +813,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_ap
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_create_scope():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_create_scope() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.secrets.create_scope.side_effect = PermissionDenied
 
@@ -830,7 +830,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cr
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_put_secret():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_put_secret() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.secrets.put_secret.side_effect = PermissionDenied
 
@@ -847,7 +847,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_pu
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_cluster_policies_edit():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_cluster_policies_edit() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.cluster_policies.edit.side_effect = PermissionDenied
 
@@ -864,7 +864,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cl
     w.secrets.delete_scope.assert_called_with("ucx")
 
 
-def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config():
+def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config() -> None:
     w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.warehouses.set_workspace_warehouse_config.side_effect = PermissionDenied
 

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -900,6 +900,29 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_se
     )
 
 
+def test_delete_global_service_principal_after_creation() -> None:
+    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
+
+    azure_resource_permission.create_uber_principal(prompts)
+    azure_resource_permission._delete_uber_principal()
+
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
+    calls = [
+        call("rol1", "2022-04-01"),
+        call("rol2", "2022-04-01"),
+        call("/v1.0/applications(appId='appIduser1')"),
+    ]
+    w.api_client.delete.assert_has_calls(calls)
+    w.secrets.delete_scope.assert_called_with("ucx")
+    w.cluster_policies.edit.assert_called_with(
+        'foo1', 'Unity Catalog Migration (ucx) (me@example.com)', definition='{"foo": "bar"}'
+    )
+    w.warehouses.set_workspace_warehouse_config.assert_called_with(
+        data_access_config=[],
+        sql_configuration_parameters=None,
+    )
+
+
 def test_create_access_connectors_for_storage_accounts_logs_no_storage_accounts(caplog):
     """A warning should be logged when no storage account is present."""
     w = create_autospec(WorkspaceClient)

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -1,4 +1,3 @@
-import dataclasses
 import json
 import logging
 from unittest.mock import call, create_autospec
@@ -8,7 +7,6 @@ from databricks.labs.blueprint.installation import MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.config import Config
 from databricks.sdk.errors import NotFound, PermissionDenied
 from databricks.sdk.service.compute import Policy
 from databricks.sdk.service.sql import (

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -917,9 +917,9 @@ def test_delete_global_service_principal_after_creation(use_backup) -> None:
 
     azure_resource_permission.create_uber_principal(prompts)
     if not use_backup:
-        installation._overwrites.pop("policy-backup.json")
-        installation._overwrites.pop("warehouse-config-backup.json")
-    azure_resource_permission._delete_uber_principal()
+        installation._overwrites.pop("policy-backup.json")  # pylint: disable=protected-access
+        installation._overwrites.pop("warehouse-config-backup.json")  # pylint: disable=protected-access
+    azure_resource_permission._delete_uber_principal()  # pylint: disable=protected-access
 
     assert installation.load(WorkspaceConfig).uber_spn_id is None
     calls = [

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -630,7 +630,7 @@ def test_create_global_spn_no_storage():
     azure_resources = create_autospec(AzureResources)
     azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, location)
     assert not azure_resource_permission.create_uber_principal(prompts)
-    azure_resources.storage_accounts.assert_not_called()
+    azure_resources.storage_accounts.assert_called_once()
     azure_resources.create_or_update_access_connector.assert_not_called()
     azure_resources.role_assignments.assert_not_called()
     azure_resources.containers.assert_not_called()

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -812,6 +812,7 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_ap
 
     assert installation.load(WorkspaceConfig).uber_spn_id is None
     w.api_client.delete.assert_called_with("/v1.0/applications(appId='appIduser1')")
+    w.secrets.delete_scope.assert_called_with("ucx")
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config():

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -881,12 +881,13 @@ def test_create_global_service_principal_cleans_up_after_permission_denied_on_cl
 
 
 def test_create_global_service_principal_cleans_up_after_permission_denied_on_set_workspace_warehouse_config() -> None:
-    w, _, prompts, azure_resource_permission = setup_create_uber_principal()
+    w, installation, prompts, azure_resource_permission = setup_create_uber_principal()
     w.warehouses.set_workspace_warehouse_config.side_effect = PermissionDenied
 
     with pytest.raises(PermissionDenied):
         azure_resource_permission.create_uber_principal(prompts)
 
+    assert installation.load(WorkspaceConfig).uber_spn_id is None
     calls = [
         call("rol1", "2022-04-01"),
         call("rol2", "2022-04-01"),

--- a/tests/unit/azure/test_resources.py
+++ b/tests/unit/azure/test_resources.py
@@ -135,7 +135,7 @@ def test_create_service_principal_no_access():
         azure_resource.create_service_principal("disNameuser1")
 
 
-def test_get_storage_permission_gets_role_assignments_endpoint():
+def test_get_storage_permission_gets_role_assignments_endpoint() -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -156,7 +156,7 @@ def test_get_storage_permission_gets_role_assignments_endpoint():
     assert permission.role_name == "Contributor"
 
 
-def test_get_storage_permission_logs_permission_denied(caplog):
+def test_get_storage_permission_logs_permission_denied(caplog) -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -174,7 +174,7 @@ def test_get_storage_permission_logs_permission_denied(caplog):
     assert path in caplog.text
 
 
-def test_get_storage_permission_handles_not_found():
+def test_get_storage_permission_handles_not_found() -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -263,7 +263,7 @@ def test_apply_storage_permission_assignment_present():
     api_client.put.assert_called_with(path, "2022-04-01", body)
 
 
-def test_delete_storage_permission():
+def test_delete_storage_permission() -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -282,7 +282,7 @@ def test_delete_storage_permission():
     api_client.delete.assert_has_calls(calls)
 
 
-def test_delete_storage_permission_logs_permission_denied_on_get(caplog):
+def test_delete_storage_permission_logs_permission_denied_on_get(caplog) -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -302,7 +302,7 @@ def test_delete_storage_permission_logs_permission_denied_on_get(caplog):
     assert principal_id in caplog.text
 
 
-def test_delete_storage_permission_logs_permission_denied_on_delete(caplog):
+def test_delete_storage_permission_logs_permission_denied_on_delete(caplog) -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -324,7 +324,7 @@ def test_delete_storage_permission_logs_permission_denied_on_delete(caplog):
     assert "rol1, rol2" in str(error.value)
 
 
-def test_delete_storage_permission_raises_not_found_on_get():
+def test_delete_storage_permission_raises_not_found_on_get() -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -340,7 +340,7 @@ def test_delete_storage_permission_raises_not_found_on_get():
         azure_resource.delete_storage_permission(principal_id, storage_account)
 
 
-def test_delete_storage_permission_safe_handles_not_found_on_get():
+def test_delete_storage_permission_safe_handles_not_found_on_get() -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(
@@ -360,7 +360,7 @@ def test_delete_storage_permission_safe_handles_not_found_on_get():
         assert True, "Safe handles NotFound"
 
 
-def test_delete_storage_permission_handles_not_found_on_delete(caplog):
+def test_delete_storage_permission_handles_not_found_on_delete(caplog) -> None:
     api_client = azure_api_client()
     azure_resource = AzureResources(api_client, api_client)
     storage_account = StorageAccount(

--- a/tests/unit/azure/test_resources.py
+++ b/tests/unit/azure/test_resources.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import create_autospec
+from unittest.mock import call, create_autospec
 
 import pytest
 from databricks.sdk.errors import NotFound, PermissionDenied, ResourceConflict
@@ -277,8 +277,9 @@ def test_delete_storage_permission():
     azure_resource.delete_storage_permission(principal_id, storage_account)
 
     path = f"{storage_account.id}/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20'{principal_id}'"
-    api_client.get.assert_called_with(path, "2022-04-01")
-    api_client.delete.assert_called_with("rol1", "2022-04-01")
+    api_client.get.assert_any_call(path, "2022-04-01")
+    calls = [call("rol1", "2022-04-01"), call("rol2", "2022-04-01")]
+    api_client.delete.assert_has_calls(calls)
 
 
 def test_delete_storage_permission_logs_permission_denied_on_get(caplog):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,7 +20,7 @@ from databricks.sdk.service.workspace import ObjectInfo, ObjectType
 from databricks.labs.ucx.assessment.aws import AWSResources, AWSRoleAction
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
-from databricks.labs.ucx.azure.resources import AzureResources
+from databricks.labs.ucx.azure.resources import AzureResource, AzureResources, StorageAccount
 from databricks.labs.ucx.cli import (
     alias,
     assign_metastore,
@@ -371,16 +371,28 @@ def test_migrate_credentials_aws(ws):
     ws.storage_credentials.list.assert_called()
 
 
-def test_migrate_credentials_limit_azure(ws):
+def test_migrate_credentials_raises_runtime_warning_when_hitting_storage_credential_limit(ws):
+    """The storage credential limit is 200, so we should raise a warning when we hit that limit."""
     azure_resources = create_autospec(AzureResources)
     external_locations = create_autospec(ExternalLocations)
-    external_locations_mock = []
+    storage_accounts_mock, external_locations_mock = [], []
     for i in range(200):
-        external_locations_mock.append(
-            ExternalLocation(
-                location=f"abfss://container{i}@storage{i}.dfs.core.windows.net/folder{i}", table_count=i % 20
-            )
+        storage_account_id = AzureResource(
+            f"/subscriptions/test/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/storage{i}"
         )
+        storage_account = StorageAccount(
+            id=storage_account_id,
+            name=f"storage{i}",
+            location="eastus",
+            default_network_action="Allow",
+        )
+        external_location = ExternalLocation(
+            location=f"abfss://container{i}@storage{i}.dfs.core.windows.net/folder{i}",
+            table_count=i % 20,
+        )
+        storage_accounts_mock.append(storage_account)
+        external_locations_mock.append(external_location)
+    azure_resources.storage_accounts.return_value = storage_accounts_mock
     external_locations.snapshot.return_value = external_locations_mock
     prompts = MockPrompts({'.*': 'yes'})
     ctx = WorkspaceContext(ws).replace(
@@ -394,11 +406,20 @@ def test_migrate_credentials_limit_azure(ws):
     ws.storage_credentials.list.assert_called()
     azure_resources.storage_accounts.assert_called()
 
-    external_locations_mock.append(
-        ExternalLocation(
-            location=f"abfss://container{201}@storage{201}.dfs.core.windows.net/folder{201}", table_count=25
-        )
+    storage_account_id = AzureResource(
+        "/subscriptions/test/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/storage201"
     )
+    storage_account = StorageAccount(
+        id=storage_account_id,
+        name="storage201",
+        location="eastus",
+        default_network_action="Allow",
+    )
+    external_location = ExternalLocation(
+        location=f"abfss://container{201}@storage{201}.dfs.core.windows.net/folder{201}", table_count=25
+    )
+    storage_accounts_mock.append(storage_account)
+    external_locations_mock.append(external_location)
     with pytest.raises(RuntimeWarning):
         migrate_credentials(ws, prompts, ctx=ctx)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -357,9 +357,16 @@ def test_save_storage_and_principal_gcp(ws):
 def test_migrate_credentials_azure(ws):
     ws.workspace.upload.return_value = "test"
     prompts = MockPrompts({'.*': 'yes'})
-    ctx = WorkspaceContext(ws).replace(is_azure=True, azure_cli_authenticated=True, azure_subscription_id='test')
+    azure_resources = create_autospec(AzureResources)
+    ctx = WorkspaceContext(ws).replace(
+        is_azure=True,
+        azure_cli_authenticated=True,
+        azure_subscription_id='test',
+        azure_resources=azure_resources,
+    )
     migrate_credentials(ws, prompts, ctx=ctx)
     ws.storage_credentials.list.assert_called()
+    azure_resources.storage_accounts.assert_called()
 
 
 def test_migrate_credentials_aws(ws):


### PR DESCRIPTION
## Changes
Clean up the resources created for the Azure uber principal if the creation fails (half way).

### Linked issues
Partially resolves #2360 (the azure part)
Resolves #2363

### Functionality

- [x] modified existing command: `databricks labs ucx create-uber-principal`

### Tests

- [ ] manually tested
- [x] added unit tests
- [x] added integration tests
