### PR TITLE
 Add `download` cli command to download file from a collection of workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
   * [`cluster-remap` command](#cluster-remap-command)
   * [`revert-cluster-remap` command](#revert-cluster-remap-command)
   * [`upload` command](#upload-command)
+  * [`download` command](#download-command)
 * [Common Challenges and the Solutions](#common-challenges-and-the-solutions)
     * [Network Connectivity Issues](#network-connectivity-issues)
     * [Insufficient Privileges](#insufficient-privileges)
@@ -1420,6 +1421,16 @@ $ databricks labs ucx upload --file <file_path> --run-as-collection True
 
 Upload a file to a single workspace (`--run-as-collection False`) or a collection of workspaces
 (`--run-as-collection True`). This command is especially useful when uploading the same file to multiple workspace.
+
+## `download` command
+
+```text
+$ databricks labs ucx download --file <file_path> --run-as-collection True
+21:31:29 INFO [d.labs.ucx] Finished downloading: <file_path>
+```
+
+Download a csv file from a single workspace (`--run-as-collection False`) or a collection of workspaces
+(`--run-as-collection True`). This command is especially useful when downloading the same file from multiple workspace.
 
 # Common Challenges and the Solutions
 Users might encounter some challenges while installing and executing UCX. Please find the listing of some common challenges and the solutions below.

--- a/labs.yml
+++ b/labs.yml
@@ -272,3 +272,11 @@ commands:
         description: The file to upload
       - name: run-as-collection
         description: Run the command for the collection of workspace with ucx installed. Default is False.
+
+  - name: download
+    description: download file from all workspaces in the account where ucx is installed
+    flags:
+      - name: file
+        description: The file to download
+      - name: run-as-collection
+        description: Run the command for the collection of workspace with ucx installed. Default is False.

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -561,7 +561,7 @@ def download(
     file = Path(file)
     if not file.suffix == ".csv":
         raise ValueError("Command only supported for CSV files")
-    contexts = get_contexts(w, run_as_collection=run_as_collection, a=a)
+    contexts = _get_workspace_contexts(w, run_as_collection=run_as_collection, a=a)
     csv_binaries = []
     for ctx in contexts:
         # Installation does not have an upload method

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -567,7 +567,8 @@ def download(
         # Installation does not have an upload method
         remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
         try:
-            csv_binaries.append(ctx.workspace_client.workspace.download(remote_file_name))
+            csv_binary = ctx.workspace_client.workspace.download(remote_file_name)
+            csv_binaries.append(csv_binary)
         except NotFound:
             logger.warning(f"File {remote_file_name} not found in {ctx.workspace_client.config.host}")
     if len(csv_binaries) == 0:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -593,7 +593,8 @@ def download(
                 logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
     if csv_header is None:
         logger.warning("No file(s) to download found")
-        file.unlink(missing_ok=True)
+    if file.is_file() and file.stat().st_size == 0:
+        file.unlink()
     else:
         logger.info(f"Finished downloading {file}")
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -574,8 +574,7 @@ def download(
             except NotFound:
                 logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
                 continue
-            # BytesIO allows to .readline() for the header and handle the StreamingResponse from the download
-            input_ = BytesIO()
+            input_ = BytesIO()  # BytesIO supports .readline() to read the header, where StreamingResponse does not
             input_.write(data.rstrip(b"\n"))
             input_.seek(0)  # Go back to the beginning of the file
             csv_header_next = input_.readline()

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -571,7 +571,7 @@ def download(
             csv_binary = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
             csv_binaries.append(csv_binary)
         except NotFound:
-            logger.warning(f"File {remote_file_name} not found in {ctx.workspace_client.config.host}")
+            logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
     if len(csv_binaries) == 0:
         logger.warn(f"No file(s) to download found")
         return

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -573,7 +573,11 @@ def download(
                 # Installation does not have a download method
                 # BytesIO allows to .readline() for the header and handle the StreamingResponse from the download
                 input_ = BytesIO()
-                bytes = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO).read()
+                bytes = (
+                    ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
+                    .read()
+                    .rstrip(b"\n")
+                )
                 input_.write(bytes)
                 input_.seek(0)  # Go back to the beginning of the file
                 csv_header_next = input_.readline()

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -579,6 +579,7 @@ def download(
         f.write(csv_binaries[0].read())
         for csv_binary in csv_binaries[1:]:
             csv_binary.readline()  # Skip header
+            f.write(b"\n")
             f.write(csv_binary.read())
     logger.info(f"Finished downloading {file}")
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -8,6 +8,7 @@ from databricks.labs.blueprint.installation import Installation, SerdeError
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
+from databricks.sdk.service.workspace import ExportFormat
 from databricks.labs.ucx.__about__ import __version__
 
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -567,7 +568,7 @@ def download(
         try:
             remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
             # Installation does not have an download method
-            csv_binary = ctx.workspace_client.workspace.download(remote_file_name)
+            csv_binary = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
             csv_binaries.append(csv_binary)
         except NotFound:
             logger.warning(f"File {remote_file_name} not found in {ctx.workspace_client.config.host}")

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -584,6 +584,7 @@ def download(
                 logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
     if csv_header is None:
         logger.warning("No file(s) to download found")
+        file.unlink(missing_ok=True)
     else:
         logger.info(f"Finished downloading {file}")
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -570,16 +570,15 @@ def download(
             try:
                 # Installation does not have a download method
                 csv_binary = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
-                new_header = csv_binary.readline()
+                csv_header_next = csv_binary.readline()
                 if csv_header is None:
-                    csv_header = new_header
+                    csv_header = csv_header_next
                     f.write(csv_header)
-                    f.write(csv_binary.read())
-                elif csv_header == new_header:
+                elif csv_header == csv_header_next:
                     f.write(b"\n")
-                    f.write(csv_binary.read())
                 else:
                     raise ValueError("CSV files have different headers")
+                f.write(csv_binary.read())
             except NotFound:
                 logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
     if csv_header is None:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -565,8 +565,8 @@ def download(
     contexts = _get_workspace_contexts(w, run_as_collection=run_as_collection, a=a)
     csv_binaries = []
     for ctx in contexts:
+        remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
         try:
-            remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
             # Installation does not have an download method
             csv_binary = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
             csv_binaries.append(csv_binary)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -568,7 +568,7 @@ def download(
         for ctx in contexts:
             remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
             try:
-                # Installation does not have an download method
+                # Installation does not have a download method
                 csv_binary = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
                 new_header = csv_binary.readline()
                 if csv_header is None:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -583,7 +583,7 @@ def download(
             except NotFound:
                 logger.warning(f"File not found for {ctx.workspace_client.config.host}: {remote_file_name}")
     if csv_header is None:
-        logger.warn(f"No file(s) to download found")
+        logger.warning("No file(s) to download found")
     else:
         logger.info(f"Finished downloading {file}")
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -8,7 +8,6 @@ from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.labs.blueprint.installation import Installation, SerdeError
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import AccountClient, WorkspaceClient
-from databricks.sdk.core import StreamingResponse
 from databricks.sdk.errors import NotFound
 from databricks.sdk.service.workspace import ExportFormat
 from databricks.labs.ucx.__about__ import __version__
@@ -573,12 +572,12 @@ def download(
                 # Installation does not have a download method
                 # BytesIO allows to .readline() for the header and handle the StreamingResponse from the download
                 input_ = BytesIO()
-                bytes = (
+                data = (
                     ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO)
                     .read()
                     .rstrip(b"\n")
                 )
-                input_.write(bytes)
+                input_.write(data)
                 input_.seek(0)  # Go back to the beginning of the file
                 csv_header_next = input_.readline()
                 if csv_header is None:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -564,9 +564,9 @@ def download(
     contexts = _get_workspace_contexts(w, run_as_collection=run_as_collection, a=a)
     csv_binaries = []
     for ctx in contexts:
-        # Installation does not have an upload method
-        remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
         try:
+            remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
+            # Installation does not have an download method
             csv_binary = ctx.workspace_client.workspace.download(remote_file_name)
             csv_binaries.append(csv_binary)
         except NotFound:

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -571,6 +571,7 @@ def download(
             remote_file_name = f"{ctx.installation.install_folder()}/{file.name}"
             try:
                 # Installation does not have a download method
+                # BytesIO allows to .readline() for the header and handle the StreamingResponse from the download
                 input_ = BytesIO()
                 bytes = ctx.workspace_client.workspace.download(remote_file_name, format=ExportFormat.AUTO).read()
                 input_.write(bytes)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -560,7 +560,7 @@ def download(
 ):
     """Download and merge a CSV file from the ucx installation in a (collection of) workspace(s)"""
     file = Path(file)
-    if not file.suffix == ".csv":
+    if file.suffix != ".csv":
         raise ValueError("Command only supported for CSV files")
     contexts = _get_workspace_contexts(w, run_as_collection=run_as_collection, a=a)
     csv_header = None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -827,7 +827,8 @@ def test_download_warns_if_file_not_found(caplog, ws1, acc_client):
     ws1.workspace.download.side_effect = NotFound("test.csv")
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.cli"):
         download(Path("test.csv"), ws1, run_as_collection=False, a=acc_client,)
-    assert "File not found for https://localhost: /Users/foo/.ucx/test.csv" in caplog.text
+    assert "File not found for https://localhost: /Users/foo/.ucx/test.csv" in caplog.messages
+    assert "No file(s) to download found" in caplog.messages
 
 
 def test_download_has_expected_content(tmp_path, workspace_clients, acc_client):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -809,15 +809,14 @@ def test_download_raises_value_error_if_not_downloading_a_csv(ws1):
 
 
 @pytest.mark.parametrize("run_as_collection", [False, True])
-def test_download_calls_workspace_download(tmp_path, workspace_clients, acc_client, run_as_collection):
+def test_download_calls_workspace_download(workspace_clients, acc_client, run_as_collection):
     if not run_as_collection:
         workspace_clients = [workspace_clients[0]]
-    test_file = tmp_path / "test.csv"
 
-    download(test_file, workspace_clients[0], run_as_collection=run_as_collection, a=acc_client)
+    download(Path("test.csv"), workspace_clients[0], run_as_collection=run_as_collection, a=acc_client,)
 
     for ws in workspace_clients:
         ws.workspace.download.assert_called_with(
-            f"/Users/foo/.ucx/{test_file.name}",
+            f"/Users/foo/.ucx/test.csv",
             format=ExportFormat.AUTO,
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -107,7 +107,8 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
 """,
     }
 
-    def download(path: str) -> io.StringIO | io.BytesIO:
+    def download(path: str, *, format: ExportFormat | None = None) -> io.StringIO | io.BytesIO:
+        _ = format
         if path not in state:
             raise NotFound(path)
         if ".csv" in path or ".log" in path:
@@ -118,7 +119,7 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
     workspace_client.get_workspace_id.return_value = workspace_id
     workspace_client.config.host = 'https://localhost'
     workspace_client.current_user.me.return_value = User(user_name="foo", groups=[ComplexValue(display="admins")])
-    workspace_client.workspace.download = download
+    workspace_client.workspace.download.side_effect = download
     workspace_client.statement_execution.execute_statement.return_value = sql.StatementResponse(
         status=sql.StatementStatus(state=sql.StatementState.SUCCEEDED),
         manifest=sql.ResultManifest(schema=sql.ResultSchema()),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -802,6 +802,12 @@ def test_join_collection():
     w.workspace.download.assert_not_called()
 
 
+def test_download_raises_value_error_if_not_downloading_a_csv(ws1):
+    with pytest.raises(ValueError) as e:
+        download(Path("test.txt"), ws1)
+    assert "Command only supported for CSV files" in str(e)
+
+
 @pytest.mark.parametrize("run_as_collection", [False, True])
 def test_download_calls_workspace_download(tmp_path, workspace_clients, acc_client, run_as_collection):
     if not run_as_collection:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import time
 from pathlib import Path
 from unittest.mock import create_autospec, patch, Mock
@@ -820,6 +821,13 @@ def test_download_calls_workspace_download(workspace_clients, acc_client, run_as
             f"/Users/foo/.ucx/test.csv",
             format=ExportFormat.AUTO,
         )
+
+
+def test_download_warns_if_file_not_found(caplog, ws1, acc_client):
+    ws1.workspace.download.side_effect = NotFound("test.csv")
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.cli"):
+        download(Path("test.csv"), ws1, run_as_collection=False, a=acc_client,)
+    assert "File not found for https://localhost: /Users/foo/.ucx/test.csv" in caplog.text
 
 
 def test_download_has_expected_content(tmp_path, workspace_clients, acc_client):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -809,12 +809,12 @@ def test_download_raises_value_error_if_not_downloading_a_csv(ws1):
 
 
 @pytest.mark.parametrize("run_as_collection", [False, True])
-def test_download_calls_workspace_download(workspace_clients, acc_client, run_as_collection):
+def test_download_calls_workspace_download(tmp_path, workspace_clients, acc_client, run_as_collection):
     if not run_as_collection:
         workspace_clients = [workspace_clients[0]]
 
     download(
-        Path("test.csv"),
+        tmp_path / "test.csv",
         workspace_clients[0],
         run_as_collection=run_as_collection,
         a=acc_client,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -108,8 +108,7 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
 """,
     }
 
-    def mock_download(path: str, *, format: ExportFormat | None = None) -> io.StringIO | io.BytesIO:
-        _ = format
+    def mock_download(path: str, **_) -> io.StringIO | io.BytesIO:
         if path not in state:
             raise NotFound(path)
         if ".csv" in path or ".log" in path:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -108,7 +108,7 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
 """,
     }
 
-    def download(path: str, *, format: ExportFormat | None = None) -> io.StringIO | io.BytesIO:
+    def mock_download(path: str, *, format: ExportFormat | None = None) -> io.StringIO | io.BytesIO:
         _ = format
         if path not in state:
             raise NotFound(path)
@@ -120,7 +120,7 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
     workspace_client.get_workspace_id.return_value = workspace_id
     workspace_client.config.host = 'https://localhost'
     workspace_client.current_user.me.return_value = User(user_name="foo", groups=[ComplexValue(display="admins")])
-    workspace_client.workspace.download.side_effect = download
+    workspace_client.workspace.download.side_effect = mock_download
     workspace_client.statement_execution.execute_statement.return_value = sql.StatementResponse(
         status=sql.StatementStatus(state=sql.StatementState.SUCCEEDED),
         manifest=sql.ResultManifest(schema=sql.ResultSchema()),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -840,6 +840,19 @@ def test_download_warns_if_file_not_found(caplog, ws1, acc_client):
     assert "No file(s) to download found" in caplog.messages
 
 
+def test_download_deletes_empty_file(tmp_path, ws1, acc_client):
+    ws1.workspace.download.side_effect = NotFound("test.csv")
+    mapping_path = tmp_path / "mapping.csv"
+
+    download(
+        mapping_path,
+        ws1,
+        run_as_collection=False,
+        a=acc_client,
+    )
+    assert not mapping_path.is_file()
+
+
 def test_download_has_expected_content(tmp_path, workspace_clients, acc_client):
     expected = (
         "workspace_name,catalog_name,src_schema,dst_schema,src_table,dst_table"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -814,11 +814,16 @@ def test_download_calls_workspace_download(workspace_clients, acc_client, run_as
     if not run_as_collection:
         workspace_clients = [workspace_clients[0]]
 
-    download(Path("test.csv"), workspace_clients[0], run_as_collection=run_as_collection, a=acc_client,)
+    download(
+        Path("test.csv"),
+        workspace_clients[0],
+        run_as_collection=run_as_collection,
+        a=acc_client,
+    )
 
     for ws in workspace_clients:
         ws.workspace.download.assert_called_with(
-            f"/Users/foo/.ucx/test.csv",
+            "/Users/foo/.ucx/test.csv",
             format=ExportFormat.AUTO,
         )
 
@@ -826,7 +831,12 @@ def test_download_calls_workspace_download(workspace_clients, acc_client, run_as
 def test_download_warns_if_file_not_found(caplog, ws1, acc_client):
     ws1.workspace.download.side_effect = NotFound("test.csv")
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.cli"):
-        download(Path("test.csv"), ws1, run_as_collection=False, a=acc_client,)
+        download(
+            Path("test.csv"),
+            ws1,
+            run_as_collection=False,
+            a=acc_client,
+        )
     assert "File not found for https://localhost: /Users/foo/.ucx/test.csv" in caplog.messages
     assert "No file(s) to download found" in caplog.messages
 
@@ -839,7 +849,12 @@ def test_download_has_expected_content(tmp_path, workspace_clients, acc_client):
     )
     mapping_path = tmp_path / "mapping.csv"
 
-    download(mapping_path, workspace_clients[0], run_as_collection=True, a=acc_client,)
+    download(
+        mapping_path,
+        workspace_clients[0],
+        run_as_collection=True,
+        a=acc_client,
+    )
 
     content = mapping_path.read_text()
     assert content == expected

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -843,7 +843,6 @@ def test_download_warns_if_file_not_found(caplog, ws1, acc_client):
 def test_download_deletes_empty_file(tmp_path, ws1, acc_client):
     ws1.workspace.download.side_effect = NotFound("test.csv")
     mapping_path = tmp_path / "mapping.csv"
-
     download(
         mapping_path,
         ws1,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -820,3 +820,17 @@ def test_download_calls_workspace_download(workspace_clients, acc_client, run_as
             f"/Users/foo/.ucx/test.csv",
             format=ExportFormat.AUTO,
         )
+
+
+def test_download_has_expected_content(tmp_path, workspace_clients, acc_client):
+    expected = (
+        "workspace_name,catalog_name,src_schema,dst_schema,src_table,dst_table"
+        "\ntest,test,test,test,test,test"
+        "\ntest,test,test,test,test,test"
+    )
+    mapping_path = tmp_path / "mapping.csv"
+
+    download(mapping_path, workspace_clients[0], run_as_collection=True, a=acc_client,)
+
+    content = mapping_path.read_text()
+    assert content == expected


### PR DESCRIPTION
## Changes
Add a `download` cli command to download file from a collection of workspaces.

### Linked issues

Progresses #1783

### Functionality

- [x] added relevant user documentation
- [x] added new CLI command: `download`

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] ~added integration tests~ : Covering after #2507
