### PR TITLE
Fixes pip install statement in debug notebook

### DIFF
--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -783,8 +783,9 @@ class WorkflowsDeployment(InstallationMixin):
             f"[{self._name(step_name)}]({self._ws.config.host}#job/{job_id})"
             for step_name, job_id in self._install_state.jobs.items()
         )
+        remote_wheels_str = " ".join(remote_wheels)
         content = DEBUG_NOTEBOOK.format(
-            remote_wheel=remote_wheels, readme_link=readme_link, job_links=job_links, config_file=self._config_file
+            remote_wheel=remote_wheels_str, readme_link=readme_link, job_links=job_links, config_file=self._config_file
         ).encode("utf8")
         self._installation.upload('DEBUG.py', content)
 


### PR DESCRIPTION
## Changes
pip install wheel is surrounded by [ ] which fails the notebook run. 

### Linked issues
Quick fix

### Functionality
- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs ucx ...`
- [ ] added a new workflow
- [ ] modified existing workflow: `...`
- [ ] added a new table
- [ ] modified existing table: `...`

### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
