### PR TITLE
Make lint log references clickable

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -112,7 +112,7 @@ class LocatedAdvice:
         if default is not None:
             path = default
         path = path.relative_to(base)
-        return f"[{path.as_posix()}]:{advice.start_line}:{advice.start_col}: [{advice.code}] {advice.message}"
+        return f"./{path.as_posix()}:{advice.start_line}:{advice.start_col}: [{advice.code}] {advice.message}"
 
 
 class Advisory(Advice):

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -112,7 +112,7 @@ class LocatedAdvice:
         if default is not None:
             path = default
         path = path.relative_to(base)
-        return f"{path.as_posix()}:{advice.start_line}:{advice.start_col}: [{advice.code}] {advice.message}"
+        return f"[{path.as_posix()}]:{advice.start_line}:{advice.start_col}: [{advice.code}] {advice.message}"
 
 
 class Advisory(Advice):


### PR DESCRIPTION
closes #2408 
Before:
<img width="1462" alt="Screenshot 2024-08-22 at 9 20 46 AM" src="https://github.com/user-attachments/assets/8d933545-a682-479f-9a92-0080279ac47e">
After:
<img width="1149" alt="Screenshot 2024-08-22 at 11 27 58 AM" src="https://github.com/user-attachments/assets/2cb4b039-9e4f-459b-9c9e-61e1e3d4aaa7">
