### PR TITLE
Fix issue when running create-missing-credential cmd tries to create the role again if already created

### DIFF
--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -61,6 +61,8 @@ class AWSResourcePermissions:
         """
         roles: list[AWSUCRoleCandidate] = []
         missing_paths = self._identify_missing_paths()
+        if len(missing_paths) == 0:
+            return []
         s3_buckets = set()
         for missing_path in missing_paths:
             match = re.match(AWSResources.S3_BUCKET, missing_path)
@@ -192,10 +194,9 @@ class AWSResourcePermissions:
         compatible_roles = self.load_uc_compatible_roles()
         missing_paths = set()
         for external_location in external_locations:
-            path = PurePath(external_location.location)
             matching_role = False
             for role in compatible_roles:
-                if path.match(role.resource_path):
+                if external_location.location.startswith(role.resource_path):
                     matching_role = True
                     continue
             if matching_role:

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -54,7 +54,7 @@ def installation_single_role():
                     "role_arn": "arn:aws:iam::12345:role/uc-role1",
                     "resource_type": "s3",
                     "privilege": "WRITE_FILES",
-                    "resource_path": "s3://BUCKETX/*",
+                    "resource_path": "s3://BUCKETX",
                 }
             ]
         }


### PR DESCRIPTION
## Changes
When running create-missing-credential, code is trying to match locations with uc_roles_access.csv entries.
If a role is already created, running the command tries the create the role again. due to the line of code here
path = PurePath(external_location.location)
            matching_role = False
            for role in compatible_roles:
                if path.match(role.resource_path):

Ex:
path = PurePath(“s3://labs-things/a/b/”)
path.match(“s3://labs-things”)
the above code returns False, when it should be True due to which its trying to create the role again.

changed it to use location.startswith()

#2336 

Resolves #2413 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
