### PR TITLE
Refactor linters

### DIFF
--- a/src/databricks/labs/ucx/account/aggregate.py
+++ b/src/databricks/labs/ucx/account/aggregate.py
@@ -16,7 +16,7 @@ from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, 
 from databricks.labs.ucx.hive_metastore.locations import LocationTrie
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -81,7 +81,7 @@ class AccountAggregate:
                         )
                     ]
                 )
-                from_table = FromTable(stub_index, CurrentSessionState(schema=inventory_database))
+                from_table = FromTableSQLLinter(stub_index, CurrentSessionState(schema=inventory_database))
                 logger.info(f"Querying Schema {inventory_database}")
 
                 workspace_specific_query = from_table.apply(query)

--- a/src/databricks/labs/ucx/hive_metastore/view_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/view_migrate.py
@@ -9,7 +9,7 @@ from sqlglot import ParseError, expressions
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, TableView
 from databricks.labs.ucx.hive_metastore.mapping import TableToMigrate
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class ViewToMigrate(TableToMigrate):
         return aliases
 
     def sql_migrate_view(self, index: MigrationIndex) -> str:
-        from_table = FromTable(index, CurrentSessionState(self.src.database))
+        from_table = FromTableSQLLinter(index, CurrentSessionState(self.src.database))
         assert self.src.view_text is not None, 'Expected a view text'
         migrated_select = from_table.apply(self.src.view_text)
         statements = sqlglot.parse(migrated_select, read='databricks')

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -9,11 +9,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from astroid import AstroidSyntaxError, NodeNG  # type: ignore
-from databricks.labs.blueprint.paths import WorkspacePath
+from sqlglot import Expression, parse as parse_sql, ParseError as SqlParseError
 
 from databricks.sdk.service import compute
 from databricks.sdk.service.workspace import Language
 
+from databricks.labs.blueprint.paths import WorkspacePath
 from databricks.labs.ucx.source_code.linters.python_ast import Tree
 
 # Code mapping between LSP, PyLint, and our own diagnostics:
@@ -136,6 +137,35 @@ class Linter:
     def lint(self, code: str) -> Iterable[Advice]: ...
 
 
+class SQLLinter(Linter):
+
+    def lint(self, code: str) -> Iterable[Advice]:
+        try:
+            expressions = parse_sql(code, read='databricks')
+            for expression in expressions:
+                if not expression:
+                    continue
+                yield from self.lint_expression(expression)
+        except SqlParseError as e:
+            logger.debug(f"Failed to parse SQL: {code}", exc_info=e)
+            yield self.sql_parse_failure(code)
+
+    @staticmethod
+    def sql_parse_failure(code: str):
+        return Failure(
+            code='sql-parse-error',
+            message=f"SQL expression is not supported yet: {code}",
+            # SQLGlot does not propagate tokens yet. See https://github.com/tobymao/sqlglot/issues/3159
+            start_line=0,
+            start_col=0,
+            end_line=0,
+            end_col=1024,
+        )
+
+    @abstractmethod
+    def lint_expression(self, expression: Expression) -> Iterable[Advice]: ...
+
+
 class PythonLinter(Linter):
 
     def lint(self, code: str) -> Iterable[Advice]:
@@ -201,13 +231,14 @@ class CurrentSessionState:
             return None
 
 
-class SequentialLinter(Linter):
-    def __init__(self, linters: list[Linter]):
+class SQLSequentialLinter(SQLLinter):
+
+    def __init__(self, linters: list[SQLLinter]):
         self._linters = linters
 
-    def lint(self, code: str) -> Iterable[Advice]:
+    def lint_expression(self, expression: Expression) -> Iterable[Advice]:
         for linter in self._linters:
-            yield from linter.lint(code)
+            yield from linter.lint_expression(expression)
 
 
 class PythonSequentialLinter(Linter):

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -591,7 +591,7 @@ class DependencyGraphWalker(abc.ABC, Generic[T]):
 
     def __init__(self, graph: DependencyGraph, walked_paths: set[Path] | None, path_lookup: PathLookup):
         self._graph = graph
-        self._walked_paths: set[Path] = walked_paths or set()
+        self._walked_paths: set[Path] = set() if walked_paths is None else walked_paths
         self._path_lookup = path_lookup
 
     def walk(self) -> Iterable[T]:

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -4,7 +4,8 @@ import abc
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import TypeVar, Generic
 
 from astroid import (  # type: ignore
     NodeNG,
@@ -581,3 +582,43 @@ class InheritedContext:
             return self
         tree = self._tree.renumber(-1)
         return InheritedContext(tree, self.found)
+
+
+T = TypeVar("T")
+
+
+class DependencyGraphWalker(abc.ABC, Generic[T]):
+
+    def __init__(self, graph: DependencyGraph, walked_paths: set[Path] | None, path_lookup: PathLookup):
+        self._graph = graph
+        self._walked_paths: set[Path] = walked_paths or set()
+        self._path_lookup = path_lookup
+
+    def walk(self) -> Iterable[T]:
+        for dependency in self._graph.root_dependencies:
+            root_path = dependency.path  # since it's a root
+            yield from self._walk_one(dependency, self._graph, root_path)
+
+    def _walk_one(self, dependency: Dependency, graph: DependencyGraph, root_path: Path) -> Iterable[T]:
+        if dependency.path in self._walked_paths:
+            return
+        self._walked_paths.add(dependency.path)
+        self._log_walk_one(dependency)
+        if dependency.path.is_file() or is_a_notebook(dependency.path):
+            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
+            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
+            yield from self._process_dependency(dependency, path_lookup, inherited_tree)
+            maybe_graph = graph.locate_dependency(dependency.path)
+            # missing graph problems have already been reported while building the graph
+            if maybe_graph.graph:
+                child_graph = maybe_graph.graph
+                for child_dependency in child_graph.local_dependencies:
+                    yield from self._walk_one(child_dependency, child_graph, root_path)
+
+    def _log_walk_one(self, dependency: Dependency):
+        logger.info(f'Analyzing dependency: {dependency}')
+
+    @abc.abstractmethod
+    def _process_dependency(
+        self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+    ) -> Iterable[T]: ...

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -28,8 +28,10 @@ from databricks.labs.ucx.source_code.graph import (
     DependencyResolver,
     SourceContainer,
     WrappingLoader,
+    DependencyGraphWalker,
 )
 from databricks.labs.ucx.source_code.linters.context import LinterContext
+from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 
@@ -389,9 +391,9 @@ class WorkflowLinter:
         return problems
 
     def _lint_task(self, task: jobs.Task, job: jobs.Job, linted_paths: set[Path]) -> Iterable[LocatedAdvice]:
-        dependency: Dependency = WorkflowTask(self._ws, task, job)
+        start_dep: Dependency = WorkflowTask(self._ws, task, job)
         # we can load it without further preparation since the WorkflowTask is merely a wrapper
-        container = dependency.load(self._path_lookup)
+        container = start_dep.load(self._path_lookup)
         assert isinstance(container, WorkflowTaskContainer)
         session_state = CurrentSessionState(
             data_security_mode=container.data_security_mode,
@@ -399,41 +401,28 @@ class WorkflowLinter:
             spark_conf=container.spark_conf,
             dbr_version=container.runtime_version,
         )
-        graph = DependencyGraph(dependency, None, self._resolver, self._path_lookup, session_state)
+        graph = DependencyGraph(start_dep, None, self._resolver, self._path_lookup, session_state)
         problems = container.build_dependency_graph(graph)
         if problems:
             for problem in problems:
                 source_path = self._UNKNOWN if problem.is_path_missing() else problem.source_path
                 yield LocatedAdvice(problem.as_advisory(), source_path)
             return
-        for dependency in graph.root_dependencies:
-            root = dependency.path  # since it's a root
-            yield from self._lint_one(task, dependency, graph, root, session_state, linted_paths)
+        migration_index = self._migration_index
 
-    def _lint_one(
-        self,
-        task: jobs.Task,
-        dependency: Dependency,
-        graph: DependencyGraph,
-        root_path: Path,
-        session_state: CurrentSessionState,
-        linted_paths: set[Path],
-    ) -> Iterable[LocatedAdvice]:
-        if dependency.path in linted_paths:
-            return
-        linted_paths.add(dependency.path)
-        logger.info(f'Linting {task.task_key} dependency: {dependency}')
-        if dependency.path.is_file() or is_a_notebook(dependency.path):
-            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
-            ctx = LinterContext(self._migration_index, session_state)
-            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
-            # FileLinter will determine which file/notebook linter to use
-            linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
-            for advice in linter.lint():
-                yield LocatedAdvice(advice, dependency.path)
-        maybe_graph = graph.locate_dependency(dependency.path)
-        # problems have already been reported while building the graph
-        if maybe_graph.graph:
-            child_graph = maybe_graph.graph
-            for child_dependency in child_graph.local_dependencies:
-                yield from self._lint_one(task, child_dependency, child_graph, root_path, session_state, linted_paths)
+        class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
+
+            def _log_walk_one(self, dependency: Dependency):
+                logger.info(f'Linting {task.task_key} dependency: {dependency}')
+
+            def _process_dependency(
+                self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+            ) -> Iterable[LocatedAdvice]:
+                ctx = LinterContext(migration_index, session_state)
+                # FileLinter will determine which file/notebook linter to use
+                linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
+                for advice in linter.lint():
+                    yield LocatedAdvice(advice, dependency.path)
+
+        walker = LintingWalker(graph, linted_paths, self._path_lookup)
+        yield from walker.walk()

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -20,7 +20,7 @@ from databricks.sdk.service import compute, jobs
 from databricks.labs.ucx.assessment.crawlers import runtime_version_tuple
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
 from databricks.labs.ucx.mixins.cached_workspace_path import WorkspaceCache
-from databricks.labs.ucx.source_code.base import CurrentSessionState, is_a_notebook, LocatedAdvice
+from databricks.labs.ucx.source_code.base import CurrentSessionState, LocatedAdvice
 from databricks.labs.ucx.source_code.graph import (
     Dependency,
     DependencyGraph,

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -16,7 +16,7 @@ from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBF
 from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
-from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectLinter
+from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectPyLinter
 from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0PyLinter
 from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
@@ -42,7 +42,7 @@ class LinterContext:
         python_linters += [
             DBFSUsagePyLinter(session_state),
             DBRv8d0PyLinter(dbr_version=session_state.dbr_version),
-            SparkConnectLinter(session_state),
+            SparkConnectPyLinter(session_state),
             DbutilsLinter(session_state),
         ]
         sql_linters.append(DbfsUsageSQLLinter())

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.source_code.base import (
     PythonLinter,
     SQLLinter,
 )
-from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBFSUsageLinter
+from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBFSUsagePyLinter
 from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
@@ -40,7 +40,7 @@ class LinterContext:
             python_fixers.append(SparkSqlPyLinter(from_table, index, session_state))
 
         python_linters += [
-            DBFSUsageLinter(session_state),
+            DBFSUsagePyLinter(session_state),
             DBRv8d0Linter(dbr_version=session_state.dbr_version),
             SparkConnectLinter(session_state),
             DbutilsLinter(session_state),

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -18,7 +18,7 @@ from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSql
 from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectLinter
 from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0Linter
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 
 class LinterContext:
@@ -33,7 +33,7 @@ class LinterContext:
         sql_fixers: list[Fixer] = []
 
         if index is not None:
-            from_table = FromTable(index, session_state=session_state)
+            from_table = FromTableSQLLinter(index, session_state=session_state)
             sql_linters.append(from_table)
             sql_fixers.append(from_table)
             python_linters.append(SparkSql(from_table, index, session_state))

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -15,7 +15,7 @@ from databricks.labs.ucx.source_code.base import (
 from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBFSUsageLinter
 from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 
-from databricks.labs.ucx.source_code.linters.pyspark import SparkSql
+from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
 from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectLinter
 from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0Linter
 from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
@@ -36,8 +36,8 @@ class LinterContext:
             from_table = FromTableSQLLinter(index, session_state=session_state)
             sql_linters.append(from_table)
             sql_fixers.append(from_table)
-            python_linters.append(SparkSql(from_table, index, session_state))
-            python_fixers.append(SparkSql(from_table, index, session_state))
+            python_linters.append(SparkSqlPyLinter(from_table, index, session_state))
+            python_fixers.append(SparkSqlPyLinter(from_table, index, session_state))
 
         python_linters += [
             DBFSUsageLinter(session_state),

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
 from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectLinter
-from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0Linter
+from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0PyLinter
 from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 
@@ -41,7 +41,7 @@ class LinterContext:
 
         python_linters += [
             DBFSUsagePyLinter(session_state),
-            DBRv8d0Linter(dbr_version=session_state.dbr_version),
+            DBRv8d0PyLinter(dbr_version=session_state.dbr_version),
             SparkConnectLinter(session_state),
             DbutilsLinter(session_state),
         ]

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.source_code.base import (
     SQLLinter,
 )
 from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBFSUsagePyLinter
-from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
+from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter
 
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
 from databricks.labs.ucx.source_code.linters.spark_connect import SparkConnectPyLinter
@@ -43,7 +43,7 @@ class LinterContext:
             DBFSUsagePyLinter(session_state),
             DBRv8d0PyLinter(dbr_version=session_state.dbr_version),
             SparkConnectPyLinter(session_state),
-            DbutilsLinter(session_state),
+            DbutilsPyLinter(session_state),
         ]
         sql_linters.append(DbfsUsageSQLLinter())
 

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.source_code.base import (
     PythonLinter,
     SQLLinter,
 )
-from databricks.labs.ucx.source_code.linters.dbfs import FromDbfsFolder, DBFSUsageLinter
+from databricks.labs.ucx.source_code.linters.dbfs import DbfsUsageSQLLinter, DBFSUsageLinter
 from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
 
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSql
@@ -45,7 +45,7 @@ class LinterContext:
             SparkConnectLinter(session_state),
             DbutilsLinter(session_state),
         ]
-        sql_linters.append(FromDbfsFolder())
+        sql_linters.append(DbfsUsageSQLLinter())
 
         self._linters: dict[Language, list[SQLLinter] | list[PythonLinter]] = {
             Language.PYTHON: python_linters,

--- a/src/databricks/labs/ucx/source_code/linters/dbfs.py
+++ b/src/databricks/labs/ucx/source_code/linters/dbfs.py
@@ -73,7 +73,7 @@ class DetectDbfsVisitor(TreeVisitor):
         yield from self._advices
 
 
-class DBFSUsageLinter(PythonLinter):
+class DBFSUsagePyLinter(PythonLinter):
 
     def __init__(self, session_state: CurrentSessionState):
         self._session_state = session_state

--- a/src/databricks/labs/ucx/source_code/linters/dbfs.py
+++ b/src/databricks/labs/ucx/source_code/linters/dbfs.py
@@ -2,13 +2,18 @@ import logging
 from collections.abc import Iterable
 
 from astroid import Call, Const, InferenceError, NodeNG  # type: ignore
-from sqlglot import Expression, parse as parse_sql, ParseError as SqlParseError
+from sqlglot import Expression
 from sqlglot.expressions import Table
 
-from databricks.labs.ucx.source_code.base import Advice, Linter, Deprecation, CurrentSessionState, PythonLinter
+from databricks.labs.ucx.source_code.base import (
+    Advice,
+    Deprecation,
+    CurrentSessionState,
+    PythonLinter,
+    SQLLinter,
+)
 from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeVisitor
 from databricks.labs.ucx.source_code.linters.python_infer import InferredValue
-from databricks.labs.ucx.source_code.queries import FromTable
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +94,7 @@ class DBFSUsageLinter(PythonLinter):
         yield from visitor.get_advices()
 
 
-class FromDbfsFolder(Linter):
+class FromDbfsFolder(SQLLinter):
     def __init__(self):
         self._dbfs_prefixes = ["/dbfs/mnt", "dbfs:/", "/mnt/", "/dbfs/", "/"]
 
@@ -97,19 +102,8 @@ class FromDbfsFolder(Linter):
     def name() -> str:
         return 'dbfs-query'
 
-    def lint(self, code: str) -> Iterable[Advice]:
-        try:
-            queries = parse_sql(code, read='databricks')
-            for query in queries:
-                if not query:
-                    continue
-                yield from self._lint_query(query)
-        except SqlParseError as e:
-            logger.debug(f"Failed to parse SQL: {code}", exc_info=e)
-            yield FromTable.sql_parse_failure(code)
-
-    def _lint_query(self, query: Expression):
-        for table in query.find_all(Table):
+    def lint_expression(self, expression: Expression):
+        for table in expression.find_all(Table):
             # Check table names for deprecated DBFS table names
             yield from self._check_dbfs_folder(table)
 

--- a/src/databricks/labs/ucx/source_code/linters/dbfs.py
+++ b/src/databricks/labs/ucx/source_code/linters/dbfs.py
@@ -94,7 +94,7 @@ class DBFSUsageLinter(PythonLinter):
         yield from visitor.get_advices()
 
 
-class FromDbfsFolder(SQLLinter):
+class DbfsUsageSQLLinter(SQLLinter):
     def __init__(self):
         self._dbfs_prefixes = ["/dbfs/mnt", "dbfs:/", "/mnt/", "/dbfs/", "/"]
 

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -7,6 +7,7 @@ import sys
 from typing import TextIO
 
 from databricks.labs.ucx.source_code.base import LocatedAdvice, CurrentSessionState, file_language, is_a_notebook
+from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
@@ -27,6 +28,7 @@ from databricks.labs.ucx.source_code.graph import (
     SourceContainer,
     DependencyResolver,
     InheritedContext,
+    DependencyGraphWalker,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,40 +143,30 @@ class LocalCodeLinter:
         is_dir = path.is_dir()
         loader = self._folder_loader if is_dir else self._file_loader
         path_lookup = self._path_lookup.change_directory(path if is_dir else path.parent)
-        dependency = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
-        graph = DependencyGraph(dependency, None, self._dependency_resolver, path_lookup, self._session_state)
-        container = dependency.load(path_lookup)
+        start_dep = Dependency(loader, path, not is_dir)  # don't inherit context when traversing folders
+        graph = DependencyGraph(start_dep, None, self._dependency_resolver, path_lookup, self._session_state)
+        container = start_dep.load(path_lookup)
         assert container is not None  # because we just created it
         problems = container.build_dependency_graph(graph)
         for problem in problems:
             problem_path = Path('UNKNOWN') if problem.is_path_missing() else problem.source_path.absolute()
             yield problem.as_advisory().for_path(problem_path)
-        if linted_paths is None:
-            linted_paths = set()
-        for dependency in graph.root_dependencies:
-            root = dependency.path  # since it's a root
-            yield from self._lint_one(dependency, graph, root, linted_paths)
+        context_factory = self._context_factory
+        session_state = self._session_state
 
-    def _lint_one(
-        self, dependency: Dependency, graph: DependencyGraph, root_path: Path, linted_paths: set[Path]
-    ) -> Iterable[LocatedAdvice]:
-        if dependency.path in linted_paths:
-            return
-        linted_paths.add(dependency.path)
-        if dependency.path.is_file() or is_a_notebook(dependency.path):
-            inherited_tree = graph.root.build_inherited_tree(root_path, dependency.path)
-            ctx = self._context_factory()
-            path_lookup = self._path_lookup.change_directory(dependency.path.parent)
-            # FileLinter will determine which file/notebook linter to use
-            linter = FileLinter(ctx, path_lookup, self._session_state, dependency.path, inherited_tree)
-            for advice in linter.lint():
-                yield advice.for_path(dependency.path)
-        maybe_graph = graph.locate_dependency(dependency.path)
-        # problems have already been reported while building the graph
-        if maybe_graph.graph:
-            child_graph = maybe_graph.graph
-            for child_dependency in child_graph.local_dependencies:
-                yield from self._lint_one(child_dependency, child_graph, root_path, linted_paths)
+        class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
+
+            def _process_dependency(
+                self, dependency: Dependency, path_lookup: PathLookup, inherited_tree: Tree | None
+            ) -> Iterable[LocatedAdvice]:
+                ctx = context_factory()
+                # FileLinter will determine which file/notebook linter to use
+                linter = FileLinter(ctx, path_lookup, session_state, dependency.path, inherited_tree)
+                for advice in linter.lint():
+                    yield LocatedAdvice(advice, dependency.path)
+
+        walker = LintingWalker(graph, linted_paths, self._path_lookup)
+        yield from walker.walk()
 
 
 class LocalFileMigrator:

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -91,7 +91,7 @@ class NotebookRunCall(NodeBase):
         for path in paths:
             dbutils.notebook.run(path)
         """
-        arg = DbutilsLinter.get_dbutils_notebook_run_path_arg(self.node)
+        arg = DbutilsPyLinter.get_dbutils_notebook_run_path_arg(self.node)
         try:
             all_inferred = InferredValue.infer_from_node(arg, session_state)
             return self._get_notebook_paths(all_inferred)
@@ -113,7 +113,7 @@ class NotebookRunCall(NodeBase):
         return has_unresolved, paths
 
 
-class DbutilsLinter(PythonLinter):
+class DbutilsPyLinter(PythonLinter):
 
     def __init__(self, session_state: CurrentSessionState):
         self._session_state = session_state

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -327,7 +327,7 @@ class SparkMatchers:
         return self._matchers
 
 
-class SparkSql(PythonLinter, Fixer):
+class SparkSqlPyLinter(PythonLinter, Fixer):
 
     _spark_matchers = SparkMatchers()
 

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.source_code.base import (
     PythonLinter,
 )
 from databricks.labs.ucx.source_code.linters.python_infer import InferredValue
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
 
 
@@ -37,12 +37,12 @@ class Matcher(ABC):
 
     @abstractmethod
     def lint(
-        self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         """raises Advices by linting the code"""
 
     @abstractmethod
-    def apply(self, from_table: FromTable, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSQLLinter, index: MigrationIndex, node: Call) -> None:
         """applies recommendations"""
 
     def _get_table_arg(self, node: Call):
@@ -78,7 +78,7 @@ class Matcher(ABC):
 class QueryMatcher(Matcher):
 
     def lint(
-        self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
         if table_arg:
@@ -93,7 +93,7 @@ class QueryMatcher(Matcher):
                 )
 
     @classmethod
-    def _lint_table_arg(cls, from_table: FromTable, call_node: NodeNG, inferred: InferredValue):
+    def _lint_table_arg(cls, from_table: FromTableSQLLinter, call_node: NodeNG, inferred: InferredValue):
         if inferred.is_inferred():
             for advice in from_table.lint(inferred.as_string()):
                 yield advice.replace_from_node(call_node)
@@ -104,7 +104,7 @@ class QueryMatcher(Matcher):
                 node=call_node,
             )
 
-    def apply(self, from_table: FromTable, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSQLLinter, index: MigrationIndex, node: Call) -> None:
         table_arg = self._get_table_arg(node)
         assert isinstance(table_arg, Const)
         new_query = from_table.apply(table_arg.value)
@@ -115,7 +115,7 @@ class QueryMatcher(Matcher):
 class TableNameMatcher(Matcher):
 
     def lint(
-        self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
         table_name = table_arg.as_string().strip("'").strip('"')
@@ -137,7 +137,7 @@ class TableNameMatcher(Matcher):
                 node=node,
             )
 
-    def apply(self, from_table: FromTable, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSQLLinter, index: MigrationIndex, node: Call) -> None:
         table_arg = self._get_table_arg(node)
         assert isinstance(table_arg, Const)
         dst = self._find_dest(index, table_arg.value, from_table.schema)
@@ -162,7 +162,7 @@ class ReturnValueMatcher(Matcher):
         )
 
     def lint(
-        self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         assert isinstance(node.func, Attribute)  # always true, avoids a pylint warning
         yield Advisory.from_node(
@@ -171,7 +171,7 @@ class ReturnValueMatcher(Matcher):
             node=node,
         )
 
-    def apply(self, from_table: FromTable, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSQLLinter, index: MigrationIndex, node: Call) -> None:
         # No transformations to apply
         return
 
@@ -200,7 +200,7 @@ class DirectFilesystemAccessMatcher(Matcher):
         )
 
     def lint(
-        self, from_table: FromTable, index: MigrationIndex, session_state: CurrentSessionState, node: NodeNG
+        self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state: CurrentSessionState, node: NodeNG
     ) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
         if not isinstance(table_arg, Const):
@@ -223,7 +223,7 @@ class DirectFilesystemAccessMatcher(Matcher):
                 node=node,
             )
 
-    def apply(self, from_table: FromTable, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSQLLinter, index: MigrationIndex, node: Call) -> None:
         # No transformations to apply
         return
 
@@ -331,7 +331,7 @@ class SparkSql(PythonLinter, Fixer):
 
     _spark_matchers = SparkMatchers()
 
-    def __init__(self, from_table: FromTable, index: MigrationIndex, session_state):
+    def __init__(self, from_table: FromTableSQLLinter, index: MigrationIndex, session_state):
         self._from_table = from_table
         self._index = index
         self._session_state = session_state

--- a/src/databricks/labs/ucx/source_code/linters/spark_connect.py
+++ b/src/databricks/labs/ucx/source_code/linters/spark_connect.py
@@ -242,7 +242,7 @@ class CommandContextMatcher(SharedClusterMatcher):
             )
 
 
-class SparkConnectLinter(PythonLinter):
+class SparkConnectPyLinter(PythonLinter):
     def __init__(self, session_state: CurrentSessionState):
         if session_state.data_security_mode != DataSecurityMode.USER_ISOLATION:
             self._matchers = []

--- a/src/databricks/labs/ucx/source_code/linters/table_creation.py
+++ b/src/databricks/labs/ucx/source_code/linters/table_creation.py
@@ -96,7 +96,7 @@ class NoFormatPythonLinter:
                 )
 
 
-class DBRv8d0Linter(PythonLinter):
+class DBRv8d0PyLinter(PythonLinter):
     """Performs Python linting for backwards incompatible changes in DBR version 8.0.
     Specifically, it yields advice for table-creation with implicit format.
     """

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -25,7 +25,7 @@ from databricks.labs.ucx.source_code.graph import (
 )
 from databricks.labs.ucx.source_code.linters.imports import (
     SysPathChange,
-    DbutilsLinter,
+    DbutilsPyLinter,
     ImportSource,
     NotebookRunCall,
     UnresolvedPath,
@@ -470,7 +470,7 @@ class PythonCodeAnalyzer:
         problems: list[DependencyProblem] = []
         tree = Tree.normalize_and_parse(self._python_code)
         syspath_changes = SysPathChange.extract_from_tree(self._context.session_state, tree)
-        run_calls = DbutilsLinter.list_dbutils_notebook_run_calls(tree)
+        run_calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
         import_sources: list[ImportSource]
         import_problems: list[DependencyProblem]
         import_sources, import_problems = ImportSource.extract_from_tree(tree, DependencyProblem.from_node)

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -7,7 +7,7 @@ from databricks.labs.ucx.source_code.base import Deprecation, Fixer, CurrentSess
 logger = logging.getLogger(__name__)
 
 
-class FromTable(SQLLinter, Fixer):
+class FromTableSQLLinter(SQLLinter, Fixer):
     """Linter and Fixer for table migrations in SQL queries.
 
     This class is responsible for identifying and fixing table migrations in

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -1,15 +1,13 @@
-from collections.abc import Iterable
-
 import logging
-from sqlglot import parse as parse_sql, ParseError as SqlParseError
+from sqlglot import parse as parse_sql
 from sqlglot.expressions import Table, Expression, Use, Create
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
-from databricks.labs.ucx.source_code.base import Advice, Deprecation, Fixer, Linter, CurrentSessionState, Failure
+from databricks.labs.ucx.source_code.base import Deprecation, Fixer, CurrentSessionState, SQLLinter
 
 logger = logging.getLogger(__name__)
 
 
-class FromTable(Linter, Fixer):
+class FromTable(SQLLinter, Fixer):
     """Linter and Fixer for table migrations in SQL queries.
 
     This class is responsible for identifying and fixing table migrations in
@@ -18,7 +16,7 @@ class FromTable(Linter, Fixer):
 
     def __init__(self, index: MigrationIndex, session_state: CurrentSessionState):
         """
-        Initializes the FromTable class.
+        Initializes the FromTableLinter class.
 
         Args:
             index: The migration index, which is a mapping of source tables to destination tables.
@@ -42,37 +40,14 @@ class FromTable(Linter, Fixer):
     def schema(self):
         return self._session_state.schema
 
-    def lint(self, code: str) -> Iterable[Advice]:
-        try:
-            statements = parse_sql(code, read='databricks')
-            for statement in statements:
-                if not statement:
-                    continue
-                yield from self._lint_statement(statement)
-        except SqlParseError as e:
-            logger.debug(f"Failed to parse SQL: {code}", exc_info=e)
-            yield self.sql_parse_failure(code)
-
-    @staticmethod
-    def sql_parse_failure(code: str):
-        return Failure(
-            code='sql-parse-error',
-            message=f"SQL query is not supported yet: {code}",
-            # SQLGlot does not propagate tokens yet. See https://github.com/tobymao/sqlglot/issues/3159
-            start_line=0,
-            start_col=0,
-            end_line=0,
-            end_col=1024,
-        )
-
-    def _lint_statement(self, statement: Expression):
-        for table in statement.find_all(Table):
-            if isinstance(statement, Use):
+    def lint_expression(self, expression: Expression):
+        for table in expression.find_all(Table):
+            if isinstance(expression, Use):
                 # Sqlglot captures the database name in the Use statement as a Table, with
                 # the schema  as the table name.
                 self._session_state.schema = table.name
                 continue
-            if isinstance(statement, Create) and getattr(statement, "kind", None) == "SCHEMA":
+            if isinstance(expression, Create) and getattr(expression, "kind", None) == "SCHEMA":
                 # Sqlglot captures the schema name in the Create statement as a Table, with
                 # the schema  as the db name.
                 self._session_state.schema = table.db

--- a/src/databricks/labs/ucx/source_code/redash.py
+++ b/src/databricks/labs/ucx/source_code/redash.py
@@ -10,7 +10,7 @@ from databricks.sdk.errors.platform import DatabricksError
 
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class Redash:
             return
         # backup the query
         self._installation.save(query, filename=f'backup/queries/{query.id}.json')
-        from_table = FromTable(self._index, self._get_session_state(query))
+        from_table = FromTableSQLLinter(self._index, self._get_session_state(query))
         new_query = UpdateQueryRequestQuery(
             query_text=from_table.apply(query.query),
             tags=self._get_migrated_tags(query.tags),

--- a/tests/unit/source_code/linters/test_dbfs.py
+++ b/tests/unit/source_code/linters/test_dbfs.py
@@ -116,7 +116,7 @@ def test_dbfs_queries_failure(query: str):
     assert actual == [
         Failure(
             code='sql-parse-error',
-            message=f'SQL query is not supported yet: {query}',
+            message=f'SQL expression is not supported yet: {query}',
             start_line=0,
             start_col=0,
             end_line=0,

--- a/tests/unit/source_code/linters/test_dbfs.py
+++ b/tests/unit/source_code/linters/test_dbfs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from databricks.labs.ucx.source_code.base import Deprecation, Advice, CurrentSessionState, Failure
-from databricks.labs.ucx.source_code.linters.dbfs import DBFSUsageLinter, FromDbfsFolder
+from databricks.labs.ucx.source_code.linters.dbfs import DBFSUsageLinter, DbfsUsageSQLLinter
 
 
 class TestDetectDBFS:
@@ -72,7 +72,7 @@ for system in systems:
     ],
 )
 def test_non_dbfs_trigger_nothing(query):
-    ftf = FromDbfsFolder()
+    ftf = DbfsUsageSQLLinter()
     assert not list(ftf.lint(query))
 
 
@@ -90,7 +90,7 @@ def test_non_dbfs_trigger_nothing(query):
     ],
 )
 def test_dbfs_tables_trigger_messages_param(query: str, table: str):
-    ftf = FromDbfsFolder()
+    ftf = DbfsUsageSQLLinter()
     actual = list(ftf.lint(query))
     assert actual == [
         Deprecation(
@@ -111,7 +111,7 @@ def test_dbfs_tables_trigger_messages_param(query: str, table: str):
     ],
 )
 def test_dbfs_queries_failure(query: str):
-    ftf = FromDbfsFolder()
+    ftf = DbfsUsageSQLLinter()
     actual = list(ftf.lint(query))
     assert actual == [
         Failure(
@@ -126,5 +126,5 @@ def test_dbfs_queries_failure(query: str):
 
 
 def test_dbfs_queries_name():
-    ftf = FromDbfsFolder()
+    ftf = DbfsUsageSQLLinter()
     assert ftf.name() == 'dbfs-query'

--- a/tests/unit/source_code/linters/test_dbfs.py
+++ b/tests/unit/source_code/linters/test_dbfs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from databricks.labs.ucx.source_code.base import Deprecation, Advice, CurrentSessionState, Failure
-from databricks.labs.ucx.source_code.linters.dbfs import DBFSUsageLinter, DbfsUsageSQLLinter
+from databricks.labs.ucx.source_code.linters.dbfs import DBFSUsagePyLinter, DbfsUsageSQLLinter
 
 
 class TestDetectDBFS:
@@ -17,7 +17,7 @@ class TestDetectDBFS:
         ],
     )
     def test_detects_dbfs_paths(self, code, expected):
-        linter = DBFSUsageLinter(CurrentSessionState())
+        linter = DBFSUsagePyLinter(CurrentSessionState())
         advices = list(linter.lint(code))
         for advice in advices:
             assert isinstance(advice, Advice)
@@ -46,7 +46,7 @@ for system in systems:
         ],
     )
     def test_dbfs_usage_linter(self, code, expected):
-        linter = DBFSUsageLinter(CurrentSessionState())
+        linter = DBFSUsagePyLinter(CurrentSessionState())
         advices = linter.lint(code)
         count = 0
         for advice in advices:
@@ -55,7 +55,7 @@ for system in systems:
         assert count == expected
 
     def test_dbfs_name(self):
-        linter = DBFSUsageLinter(CurrentSessionState())
+        linter = DBFSUsagePyLinter(CurrentSessionState())
         assert linter.name() == "dbfs-usage"
 
 

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -4,14 +4,14 @@ from astroid import Call, Const, Expr  # type: ignore
 
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState
 from databricks.labs.ucx.source_code.linters.python_ast import Tree, TreeHelper
-from databricks.labs.ucx.source_code.linters.pyspark import TableNameMatcher, SparkSql
+from databricks.labs.ucx.source_code.linters.pyspark import TableNameMatcher, SparkSqlPyLinter
 from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 
 def test_spark_no_sql(empty_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(empty_index, session_state)
-    sqf = SparkSql(ftf, empty_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, empty_index, session_state)
 
     assert not list(sqf.lint("print(1)"))
 
@@ -23,14 +23,14 @@ df4.write.saveAsTable(f"{schema}.member_measure")
 """
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(empty_index, session_state)
-    sqf = SparkSql(ftf, empty_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, empty_index, session_state)
     assert not list(sqf.lint(source))
 
 
 def test_spark_sql_no_match(empty_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(empty_index, session_state)
-    sqf = SparkSql(ftf, empty_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, empty_index, session_state)
 
     old_code = """
 for i in range(10):
@@ -44,7 +44,7 @@ for i in range(10):
 def test_spark_sql_match(migration_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(migration_index, session_state)
-    sqf = SparkSql(ftf, migration_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, migration_index, session_state)
 
     old_code = """
 spark.read.csv("s3://bucket/path")
@@ -75,7 +75,7 @@ for i in range(10):
 def test_spark_sql_match_named(migration_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(migration_index, session_state)
-    sqf = SparkSql(ftf, migration_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, migration_index, session_state)
 
     old_code = """
 spark.read.csv("s3://bucket/path")
@@ -106,7 +106,7 @@ for i in range(10):
 def test_spark_table_return_value_apply(migration_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(migration_index, session_state)
-    sqf = SparkSql(ftf, migration_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, migration_index, session_state)
     old_code = """spark.read.csv('s3://bucket/path')
 for table in spark.catalog.listTables():
     do_stuff_with_table(table)"""
@@ -118,7 +118,7 @@ for table in spark.catalog.listTables():
 def test_spark_sql_fix(migration_index):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(migration_index, session_state)
-    sqf = SparkSql(ftf, migration_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, migration_index, session_state)
 
     old_code = """spark.read.csv("s3://bucket/path")
 for i in range(10):
@@ -542,7 +542,7 @@ for i in range(10):
 def test_spark_cloud_direct_access(empty_index, code, expected):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(empty_index, session_state)
-    sqf = SparkSql(ftf, empty_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, empty_index, session_state)
     advisories = list(sqf.lint(code))
     assert advisories == expected
 
@@ -562,7 +562,7 @@ FS_FUNCTIONS = [
 def test_direct_cloud_access_reports_nothing(empty_index, fs_function):
     session_state = CurrentSessionState()
     ftf = FromTableSQLLinter(empty_index, session_state)
-    sqf = SparkSql(ftf, empty_index, session_state)
+    sqf = SparkSqlPyLinter(ftf, empty_index, session_state)
     # ls function calls have to be from dbutils.fs, or we ignore them
     code = f"""spark.{fs_function}("/bucket/path")"""
     advisories = list(sqf.lint(code))

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -8,14 +8,14 @@ from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyProblem
 from databricks.labs.ucx.source_code.linters.files import FileLoader
 
-from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter, ImportSource, SysPathChange
+from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter, ImportSource, SysPathChange
 from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.cells import PythonCodeAnalyzer
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls():
     tree = Tree.parse('')
-    assert not DbutilsLinter.list_dbutils_notebook_run_calls(tree)
+    assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
 
 
 def test_linter_returns_list_of_dbutils_notebook_run_calls():
@@ -25,7 +25,7 @@ for i in z:
     ww =   dbutils.notebook.run("toto")
 """
     tree = Tree.parse(code)
-    calls = DbutilsLinter.list_dbutils_notebook_run_calls(tree)
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
     assert {"toto", "stuff"} == {str(call.node.args[0].value) for call in calls}
 
 
@@ -189,7 +189,7 @@ dbutils.notebook.run(name)
 )
 def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
     tree = Tree.parse(code)
-    calls = DbutilsLinter.list_dbutils_notebook_run_calls(tree)
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
     all_paths: list[str] = []
     for call in calls:
         _, paths = call.get_notebook_paths(CurrentSessionState())

--- a/tests/unit/source_code/linters/test_table_creation.py
+++ b/tests/unit/source_code/linters/test_table_creation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from databricks.labs.ucx.source_code.base import Advice
-from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0Linter
+from databricks.labs.ucx.source_code.linters.table_creation import DBRv8d0PyLinter
 
 
 METHOD_NAMES = [
@@ -60,7 +60,7 @@ def lint(
     dbr_version: tuple[int, int] | None = (7, 9),
 ) -> list[Advice]:
     """Invoke linting for the given dbr version"""
-    return list(DBRv8d0Linter(dbr_version).lint(code))
+    return list(DBRv8d0PyLinter(dbr_version).lint(code))
 
 
 @pytest.mark.parametrize("method_name", METHOD_NAMES)

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import DependencyGraph, SourceContainer, DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader
-from databricks.labs.ucx.source_code.linters.imports import DbutilsLinter
+from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter
 from databricks.labs.ucx.source_code.linters.python_ast import Tree
 from databricks.labs.ucx.source_code.notebooks.sources import Notebook
 from databricks.labs.ucx.source_code.notebooks.loaders import (
@@ -253,7 +253,7 @@ do_something_with_stuff(stuff)
 stuff2 = dbutils.notebook.run("where is notebook 1?")
 stuff3 = dbutils.notebook.run("where is notebook 2?")
 """
-    linter = DbutilsLinter(CurrentSessionState())
+    linter = DbutilsPyLinter(CurrentSessionState())
     tree = Tree.parse(source)
     nodes = linter.list_dbutils_notebook_run_calls(tree)
     assert len(nodes) == 2
@@ -265,7 +265,7 @@ import stuff
 do_something_with_stuff(stuff)
 stuff2 = notebook.run("where is notebook 1?")
 """
-    linter = DbutilsLinter(CurrentSessionState())
+    linter = DbutilsPyLinter(CurrentSessionState())
     tree = Tree.parse(source)
     nodes = linter.list_dbutils_notebook_run_calls(tree)
     assert len(nodes) == 0
@@ -277,7 +277,7 @@ name1 = "John"
 name2 = f"{name1}"
 dbutils.notebook.run(f"Hey {name2}")
     """
-    linter = DbutilsLinter(CurrentSessionState())
+    linter = DbutilsPyLinter(CurrentSessionState())
     advices = list(linter.lint(source))
     assert len(advices) == 1
     assert advices[0].code == "notebook-run-cannot-compute-value"

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -1,9 +1,9 @@
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState, Failure
-from databricks.labs.ucx.source_code.queries import FromTable
+from databricks.labs.ucx.source_code.queries import FromTableSQLLinter
 
 
 def test_not_migrated_tables_trigger_nothing(empty_index):
-    ftf = FromTable(empty_index, CurrentSessionState())
+    ftf = FromTableSQLLinter(empty_index, CurrentSessionState())
 
     old_query = "SELECT * FROM old.things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
     actual = list(ftf.lint(old_query))
@@ -11,7 +11,7 @@ def test_not_migrated_tables_trigger_nothing(empty_index):
 
 
 def test_migrated_tables_trigger_messages(migration_index):
-    ftf = FromTable(migration_index, CurrentSessionState())
+    ftf = FromTableSQLLinter(migration_index, CurrentSessionState())
 
     old_query = "SELECT * FROM old.things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
 
@@ -36,7 +36,7 @@ def test_migrated_tables_trigger_messages(migration_index):
 
 
 def test_fully_migrated_queries_match(migration_index):
-    ftf = FromTable(migration_index, CurrentSessionState())
+    ftf = FromTableSQLLinter(migration_index, CurrentSessionState())
 
     old_query = "SELECT * FROM old.things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
     new_query = "SELECT * FROM brand.new.stuff LEFT JOIN some.certain.issues USING (x) WHERE state > 1 LIMIT 10"
@@ -46,7 +46,7 @@ def test_fully_migrated_queries_match(migration_index):
 
 def test_fully_migrated_queries_match_no_db(migration_index):
     session_state = CurrentSessionState(schema="old")
-    ftf = FromTable(migration_index, session_state=session_state)
+    ftf = FromTableSQLLinter(migration_index, session_state=session_state)
 
     old_query = "SELECT * FROM things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
     new_query = "SELECT * FROM brand.new.stuff LEFT JOIN some.certain.issues USING (x) WHERE state > 1 LIMIT 10"
@@ -56,7 +56,7 @@ def test_fully_migrated_queries_match_no_db(migration_index):
 
 def test_use_database_change(migration_index):
     session_state = CurrentSessionState(schema="old")
-    ftf = FromTable(migration_index, session_state=session_state)
+    ftf = FromTableSQLLinter(migration_index, session_state=session_state)
     query = """
     USE newcatalog;
     SELECT * FROM things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1
@@ -67,7 +67,7 @@ def test_use_database_change(migration_index):
 
 def test_use_database_stops_migration(migration_index):
     session_state = CurrentSessionState(schema="old")
-    ftf = FromTable(migration_index, session_state=session_state)
+    ftf = FromTableSQLLinter(migration_index, session_state=session_state)
     query = "SELECT * FROM things LEFT JOIN hive_metastore.other.matters USING (x) WHERE state > 1 LIMIT 10"
     old_query = f"{query}; USE newcatalog; {query}"
     new_query = (
@@ -82,7 +82,7 @@ def test_use_database_stops_migration(migration_index):
 def test_parses_create_schema(migration_index):
     query = "CREATE SCHEMA xyz"
     session_state = CurrentSessionState(schema="old")
-    ftf = FromTable(migration_index, session_state=session_state)
+    ftf = FromTableSQLLinter(migration_index, session_state=session_state)
     advices = ftf.lint(query)
     assert not list(advices)
 
@@ -90,7 +90,7 @@ def test_parses_create_schema(migration_index):
 def test_raises_advice_when_parsing_unsupported_sql(migration_index):
     query = "XDESCRIBE DETAILS xyz"  # not a valid query
     session_state = CurrentSessionState(schema="old")
-    ftf = FromTable(migration_index, session_state=session_state)
+    ftf = FromTableSQLLinter(migration_index, session_state=session_state)
     advices = list(ftf.lint(query))
     assert isinstance(advices[0], Failure)
     assert 'not supported' in advices[0].message


### PR DESCRIPTION
## Changes
Naming of current linters is inconsistent, making the existing code very hard to read.
Also, SQL linters do not derive from a specialized base linter, leading to code duplication and suboptimal performance
This PR:
 - introduces specialized SQLLinter and SQLSequentialLinter
 - renames existing linters such that their names are self-explanatory

### Linked issues
None

### Functionality
None

### Tests
- [x] ran existing unit tests
