### PR TITLE
Enable `principal-prefix-access` command to run as collection

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -132,6 +132,8 @@ commands:
         description: Subscription to scan storage account in
       - name: aws-profile
         description: AWS Profile to use for authentication
+      - name: run-as-collection
+        description: boolean flag to indicate to run the cmd as a collection. Default is False.
 
   - name: create-missing-principals
     description: For AWS, this command identifies all the S3 locations that are missing a UC compatible role and

--- a/src/databricks/labs/ucx/azure/resources.py
+++ b/src/databricks/labs/ucx/azure/resources.py
@@ -581,7 +581,7 @@ class AzureResources:
         result = self._mgmt.get(f"{resource_id}/providers/Microsoft.Authorization/roleAssignments", "2022-04-01")
         for role_assignment in result.get("value", []):
             principal_type = role_assignment.get("properties", {}).get("principalType")
-            if not principal_type and principal_type not in principal_types:
+            if not principal_type or principal_type not in principal_types:
                 continue
             assignment = self._role_assignment(role_assignment, resource_id)
             if not assignment:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -310,12 +310,14 @@ def principal_prefix_access(
     if w.config.is_azure:
         for workspace_ctx in workspaces_context:
             workspace_ctx.azure_resource_permissions.save_spn_permissions()
+        return
     if w.config.is_aws:
         for workspace_ctx in workspaces_context:
             instance_role_path = workspace_ctx.aws_resource_permissions.save_instance_profile_permissions()
             logger.info(f"Instance profile and bucket info saved {instance_role_path}")
             logger.info("Generating UC roles and bucket permission info")
             workspace_ctx.aws_resource_permissions.save_uc_compatible_roles()
+        return
     raise ValueError("Unsupported cloud provider")
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -26,6 +26,16 @@ CANT_FIND_UCX_MSG = (
 )
 
 
+def get_contexts(
+    w: WorkspaceClient, a: AccountClient | None = None, run_as_collection: bool = False, **named_parameters
+) -> list[WorkspaceContext]:
+    if not a:
+        a = AccountClient(product='ucx', product_version=__version__)
+    account_installer = AccountInstaller(a)
+    workspace_contexts = account_installer.get_workspace_contexts(w, run_as_collection, **named_parameters)
+    return workspace_contexts
+
+
 @ucx.command
 def workflows(w: WorkspaceClient):
     """Show deployed workflows and their state"""
@@ -159,10 +169,7 @@ def validate_external_locations(w: WorkspaceClient, prompts: Prompts):
 @ucx.command
 def ensure_assessment_run(w: WorkspaceClient, run_as_collection: bool = False, a: AccountClient | None = None):
     """ensure the assessment job was run on a workspace"""
-    if not a:
-        a = AccountClient(product='ucx', product_version=__version__)
-    account_installer = AccountInstaller(a)
-    workspace_contexts = account_installer.get_workspace_contexts(w, run_as_collection)
+    workspace_contexts = get_contexts(w, a, run_as_collection)
     # if running the cmd as a collection, don't wait for each assessment job to finish as that will take long time
     skip_job_status = bool(run_as_collection)
     for ctx in workspace_contexts:
@@ -300,11 +307,7 @@ def principal_prefix_access(
     its access to all the S3 buckets, along with AWS roles that are set with UC access and its access to S3 buckets.
     The output is stored in the workspace install folder.
     Pass subscription_id for azure and aws_profile for aws."""
-
-    if not a:
-        a = AccountClient(product='ucx', product_version=__version__)
-    account_installer = AccountInstaller(a)
-    workspace_contexts = account_installer.get_workspace_contexts(w, run_as_collection, **named_parameters)
+    workspace_contexts = get_contexts(w, a, run_as_collection, **named_parameters)
     if ctx:
         workspace_contexts = [ctx]
     if w.config.is_azure:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -162,10 +162,10 @@ def ensure_assessment_run(w: WorkspaceClient, run_as_collection: bool = False, a
     if not a:
         a = AccountClient(product='ucx', product_version=__version__)
     account_installer = AccountInstaller(a)
-    workspaces_context = account_installer.get_workspace_contexts(w, run_as_collection)
+    workspace_contexts = account_installer.get_workspace_contexts(w, run_as_collection)
     # if running the cmd as a collection, don't wait for each assessment job to finish as that will take long time
     skip_job_status = bool(run_as_collection)
-    for ctx in workspaces_context:
+    for ctx in workspace_contexts:
         logger.info(f"Running cmd for workspace {ctx.workspace_client.get_workspace_id()}")
         deployed_workflows = ctx.deployed_workflows
         if not deployed_workflows.validate_step("assessment"):
@@ -304,15 +304,15 @@ def principal_prefix_access(
     if not a:
         a = AccountClient(product='ucx', product_version=__version__)
     account_installer = AccountInstaller(a)
-    workspaces_context = account_installer.get_workspace_contexts(w, run_as_collection, **named_parameters)
+    workspace_contexts = account_installer.get_workspace_contexts(w, run_as_collection, **named_parameters)
     if ctx:
-        workspaces_context = [ctx]
+        workspace_contexts = [ctx]
     if w.config.is_azure:
-        for workspace_ctx in workspaces_context:
+        for workspace_ctx in workspace_contexts:
             workspace_ctx.azure_resource_permissions.save_spn_permissions()
         return
     if w.config.is_aws:
-        for workspace_ctx in workspaces_context:
+        for workspace_ctx in workspace_contexts:
             instance_role_path = workspace_ctx.aws_resource_permissions.save_instance_profile_permissions()
             logger.info(f"Instance profile and bucket info saved {instance_role_path}")
             logger.info("Generating UC roles and bucket permission info")

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -309,10 +309,12 @@ def principal_prefix_access(
         workspace_contexts = [ctx]
     if w.config.is_azure:
         for workspace_ctx in workspace_contexts:
+            logger.info(f"Running cmd for workspace {workspace_ctx.workspace_client.get_workspace_id()}")
             workspace_ctx.azure_resource_permissions.save_spn_permissions()
         return
     if w.config.is_aws:
         for workspace_ctx in workspace_contexts:
+            logger.info(f"Running cmd for workspace {workspace_ctx.workspace_client.get_workspace_id()}")
             instance_role_path = workspace_ctx.aws_resource_permissions.save_instance_profile_permissions()
             logger.info(f"Instance profile and bucket info saved {instance_role_path}")
             logger.info("Generating UC roles and bucket permission info")

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -159,16 +159,12 @@ def validate_external_locations(w: WorkspaceClient, prompts: Prompts):
 @ucx.command
 def ensure_assessment_run(w: WorkspaceClient, run_as_collection: bool = False, a: AccountClient | None = None):
     """ensure the assessment job was run on a workspace"""
-    if run_as_collection:
-        if not a:
-            a = AccountClient(product='ucx', product_version=__version__)
-        account_installer = AccountInstaller(a)
-        workspaces_context = account_installer.get_workspace_contexts(w.get_workspace_id())
-        # if running the cmd as a collection, dont wait for each assessment job to finish as that will take long time
-        skip_job_status = True
-    else:
-        skip_job_status = False
-        workspaces_context = [WorkspaceContext(w)]
+    if not a:
+        a = AccountClient(product='ucx', product_version=__version__)
+    account_installer = AccountInstaller(a)
+    workspaces_context = account_installer.get_workspace_contexts(w, run_as_collection)
+    # if running the cmd as a collection, don't wait for each assessment job to finish as that will take long time
+    skip_job_status = bool(run_as_collection)
     for ctx in workspaces_context:
         logger.info(f"Running cmd for workspace {ctx.workspace_client.get_workspace_id()}")
         deployed_workflows = ctx.deployed_workflows
@@ -292,21 +288,34 @@ def create_uber_principal(
 
 
 @ucx.command
-def principal_prefix_access(w: WorkspaceClient, ctx: WorkspaceContext | None = None, **named_parameters):
+def principal_prefix_access(
+    w: WorkspaceClient,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+    **named_parameters,
+):
     """For azure cloud, identifies all storage accounts used by tables in the workspace, identify spn and its
     permission on each storage accounts. For aws, identifies all the Instance Profiles configured in the workspace and
     its access to all the S3 buckets, along with AWS roles that are set with UC access and its access to S3 buckets.
     The output is stored in the workspace install folder.
     Pass subscription_id for azure and aws_profile for aws."""
-    if not ctx:
-        ctx = WorkspaceContext(w, named_parameters)
-    if ctx.is_azure:
-        return ctx.azure_resource_permissions.save_spn_permissions()
-    if ctx.is_aws:
-        instance_role_path = ctx.aws_resource_permissions.save_instance_profile_permissions()
-        logger.info(f"Instance profile and bucket info saved {instance_role_path}")
-        logger.info("Generating UC roles and bucket permission info")
-        return ctx.aws_resource_permissions.save_uc_compatible_roles()
+
+    if not a:
+        a = AccountClient(product='ucx', product_version=__version__)
+    account_installer = AccountInstaller(a)
+    workspaces_context = account_installer.get_workspace_contexts(w, run_as_collection, **named_parameters)
+    if ctx:
+        workspaces_context = [ctx]
+    if w.config.is_azure:
+        for workspace_ctx in workspaces_context:
+            workspace_ctx.azure_resource_permissions.save_spn_permissions()
+    if w.config.is_aws:
+        for workspace_ctx in workspaces_context:
+            instance_role_path = workspace_ctx.aws_resource_permissions.save_instance_profile_permissions()
+            logger.info(f"Instance profile and bucket info saved {instance_role_path}")
+            logger.info("Generating UC roles and bucket permission info")
+            workspace_ctx.aws_resource_permissions.save_uc_compatible_roles()
     raise ValueError("Unsupported cloud provider")
 
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -780,13 +780,9 @@ class AccountInstaller(AccountContext):
             return [WorkspaceContext(ws, named_parameters)]
         other_workspace_id = ws.get_workspace_id()
         workspace_contexts = []
-        print(other_workspace_id)
         account_client = self._get_safe_account_client()
         acct_ctx = AccountContext(account_client)
-        print("test")
-        print("sdsd")
         collection_workspace = account_client.workspaces.get(workspace_id=other_workspace_id)
-        print('enter')
         if not acct_ctx.account_workspaces.can_administer(collection_workspace):
             logger.error(f"User is not workspace admin of collection workspace {other_workspace_id}")
             return []

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -775,13 +775,18 @@ class AccountInstaller(AccountContext):
     def get_workspace_contexts(
         self, ws: WorkspaceClient, run_as_collection: bool, **named_parameters
     ) -> list[WorkspaceContext]:
+
         if not run_as_collection:
             return [WorkspaceContext(ws, named_parameters)]
         other_workspace_id = ws.get_workspace_id()
         workspace_contexts = []
+        print(other_workspace_id)
         account_client = self._get_safe_account_client()
         acct_ctx = AccountContext(account_client)
-        collection_workspace = account_client.workspaces.get(other_workspace_id)
+        print("test")
+        print("sdsd")
+        collection_workspace = account_client.workspaces.get(workspace_id=other_workspace_id)
+        print('enter')
         if not acct_ctx.account_workspaces.can_administer(collection_workspace):
             logger.error(f"User is not workspace admin of collection workspace {other_workspace_id}")
             return []

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -772,7 +772,12 @@ class AccountInstaller(AccountContext):
         # upload the json dump of workspace info in the .ucx folder
         ctx.account_workspaces.sync_workspace_info(installed_workspaces)
 
-    def get_workspace_contexts(self, other_workspace_id: int) -> list[WorkspaceContext]:
+    def get_workspace_contexts(
+        self, ws: WorkspaceClient, run_as_collection: bool, **named_parameters
+    ) -> list[WorkspaceContext]:
+        if not run_as_collection:
+            return [WorkspaceContext(ws, named_parameters)]
+        other_workspace_id = ws.get_workspace_id()
         workspace_contexts = []
         account_client = self._get_safe_account_client()
         acct_ctx = AccountContext(account_client)
@@ -790,7 +795,7 @@ class AccountInstaller(AccountContext):
                 logger.error(f"User is not workspace admin of workspace {workspace_id}")
                 return []
             workspace_client = account_client.get_workspace_client(workspace)
-            ctx = WorkspaceContext(workspace_client)
+            ctx = WorkspaceContext(workspace_client, named_parameters)
             workspace_contexts.append(ctx)
         return workspace_contexts
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -171,6 +171,7 @@ def mock_workspace_client(
     ws.pipelines.list_pipelines.return_value = _id_list(PipelineStateInfo, pipeline_ids)
     ws.pipelines.get = _pipeline
     ws.workspace.get_status = lambda _: ObjectInfo(object_id=123)
+    ws.get_workspace_id.return_value = 123
     ws.jobs.list.return_value = _id_list(BaseJob, job_ids)
     ws.jobs.list_runs.return_value = _id_list(BaseRun, jobruns_ids)
     ws.warehouses.get_workspace_warehouse_config().data_access_config = _load_list(EndpointConfPair, warehouse_config)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -331,7 +331,7 @@ def test_save_storage_and_principal_azure(ws, caplog, acc_client):
     azure_resource_permissions = create_autospec(AzureResourcePermissions)
     ws.config.is_azure = True
     ws.config.is_aws = False
-    ctx = WorkspaceContext(ws).replace(is_azure=True, azure_resource_permissions=azure_resource_permissions)
+    ctx = WorkspaceContext(ws).replace(azure_resource_permissions=azure_resource_permissions)
     principal_prefix_access(ws, ctx, False, a=acc_client)
     azure_resource_permissions.save_spn_permissions.assert_called_once()
 
@@ -341,10 +341,12 @@ def test_validate_groups_membership(ws):
     ws.groups.list.assert_called()
 
 
-def test_save_storage_and_principal_aws(ws):
+def test_save_storage_and_principal_aws(ws, acc_client):
     aws_resource_permissions = create_autospec(AWSResourcePermissions)
-    ctx = WorkspaceContext(ws).replace(is_aws=True, is_azure=False, aws_resource_permissions=aws_resource_permissions)
-    principal_prefix_access(ws, ctx=ctx)
+    ws.config.is_azure = False
+    ws.config.is_aws = True
+    ctx = WorkspaceContext(ws).replace(aws_resource_permissions=aws_resource_permissions)
+    principal_prefix_access(ws, ctx=ctx, a=acc_client)
     aws_resource_permissions.save_instance_profile_permissions.assert_called_once()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -216,13 +216,11 @@ def test_validate_external_locations(ws):
     ws.statement_execution.execute_statement.assert_called()
 
 
-def test_ensure_assessment_run(ws):
+def test_ensure_assessment_run(ws, acc_client):
     ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
         state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000
     )
-
-    ensure_assessment_run(ws)
-
+    ensure_assessment_run(ws, a=acc_client)
     ws.jobs.list_runs.assert_called_once()
     ws.jobs.wait_get_run_job_terminated_or_skipped.assert_called_once()
 
@@ -326,13 +324,15 @@ def test_save_storage_and_principal_azure_no_azure_cli(ws):
     ws.config.is_azure = True
     ctx = WorkspaceContext(ws)
     with pytest.raises(ValueError):
-        principal_prefix_access(ws, ctx=ctx)
+        principal_prefix_access(ws, ctx, False)
 
 
-def test_save_storage_and_principal_azure(ws, caplog):
+def test_save_storage_and_principal_azure(ws, caplog, acc_client):
     azure_resource_permissions = create_autospec(AzureResourcePermissions)
+    ws.config.is_azure = True
+    ws.config.is_aws = False
     ctx = WorkspaceContext(ws).replace(is_azure=True, azure_resource_permissions=azure_resource_permissions)
-    principal_prefix_access(ws, ctx=ctx)
+    principal_prefix_access(ws, ctx, False, a=acc_client)
     azure_resource_permissions.save_spn_permissions.assert_called_once()
 
 

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -143,7 +143,7 @@ def test_get_workspaces_context_not_collection_admin(caplog):
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_installer = AccountInstaller(account_client)
-    workspaces_ctx = account_installer.get_workspace_contexts(123)
+    workspaces_ctx = account_installer.get_workspace_contexts(ws, True)
     assert len(workspaces_ctx) == 0
     assert 'User is not workspace admin of collection workspace 123' in caplog.text
 
@@ -167,7 +167,7 @@ def test_get_workspaces_context_empty_collection(caplog):
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_installer = AccountInstaller(account_client)
-    workspaces_ctx = account_installer.get_workspace_contexts(123)
+    workspaces_ctx = account_installer.get_workspace_contexts(ws, True)
     assert len(workspaces_ctx) == 0
     assert 'No collection info found in the workspace 123' in caplog.text
 
@@ -183,7 +183,7 @@ def test_get_workspaces_context_not_workspace_admin(caplog):
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_installer = AccountInstaller(account_client)
-    workspaces_ctx = account_installer.get_workspace_contexts(123)
+    workspaces_ctx = account_installer.get_workspace_contexts(ws, True)
     assert len(workspaces_ctx) == 0
     assert 'User is not workspace admin of workspace 456' in caplog.text
 
@@ -193,5 +193,5 @@ def test_get_workspaces_context():
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_installer = AccountInstaller(account_client)
-    workspaces_ctx = account_installer.get_workspace_contexts(123)
+    workspaces_ctx = account_installer.get_workspace_contexts(ws, True)
     assert len(workspaces_ctx) == 2


### PR DESCRIPTION
## Changes
This PR enables principal-prefix-access to run as a collection. It also wraps common functionalities into get_workspace_context function.

https://github.com/user-attachments/assets/a82eecb7-50b9-4afe-832a-979bd641bdf1


### Linked issues
#1782 