### PR TITLE
Fix raise logs `ResourceDoesNotExists` when iterating the log paths

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -255,7 +255,7 @@ class DeployedWorkflows:
         """
         log_path = f"{self._install_state.install_folder()}/logs/{workflow}"
         try:
-            log_path_objects = self._ws.workspace.list(log_path)
+            log_path_objects = list(self._ws.workspace.list(log_path))
         except ResourceDoesNotExist:
             logger.warning(f"Can not fetch logs as folder {log_path} does not exist")
             return []

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -13,10 +13,15 @@ from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.installer.workflows import DeployedWorkflows, WorkflowsDeployment
 
 
+class ResourceDoesNotExistIter:
+    def __iter__(self):
+        raise ResourceDoesNotExist("logs")
+
+
 def test_deployed_workflows_handles_log_folder_does_not_exists(mock_installation):
     ws = create_autospec(WorkspaceClient)
     ws.jobs.list_runs.return_value = [BaseRun(run_id=456)]
-    ws.workspace.list.side_effect = ResourceDoesNotExist("logs")
+    ws.workspace.list.return_value = ResourceDoesNotExistIter()
     install_state = InstallState.from_installation(mock_installation)
     deployed_workflows = DeployedWorkflows(ws, install_state, timedelta(minutes=2))
 


### PR DESCRIPTION
## Changes
Fix raise logs `ResourceDoesNotExists` when iterating the log paths. The test did not mimic the actual behavior, these changes do

### Tests

- [ ] added unit tests
