### PR TITLE
Bug: Generate custom warning when doing table size check and encountering DELTA_INVALID_FORMAT exception

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_size.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_size.py
@@ -79,6 +79,11 @@ class TableSizeCrawler(CrawlerBase):
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(e) or "[DELTA_TABLE_NOT_FOUND]" in str(e):
                 logger.warning(f"Failed to evaluate {table_full_name} table size. Table not found.")
                 return None
+            if "[DELTA_INVALID_FORMAT]" in str(e):
+                logger.warning(
+                    f"Unable to read Delta table {table_full_name}, please check table structure and try again."
+                )
+                return None
             if "[DELTA_MISSING_TRANSACTION_LOG]" in str(e):
                 logger.warning(f"Delta table {table_full_name} is corrupted: missing transaction log.")
                 return None

--- a/tests/unit/hive_metastore/test_table_size.py
+++ b/tests/unit/hive_metastore/test_table_size.py
@@ -130,3 +130,26 @@ def test_table_size_when_table_corrupted(mocker):
     results = tsc.snapshot()
 
     assert len(results) == 0
+
+
+def test_table_size_when_delta_invalid_format_error(mocker):
+    errors = {}
+    rows = {
+        "table_size": [],
+        "hive_metastore.inventory_database.tables": [
+            ("hive_metastore", "db1", "table1", "MANAGED", "DELTA", "dbfs:/location/table", None),
+        ],
+        "SHOW DATABASES": [("db1",)],
+    }
+    backend = MockBackend(fails_on_first=errors, rows=rows)
+    pyspark_sql_session = mocker.Mock()
+    sys.modules["pyspark.sql.session"] = pyspark_sql_session
+    tsc = TableSizeCrawler(backend, "inventory_database")
+
+    tsc._spark._jsparkSession.table().queryExecution().analyzed().stats().sizeInBytes.side_effect = Exception(
+        "[DELTA_INVALID_FORMAT]"
+    )
+
+    results = tsc.snapshot()
+
+    assert len(results) == 0


### PR DESCRIPTION
## Changes

When performing table size, we are getting exception for table with DELTA_INVALID_FORMAT , this PR converts the error to a warning and proceeds with rest of the table


Resolves #1913 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [X] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
