### PR TITLE
Improve log warning about skipped grants

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -736,7 +736,10 @@ class MigrateGrants:
         for grant in self._match_grants(src):
             acl_migrate_sql = grant.uc_grant_sql(src.kind, uc_table_key)
             if acl_migrate_sql is None:
-                logger.warning(f"failed-to-migrate: Cannot identify UC grant for {src.kind} {uc_table_key}. Skipping.")
+                logger.warning(
+                    f"failed-to-migrate: Cannot identify UC grant for hive metastore grant {grant.action_type} on "
+                    f"{src.kind} {uc_table_key}. Skipping."
+                )
                 continue
             logger.debug(f"Migrating acls on {uc_table_key} using SQL query: {acl_migrate_sql}")
             try:

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -737,8 +737,8 @@ class MigrateGrants:
             acl_migrate_sql = grant.uc_grant_sql(src.kind, uc_table_key)
             if acl_migrate_sql is None:
                 logger.warning(
-                    f"failed-to-migrate: Cannot identify UC grant for hive metastore grant {grant.action_type} on "
-                    f"{src.kind} {uc_table_key}. Skipping."
+                    f"failed-to-migrate: Hive metastore grant '{grant.action_type}' cannot be mapped to UC grant for "
+                    f"{src.kind} '{uc_table_key}'. Skipping."
                 )
                 continue
             logger.debug(f"Migrating acls on {uc_table_key} using SQL query: {acl_migrate_sql}")

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -496,5 +496,8 @@ def test_migrate_grants_logs_unmapped_acl(caplog) -> None:
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.hive_metastore.grants"):
         migrate_grants.apply(table, f"uc.{table.database}.{table.name}")
-    assert "failed-to-migrate: Hive metastore grant 'READ_METADATA' cannot be mapped to UC grant for TABLE 'uc.database.table'" in caplog.text
+    assert (
+        "failed-to-migrate: Hive metastore grant 'READ_METADATA' cannot be mapped to UC grant for TABLE 'uc.database.table'"
+        in caplog.text
+    )
     group_manager.assert_not_called()

--- a/tests/unit/hive_metastore/test_grants.py
+++ b/tests/unit/hive_metastore/test_grants.py
@@ -496,5 +496,5 @@ def test_migrate_grants_logs_unmapped_acl(caplog) -> None:
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.hive_metastore.grants"):
         migrate_grants.apply(table, f"uc.{table.database}.{table.name}")
-    assert "failed-to-migrate: Cannot identify UC grant for hive metastore grant READ_METADATA on TABLE uc.database.table" in caplog.text
+    assert "failed-to-migrate: Hive metastore grant 'READ_METADATA' cannot be mapped to UC grant for TABLE 'uc.database.table'" in caplog.text
     group_manager.assert_not_called()


### PR DESCRIPTION
Improve log warning about skipped grants. Missing information when verifying ucx behavior of ACL migration