### PR TITLE
Retry deploy workflow on `InternalError`

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -576,6 +576,8 @@ class WorkflowsDeployment(InstallationMixin):
             return {"spark.sql.sources.parallelPartitionDiscovery.parallelism": "200"} | conf_from_installation
         return conf_from_installation
 
+    # Workflow creation might fail on an InternalError with no message
+    @retried(on=[InternalError], timeout=timedelta(minutes=2))
     def _deploy_workflow(self, step_name: str, settings):
         if step_name in self._install_state.jobs:
             try:


### PR DESCRIPTION
## Changes
Retry deploy workflow on `InternalError` to improve resilience of deploying workflow, e.g. failed https://github.com/databrickslabs/ucx/actions/runs/10676861894

### Linked issues
Resolves #2522
