### PR TITLE
More escaping of SQL identifiers

### DIFF
--- a/src/databricks/labs/ucx/framework/utils.py
+++ b/src/databricks/labs/ucx/framework/utils.py
@@ -17,7 +17,7 @@ def escape_sql_identifier(path: str) -> str:
     if not path:
         return path
     parts = path.split(".", maxsplit=2)
-    escaped = [f"`{part.strip('`')}`" for part in parts]
+    escaped = [f"`{part.strip('`').replace('`', '``')}`" for part in parts]
     return ".".join(escaped)
 
 

--- a/src/databricks/labs/ucx/recon/base.py
+++ b/src/databricks/labs/ucx/recon/base.py
@@ -11,15 +11,15 @@ class TableIdentifier:
 
     @property
     def catalog_escaped(self):
-        return f"`{self.catalog}`"
+        return f"`{self.catalog.replace('`','``')}`"
 
     @property
     def schema_escaped(self):
-        return f"`{self.schema}`"
+        return f"`{self.schema.replace('`','``')}`"
 
     @property
     def table_escaped(self):
-        return f"`{self.table}`"
+        return f"`{self.table.replace('`','``')}`"
 
     @property
     def fqn_escaped(self):

--- a/src/databricks/labs/ucx/recon/migration_recon.py
+++ b/src/databricks/labs/ucx/recon/migration_recon.py
@@ -8,6 +8,7 @@ from databricks.sdk.errors import DatabricksError
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
+from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
 from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatusRefresher
 from databricks.labs.ucx.recon.base import (
@@ -145,5 +146,5 @@ class MigrationRecon(CrawlerBase[ReconResult]):
         return round(abs(source_row_count - target_row_count) / source_row_count * 100)
 
     def _try_fetch(self) -> Iterable[ReconResult]:
-        for row in self._fetch(f"SELECT * FROM {self._schema}.{self._table}"):
+        for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield ReconResult(*row)

--- a/tests/unit/framework/test_utils.py
+++ b/tests/unit/framework/test_utils.py
@@ -21,6 +21,7 @@ from databricks.labs.ucx.framework.utils import escape_sql_identifier
         ("a-b.c.d", "`a-b`.`c`.`d`"),
         ("a.b-c.d", "`a`.`b-c`.`d`"),
         ("a.b.c-d", "`a`.`b`.`c-d`"),
+        ("a.b.c`d", "`a`.`b`.`c``d`"),
         ("✨.🍰.✨", "`✨`.`🍰`.`✨`"),
         ("", ""),
     ],


### PR DESCRIPTION
## Changes

Following on from #2485, this PR:

 - Updates a missed SQL statement in one of the crawlers where the identifiers should be escaped.
 - Adds in a missing (and not well known) corner-case for the escaping of identifiers: Spark/Databricks supports backticks in the names of identifiers, and these need to be doubled when quoting in the same manner as single-quotes in SQL strings.
 - Updates SQL escaping for the same thing in another part of the code where the same thing is done in the `migrate-data-reconciliation` workflow when working with the workspace resources.

### Linked issues

Follows #2485.

### Functionality

- modified existing workflow: `migrate-data-reconciliation`

### Tests

- updated unit tests
