### PR TITLE
Changes the security mode for assessment cluster

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -727,7 +727,7 @@ class WorkflowsDeployment(InstallationMixin):
                 jobs.JobCluster(
                     job_cluster_key="main",
                     new_cluster=compute.ClusterSpec(
-                        data_security_mode=compute.DataSecurityMode.LEGACY_SINGLE_USER,
+                        data_security_mode=compute.DataSecurityMode.LEGACY_SINGLE_USER_STANDARD,
                         spark_conf=self._job_cluster_spark_conf("main"),
                         custom_tags={"ResourceClass": "SingleNode"},
                         num_workers=0,


### PR DESCRIPTION
## Changes
Changes the security mode of the assessment 'main' cluster.
LEGACY_SINGLE_USER_STANDARD does not have passthrough enabled.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1717 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
