### PR TITLE
Generate custom error during installation due to external metastore connectivity issues

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -41,6 +41,7 @@ from databricks.sdk.errors import (
     ResourceAlreadyExists,
     ResourceDoesNotExist,
     Unauthenticated,
+    OperationFailed
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service.dashboards import LifecycleState
@@ -538,7 +539,7 @@ class WorkspaceInstallation(InstallationMixin):
                     "UCX Uninstall: databricks labs uninstall ucx.\n"
                     "UCX Install: databricks labs install ucx"
                 )
-                raise BadRequest(msg) from err
+                raise OperationFailed(msg) from err
             raise err
 
     def _get_create_dashboard_tasks(self) -> Iterable[Callable[[], None]]:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -529,6 +529,16 @@ class WorkspaceInstallation(InstallationMixin):
                     "UCX Install: databricks labs install ucx"
                 )
                 raise BadRequest(msg) from err
+            if "Unable to load AWS credentials from any provider in the chain" in str(err):
+                msg = (
+                    "The UCX installation is configured to use external metastore. There is issue with the external metastore connectivity.\n"
+                    "Please check the UCX installation instruction https://github.com/databrickslabs/ucx?tab=readme-ov-file#prerequisites"
+                    "and re-run installation.\n"
+                    "Please Follow the Below Command to uninstall and Install UCX\n"
+                    "UCX Uninstall: databricks labs uninstall ucx.\n"
+                    "UCX Install: databricks labs install ucx"
+                )
+                raise BadRequest(msg) from err
             raise err
 
     def _get_create_dashboard_tasks(self) -> Iterable[Callable[[], None]]:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -41,7 +41,7 @@ from databricks.sdk.errors import (
     ResourceAlreadyExists,
     ResourceDoesNotExist,
     Unauthenticated,
-    OperationFailed
+    OperationFailed,
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service.dashboards import LifecycleState


### PR DESCRIPTION
## Changes
During installation, if there is an error due to external metastore connectivity, the installation raises an exception which may be confusing. This PR raises a custom exception msg and points user to the installation instruction for UCX to ext metastore.

Resolves #1967 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
Tested by trying to install the ucx on a workspace with incorrect ext metastore connectivity

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
