### PR TITLE
Remove `TODO` referring to #411 (won't do)

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/base.py
+++ b/src/databricks/labs/ucx/workspace_access/base.py
@@ -8,7 +8,6 @@ from databricks.labs.ucx.workspace_access.groups import MigrationState
 logger = Logger(__name__)
 
 
-# TODO: fix order to standard https://github.com/databrickslabs/ucx/issues/411
 @dataclass
 class Permissions:
     object_id: str


### PR DESCRIPTION
## Changes

Remove an internal `TODO` marker: it refers to #411, an issue which has been closed and won't be done.
