### PR TITLE
Bugfix: `test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only`

### DIFF
--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -115,7 +115,7 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
         _ = ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
-    with pytest.raises(NotFound, match=f"Group with id {ws_group.id} not found."):
+    with pytest.raises(NotFound):
         get_group(ws_group.id)
 
 


### PR DESCRIPTION
## Changes

This PR updates an integration test that started failing after the Databricks 0.32.0 release. In this test we check the error message associated with an expected failure, but the message changed with the new version of the SDK so the test now fails.

_Note: This is probably a bug introduced in the upstream SDK release._ For a call to `ws.groups.get(id)` where the ID doesn't exist:

 - Previously we would get the message: `Group with id $ID not found.`
 - As of the new release we get: `None request failed`

### Linked issues

Resolves #2539.

### Tests

- updated integration test
