### PR TITLE
Increases min memory for job cluster fixtures

### DIFF
--- a/src/databricks/labs/ucx/mixins/fixtures.py
+++ b/src/databricks/labs/ucx/mixins/fixtures.py
@@ -807,7 +807,7 @@ def make_job(ws, make_random, make_notebook):
                     description=make_random(4),
                     new_cluster=compute.ClusterSpec(
                         num_workers=1,
-                        node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
+                        node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=32),
                         spark_version=ws.clusters.select_spark_version(latest=True),
                         spark_conf=task_spark_conf,
                     ),


### PR DESCRIPTION
## Changes
Mismatch in job cluster memory
<img width="379" alt="Standard_E4as_v4" src="https://github.com/user-attachments/assets/8bec81ea-4875-4d7e-811b-030b29d4b4be">
<img width="377" alt="Standard_D4s_v3" src="https://github.com/user-attachments/assets/1c1eab56-8bab-4341-9e7e-d0e01b9ebeee">

Increasing memory in the fixtures for failing integration tests

### Linked issues
Resolves #2478 

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
