### PR TITLE
Fix various `mypy`/`pylint`/`pytest` build warnings

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/linters/python_ast.py
@@ -215,7 +215,7 @@ class Tree:
                 globs[key] = nodes_in_scope
         return globs
 
-    def line_count(self):
+    def line_count(self) -> int:
         if not isinstance(self.node, Module):
             raise NotImplementedError(f"Can't count lines from {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -207,7 +207,7 @@ def test_lint_local_code(simple_ctx):
 
 
 @pytest.mark.parametrize("order", [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]])
-def test_graph_computes_magic_run_route_recursively_in_parent_folder(simple_ctx, order):
+def test_graph_computes_magic_run_route_recursively_in_parent_folder(simple_ctx, order) -> None:
     # order in which we consider files influences the algorithm so we check all order
     parent_local_path = (
         Path(__file__).parent.parent.parent / "unit" / "source_code" / "samples" / "parent-child-context"
@@ -241,6 +241,7 @@ def test_graph_computes_magic_run_route_recursively_in_parent_folder(simple_ctx,
         dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()
     )
     container = dependency.load(simple_ctx.path_lookup)
+    assert container
     container.build_dependency_graph(root_graph)
     roots = root_graph.root_dependencies
     assert len(roots) == 1

--- a/tests/unit/azure/test_credentials.py
+++ b/tests/unit/azure/test_credentials.py
@@ -405,7 +405,6 @@ def test_read_secret_value_decode(sp_migrations, secret_bytes_value, num_migrate
     # we need to access the protected attribute to keep the test small.
     # this test also reveals a design flaw in test code and perhaps in
     # the code under test as well.
-    # pylint: disable-next=protected-access
     sp_migration, _, ws = sp_migrations
     ws.secrets.get_secret.return_value = secret_bytes_value
 
@@ -423,7 +422,6 @@ def test_read_secret_value_none(sp_migrations):
     # we need to access the protected attribute to keep the test small.
     # this test also reveals a design flaw in test code and perhaps in
     # the code under test as well.
-    # pylint: disable-next=protected-access
     sp_migration, _, ws = sp_migrations
     ws.secrets.get_secret.return_value = GetSecretResponse(value=None)
     prompts = MockPrompts(
@@ -442,7 +440,6 @@ def test_read_secret_read_exception(caplog, sp_migrations):
     # we need to access the protected attribute to keep the test small.
     # this test also reveals a design flaw in test code and perhaps in
     # the code under test as well.
-    # pylint: disable-next=protected-access
     sp_migration, _, ws = sp_migrations
     ws.secrets.get_secret.side_effect = ResourceDoesNotExist()
 

--- a/tests/unit/mixins/test_cached_workspace_path.py
+++ b/tests/unit/mixins/test_cached_workspace_path.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.mixins.cached_workspace_path import WorkspaceCache
 from databricks.labs.ucx.source_code.base import guess_encoding
 
 
-class TestWorkspaceCache(WorkspaceCache):
+class _WorkspaceCacheFriend(WorkspaceCache):
 
     @property
     def data_cache(self):
@@ -20,7 +20,7 @@ class TestWorkspaceCache(WorkspaceCache):
 
 
 def test_path_like_returns_cached_instance():
-    cache = TestWorkspaceCache(mock_workspace_client())
+    cache = _WorkspaceCacheFriend(mock_workspace_client())
     parent = cache.get_path("path")
     child = parent / "child"
     _cache = getattr(child, "_cache")
@@ -31,7 +31,7 @@ def test_iterdir_returns_cached_instances():
     ws = create_autospec(WorkspaceClient)
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)
     ws.workspace.list.return_value = list(ObjectInfo(object_type=ObjectType.FILE, path=s) for s in ("a", "b", "c"))
-    cache = TestWorkspaceCache(ws)
+    cache = _WorkspaceCacheFriend(ws)
     parent = cache.get_path("dir")
     assert parent.is_dir()
     for child in parent.iterdir():

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -125,7 +125,7 @@ def local_code_linter(mock_path_lookup, migration_index):
     )
 
 
-def test_linter_walks_directory(mock_path_lookup, local_code_linter):
+def test_linter_walks_directory(mock_path_lookup, local_code_linter) -> None:
     mock_path_lookup.append_path(Path(_samples_path(SourceContainer)))
     path = Path(__file__).parent / "../samples" / "simulate-sys-path"
     paths: set[Path] = set()
@@ -134,7 +134,7 @@ def test_linter_walks_directory(mock_path_lookup, local_code_linter):
     assert not advices
 
 
-def test_linter_lints_children_in_context(mock_path_lookup, local_code_linter):
+def test_linter_lints_children_in_context(mock_path_lookup, local_code_linter) -> None:
     mock_path_lookup.append_path(Path(_samples_path(SourceContainer)))
     path = Path(__file__).parent.parent / "samples" / "parent-child-context"
     paths: set[Path] = set()


### PR DESCRIPTION
## Changes

This PR fixes some warnings at build-time that are produced by our `mypy`/`pylint`/`pytest` tooling:

 - Pylint warnings due to unnecessary suppressions. (Removed.)
 - Mypy warnings about bodies with hints not being linted. (Now they are.)
 - Pytest warnings about not being able to collect tests. (Now it doesn't try.)
