### PR TITLE
Spike: Use a wheelhouse to install ucx at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ share/python-wheels/
 *.egg
 !tests/integration/source_code/samples/library-egg/*.egg
 MANIFEST
+# TODO: Do we want to keep (generated) requirements.txt in git?
+# Pro: it would allow us to update single requirements instead of all
+requirements.txt
+wheelhouse.zip
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ share/python-wheels/
 *.egg
 !tests/integration/source_code/samples/library-egg/*.egg
 MANIFEST
-# TODO: Do we want to keep (generated) requirements.txt in git?
-# Pro: it would allow us to update single requirements instead of all
 requirements.txt
 ucx.wheelhouse.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ MANIFEST
 # TODO: Do we want to keep (generated) requirements.txt in git?
 # Pro: it would allow us to update single requirements instead of all
 requirements.txt
-wheelhouse.zip
+ucx.wheelhouse.zip
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,7 @@ known:
 solacc:
 	hatch run python tests/integration/source_code/solacc.py
 
-.PHONY: all clean dev lint fmt test integration coverage known solacc
+wheelhouse:
+	CUSTOM_COMPILE_COMMAND="make wheelhouse" hatch run wheelhouse
+
+.PHONY: all clean dev lint fmt test integration coverage known solacc wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,12 +106,10 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
-wheelhouse   = [
-    "rm -rf wheels/ ucx.wheelhouse.zip",
-    "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
-    "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
-]
+wheelhouse   = ["rm -rf wheels/ ucx.wheelhouse.zip",
+                "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
+                "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
+                "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt"]
 
 [tool.pytest.ini_options]
 # TODO: remove `-p no:warnings`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,12 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
 # TODO: Make wheelhouse for multiple python versions
+# TODO: Should ucx be part of the wheelhouse?
 wheelhouse   = [
-    "rm -rf dist/ ucx.wheelhouse.zip",
-    "hatch build",
+    "rm -rf wheels/ ucx.wheelhouse.zip",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download --platform any --no-deps --python-version 311 -r requirements.txt --dest dist/",
-    "zip -j -r ucx.wheelhouse.zip dist/*.whl requirements.txt",
+    "pip download --platform any --no-deps --python-version 311 -r requirements.txt --dest wheels/",
+    "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ cmds         = "python tests/integration/cmds.py"
 wheelhouse   = ["rm -rf wheels/ ucx.wheelhouse.zip",
                 "pip-compile --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
                 "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
-                "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt"]
+                "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt labs.yml"]
 
 [tool.pytest.ini_options]
 # TODO: remove `-p no:warnings`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,11 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
 wheelhouse   = [
-    "rm -rf wheels/",
-    "rm -f ucx.wheelhouse.zip",
-    "mkdir -p wheels",
+    "rm -rf dist/ ucx.wheelhouse.zip",
+    "hatch build",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
-    "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
+    "pip download --platform any --no-deps -r requirements.txt --dest dist/",
+    "zip -j -r ucx.wheelhouse.zip dist/*.whl requirements.txt",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
 wheelhouse   = ["rm -rf wheels/ ucx.wheelhouse.zip",
-                "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
+                "pip-compile --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
                 "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
                 "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ wheelhouse   = [
     "mkdir -p wheels",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
     "pip download -r requirements.txt --dest wheels/",
-    "zip -j -r wheelhouse.zip wheels/*.whl requirements.txt",
+    "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "ruff~=0.3.4",
     "types-PyYAML~=6.0.12",
     "types-requests~=2.31.0",
+    "pip-tools~=7.4.1",
 ]
 
 # store virtual env as the child of this folder. Helps VSCode (and PyCharm) to run better
@@ -105,6 +106,13 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
+wheelhouse   = [
+    "rm -rf wheels/",
+    "mkdir -p wheels",
+    "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
+    "pip download -r requirements.txt --dest wheels/",
+    "zip -r wheelhouse.zip wheels/ requirements.txt",
+]
 
 [tool.pytest.ini_options]
 # TODO: remove `-p no:warnings`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,11 +106,12 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
+# TODO: Make wheelhouse for multiple python versions
 wheelhouse   = [
     "rm -rf dist/ ucx.wheelhouse.zip",
     "hatch build",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download --platform any --no-deps -r requirements.txt --dest dist/",
+    "pip download --platform any --no-deps --python-version 311 -r requirements.txt --dest dist/",
     "zip -j -r ucx.wheelhouse.zip dist/*.whl requirements.txt",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
 wheelhouse   = [
     "rm -rf wheels/",
+    "rm -f ucx.wheelhouse.zip",
     "mkdir -p wheels",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
     "pip download --platform any --no-deps -r requirements.txt --dest wheels/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ wheelhouse   = [
     "rm -rf wheels/",
     "mkdir -p wheels",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download -r requirements.txt --dest wheels/",
+    "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
     "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
 # TODO: Make wheelhouse for multiple python versions
-# TODO: Should ucx be part of the wheelhouse?
 wheelhouse   = [
     "rm -rf wheels/ ucx.wheelhouse.zip",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,11 +106,10 @@ verify      = ["black --check . --extend-exclude 'tests/unit/source_code/samples
                "pylint --output-format=colorized -j 0 src tests"]
 lint         = ["pylint --output-format=colorized -j 0 src tests"]
 cmds         = "python tests/integration/cmds.py"
-# TODO: Make wheelhouse for multiple python versions
 wheelhouse   = [
     "rm -rf wheels/ ucx.wheelhouse.zip",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
-    "pip download --platform any --no-deps --python-version 311 -r requirements.txt --dest wheels/",
+    "pip download --platform any --no-deps -r requirements.txt --dest wheels/",
     "zip -j -r ucx.wheelhouse.zip wheels/*.whl requirements.txt",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ wheelhouse   = [
     "mkdir -p wheels",
     "pip-compile --all-build-deps --all-extras --output-file=requirements.txt --strip-extras pyproject.toml",
     "pip download -r requirements.txt --dest wheels/",
-    "zip -r wheelhouse.zip wheels/ requirements.txt",
+    "zip -j -r wheelhouse.zip wheels/*.whl requirements.txt",
 ]
 
 [tool.pytest.ini_options]

--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -177,6 +177,17 @@ class Assessment(Workflow):
         ctx.group_manager.snapshot()
 
 
+class Succeeding(Workflow):
+    def __init__(self):
+        super().__init__('succeeding')
+
+    @job_task
+    def succeeding_task(self, ctx: RuntimeContext):
+        """This task always succeeds. It is used to test workflow installation."""
+        _ = ctx
+        logger.info("This task always succeeds.")
+
+
 class Failing(Workflow):
     def __init__(self):
         super().__init__('failing')

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -67,7 +67,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # Whether to upload dependent libraries to the workspace
     upload_dependencies: bool = False
-    wheelhouse: Path | None = None
+    wheelhouse: str | None
 
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 
 from databricks.sdk.core import Config
 

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 from databricks.sdk.core import Config
 
@@ -66,6 +67,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # Whether to upload dependent libraries to the workspace
     upload_dependencies: bool = False
+    wheelhouse: Path | None = None
 
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -67,7 +67,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # Whether to upload dependent libraries to the workspace
     upload_dependencies: bool = False
-    wheelhouse: str | None
+    wheelhouse: str | None = None
 
     # [INTERNAL ONLY] Whether the assessment should capture only specific object permissions.
     include_object_permissions: list[str] | None = None

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -23,7 +23,7 @@ class Task:
     cloud: str | None = None
 
     def is_testing(self):
-        return self.workflow in {"failing"}
+        return self.workflow in {"succeeding", "failing"}
 
     def dependencies(self):
         if not self.depends_on:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -237,6 +237,12 @@ class WorkspaceInstaller(WorkspaceContext):
         upload_dependencies = self.prompts.confirm(
             f"Does given workspace {self.workspace_client.get_workspace_id()} " f"block Internet access?"
         )
+        wheelhouse: str | None = None
+        if upload_dependencies:
+            wheelhouse = self.prompts.question(
+                "Path to wheelhouse, leave empty if not using a wheelhouse", default=None
+            )
+
         trigger_job = self.prompts.confirm("Do you want to trigger assessment job after installation?")
         recon_tolerance_percent = int(
             self.prompts.question("Reconciliation threshold, in percentage", default="5", valid_number=True)
@@ -255,6 +261,7 @@ class WorkspaceInstaller(WorkspaceContext):
             trigger_job=trigger_job,
             recon_tolerance_percent=recon_tolerance_percent,
             upload_dependencies=upload_dependencies,
+            wheelhouse=wheelhouse,
         )
 
     def _compare_remote_local_versions(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -235,7 +235,7 @@ class WorkspaceInstaller(WorkspaceContext):
         configure_groups.run()
         include_databases = self._select_databases()
         upload_dependencies = self.prompts.confirm(
-            f"Does given workspace {self.workspace_client.get_workspace_id()} " f"block Internet access?"
+            f"Does given workspace {self.workspace_client.get_workspace_id()} block Internet access?"
         )
         wheelhouse: str | None = None
         if upload_dependencies:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -623,6 +623,8 @@ class WorkflowsDeployment(InstallationMixin):
                 job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
                 job_task.job_cluster_key = None
                 job_task.libraries = None
+            # TODO: Introduced in https://github.com/databrickslabs/ucx/pull/414 to isolate test runs. Verify if it
+            # is still needed.
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None
                 widget_values = {"task": job_task.task_key, 'workflow': workflow_name} | EXTRA_TASK_PARAMS

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -576,8 +576,10 @@ class WorkflowsDeployment(InstallationMixin):
         ----
         Move this method into the WheelsV2 class.
         """
-        remote_path = self._installation.upload(f"wheels/{path.name}", path.read_bytes())
-        return [remote_path]
+        if not self._config.override_clusters:
+            remote_path = self._installation.upload(f"wheels/{path.name}", path.read_bytes())
+            return [remote_path]
+        # Override clusters are used in testing, so we need to upload all wheels
         remote_paths = []
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -580,14 +580,14 @@ class WorkflowsDeployment(InstallationMixin):
             # Removing the .zip suffix is a HACK. We can not upload a .zip file to the workspace as the platform fails
             # when extracting all files inside the zip archive
             remote_path = self._installation.upload(path.name.removesuffix(".zip"), path.read_bytes())
-            return [remote_path]
+            return [f"/Workspace{remote_path}"]
         # Override clusters are used in testing, so we need to upload all wheels
         remote_paths = []
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)
             for wheel in Path(directory).glob("*.whl"):
                 remote_wheel = self._installation.upload(f"wheels/{wheel.name}", wheel.read_bytes())
-                remote_paths.append(remote_wheel)
+                remote_paths.append(f"/Workspace{remote_wheel}")
             return remote_paths
 
     def _upload_installation_wheel(self) -> list[str]:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -588,6 +588,7 @@ class WorkflowsDeployment(InstallationMixin):
             for wheel in Path(directory).glob("*.whl"):
                 remote_wheel = self._installation.upload(f"wheels/{wheel.name}", wheel.read_bytes())
                 remote_paths.append(f"/Workspace{remote_wheel}")
+            remote_paths.sort(key=WorkflowsDeployment._library_dep_order)
             return remote_paths
 
     def _upload_installation_wheel(self) -> list[str]:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -566,8 +566,6 @@ class WorkflowsDeployment(InstallationMixin):
                 return 1
             case library if 'sqlglot' in library:
                 return 2
-            case library if 'ucx' in library:
-                return 999
             case _:
                 return 3
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -625,8 +625,6 @@ class WorkflowsDeployment(InstallationMixin):
                 job_task.existing_cluster_id = overrides[job_task.job_cluster_key]
                 job_task.job_cluster_key = None
                 job_task.libraries = None
-            # TODO: Introduced in https://github.com/databrickslabs/ucx/pull/414 to isolate test runs. Verify if it
-            # is still needed.
             if job_task.python_wheel_task is not None:
                 job_task.python_wheel_task = None
                 widget_values = {"task": job_task.task_key, 'workflow': workflow_name} | EXTRA_TASK_PARAMS

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -590,7 +590,7 @@ class WorkflowsDeployment(InstallationMixin):
         wheel_paths = []
         with self._wheels:
             if self._config.wheelhouse is not None and Path(self._config.wheelhouse).is_file():
-                wheel_paths = self._upload_wheelhouse(Path(self._config.wheelhouse))
+                wheel_paths.extend(self._upload_wheelhouse(Path(self._config.wheelhouse)))
             elif self._config.upload_dependencies:  # The wheelhouse contains the dependencies as well
                 wheel_paths.extend(self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "astroid"]))
             wheel_paths.sort(key=WorkflowsDeployment._library_dep_order)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -45,7 +45,7 @@ from databricks.sdk.errors import (
 from databricks.sdk.retries import retried
 from databricks.sdk.service import compute, jobs
 from databricks.sdk.service.jobs import RunLifeCycleState, RunResultState
-from databricks.sdk.service.workspace import ImportFormat, ObjectType
+from databricks.sdk.service.workspace import ObjectType
 
 import databricks
 from databricks.labs.ucx.config import WorkspaceConfig

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -587,8 +587,8 @@ class WorkflowsDeployment(InstallationMixin):
 
     def _upload_wheel(self) -> list[str]:
         wheel_paths = []
-        if self._config.wheelhouse is not None and self._config.wheelhouse.is_file():
-            return self._upload_wheelhouse(self._config.wheelhouse)
+        if self._config.wheelhouse is not None and Path(self._config.wheelhouse).is_file():
+            return self._upload_wheelhouse(Path(self._config.wheelhouse))
         with self._wheels:
             if self._config.upload_dependencies:
                 wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "astroid"])

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -588,11 +588,10 @@ class WorkflowsDeployment(InstallationMixin):
 
     def _upload_wheel(self) -> list[str]:
         wheel_paths = []
-        if self._config.wheelhouse is not None and Path(self._config.wheelhouse).is_file():
-            wheel_paths = self._upload_wheelhouse(Path(self._config.wheelhouse))
         with self._wheels:
-            # TODO: `wheelhouse` is similar to `upload_dependencies`, merge logic
-            if self._config.upload_dependencies and self._config.wheelhouse is not None:
+            if self._config.wheelhouse is not None and Path(self._config.wheelhouse).is_file():
+                wheel_paths = self._upload_wheelhouse(Path(self._config.wheelhouse))
+            elif self._config.upload_dependencies:  # The wheelhouse contains the dependencies as well
                 wheel_paths.extend(self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "astroid"]))
             wheel_paths.sort(key=WorkflowsDeployment._library_dep_order)
             wheel_paths.append(self._wheels.upload_to_wsfs())

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -576,12 +576,8 @@ class WorkflowsDeployment(InstallationMixin):
         ----
         Move this method into the WheelsV2 class.
         """
-        if not self._config.override_clusters:
-            # Removing the .zip suffix is a HACK. We can not upload a .zip file to the workspace as the platform fails
-            # when extracting all files inside the zip archive
-            remote_path = self._installation.upload(path.name.removesuffix(".zip"), path.read_bytes())
-            return [f"/Workspace{remote_path}"]
-        # Override clusters are used in testing, so we need to upload all wheels separately
+        # We can not upload a .zip file to the workspace as the platform fails when extracting all files inside the zip
+        # archive, therefore, we upload the wheels separately.
         remote_paths = []
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -258,7 +258,7 @@ class DeployedWorkflows:
             # Ensure any exception is triggered early.
             log_path_objects = list(self._ws.workspace.list(log_path))
         except ResourceDoesNotExist:
-            logger.warning(f"Can not fetch logs as folder {log_path} does not exist")
+            logger.warning(f"Cannot fetch logs as folder {log_path} does not exist")
             return []
         run_folders = []
         for run_folder in log_path_objects:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -582,8 +582,8 @@ class WorkflowsDeployment(InstallationMixin):
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)
             for wheel in Path(directory).glob("*.whl"):
-                remote_wheel = self._installation.upload(f"wheels/{wheel.name}", wheel.read_bytes())
-                remote_paths.append(f"/Workspace{remote_wheel}")
+                remote_path = self._installation.upload(f"wheels/{wheel.name}", wheel.read_bytes())
+                remote_paths.append(remote_path)
             return remote_paths
 
     def _upload_wheel(self) -> list[str]:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -577,7 +577,9 @@ class WorkflowsDeployment(InstallationMixin):
         Move this method into the WheelsV2 class.
         """
         if not self._config.override_clusters:
-            remote_path = self._installation.upload(f"wheels/{path.name}", path.read_bytes())
+            # Removing the .zip suffix is a HACK. We can not upload a .zip file to the workspace as the platform fails
+            # when extracting all files inside the zip archive
+            remote_path = self._installation.upload(path.name.removesuffix(".zip"), path.read_bytes())
             return [remote_path]
         # Override clusters are used in testing, so we need to upload all wheels
         remote_paths = []

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -593,6 +593,7 @@ class WorkflowsDeployment(InstallationMixin):
 
     def _upload_installation_wheel(self) -> list[str]:
         with self._wheels:
+            # TODO: `wheelhouse` is similar to `upload_dependencies`, merge logic
             if self._config.upload_dependencies:
                 wheel_paths = self._wheels.upload_wheel_dependencies(["databricks", "sqlglot", "astroid"])
             wheel_paths.sort(key=WorkflowsDeployment._library_dep_order)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -255,6 +255,7 @@ class DeployedWorkflows:
         """
         log_path = f"{self._install_state.install_folder()}/logs/{workflow}"
         try:
+            # Ensure any exception is triggered early.
             log_path_objects = list(self._ws.workspace.list(log_path))
         except ResourceDoesNotExist:
             logger.warning(f"Can not fetch logs as folder {log_path} does not exist")

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -576,6 +576,7 @@ class WorkflowsDeployment(InstallationMixin):
         ----
         Move this method into the WheelsV2 class.
         """
+        return [self._installation.upload(f"wheels/{path.name}", path.read_bytes())]
         remote_paths = []
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -581,7 +581,7 @@ class WorkflowsDeployment(InstallationMixin):
             # when extracting all files inside the zip archive
             remote_path = self._installation.upload(path.name.removesuffix(".zip"), path.read_bytes())
             return [f"/Workspace{remote_path}"]
-        # Override clusters are used in testing, so we need to upload all wheels
+        # Override clusters are used in testing, so we need to upload all wheels separately
         remote_paths = []
         with tempfile.TemporaryDirectory() as directory, zipfile.ZipFile(path, "r") as zip_ref:
             zip_ref.extractall(directory)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -255,7 +255,7 @@ class DeployedWorkflows:
         """
         log_path = f"{self._install_state.install_folder()}/logs/{workflow}"
         try:
-            log_path_objects = self._ws.workspace.list(log_path)
+            log_path_objects = list(self._ws.workspace.list(log_path))
         except ResourceDoesNotExist:
             logger.warning(f"Can not fetch logs as folder {log_path} does not exist")
             return []

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from databricks.sdk.config import with_user_agent_extra
 
 from databricks.labs.ucx.__about__ import __version__
-from databricks.labs.ucx.assessment.workflows import Assessment, Failing
+from databricks.labs.ucx.assessment.workflows import Assessment, Failing, Succeeding
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 from databricks.labs.ucx.framework.tasks import Task, Workflow, parse_args
 from databricks.labs.ucx.installer.logs import TaskLogger
@@ -58,6 +58,7 @@ class Workflows:
                 PermissionsMigrationAPI(),
                 ExperimentalWorkflowLinter(),
                 MigrationRecon(),
+                Succeeding(),
                 Failing(),
             ]
         )

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 import logging
 from datetime import timedelta
+from pathlib import Path
 from typing import NoReturn
 
 import pytest
@@ -470,10 +471,16 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
 
 
 def test_workflow_with_wheelhouse(ws, installation_ctx):
-    installation_ctx.workspace_installation.run()
+    ctx = installation_ctx.replace(
+        config_transform=lambda wc: dataclasses.replace(
+            wc,
+            wheelhouse=Path(__file__).parent.parent.parent.parent / "wheelhouse.zip",
+        )
+    )
+    ctx.workspace_installation.run()
 
     with pytest.raises(ManyError):
-        installation_ctx.deployed_workflows.run_workflow("failing")
-    installation_ctx.deployed_workflows.repair_run("failing")
+        ctx.deployed_workflows.run_workflow("failing")
+    ctx.deployed_workflows.repair_run("failing")
 
-    assert installation_ctx.deployed_workflows.validate_step("failing")
+    assert ctx.deployed_workflows.validate_step("failing")

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -481,6 +481,7 @@ def test_workflow_with_wheelhouse(ws, installation_ctx, reset_override_clusters)
         if reset_override_clusters:
             # Override clusters are set by a test fixture to speed up tests by attaching existing (running) clusters
             # A test without this override is slower, however, it is closer to user installation
+            # AND it tests with the zipped wheelhouse (instead of unzipped wheelhouse)
             config = dataclasses.replace(config, override_clusters=None)
         return dataclasses.replace(config, wheelhouse=_WHEEL_HOUSE_PATH.as_posix())
     ctx = installation_ctx.replace(config_transform=config_transform)

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -483,6 +483,7 @@ def test_workflow_with_wheelhouse(ws, installation_ctx, reset_override_clusters)
             # A test without this override is slower, however, it is closer to user installation
             config = dataclasses.replace(config, override_clusters=None)
         return dataclasses.replace(config, wheelhouse=_WHEEL_HOUSE_PATH.as_posix())
+
     ctx = installation_ctx.replace(config_transform=config_transform)
 
     ctx.workspace_installation.run()

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -33,6 +33,7 @@ from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 from ..conftest import MockInstallationContext
 
 logger = logging.getLogger(__name__)
+_WHEEL_HOUSE_PATH = Path(__file__).parent.parent.parent.parent / "wheelhouse.zip"
 
 
 @pytest.fixture
@@ -470,11 +471,15 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
     assert installation_ctx.deployed_workflows.validate_step("failing")
 
 
+@pytest.mark.skipif(
+    not _WHEEL_HOUSE_PATH.is_file(),
+    reason="No wheelhouse available; run `make wheelhouse` in project root",
+)
 def test_workflow_with_wheelhouse(ws, installation_ctx):
     ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
             wc,
-            wheelhouse=Path(__file__).parent.parent.parent.parent / "wheelhouse.zip",
+            wheelhouse=_WHEEL_HOUSE_PATH,
         )
     )
     ctx.workspace_installation.run()

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -467,3 +467,13 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
 
     installation_ctx.deployed_workflows.repair_run("failing")
     assert installation_ctx.deployed_workflows.validate_step("failing")
+
+
+def test_workflow_with_wheelhouse(ws, installation_ctx):
+    installation_ctx.workspace_installation.run()
+
+    with pytest.raises(ManyError):
+        installation_ctx.deployed_workflows.run_workflow("failing")
+    installation_ctx.deployed_workflows.repair_run("failing")
+
+    assert installation_ctx.deployed_workflows.validate_step("failing")

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -33,7 +33,7 @@ from databricks.labs.ucx.workspace_access.groups import MigratedGroup
 from ..conftest import MockInstallationContext
 
 logger = logging.getLogger(__name__)
-_WHEEL_HOUSE_PATH = Path(__file__).parent.parent.parent.parent / "wheelhouse.zip"
+_WHEEL_HOUSE_PATH = Path(__file__).parent.parent.parent.parent / "ucx.wheelhouse.zip"
 
 
 @pytest.fixture

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -480,7 +480,7 @@ def test_workflow_with_wheelhouse(ws, installation_ctx):
     ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
             wc,
-            wheelhouse=_WHEEL_HOUSE_PATH,
+            wheelhouse=_WHEEL_HOUSE_PATH.as_posix(),
         )
     )
     ctx.workspace_installation.run()

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -475,7 +475,10 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
     not _WHEEL_HOUSE_PATH.is_file(),
     reason="No wheelhouse available; run `make wheelhouse` in project root",
 )
-@pytest.mark.parametrize("reset_override_clusters", [False, True])
+@pytest.mark.parametrize(
+    "reset_override_clusters",
+    [False, pytest.param(True, marks=pytest.mark.xfail(reason="Wheelhouse archive does not work")),]
+)
 def test_workflow_with_wheelhouse(ws, installation_ctx, reset_override_clusters):
     def config_transform(config: WorkspaceConfig) -> WorkspaceConfig:
         if reset_override_clusters:

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -484,7 +484,6 @@ def test_workflow_with_wheelhouse(ws, installation_ctx, reset_override_clusters)
         if reset_override_clusters:
             # Override clusters are set by a test fixture to speed up tests by attaching existing (running) clusters
             # A test without this override is slower, however, it is closer to user installation
-            # AND it tests with the zipped wheelhouse (instead of unzipped wheelhouse)
             config = dataclasses.replace(config, override_clusters=None)
         return dataclasses.replace(config, wheelhouse=_WHEEL_HOUSE_PATH.as_posix())
     ctx = installation_ctx.replace(config_transform=config_transform)

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -479,8 +479,5 @@ def test_workflow_with_wheelhouse(ws, installation_ctx):
     )
     ctx.workspace_installation.run()
 
-    with pytest.raises(ManyError):
-        ctx.deployed_workflows.run_workflow("failing")
-    ctx.deployed_workflows.repair_run("failing")
-
-    assert ctx.deployed_workflows.validate_step("failing")
+    ctx.deployed_workflows.run_workflow("succeeding")
+    assert ctx.deployed_workflows.validate_step("succeeding")

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -475,10 +475,7 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
     not _WHEEL_HOUSE_PATH.is_file(),
     reason="No wheelhouse available; run `make wheelhouse` in project root",
 )
-@pytest.mark.parametrize(
-    "reset_override_clusters",
-    [False, pytest.param(True, marks=pytest.mark.xfail(reason="Wheelhouse archive does not work")),]
-)
+@pytest.mark.parametrize("reset_override_clusters", [False, True])
 def test_workflow_with_wheelhouse(ws, installation_ctx, reset_override_clusters):
     def config_transform(config: WorkspaceConfig) -> WorkspaceConfig:
         if reset_override_clusters:

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -476,6 +476,7 @@ def test_installation_with_dependency_upload(ws, installation_ctx, mocker):
     reason="No wheelhouse available; run `make wheelhouse` in project root",
 )
 def test_workflow_with_wheelhouse(ws, installation_ctx):
+    # TODO: Test with `override_clusters` as None
     ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
             wc,

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -135,7 +135,7 @@ def test_create_database(ws, caplog, mock_installation, any_prompt):
             raise e.errs[0]
 
     assert "Kindly uninstall and reinstall UCX" in str(failure.value)
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 def test_install_cluster_override_jobs(ws, mock_installation):
@@ -523,7 +523,7 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
     workspace_installation.run()
 
     webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/README')
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
     wheels.upload_to_dbfs.assert_not_called()
 
 
@@ -1160,7 +1160,7 @@ def test_triggering_assessment_wf(ws, mocker, mock_installation):
         config, installation, install_state, sql_backend, ws, workflows_installer, prompts, PRODUCT_INFO
     )
     workspace_installation.run()
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
     ws.jobs.run_now.assert_not_called()
 
 
@@ -1193,7 +1193,7 @@ def test_triggering_assessment_wf_w_job(ws, mocker, mock_installation):
         config, installation, install_state, sql_backend, ws, workflows_installer, prompts, PRODUCT_INFO
     )
     workspace_installation.run()
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
     ws.jobs.run_now.assert_called_once()
 
 
@@ -1220,7 +1220,7 @@ def test_runs_upgrades_on_too_old_version(ws, any_prompt):
         verify_timeout=timedelta(seconds=60),
     )
 
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
@@ -1249,7 +1249,7 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
     )
 
     existing_installation.assert_file_uploaded('logs/README.md')
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 def test_fresh_install(ws, mock_installation):
@@ -1323,7 +1323,7 @@ def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt):
 
     workspace_installation.run()
     ws.jobs.delete.assert_called_with("123")
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 def test_remove_jobs_already_deleted(ws, caplog, mock_installation_extra_jobs, any_prompt):
@@ -1354,7 +1354,7 @@ def test_remove_jobs_already_deleted(ws, caplog, mock_installation_extra_jobs, a
     )
 
     workspace_installation.run()
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 def test_get_existing_installation_global(ws, mock_installation):
@@ -1823,7 +1823,7 @@ def test_upload_dependencies(ws, mock_installation):
     )
     workspace_installation.run()
     wheels.upload_wheel_dependencies.assert_called_once()
-    wheels.upload_to_wsfs.assert_called_once()
+    wheels.upload_to_wsfs.assert_called()
 
 
 @pytest.fixture

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -21,6 +21,7 @@ class ResourceDoesNotExistIter:
 def test_deployed_workflows_handles_log_folder_does_not_exists(mock_installation):
     ws = create_autospec(WorkspaceClient)
     ws.jobs.list_runs.return_value = [BaseRun(run_id=456)]
+    # Raise the error when the result is iterated over, NOT when the method is called.
     ws.workspace.list.return_value = ResourceDoesNotExistIter()
     install_state = InstallState.from_installation(mock_installation)
     deployed_workflows = DeployedWorkflows(ws, install_state, timedelta(minutes=2))

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -13,10 +13,15 @@ from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.installer.workflows import DeployedWorkflows, WorkflowsDeployment
 
 
+class ResourceDoesNotExistIter:
+    def __iter__(self):
+        raise ResourceDoesNotExist("logs")
+
+
 def test_deployed_workflows_handles_log_folder_does_not_exists(mock_installation):
     ws = create_autospec(WorkspaceClient)
     ws.jobs.list_runs.return_value = [BaseRun(run_id=456)]
-    ws.workspace.list.side_effect = ResourceDoesNotExist("logs")
+    ws.workspace.list.return_value = ResourceDoesNotExistIter()
     install_state = InstallState.from_installation(mock_installation)
     deployed_workflows = DeployedWorkflows(ws, install_state, timedelta(minutes=2))
 


### PR DESCRIPTION
## Changes
The changes are a spike to use a wheelhouse to install ucx at runtime. It is part of the bigger plan to support offline installs, which require changes on the [cli](https://github.com/databricks/cli/issues/1646) as well

### Functionality

- [ ] modified existing command: `databricks labs ucx install`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
