### PR TITLE
Fix Driver OOM error by increasing the min memory requirement for node from 16GB to 32 GB

### DIFF
--- a/src/databricks/labs/ucx/installer/policy.py
+++ b/src/databricks/labs/ucx/installer/policy.py
@@ -107,7 +107,7 @@ class ClusterPolicyInstaller:
 
     def _definition(self, conf: dict, instance_profile: str | None, instance_pool_id: str | None) -> str:
         latest_lts_dbr = self._ws.clusters.select_spark_version(latest=True)
-        node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
+        node_type_id = self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=32)
         policy_definition = {
             "spark_version": self._policy_config(latest_lts_dbr),
             "node_type_id": self._policy_config(node_type_id),


### PR DESCRIPTION
## Changes
This PR increases the min memory of the workflow job from 16GB to 32GB, this is to avoid driver crashes during assessment run

Resolves #2398 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
