### PR TITLE
Avoid false positives when linting for pyspark patterns

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -158,9 +158,7 @@ class ReturnValueMatcher(Matcher):
 
     def matches(self, node: NodeNG):
         return (
-            isinstance(node, Call)
-            and isinstance(node.func, Attribute)
-            and Tree(node.func.expr).is_from_module("spark")
+            isinstance(node, Call) and isinstance(node.func, Attribute) and Tree(node.func.expr).is_from_module("spark")
         )
 
     def lint(

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -157,7 +157,11 @@ class TableNameMatcher(Matcher):
 class ReturnValueMatcher(Matcher):
 
     def matches(self, node: NodeNG):
-        return isinstance(node, Call) and isinstance(node.func, Attribute)
+        return (
+            isinstance(node, Call)
+            and isinstance(node.func, Attribute)
+            and Tree(node.func.expr).is_from_module("spark")
+        )
 
     def lint(
         self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: Call
@@ -190,7 +194,12 @@ class DirectFilesystemAccessMatcher(Matcher):
     }
 
     def matches(self, node: NodeNG):
-        return isinstance(node, Call) and isinstance(node.func, Attribute) and self._get_table_arg(node) is not None
+        return (
+            isinstance(node, Call)
+            and self._get_table_arg(node) is not None
+            and isinstance(node.func, Attribute)
+            and (Tree(node.func.expr).is_from_module("spark") or Tree(node.func.expr).is_from_module("dbutils"))
+        )
 
     def lint(
         self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: NodeNG

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -266,7 +266,8 @@ for i in range(10):
         ),
         # Test for option function
         (
-            """(df.write
+            """df=spark.sql('SELECT * FROm dual')
+(df.write
   .format("parquet")
   .option("path", "s3a://your_bucket_name/your_directory/")
   .option("spark.hadoop.fs.s3a.access.key", "your_access_key")
@@ -277,9 +278,9 @@ for i in range(10):
                     code='direct-filesystem-access',
                     message='The use of direct filesystem references is deprecated: '
                     "s3a://your_bucket_name/your_directory/",
-                    start_line=0,
+                    start_line=1,
                     start_col=1,
-                    end_line=2,
+                    end_line=3,
                     end_col=59,
                 )
             ],

--- a/tests/unit/source_code/samples/functional/pyspark/catalog/spark-catalog-list-tables.py
+++ b/tests/unit/source_code/samples/functional/pyspark/catalog/spark-catalog-list-tables.py
@@ -42,8 +42,6 @@ for table in spark.catalog.listTables(name):
 for table in spark.catalog.listTables(f"boop{stuff}"):
     do_stuff_with_table(table)
 
-## Some trivial references to the method or table in unrelated contexts that should not trigger warnigns.
-# FIXME: This is a false positive; any method named 'listTables' is triggering the warning.
-# ucx[changed-result-format-in-uc:+1:0:+1:39] Call to 'listTables' will return a list of <catalog>.<database>.<table> instead of <database>.<table>.
+## Some trivial references to the method or table in unrelated contexts that should not trigger warnings.
 something_else.listTables("old.things")
 a_function("old.things")


### PR DESCRIPTION
## Changes
Check originating module when linting for pyspark calls

### Linked issues
None

### Functionality
None

### Tests
- [x] ran unit tests
