### PR TITLE
Enable `migrate-credentials` command to run as collection

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -133,7 +133,7 @@ commands:
       - name: aws-profile
         description: AWS Profile to use for authentication
       - name: run-as-collection
-        description: boolean flag to indicate to run the cmd as a collection. Default is False.
+        description: (Optional) boolean flag to indicate to run the cmd as a collection. Default is False.
 
   - name: create-missing-principals
     description: For AWS, this command identifies all the S3 locations that are missing a UC compatible role and
@@ -175,6 +175,8 @@ commands:
         description: Subscription to scan storage account in
       - name: aws-profile
         description: AWS Profile to use for authentication
+      - name: run-as-collection
+        description: (Optional) boolean flag to indicate to run the cmd as a collection. Default is False.
 
   - name: create-account-groups
     is_account_level: true

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -348,7 +348,14 @@ def create_missing_principals(
 
 
 @ucx.command
-def migrate_credentials(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None, **named_parameters):
+def migrate_credentials(
+    w: WorkspaceClient,
+    prompts: Prompts,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+    **named_parameters,
+):
     """For Azure, this command prompts to i) create UC storage credentials for the access connectors with a
     managed identity created for each storage account present in the ADLS Gen2 locations, the access connectors are
     granted Storage Blob Data Contributor permissions on their corresponding storage account, to prepare for adopting to
@@ -364,13 +371,19 @@ def migrate_credentials(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceCont
     Please review the file and delete the Roles you do not want to be migrated.
     Pass aws_profile for aws.
     """
-    if not ctx:
-        ctx = WorkspaceContext(w, named_parameters)
-    if ctx.is_azure:
-        return ctx.service_principal_migration.run(prompts)
-    if ctx.is_aws:
-        return ctx.iam_role_migration.run(prompts)
-    raise ValueError("Unsupported cloud provider")
+    workspace_contexts = get_contexts(w, a, run_as_collection, **named_parameters)
+    if ctx:
+        workspace_contexts = [ctx]
+    if w.config.is_azure:
+        for workspace_ctx in workspace_contexts:
+            logger.info(f"Running cmd for workspace {workspace_ctx.workspace_client.get_workspace_id()}")
+            workspace_ctx.service_principal_migration.run(prompts)
+    if w.config.is_aws:
+        for workspace_ctx in workspace_contexts:
+            logger.info(f"Running cmd for workspace {workspace_ctx.workspace_client.get_workspace_id()}")
+            workspace_ctx.iam_role_migration.run(prompts)
+    if w.config.is_gcp:
+        raise ValueError("Unsupported cloud provider")
 
 
 @ucx.command

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -356,7 +356,10 @@ def test_save_storage_and_principal_gcp(ws):
         principal_prefix_access(ws, ctx=ctx)
 
 
-def test_migrate_credentials_azure(ws):
+def test_migrate_credentials_azure(ws, acc_client):
+    ws.config.is_azure = True
+    ws.config.is_aws = False
+    ws.config.is_gcp = False
     ws.workspace.upload.return_value = "test"
     prompts = MockPrompts({'.*': 'yes'})
     azure_resources = create_autospec(AzureResources)
@@ -366,22 +369,28 @@ def test_migrate_credentials_azure(ws):
         azure_subscription_id='test',
         azure_resources=azure_resources,
     )
-    migrate_credentials(ws, prompts, ctx=ctx)
+    migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
     ws.storage_credentials.list.assert_called()
     azure_resources.storage_accounts.assert_called()
 
 
-def test_migrate_credentials_aws(ws):
+def test_migrate_credentials_aws(ws, acc_client):
+    ws.config.is_azure = False
+    ws.config.is_aws = True
+    ws.config.is_gcp = False
     aws_resources = create_autospec(AWSResources)
     aws_resources.validate_connection.return_value = {"Account": "123456789012"}
     prompts = MockPrompts({'.*': 'yes'})
     ctx = WorkspaceContext(ws).replace(is_aws=True, aws_resources=aws_resources)
-    migrate_credentials(ws, prompts, ctx=ctx)
+    migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
     ws.storage_credentials.list.assert_called()
 
 
-def test_migrate_credentials_raises_runtime_warning_when_hitting_storage_credential_limit(ws):
+def test_migrate_credentials_raises_runtime_warning_when_hitting_storage_credential_limit(ws, acc_client):
     """The storage credential limit is 200, so we should raise a warning when we hit that limit."""
+    ws.config.is_azure = True
+    ws.config.is_aws = False
+    ws.config.is_gcp = False
     azure_resources = create_autospec(AzureResources)
     external_locations = create_autospec(ExternalLocations)
     storage_accounts_mock, external_locations_mock = [], []
@@ -411,7 +420,7 @@ def test_migrate_credentials_raises_runtime_warning_when_hitting_storage_credent
         azure_resources=azure_resources,
         external_locations=external_locations,
     )
-    migrate_credentials(ws, prompts, ctx=ctx)
+    migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
     ws.storage_credentials.list.assert_called()
     azure_resources.storage_accounts.assert_called()
 
@@ -430,10 +439,13 @@ def test_migrate_credentials_raises_runtime_warning_when_hitting_storage_credent
     storage_accounts_mock.append(storage_account)
     external_locations_mock.append(external_location)
     with pytest.raises(RuntimeWarning):
-        migrate_credentials(ws, prompts, ctx=ctx)
+        migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
 
 
-def test_migrate_credentials_limit_aws(ws):
+def test_migrate_credentials_limit_aws(ws, acc_client):
+    ws.config.is_azure = False
+    ws.config.is_aws = True
+    ws.config.is_gcp = False
     aws_resources = create_autospec(AWSResources)
     external_locations = create_autospec(ExternalLocations)
 
@@ -458,7 +470,7 @@ def test_migrate_credentials_limit_aws(ws):
     AWSResourcePermissions.load_uc_compatible_roles = Mock()
     AWSResourcePermissions.load_uc_compatible_roles.return_value = aws_role_actions_mock
     ctx = WorkspaceContext(ws).replace(is_aws=True, aws_resources=aws_resources, external_locations=external_locations)
-    migrate_credentials(ws, prompts, ctx=ctx)
+    migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
     ws.storage_credentials.list.assert_called()
 
     external_locations_mock.append(ExternalLocation(location="s3://labsawsbucket/201", table_count=25))
@@ -471,7 +483,7 @@ def test_migrate_credentials_limit_aws(ws):
         )
     )
     with pytest.raises(RuntimeWarning):
-        migrate_credentials(ws, prompts, ctx=ctx)
+        migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
 
 
 def test_create_master_principal_not_azure(ws):


### PR DESCRIPTION

## Changes
This PR enables migrate-credentials to run as a collection. 

Linked issues #1782 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
