### PR TITLE
Uses PermissionDenied instead of PermissionError

### DIFF
--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -9,7 +9,7 @@ from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.blueprint.tui import Prompts
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import NotFound, ResourceDoesNotExist
+from databricks.sdk.errors import NotFound, ResourceDoesNotExist, PermissionDenied
 from databricks.sdk.service.catalog import Privilege
 from databricks.sdk.service.compute import Policy
 from databricks.sdk.service.sql import SetWorkspaceWarehouseConfigRequestSecurityPolicy
@@ -358,7 +358,7 @@ class AWSResourcePermissions:
             self._update_cluster_policy_with_instance_profile(cluster_policy, iam_instance_profile)
             self._update_sql_dac_with_instance_profile(iam_instance_profile, prompts)
             logger.info(f"Cluster policy \"{cluster_policy.name}\" updated successfully")
-        except PermissionError:
+        except PermissionDenied:
             logger.error(f"Failed to assign instance profile to cluster policy {iam_role_name}")
             self._aws_resources.delete_instance_profile(iam_role_name, iam_role_name)
 

--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -307,7 +307,7 @@ class AWSResourcePermissions:
             )
         ):
             self._aws_resources.delete_instance_profile(iam_role_name, iam_role_name)
-            raise PermissionError(f"Failed to create migration role and instance profile {iam_role_name}")
+            raise PermissionDenied(f"Failed to create migration role and instance profile {iam_role_name}")
 
     def create_uber_principal(self, prompts: Prompts):
         config = self._installation.load(WorkspaceConfig)

--- a/src/databricks/labs/ucx/installer/mixins.py
+++ b/src/databricks/labs/ucx/installer/mixins.py
@@ -3,6 +3,7 @@ import os
 
 from databricks.labs.blueprint.installation import Installation
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import PermissionDenied
 from databricks.sdk.service.sql import EndpointInfoWarehouseType
 
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -27,7 +28,7 @@ class InstallationMixin:
             is_workspace_admin = any(g.display == "admins" for g in self._me.groups)
             if not is_workspace_admin:
                 msg = "Current user is not a workspace admin"
-                raise PermissionError(msg)
+                raise PermissionDenied(msg)
         return self._me.user_name
 
     @property

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -7,7 +7,7 @@ from databricks.labs.blueprint.installation import MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import ResourceDoesNotExist
+from databricks.sdk.errors import ResourceDoesNotExist, PermissionDenied
 from databricks.sdk.service import iam
 from databricks.sdk.service.catalog import (
     AwsIamRoleResponse,
@@ -340,7 +340,7 @@ def test_failed_create_uber_principal(mock_ws, mock_installation, backend, locat
         locations,
     )
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionDenied):
         aws_resource_permissions.create_uber_principal(prompts)
 
     assert len([cmd for cmd in command_calls if "delete-instance-profile" in cmd]) == 1

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1555,7 +1555,7 @@ def test_user_not_admin(ws, mock_installation):
         Workflows.all().tasks(),
     )
 
-    with pytest.raises(PermissionError) as failure:
+    with pytest.raises(PermissionDenied) as failure:
         workspace_installation.create_jobs()
     assert "Current user is not a workspace admin" in str(failure.value)
 


### PR DESCRIPTION
## Changes
Uses PermissionDenied instead of PermissionError for handling Databricks' object errors

### Linked issues
Resolves #2407 

### Tests
Used existing tests