### PR TITLE
More crawler snapshot refactoring

### DIFF
--- a/src/databricks/labs/ucx/assessment/azure.py
+++ b/src/databricks/labs/ucx/assessment/azure.py
@@ -44,9 +44,6 @@ class AzureServicePrincipalCrawler(CrawlerBase[AzureServicePrincipalInfo], JobsM
         super().__init__(sbe, "hive_metastore", schema, "azure_service_principals", AzureServicePrincipalInfo)
         self._ws = ws
 
-    def snapshot(self) -> Iterable[AzureServicePrincipalInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[AzureServicePrincipalInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield AzureServicePrincipalInfo(*row)

--- a/src/databricks/labs/ucx/assessment/clusters.py
+++ b/src/databricks/labs/ucx/assessment/clusters.py
@@ -170,9 +170,6 @@ class ClustersCrawler(CrawlerBase[ClusterInfo], CheckClusterMixin):
                 cluster_info.failures = json.dumps(failures)
             yield cluster_info
 
-    def snapshot(self) -> Iterable[ClusterInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[ClusterInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield ClusterInfo(*row)
@@ -224,9 +221,6 @@ class PoliciesCrawler(CrawlerBase[PolicyInfo], CheckClusterMixin):
                 policy_info.success = 0
                 policy_info.failures = json.dumps(failures)
             yield policy_info
-
-    def snapshot(self) -> Iterable[PolicyInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
 
     def _try_fetch(self) -> Iterable[PolicyInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):

--- a/src/databricks/labs/ucx/assessment/init_scripts.py
+++ b/src/databricks/labs/ucx/assessment/init_scripts.py
@@ -79,9 +79,6 @@ class GlobalInitScriptCrawler(CrawlerBase[GlobalInitScriptInfo], CheckInitScript
                 global_init_script_info.success = 0
             yield global_init_script_info
 
-    def snapshot(self) -> Iterable[GlobalInitScriptInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[GlobalInitScriptInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield GlobalInitScriptInfo(*row)

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -127,9 +127,6 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
             )
         return job_assessment, job_details
 
-    def snapshot(self) -> Iterable[JobInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[JobInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield JobInfo(*row)
@@ -164,9 +161,6 @@ class SubmitRunsCrawler(CrawlerBase[SubmitRunInfo], JobsMixin, CheckClusterMixin
         super().__init__(sbe, "hive_metastore", schema, "submit_runs", SubmitRunInfo)
         self._ws = ws
         self._num_days_history = num_days_history
-
-    def snapshot(self) -> Iterable[SubmitRunInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
 
     @staticmethod
     def _dt_to_ms(date_time: datetime):

--- a/src/databricks/labs/ucx/assessment/pipelines.py
+++ b/src/databricks/labs/ucx/assessment/pipelines.py
@@ -69,9 +69,6 @@ class PipelinesCrawler(CrawlerBase[PipelineInfo], CheckClusterMixin):
             if cluster.init_scripts:
                 failures.extend(self._check_cluster_init_script(cluster.init_scripts, "pipeline cluster"))
 
-    def snapshot(self) -> Iterable[PipelineInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[PipelineInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield PipelineInfo(*row)

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -89,8 +89,24 @@ class CrawlerBase(ABC, Generic[Result]):
             return None
         return cls._valid(name)
 
+    def snapshot(self) -> Iterable[Result]:
+        return self._snapshot(self._try_fetch, self._crawl)
+
     @abstractmethod
-    def snapshot(self) -> Iterable[Result]: ...
+    def _try_fetch(self) -> Iterable[Result]:
+        """Fetch existing data that has (previously) been crawled by this crawler.
+
+        Returns:
+            Iterable[Result]: The data that has already been crawled.
+        """
+
+    @abstractmethod
+    def _crawl(self) -> Iterable[Result]:
+        """Perform the (potentially slow) crawling necessary to capture the current state of the environment.
+
+        Returns:
+            Iterable[Result]: Records that capture the results of crawling the environment.
+        """
 
     def _snapshot(self, fetcher: ResultFn, loader: ResultFn) -> list[Result]:
         """
@@ -107,7 +123,7 @@ class CrawlerBase(ABC, Generic[Result]):
           re-raised.
 
         Returns:
-        list[any]: A list of data records, either fetched or loaded.
+        list[Result]: A list of data records, either fetched or loaded.
         """
         logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
         try:

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -203,13 +203,13 @@ class GrantsCrawler(CrawlerBase[Grant]):
 
     def snapshot(self) -> Iterable[Grant]:
         try:
-            return self._snapshot(partial(self._try_load), partial(self._crawl))
+            return super().snapshot()
         except Exception as e:  # pylint: disable=broad-exception-caught
             log_fn = logger.warning if CLUSTER_WITHOUT_ACL_FRAGMENT in repr(e) else logger.error
             log_fn(f"Couldn't fetch grants snapshot: {e}")
             return []
 
-    def _try_load(self):
+    def _try_fetch(self):
         for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield Grant(*row)
 
@@ -580,7 +580,7 @@ class PrincipalACL:
         self._compute_locations = cluster_locations
 
     def get_interactive_cluster_grants(self) -> list[Grant]:
-        tables = self._tables_crawler.snapshot()
+        tables = list(self._tables_crawler.snapshot())
         mounts = list(self._mounts_crawler.snapshot())
         grants: set[Grant] = set()
 

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -96,8 +96,8 @@ class TableMapping:
         self._recon_tolerance_percent = recon_tolerance_percent
 
     def current_tables(self, tables: TablesCrawler, workspace_name: str, catalog_name: str):
-        tables_snapshot = tables.snapshot()
-        if len(tables_snapshot) == 0:
+        tables_snapshot = list(tables.snapshot())
+        if not tables_snapshot:
             msg = "No tables found. Please run: databricks labs ucx ensure-assessment-run"
             raise ValueError(msg)
         for table in tables_snapshot:

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -74,9 +74,6 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
         self._ws = ws
         self._table_crawler = table_crawler
 
-    def snapshot(self) -> Iterable[MigrationStatus]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def index(self) -> MigrationIndex:
         return MigrationIndex(list(self.snapshot()))
 

--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -1,7 +1,6 @@
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-from functools import partial
 
 from databricks.labs.lsql.backends import SqlBackend
 
@@ -53,20 +52,10 @@ class TableSizeCrawler(CrawlerBase):
                 catalog=table.catalog, database=table.database, name=table.name, size_in_bytes=size_in_bytes
             )
 
-    def _try_load(self) -> Iterable[TableSize]:
+    def _try_fetch(self) -> Iterable[TableSize]:
         """Tries to load table information from the database or throws TABLE_OR_VIEW_NOT_FOUND error"""
         for row in self._fetch(f"SELECT * FROM {self.full_name}"):
             yield TableSize(*row)
-
-    def snapshot(self) -> list[TableSize]:
-        """
-        Takes a snapshot of tables in the specified catalog and database.
-        Return None if the table cannot be found anymore.
-
-        Returns:
-            list[Table]: A list of Table objects representing the snapshot of tables.
-        """
-        return self._snapshot(partial(self._try_load), partial(self._crawl))
 
     def _safe_get_table_size(self, table_full_name: str) -> int | None:
         logger.debug(f"Evaluating {table_full_name} table size.")

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -353,15 +353,6 @@ class TablesCrawler(CrawlerBase):
             return [row[0] for row in self._fetch("SHOW DATABASES")]
         return self._include_database
 
-    def snapshot(self) -> list[Table]:
-        """
-        Takes a snapshot of tables in the specified catalog and database.
-
-        Returns:
-            list[Table]: A list of Table objects representing the snapshot of tables.
-        """
-        return self._snapshot(partial(self._try_load), partial(self._crawl))
-
     @staticmethod
     def _parse_table_props(tbl_props: str) -> dict:
         pattern = r"([^,\[\]]+)=([^,\[\]]+)"
@@ -376,7 +367,7 @@ class TablesCrawler(CrawlerBase):
         # Convert key-value pairs to dictionary
         return dict(key_value_pairs)
 
-    def _try_load(self) -> Iterable[Table]:
+    def _try_fetch(self) -> Iterable[Table]:
         """Tries to load table information from the database or throws TABLE_OR_VIEW_NOT_FOUND error"""
         for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield Table(*row)

--- a/src/databricks/labs/ucx/hive_metastore/udfs.py
+++ b/src/databricks/labs/ucx/hive_metastore/udfs.py
@@ -50,16 +50,7 @@ class UdfsCrawler(CrawlerBase):
             return [row[0] for row in self._fetch("SHOW DATABASES")]
         return self._include_database
 
-    def snapshot(self) -> list[Udf]:
-        """
-        Takes a snapshot of tables in the specified catalog and database.
-
-        Returns:
-            list[Udf]: A list of Udf objects representing the snapshot of tables.
-        """
-        return self._snapshot(self._try_load, self._crawl)
-
-    def _try_load(self) -> Iterable[Udf]:
+    def _try_fetch(self) -> Iterable[Udf]:
         """Tries to load udf information from the database or throws TABLE_OR_VIEW_NOT_FOUND error"""
         for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield Udf(*row)

--- a/src/databricks/labs/ucx/recon/migration_recon.py
+++ b/src/databricks/labs/ucx/recon/migration_recon.py
@@ -52,9 +52,6 @@ class MigrationRecon(CrawlerBase[ReconResult]):
         self._data_comparator = data_comparator
         self._default_threshold = default_threshold
 
-    def snapshot(self) -> Iterable[ReconResult]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _crawl(self) -> Iterable[ReconResult]:
         self._migration_status_refresher.reset()
         migration_index = self._migration_status_refresher.index()

--- a/src/databricks/labs/ucx/workspace_access/generic.py
+++ b/src/databricks/labs/ucx/workspace_access/generic.py
@@ -359,9 +359,6 @@ class WorkspaceListing(Listing, CrawlerBase[WorkspaceObjectInfo]):
                 language=raw.get("language", None),
             )
 
-    def snapshot(self) -> Iterable[WorkspaceObjectInfo]:
-        return self._snapshot(self._try_fetch, self._crawl)
-
     def _try_fetch(self) -> Iterable[WorkspaceObjectInfo]:
         for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
             yield WorkspaceObjectInfo(

--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from collections.abc import Iterable, Collection
 from dataclasses import dataclass
 from datetime import timedelta
+from itertools import islice
 from typing import ClassVar
 
 from databricks.labs.blueprint.limiter import rate_limited
@@ -430,11 +431,9 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         self._external_id_match = external_id_match
         self._verify_timeout = verify_timeout
 
-    def snapshot(self) -> list[MigratedGroup]:
-        return self._snapshot(self._fetcher, self._crawler)
-
     def has_groups(self) -> bool:
-        return len(self.snapshot()) > 0
+        first_element = islice(self.snapshot(), 1)
+        return bool(list(first_element))
 
     def rename_groups(self):
         account_groups_in_workspace = self._account_groups_in_workspace()
@@ -578,7 +577,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
             raise ManyError(errors)
 
     def get_migration_state(self) -> MigrationState:
-        return MigrationState(self.snapshot())
+        return MigrationState(list(self.snapshot()))
 
     def delete_original_workspace_groups(self):
         account_groups_in_workspace = self._account_groups_in_workspace()
@@ -625,7 +624,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         # Step 3: Confirm that enumeration no longer returns the deleted groups.
         self._wait_for_deleted_workspace_groups(deleted_groups)
 
-    def _fetcher(self) -> Iterable[MigratedGroup]:
+    def _try_fetch(self) -> Iterable[MigratedGroup]:
         state = []
         for row in self._backend.fetch(f"SELECT * FROM {self.full_name}"):
             state.append(MigratedGroup(*row))
@@ -645,7 +644,7 @@ class GroupManager(CrawlerBase[MigratedGroup]):
                 )
         return new_state
 
-    def _crawler(self) -> Iterable[MigratedGroup]:
+    def _crawl(self) -> Iterable[MigratedGroup]:
         workspace_groups_in_workspace = self._workspace_groups_in_workspace()
         account_groups_in_account = self._account_groups_in_account()
         strategy = self._get_strategy(workspace_groups_in_workspace, account_groups_in_account)

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -20,9 +20,6 @@ class PermissionManager(CrawlerBase[Permissions]):
         super().__init__(backend, "hive_metastore", inventory_database, "permissions", Permissions)
         self._acl_support = crawlers
 
-    def snapshot(self) -> Iterable[Permissions]:
-        return self._snapshot(self._fetcher, self._crawl)
-
     def _crawl(self) -> Iterable[Permissions]:
         logger.debug("Crawling permissions")
         crawler_tasks = list(self._get_crawler_tasks())
@@ -126,7 +123,7 @@ class PermissionManager(CrawlerBase[Permissions]):
                 appliers[object_type] = support
         return appliers
 
-    def _fetcher(self) -> Iterable[Permissions]:
+    def _try_fetch(self) -> Iterable[Permissions]:
         for row in self._fetch(f"SELECT object_id, object_type, raw FROM {escape_sql_identifier(self.full_name)}"):
             yield Permissions(*row)
 

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -44,8 +44,11 @@ class _CrawlerFixture(CrawlerBase[Result]):
         self._fetcher = fetcher
         self._loader = loader
 
-    def snapshot(self) -> Iterable[Result]:
-        return self._snapshot(self._fetcher, self._loader)
+    def _try_fetch(self) -> Iterable[Result]:
+        return self._fetcher()
+
+    def _crawl(self) -> Iterable[Result]:
+        return self._loader()
 
 
 def test_invalid():


### PR DESCRIPTION
## Changes

This PR is stacked on top of #2402 and is further refactors the crawler snapshotting pattern to use common code without changing the existing system behaviour. This is intended as groundwork to the next step, whereby `snapshot()` will be updated to support refreshing the inventory.

### Linked issues

Progresses #2074, stacked on top of #2402.

### Tests

- existing unit tests (with minor updates)
- existing integration tests
