### PR TITLE
Add support for DBFS root location resolution for HMS federation

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/federation.py
+++ b/src/databricks/labs/ucx/hive_metastore/federation.py
@@ -6,6 +6,8 @@ class DbfsRootResolver:
 
     def run(self) -> str:
         code = """
+// Warning: relying on an undocumented API here. This is brittle, as it may break.
+// TODO: switch to a publicly documented API when available.
 URI = spark._jvm.java.net.URI
 Some = spark._jvm.scala.Some
 HmsFedDbfsUtils = spark._jvm.com.databricks.sql.managedcatalog.connections.HmsFedDbfsUtils

--- a/src/databricks/labs/ucx/hive_metastore/federation.py
+++ b/src/databricks/labs/ucx/hive_metastore/federation.py
@@ -1,0 +1,22 @@
+from databricks.labs.blueprint.commands import CommandExecutor
+
+class DbfsRootResolver:
+    def __init__(self, command_executor: CommandExecutor):
+        self._command_executor = command_executor
+
+    def run(self) -> str:
+        code = """
+URI = spark._jvm.java.net.URI
+Some = spark._jvm.scala.Some
+HmsFedDbfsUtils = spark._jvm.com.databricks.sql.managedcatalog.connections.HmsFedDbfsUtils
+rootLocationOpt = HmsFedDbfsUtils.resolveDbfsPath(Some(URI("dbfs:/user/hive/warehouse")))
+if rootLocationOpt.isDefined():
+    print(rootLocationOpt.get().toString())
+else:
+    print("Unknown")
+        """
+        results = self._command_executor.run(code)
+        if (results == "Unknown"):
+            raise ValueError("Could not resolve the root location of the workspace")
+        return results
+

--- a/tests/integration/hive_metastore/test_federation.py
+++ b/tests/integration/hive_metastore/test_federation.py
@@ -1,0 +1,10 @@
+from databricks.labs.blueprint.commands import CommandExecutor
+from databricks.labs.ucx.hive_metastore.federation import DbfsRootResolver
+
+
+def test_dbfs_root_resolver(ws, env_or_skip):
+    command_executor = CommandExecutor(ws.clusters, ws.command_execution, lambda: env_or_skip("DATABRICKS_CLUSTER_ID"))
+    root_resolver = DbfsRootResolver(command_executor)
+    root = root_resolver.run()
+    assert root is not None
+    assert root is not "Unknown"

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -1,9 +1,12 @@
 from unittest.mock import Mock, call, create_autospec
 
 import pytest
+
+from databricks.labs.blueprint.commands import CommandExecutor
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.lsql import Row
 from databricks.labs.lsql.backends import MockBackend
+from databricks.labs.ucx.hive_metastore.federation import DbfsRootResolver
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.dbutils import FileInfo, MountInfo
 from databricks.sdk.service.catalog import ExternalLocationInfo
@@ -719,3 +722,10 @@ def test_mount_listing_seen_tables():
     assert results[0].location == "adls://bucket/table1"
     assert results[1].location == "dbfs:/mnt/test_mount/table2"
     assert results[2].location is None
+
+
+def test_dbfs_root_resolution():
+    command_executor_mock = create_autospec(CommandExecutor)
+    command_executor_mock.run.return_value = "s3://bucket/dbfsrootpath"
+    root_resolver = DbfsRootResolver(command_executor_mock)
+    assert root_resolver.run() == "s3://bucket/dbfsrootpath"

--- a/ucx.iml
+++ b/ucx.iml
@@ -7,7 +7,7 @@
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.10 (ucx)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.12 (.venv)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>


### PR DESCRIPTION
This PR adds a DBFS Resolver which is used by HMS federation to resolve the DBFS root locations.

TODO:

- [ ] rewrite `ExternalLocations` to fetch from `mounts` table bypassing the `Mounts` crawler
- [ ] resolve special `/user/hive/metastore` as special case of DBFS mount
- [ ] use `LocationTrie` to come guess locations

