### PR TITLE
Implement dependency graph walker

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -591,7 +591,7 @@ class DependencyGraphWalker(abc.ABC, Generic[T]):
 
     def __init__(self, graph: DependencyGraph, walked_paths: set[Path] | None, path_lookup: PathLookup):
         self._graph = graph
-        self._walked_paths: set[Path] = walked_paths or set()
+        self._walked_paths: set[Path] = set() if walked_paths is None else walked_paths
         self._path_lookup = path_lookup
 
     def walk(self) -> Iterable[T]:

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -4,7 +4,8 @@ import abc
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import TypeVar, Generic
 
 from astroid import (  # type: ignore
     NodeNG,
@@ -581,3 +582,43 @@ class InheritedContext:
             return self
         tree = self._tree.renumber(-1)
         return InheritedContext(tree, self.found)
+
+
+T = TypeVar("T")
+
+
+class DependencyGraphWalker(abc.ABC, Generic[T]):
+
+    def __init__(self, graph: DependencyGraph, walked_paths: set[Path] | None, path_lookup: PathLookup):
+        self._graph = graph
+        self._walked_paths: set[Path] = walked_paths or set()
+        self._path_lookup = path_lookup
+
+    def walk(self) -> Iterable[T]:
+        for dependency in self._graph.root_dependencies:
+            root_path = dependency.path  # since it's a root
+            yield from self._walk_one(dependency, self._graph, root_path)
+
+    def _walk_one(self, dependency: Dependency, graph: DependencyGraph, root_path: Path) -> Iterable[T]:
+        if dependency.path in self._walked_paths:
+            return
+        self._walked_paths.add(dependency.path)
+        self._log_walk_one(dependency)
+        if dependency.path.is_file() or is_a_notebook(dependency.path):
+            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
+            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
+            yield from self._process_dependency(dependency, path_lookup, inherited_tree)
+            maybe_graph = graph.locate_dependency(dependency.path)
+            # missing graph problems have already been reported while building the graph
+            if maybe_graph.graph:
+                child_graph = maybe_graph.graph
+                for child_dependency in child_graph.local_dependencies:
+                    yield from self._walk_one(child_dependency, child_graph, root_path)
+
+    def _log_walk_one(self, dependency: Dependency):
+        logger.info(f'Analyzing dependency: {dependency}')
+
+    @abc.abstractmethod
+    def _process_dependency(
+        self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+    ) -> Iterable[T]: ...

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -391,9 +391,9 @@ class WorkflowLinter:
         return problems
 
     def _lint_task(self, task: jobs.Task, job: jobs.Job, linted_paths: set[Path]) -> Iterable[LocatedAdvice]:
-        start_dep: Dependency = WorkflowTask(self._ws, task, job)
+        root_dependency: Dependency = WorkflowTask(self._ws, task, job)
         # we can load it without further preparation since the WorkflowTask is merely a wrapper
-        container = start_dep.load(self._path_lookup)
+        container = root_dependency.load(self._path_lookup)
         assert isinstance(container, WorkflowTaskContainer)
         session_state = CurrentSessionState(
             data_security_mode=container.data_security_mode,
@@ -401,28 +401,43 @@ class WorkflowLinter:
             spark_conf=container.spark_conf,
             dbr_version=container.runtime_version,
         )
-        graph = DependencyGraph(start_dep, None, self._resolver, self._path_lookup, session_state)
+        graph = DependencyGraph(root_dependency, None, self._resolver, self._path_lookup, session_state)
         problems = container.build_dependency_graph(graph)
         if problems:
             for problem in problems:
                 source_path = self._UNKNOWN if problem.is_path_missing() else problem.source_path
                 yield LocatedAdvice(problem.as_advisory(), source_path)
             return
-        migration_index = self._migration_index
+        walker = LintingWalker(
+            graph, linted_paths, self._path_lookup, task.task_key, session_state, self._migration_index
+        )
+        yield from walker
 
-        class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
 
-            def _log_walk_one(self, dependency: Dependency):
-                logger.info(f'Linting {task.task_key} dependency: {dependency}')
+class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
 
-            def _process_dependency(
-                self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
-            ) -> Iterable[LocatedAdvice]:
-                ctx = LinterContext(migration_index, session_state)
-                # FileLinter determines which file/notebook linter to use
-                linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
-                for advice in linter.lint():
-                    yield LocatedAdvice(advice, dependency.path)
+    def __init__(
+        self,
+        graph: DependencyGraph,
+        linted_paths: set[Path],
+        path_lookup: PathLookup,
+        key: str,
+        session_state: CurrentSessionState,
+        migration_index: MigrationIndex,
+    ):
+        super().__init__(graph, linted_paths, path_lookup)
+        self._key = key
+        self._session_state = session_state
+        self._migration_index = migration_index
 
-        walker = LintingWalker(graph, linted_paths, self._path_lookup)
-        yield from walker.walk()
+    def _log_walk_one(self, dependency: Dependency):
+        logger.info(f'Linting {self._key} dependency: {dependency}')
+
+    def _process_dependency(
+        self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+    ) -> Iterable[LocatedAdvice]:
+        ctx = LinterContext(self._migration_index, self._session_state)
+        # FileLinter determines which file/notebook linter to use
+        linter = FileLinter(ctx, path_lookup, self._session_state, dependency.path, inherited_tree)
+        for advice in linter.lint():
+            yield LocatedAdvice(advice, dependency.path)

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -419,7 +419,7 @@ class WorkflowLinter:
                 self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
             ) -> Iterable[LocatedAdvice]:
                 ctx = LinterContext(migration_index, session_state)
-                # FileLinter will determine which file/notebook linter to use
+                # FileLinter determines which file/notebook linter to use
                 linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
                 for advice in linter.lint():
                     yield LocatedAdvice(advice, dependency.path)

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -19,7 +19,7 @@ from databricks.sdk.service import compute, jobs
 
 from databricks.labs.ucx.assessment.crawlers import runtime_version_tuple
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
-from databricks.labs.ucx.source_code.base import CurrentSessionState, is_a_notebook, LocatedAdvice
+from databricks.labs.ucx.source_code.base import CurrentSessionState, LocatedAdvice
 from databricks.labs.ucx.source_code.graph import (
     Dependency,
     DependencyGraph,
@@ -27,8 +27,10 @@ from databricks.labs.ucx.source_code.graph import (
     DependencyResolver,
     SourceContainer,
     WrappingLoader,
+    DependencyGraphWalker,
 )
 from databricks.labs.ucx.source_code.linters.context import LinterContext
+from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 
@@ -387,9 +389,9 @@ class WorkflowLinter:
         return problems
 
     def _lint_task(self, task: jobs.Task, job: jobs.Job, linted_paths: set[Path]) -> Iterable[LocatedAdvice]:
-        dependency: Dependency = WorkflowTask(self._ws, task, job)
+        start_dep: Dependency = WorkflowTask(self._ws, task, job)
         # we can load it without further preparation since the WorkflowTask is merely a wrapper
-        container = dependency.load(self._path_lookup)
+        container = start_dep.load(self._path_lookup)
         assert isinstance(container, WorkflowTaskContainer)
         session_state = CurrentSessionState(
             data_security_mode=container.data_security_mode,
@@ -397,41 +399,28 @@ class WorkflowLinter:
             spark_conf=container.spark_conf,
             dbr_version=container.runtime_version,
         )
-        graph = DependencyGraph(dependency, None, self._resolver, self._path_lookup, session_state)
+        graph = DependencyGraph(start_dep, None, self._resolver, self._path_lookup, session_state)
         problems = container.build_dependency_graph(graph)
         if problems:
             for problem in problems:
                 source_path = self._UNKNOWN if problem.is_path_missing() else problem.source_path
                 yield LocatedAdvice(problem.as_advisory(), source_path)
             return
-        for dependency in graph.root_dependencies:
-            root = dependency.path  # since it's a root
-            yield from self._lint_one(task, dependency, graph, root, session_state, linted_paths)
+        migration_index = self._migration_index
 
-    def _lint_one(
-        self,
-        task: jobs.Task,
-        dependency: Dependency,
-        graph: DependencyGraph,
-        root_path: Path,
-        session_state: CurrentSessionState,
-        linted_paths: set[Path],
-    ) -> Iterable[LocatedAdvice]:
-        if dependency.path in linted_paths:
-            return
-        linted_paths.add(dependency.path)
-        logger.info(f'Linting {task.task_key} dependency: {dependency}')
-        if dependency.path.is_file() or is_a_notebook(dependency.path):
-            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
-            ctx = LinterContext(self._migration_index, session_state)
-            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
-            # FileLinter will determine which file/notebook linter to use
-            linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
-            for advice in linter.lint():
-                yield LocatedAdvice(advice, dependency.path)
-        maybe_graph = graph.locate_dependency(dependency.path)
-        # problems have already been reported while building the graph
-        if maybe_graph.graph:
-            child_graph = maybe_graph.graph
-            for child_dependency in child_graph.local_dependencies:
-                yield from self._lint_one(task, child_dependency, child_graph, root_path, session_state, linted_paths)
+        class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
+
+            def _log_walk_one(self, dependency: Dependency):
+                logger.info(f'Linting {task.task_key} dependency: {dependency}')
+
+            def _process_dependency(
+                self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+            ) -> Iterable[LocatedAdvice]:
+                ctx = LinterContext(migration_index, session_state)
+                # FileLinter will determine which file/notebook linter to use
+                linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
+                for advice in linter.lint():
+                    yield LocatedAdvice(advice, dependency.path)
+
+        walker = LintingWalker(graph, linted_paths, self._path_lookup)
+        yield from walker.walk()

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -143,9 +143,9 @@ class LocalCodeLinter:
         is_dir = path.is_dir()
         loader = self._folder_loader if is_dir else self._file_loader
         path_lookup = self._path_lookup.change_directory(path if is_dir else path.parent)
-        start_dep = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
-        graph = DependencyGraph(start_dep, None, self._dependency_resolver, path_lookup, self._session_state)
-        container = start_dep.load(path_lookup)
+        root_dependency = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
+        graph = DependencyGraph(root_dependency, None, self._dependency_resolver, path_lookup, self._session_state)
+        container = root_dependency.load(path_lookup)
         assert container is not None  # because we just created it
         problems = container.build_dependency_graph(graph)
         for problem in problems:
@@ -165,8 +165,10 @@ class LocalCodeLinter:
                 for advice in linter.lint():
                     yield LocatedAdvice(advice, dependency.path)
 
+        if linted_paths is None:
+            linted_paths = set()
         walker = LintingWalker(graph, linted_paths, self._path_lookup)
-        yield from walker.walk()
+        yield from walker
 
 
 class LocalFileMigrator:

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -7,6 +7,7 @@ import sys
 from typing import TextIO
 
 from databricks.labs.ucx.source_code.base import LocatedAdvice, CurrentSessionState, file_language, is_a_notebook
+from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
@@ -27,6 +28,7 @@ from databricks.labs.ucx.source_code.graph import (
     SourceContainer,
     DependencyResolver,
     InheritedContext,
+    DependencyGraphWalker,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,40 +143,30 @@ class LocalCodeLinter:
         is_dir = path.is_dir()
         loader = self._folder_loader if is_dir else self._file_loader
         path_lookup = self._path_lookup.change_directory(path if is_dir else path.parent)
-        dependency = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
-        graph = DependencyGraph(dependency, None, self._dependency_resolver, path_lookup, self._session_state)
-        container = dependency.load(path_lookup)
+        start_dep = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
+        graph = DependencyGraph(start_dep, None, self._dependency_resolver, path_lookup, self._session_state)
+        container = start_dep.load(path_lookup)
         assert container is not None  # because we just created it
         problems = container.build_dependency_graph(graph)
         for problem in problems:
             problem_path = Path('UNKNOWN') if problem.is_path_missing() else problem.source_path.absolute()
             yield problem.as_advisory().for_path(problem_path)
-        if linted_paths is None:
-            linted_paths = set()
-        for dependency in graph.root_dependencies:
-            root = dependency.path  # since it's a root
-            yield from self._lint_one(dependency, graph, root, linted_paths)
+        context_factory = self._context_factory
+        session_state = self._session_state
 
-    def _lint_one(
-        self, dependency: Dependency, graph: DependencyGraph, root_path: Path, linted_paths: set[Path]
-    ) -> Iterable[LocatedAdvice]:
-        if dependency.path in linted_paths:
-            return
-        linted_paths.add(dependency.path)
-        if dependency.path.is_file() or is_a_notebook(dependency.path):
-            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
-            ctx = self._context_factory()
-            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
-            # FileLinter will determine which file/notebook linter to use
-            linter = FileLinter(ctx, path_lookup, self._session_state, dependency.path, inherited_tree)
-            for advice in linter.lint():
-                yield advice.for_path(dependency.path)
-        maybe_graph = graph.locate_dependency(dependency.path)
-        # problems have already been reported while building the graph
-        if maybe_graph.graph:
-            child_graph = maybe_graph.graph
-            for child_dependency in child_graph.local_dependencies:
-                yield from self._lint_one(child_dependency, child_graph, root_path, linted_paths)
+        class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
+
+            def _process_dependency(
+                self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+            ) -> Iterable[LocatedAdvice]:
+                ctx = context_factory()
+                # FileLinter will determine which file/notebook linter to use
+                linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
+                for advice in linter.lint():
+                    yield LocatedAdvice(advice, dependency.path)
+
+        walker = LintingWalker(graph, linted_paths, self._path_lookup)
+        yield from walker.walk()
 
 
 class LocalFileMigrator:


### PR DESCRIPTION
## Changes
There is redundant code for walking a dependency graph 'properly' i.e. from roots to leaves, populating python globals etc...
This PR makes it trivial to reuse the correct code, and reuses it for local code linting and jobs linting.
This will also be used by #2371 

### Linked issues
None

### Functionality
None

### Tests
- [x] ran existing unit tests
