### PR TITLE
Fix issue with Interactive Dashboard not showing output

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/interactive/01_0_compute_access_mode_limitation_summary.sql
+++ b/src/databricks/labs/ucx/queries/assessment/interactive/01_0_compute_access_mode_limitation_summary.sql
@@ -2,8 +2,8 @@
 WITH iteractive_cluster_commands AS (
   SELECT
     a.event_id,
-    a.request_params.notebookid AS notebook_id,
-    a.request_params.clusterid AS cluster_id,
+    a.request_params.notebookId AS notebook_id,
+    a.request_params.clusterId AS cluster_id,
     a.workspace_id,
     a.user_identity.email,
     TRY_CAST(SPLIT(c.spark_version, '[\\.-]')[0] AS INT) AS dbr_version_major,
@@ -14,7 +14,7 @@ WITH iteractive_cluster_commands AS (
     MD5(a.request_params.commandtext) AS commandhash
   FROM system.access.audit AS a
   LEFT OUTER JOIN inventory.clusters AS c
-    ON a.request_params.clusterid = c.cluster_id AND a.action_name = 'runCommand'
+    ON a.request_params.clusterId = c.cluster_id AND a.action_name = 'runCommand'
   WHERE
     a.event_date >= DATEADD(DAY, 90 * -1, CURRENT_DATE)
 ), misc_patterns AS (

--- a/src/databricks/labs/ucx/queries/assessment/interactive/03_0_cluster_summary.sql
+++ b/src/databricks/labs/ucx/queries/assessment/interactive/03_0_cluster_summary.sql
@@ -2,8 +2,8 @@
 WITH iteractive_cluster_commands AS (
   SELECT
     a.event_id,
-    a.request_params.notebookid AS notebook_id,
-    a.request_params.clusterid AS cluster_id,
+    a.request_params.notebookId AS notebook_id,
+    a.request_params.clusterId AS cluster_id,
     a.workspace_id,
     a.user_identity.email,
     TRY_CAST(SPLIT(c.spark_version, '[\\.-]')[0] AS INT) AS dbr_version_major,
@@ -18,7 +18,7 @@ WITH iteractive_cluster_commands AS (
     a.event_date
   FROM system.access.audit AS a
   LEFT OUTER JOIN inventory.clusters AS c
-    ON a.request_params.clusterid = c.cluster_id AND a.action_name = 'runCommand'
+    ON a.request_params.clusterId = c.cluster_id AND a.action_name = 'runCommand'
   WHERE
     a.event_date >= DATEADD(DAY, 90 * -1, CURRENT_DATE)
 ), misc_patterns AS (


### PR DESCRIPTION
## Changes
Interactive dashboard query has a bug where it is joining on 
FROM system.access.audit AS a
  LEFT OUTER JOIN inventory.clusters AS c
    ON a.request_params.clusterid = c.cluster_id AND a.action_name = 'runCommand'
There is no field request_params.clusterid but there is field request_params.clusterId

same in the select clause 
a.request_params.notebookid AS notebook_id,
    a.request_params.clusterid AS cluster_id,

needs to be changed to 

a.request_params.notebookId AS notebook_id,
    a.request_params.clusterId AS cluster_id,

Resolves #2475 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
