### PR TITLE
Drop source table after successful table move not before

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_move.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_move.py
@@ -242,14 +242,14 @@ class TableMove:
                 self._execute(drop_table)
         else:
             create_sql = str(next(self._fetch(f"SHOW CREATE TABLE {escape_sql_identifier(from_table_name)}"))[0])
-            logger.info(f"Dropping source table {from_table_name}")
-            self._execute(drop_table)
             create_table_sql = create_sql.replace(
                 f"CREATE TABLE {escape_sql_identifier(from_table_name)}",
                 f"CREATE TABLE {escape_sql_identifier(to_table_name)}",
             )
             logger.info(f"Creating table {to_table_name}")
             self._execute(create_table_sql)
+            logger.info(f"Dropping source table {from_table_name}")
+            self._execute(drop_table)
 
     def _create_alias_view(self, from_table_name, to_table_name):
         create_view_sql = (

--- a/tests/integration/hive_metastore/test_table_move.py
+++ b/tests/integration/hive_metastore/test_table_move.py
@@ -203,7 +203,7 @@ def test_alias_tables(
 
 def test_move_tables_table_properties_mismatch_preserves_original(
     ws, sql_backend, make_catalog, make_schema, make_table, make_acc_group, make_random, env_or_skip
-):  # pylint: disable=too-many-locals
+):
     table_move = TableMove(ws, sql_backend)
     from_catalog = make_catalog()
     from_schema = make_schema(catalog_name=from_catalog.name)

--- a/tests/integration/hive_metastore/test_table_move.py
+++ b/tests/integration/hive_metastore/test_table_move.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import timedelta
 
-from databricks.sdk.errors import NotFound
+import pytest
+from databricks.sdk.errors import NotFound, BadRequest
 from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import Privilege, PrivilegeAssignment, SecurableType
 
@@ -198,3 +199,31 @@ def test_alias_tables(
     assert table_2_grant.privilege_assignments == expected_table_2_grant
     assert table_3_grant.privilege_assignments == expected_table_3_grant
     assert view_1_grant.privilege_assignments == expected_view_1_grant
+
+
+def test_move_tables_table_properties_mismatch_preserves_original(
+    ws, sql_backend, make_catalog, make_schema, make_table, make_acc_group, make_random, env_or_skip
+):  # pylint: disable=too-many-locals
+    table_move = TableMove(ws, sql_backend)
+    from_catalog = make_catalog()
+    from_schema = make_schema(catalog_name=from_catalog.name)
+    tbl_path = make_random(4).lower()
+    tbl_properties = {"delta.enableDeletionVectors": "true"}
+    from_table_1 = make_table(
+        catalog_name=from_catalog.name,
+        schema_name=from_schema.name,
+        external_delta=f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{tbl_path}",
+        tbl_properties=tbl_properties,
+    )
+    table_in_mount_location = f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{tbl_path}"
+    from_table_1.storage_location = table_in_mount_location
+
+    to_catalog = make_catalog()
+    to_schema = make_schema(catalog_name=to_catalog.name)
+
+    with pytest.raises(BadRequest):
+        table_move.move(from_catalog.name, from_schema.name, "*", to_catalog.name, to_schema.name, del_table=False)
+
+    fetch_original_table = ws.tables.list(catalog_name=from_catalog.name, schema_name=from_schema.name)
+    for table in fetch_original_table:
+        assert table.name == from_table_1.name


### PR DESCRIPTION
## Changes
Table fails with [DELTA_CREATE_TABLE_WITH_DIFFERENT_PROPERTY] during move but the source table is already dropped. Dropping table is moved after the new table creation so that the process fails if there are issues during creation and the source table is preserved

### Linked issues
Resolves #2424 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [ ] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
