### PR TITLE
Appends metastore_id or location_name to roles for uniqueness

### DIFF
--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -69,12 +69,12 @@ class AWSResourcePermissions:
             if match:
                 s3_buckets.add(match.group(1))
         if single_role:
-            role_name = self._generate_role_name(single_role, role_name, "")
-            roles.append(AWSUCRoleCandidate(role_name, policy_name, list(s3_buckets)))
+            roles.append(AWSUCRoleCandidate(self._generate_role_name(single_role, role_name, ""),
+                                            policy_name, list(s3_buckets)))
         else:
             for s3_prefix in list(s3_buckets):
-                role_name = self._generate_role_name(single_role, role_name, s3_prefix)
-                roles.append(AWSUCRoleCandidate(role_name, policy_name, [s3_prefix]))
+                roles.append(AWSUCRoleCandidate(self._generate_role_name(single_role, role_name, s3_prefix),
+                                                policy_name, [s3_prefix]))
         return roles
 
     def create_uc_roles(self, roles: list[AWSUCRoleCandidate]):

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -69,12 +69,16 @@ class AWSResourcePermissions:
             if match:
                 s3_buckets.add(match.group(1))
         if single_role:
-            roles.append(AWSUCRoleCandidate(self._generate_role_name(single_role, role_name, ""),
-                                            policy_name, list(s3_buckets)))
+            roles.append(
+                AWSUCRoleCandidate(self._generate_role_name(single_role, role_name, ""), policy_name, list(s3_buckets))
+            )
         else:
             for s3_prefix in list(s3_buckets):
-                roles.append(AWSUCRoleCandidate(self._generate_role_name(single_role, role_name, s3_prefix),
-                                                policy_name, [s3_prefix]))
+                roles.append(
+                    AWSUCRoleCandidate(
+                        self._generate_role_name(single_role, role_name, s3_prefix), policy_name, [s3_prefix]
+                    )
+                )
         return roles
 
     def create_uc_roles(self, roles: list[AWSUCRoleCandidate]):

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -212,6 +212,7 @@ class IamRoleCreation:
 
     def run(self, prompts: Prompts, *, single_role=False, role_name="UC_ROLE", policy_name="UC_POLICY"):
 
+        role_name = self._generate_role_name(role_name)
         iam_list = self._resource_permissions.list_uc_roles(
             single_role=single_role,
             role_name=role_name,
@@ -230,3 +231,7 @@ class IamRoleCreation:
 
         self._resource_permissions.create_uc_roles(iam_list)
         self._resource_permissions.save_uc_compatible_roles()
+
+    def _generate_role_name(self, role_name: str, rand: str) -> str:
+        return f"{role_name}_{self._ws.metastore['metastore_id']}"
+

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -233,5 +233,5 @@ class IamRoleCreation:
         self._resource_permissions.save_uc_compatible_roles()
 
     def _generate_role_name(self, role_name: str) -> str:
-        metastore_id = self._ws.metastores.current().metastore_id
-        return f"{role_name}_{self._ws.metastores.get(metastore_id).name}"
+        metastore_id = self._ws.metastores.current().as_dict()["metastore_id"]
+        return f"{role_name}_{metastore_id}"

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -212,7 +212,6 @@ class IamRoleCreation:
 
     def run(self, prompts: Prompts, *, single_role=False, role_name="UC_ROLE", policy_name="UC_POLICY"):
 
-        role_name = self._generate_role_name(role_name)
         iam_list = self._resource_permissions.list_uc_roles(
             single_role=single_role,
             role_name=role_name,
@@ -231,7 +230,3 @@ class IamRoleCreation:
 
         self._resource_permissions.create_uc_roles(iam_list)
         self._resource_permissions.save_uc_compatible_roles()
-
-    def _generate_role_name(self, role_name: str) -> str:
-        metastore_id = self._ws.metastores.current().as_dict()["metastore_id"]
-        return f"{role_name}_{metastore_id}"

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -233,4 +233,5 @@ class IamRoleCreation:
         self._resource_permissions.save_uc_compatible_roles()
 
     def _generate_role_name(self, role_name: str) -> str:
-        return f"{role_name}_{self._ws.metastores.current().metastore_id}"
+        metastore_id = self._ws.metastores.current().metastore_id
+        return f"{role_name}_{self._ws.metastores.get(metastore_id).name}"

--- a/src/databricks/labs/ucx/aws/credentials.py
+++ b/src/databricks/labs/ucx/aws/credentials.py
@@ -232,6 +232,5 @@ class IamRoleCreation:
         self._resource_permissions.create_uc_roles(iam_list)
         self._resource_permissions.save_uc_compatible_roles()
 
-    def _generate_role_name(self, role_name: str, rand: str) -> str:
-        return f"{role_name}_{self._ws.metastore['metastore_id']}"
-
+    def _generate_role_name(self, role_name: str) -> str:
+        return f"{role_name}_{self._ws.metastores.current().metastore_id}"

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -21,12 +21,13 @@ def test_create_external_location(ws, env_or_skip, make_random, inventory_schema
     sql_backend.save_table(
         f"{inventory_schema}.external_locations",
         [ExternalLocation(f"s3://bucket{rand}/FOLDER1", 1), ExternalLocation(f"s3://bucket{rand}/FOLDER2", 1)],
+        ExternalLocation
     )
     aws = AWSResources(profile)
     role_name = f"UCX_ROLE_{rand}"
     policy_name = f"UCX_POLICY_{rand}"
     account_id = aws.validate_connection().get("Account")
-    s3_prefixes = {f"bucket{rand}"}
+    s3_prefixes = {f"s3://bucket{rand}"}
     aws.create_uc_role(role_name)
     aws.put_role_policy(role_name, policy_name, s3_prefixes, account_id)
     ws.storage_credentials.create(
@@ -87,6 +88,7 @@ def test_create_uber_instance_profile(
             {
                 "Do you want to create new migration role*": "yes",
                 "We have identified existing UCX migration role*": "yes",
+                ".*": "no"
             }
         )
     )

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -21,7 +21,7 @@ def test_create_external_location(ws, env_or_skip, make_random, inventory_schema
     sql_backend.save_table(
         f"{inventory_schema}.external_locations",
         [ExternalLocation(f"s3://bucket{rand}/FOLDER1", 1), ExternalLocation(f"s3://bucket{rand}/FOLDER2", 1)],
-        ExternalLocation
+        ExternalLocation,
     )
     aws = AWSResources(profile)
     role_name = f"UCX_ROLE_{rand}"
@@ -88,7 +88,7 @@ def test_create_uber_instance_profile(
             {
                 "Do you want to create new migration role*": "yes",
                 "We have identified existing UCX migration role*": "yes",
-                ".*": "no"
+                ".*": "no",
             }
         )
     )

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -350,6 +350,7 @@ def test_create_uber_principal_no_storage(mock_ws, mock_installation, locations)
 
 
 def test_create_uc_role_single(mock_ws, installation_single_role, backend, locations):
+    mock_ws.metastores.current.as_dict.return_value = {"metastore_id": "12345"}
     aws = create_autospec(AWSResources)
     aws.validate_connection.return_value = {}
     aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, aws, locations)

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -9,7 +9,8 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import ResourceDoesNotExist
 from databricks.sdk.service import iam
-from databricks.sdk.service.catalog import AwsIamRoleResponse, ExternalLocationInfo, StorageCredentialInfo
+from databricks.sdk.service.catalog import AwsIamRoleResponse, ExternalLocationInfo, StorageCredentialInfo, \
+    MetastoreAssignment
 from databricks.sdk.service.compute import InstanceProfile, Policy
 from databricks.sdk.service.sql import (
     EndpointConfPair,
@@ -350,7 +351,7 @@ def test_create_uber_principal_no_storage(mock_ws, mock_installation, locations)
 
 
 def test_create_uc_role_single(mock_ws, installation_single_role, backend, locations):
-    mock_ws.metastores.current.as_dict.return_value = {"metastore_id": "12345"}
+    mock_ws.metastores.current.return_value = MetastoreAssignment(metastore_id="123123", workspace_id="456456")
     aws = create_autospec(AWSResources)
     aws.validate_connection.return_value = {}
     aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, aws, locations)
@@ -359,7 +360,7 @@ def test_create_uc_role_single(mock_ws, installation_single_role, backend, locat
     role_creation.run(MockPrompts({"Above *": "yes"}), single_role=True)
     assert aws.create_uc_role.assert_called
     assert (
-        call('UC_ROLE', 'UC_POLICY', {'s3://BUCKET1', 's3://BUCKET1/*', 's3://BUCKET2', 's3://BUCKET2/*'}, None, None)
+        call('UC_ROLE_123123', 'UC_POLICY', {'s3://BUCKET1', 's3://BUCKET1/*', 's3://BUCKET2', 's3://BUCKET2/*'}, None, None)
         in aws.put_role_policy.call_args_list
     )
 

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -371,14 +371,14 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
     role_creation = IamRoleCreation(installation_single_role, mock_ws, aws_resource_permissions)
     aws.list_all_uc_roles.return_value = []
     role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
-    assert call('UC_ROLE_1') in aws.create_uc_role.call_args_list
-    assert call('UC_ROLE_2') in aws.create_uc_role.call_args_list
+    assert call('UC_ROLE_BUCKET1') in aws.create_uc_role.call_args_list
+    assert call('UC_ROLE_BUCKET2') in aws.create_uc_role.call_args_list
     assert (
-        call('UC_ROLE_1', 'UC_POLICY', {'s3://BUCKET1/*', 's3://BUCKET1'}, None, None)
+        call('UC_ROLE_BUCKET1', 'UC_POLICY', {'s3://BUCKET1/*', 's3://BUCKET1'}, None, None)
         in aws.put_role_policy.call_args_list
     )
     assert (
-        call('UC_ROLE_2', 'UC_POLICY', {'s3://BUCKET2/*', 's3://BUCKET2'}, None, None)
+        call('UC_ROLE_BUCKET2', 'UC_POLICY', {'s3://BUCKET2/*', 's3://BUCKET2'}, None, None)
         in aws.put_role_policy.call_args_list
     )
 

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -9,8 +9,12 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import ResourceDoesNotExist
 from databricks.sdk.service import iam
-from databricks.sdk.service.catalog import AwsIamRoleResponse, ExternalLocationInfo, StorageCredentialInfo, \
-    MetastoreAssignment
+from databricks.sdk.service.catalog import (
+    AwsIamRoleResponse,
+    ExternalLocationInfo,
+    StorageCredentialInfo,
+    MetastoreAssignment,
+)
 from databricks.sdk.service.compute import InstanceProfile, Policy
 from databricks.sdk.service.sql import (
     EndpointConfPair,
@@ -360,7 +364,13 @@ def test_create_uc_role_single(mock_ws, installation_single_role, backend, locat
     role_creation.run(MockPrompts({"Above *": "yes"}), single_role=True)
     assert aws.create_uc_role.assert_called
     assert (
-        call('UC_ROLE_123123', 'UC_POLICY', {'s3://BUCKET1', 's3://BUCKET1/*', 's3://BUCKET2', 's3://BUCKET2/*'}, None, None)
+        call(
+            'UC_ROLE_123123',
+            'UC_POLICY',
+            {'s3://BUCKET1', 's3://BUCKET1/*', 's3://BUCKET2', 's3://BUCKET2/*'},
+            None,
+            None,
+        )
         in aws.put_role_policy.call_args_list
     )
 


### PR DESCRIPTION
## Changes
create-missing-principals does not enforce role uniqueness on AWS. Add a method to generate role name.

### Linked issues

Resolves #2336

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
