### PR TITLE
Refactors verify_timeout property on DeployedWorkflows

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -364,7 +364,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def deployed_workflows(self):
-        return DeployedWorkflows(self.workspace_client, self.install_state, self.verify_timeout)
+        return DeployedWorkflows(self.workspace_client, self.install_state)
 
     @cached_property
     def workspace_info(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -191,7 +191,6 @@ class WorkspaceInstaller(WorkspaceContext):
                 self.workspace_client,
                 self.wheels,
                 self.product_info,
-                verify_timeout,
                 self._tasks,
             )
             workspace_installation = WorkspaceInstallation(
@@ -468,11 +467,8 @@ class WorkspaceInstallation(InstallationMixin):
         sql_backend = StatementExecutionBackend(ws, config.warehouse_id)
         wheels = product_info.wheels(ws)
         prompts = Prompts()
-        timeout = timedelta(minutes=2)
         tasks = Workflows.all().tasks()
-        workflows_installer = WorkflowsDeployment(
-            config, installation, install_state, ws, wheels, product_info, timeout, tasks
-        )
+        workflows_installer = WorkflowsDeployment(config, installation, install_state, ws, wheels, product_info, tasks)
 
         return cls(
             config,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -175,7 +175,6 @@ class WorkspaceInstaller(WorkspaceContext):
     def run(
         self,
         default_config: WorkspaceConfig | None = None,
-        verify_timeout=timedelta(minutes=2),
         config: WorkspaceConfig | None = None,
     ) -> WorkspaceConfig:
         logger.info(f"Installing UCX v{self.product_info.version()}")

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -174,7 +174,7 @@ class DeployedWorkflows:
                 f"Completed {step} job run {run_id} duration: {duration or 'N/A'} ({start_time or 'N/A'} thru {end_time or 'N/A'})"
             )
 
-    def repair_run(self, workflow, verify_timeout: timedelta):
+    def repair_run(self, workflow, verify_timeout: timedelta = timedelta(minutes=2)):
         try:
             job_id, run_id = self._repair_workflow(workflow, verify_timeout)
             run_details = self._ws.jobs.get_run(run_id=run_id, include_history=True)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -442,7 +442,6 @@ class WorkflowsDeployment(InstallationMixin):
         ws: WorkspaceClient,
         wheels: WheelsV2,
         product_info: ProductInfo,
-        verify_timeout: timedelta,
         tasks: list[Task],
     ):
         self._config = config
@@ -451,7 +450,6 @@ class WorkflowsDeployment(InstallationMixin):
         self._install_state = install_state
         self._wheels = wheels
         self._product_info = product_info
-        self._verify_timeout = verify_timeout
         self._tasks = tasks
         self._this_file = Path(__file__)
         super().__init__(config, installation, ws)

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -178,13 +178,16 @@ class DeployedWorkflows:
         try:
             job_id, run_id = self._repair_workflow(workflow, verify_timeout)
             run_details = self._ws.jobs.get_run(run_id=run_id, include_history=True)
-            latest_repair_run_id = run_details.repair_history[-1].id
-            job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
-            logger.debug(f"Repairing {workflow} job: {job_url}")
-            self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id)
-            webbrowser.open(job_url)
-        except InvalidParameterValue as e:
-            logger.warning(f"Skipping {workflow}: {e}")
+            if run_details.repair_history:
+                latest_repair_run_id = run_details.repair_history[-1].id
+                job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
+                logger.debug(f"Repairing {workflow} job: {job_url}")
+                self._ws.jobs.repair_run(
+                    run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id
+                )
+                webbrowser.open(job_url)
+            else:
+                logger.warning(f"No repair history found for run_id={run_id}")
         except TimeoutError:
             logger.warning(f"Skipping the {workflow} due to time out. Please try after sometime")
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -179,6 +179,8 @@ class DeployedWorkflows:
             job_id, run_id = self._repair_workflow(workflow, verify_timeout)
             run_details = self._ws.jobs.get_run(run_id=run_id, include_history=True)
             self._handle_repair_run(run_details, job_id, run_id, workflow)
+        except InvalidParameterValue as e:
+            logger.warning(f"Skipping {workflow}: {e}")
         except TimeoutError:
             logger.warning(f"Skipping the {workflow} due to time out. Please try after sometime")
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -178,18 +178,19 @@ class DeployedWorkflows:
         try:
             job_id, run_id = self._repair_workflow(workflow, verify_timeout)
             run_details = self._ws.jobs.get_run(run_id=run_id, include_history=True)
-            if run_details.repair_history:
-                latest_repair_run_id = run_details.repair_history[-1].id
-                job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
-                logger.debug(f"Repairing {workflow} job: {job_url}")
-                self._ws.jobs.repair_run(
-                    run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id
-                )
-                webbrowser.open(job_url)
-            else:
-                logger.warning(f"No repair history found for run_id={run_id}")
+            self._handle_repair_run(run_details, job_id, run_id, workflow)
         except TimeoutError:
             logger.warning(f"Skipping the {workflow} due to time out. Please try after sometime")
+
+    def _handle_repair_run(self, run_details, job_id, run_id, workflow):
+        if run_details.repair_history:
+            latest_repair_run_id = run_details.repair_history[-1].id
+            job_url = f"{self._ws.config.host}#job/{job_id}/run/{run_id}"
+            logger.debug(f"Repairing {workflow} job: {job_url}")
+            self._ws.jobs.repair_run(run_id=run_id, rerun_all_failed_tasks=True, latest_repair_id=latest_repair_run_id)
+            webbrowser.open(job_url)
+        else:
+            logger.warning(f"No repair history found for run_id={run_id}")
 
     def latest_job_status(self) -> list[dict]:
         latest_status = []

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ import os
 import logging
 from dataclasses import replace
 from functools import partial, cached_property
-from datetime import timedelta
 import shutil
 import subprocess
 import databricks.sdk.core
@@ -722,7 +721,6 @@ class MockInstallationContext(MockRuntimeContext):
             self.workspace_client,
             self.product_info.wheels(self.workspace_client),
             self.product_info,
-            timedelta(minutes=3),
             self.tasks,
         )
 

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -112,7 +112,6 @@ def test_create_database(ws, caplog, mock_installation, any_prompt):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
 
@@ -147,7 +146,6 @@ def test_install_cluster_override_jobs(ws, mock_installation):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         Workflows.all().tasks(),
     )
 
@@ -170,7 +168,6 @@ def test_writeable_dbfs(ws, tmp_path, mock_installation):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         Workflows.all().tasks(),
     )
 
@@ -507,7 +504,6 @@ def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_insta
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
     workspace_installation = WorkspaceInstallation(
@@ -579,7 +575,6 @@ def test_remove_jobs_no_state(ws):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
     workspace_installation = WorkspaceInstallation(
@@ -614,7 +609,6 @@ def test_remove_jobs_with_state_missing_job(ws, caplog, mock_installation_with_j
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
     workspace_installation = WorkspaceInstallation(
@@ -1148,7 +1142,6 @@ def test_triggering_assessment_wf(ws, mocker, mock_installation):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         Workflows.all().tasks(),
     )
     workspace_installation = WorkspaceInstallation(
@@ -1181,7 +1174,6 @@ def test_triggering_assessment_wf_w_job(ws, mocker, mock_installation):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         Workflows.all().tasks(),
     )
     workspace_installation = WorkspaceInstallation(
@@ -1211,9 +1203,7 @@ def test_runs_upgrades_on_too_old_version(ws, any_prompt):
         wheels=wheels,
     )
 
-    install.run(
-        verify_timeout=timedelta(seconds=60),
-    )
+    install.run()
 
     wheels.upload_to_wsfs.assert_called()
 
@@ -1239,9 +1229,7 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
         wheels=wheels,
     )
 
-    install.run(
-        verify_timeout=timedelta(seconds=10),
-    )
+    install.run()
 
     existing_installation.assert_file_uploaded('logs/README.md')
     wheels.upload_to_wsfs.assert_called()
@@ -1301,7 +1289,6 @@ def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
 
@@ -1333,7 +1320,6 @@ def test_remove_jobs_already_deleted(ws, caplog, mock_installation_extra_jobs, a
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         [],
     )
 
@@ -1546,7 +1532,6 @@ def test_user_not_admin(ws, mock_installation):
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=1),
         Workflows.all().tasks(),
     )
 

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -211,7 +211,7 @@ def test_run_workflow_creates_proper_failure(ws, mocker, mock_installation_with_
     ws.jobs.get_run_output.return_value = jobs.RunOutput(error="does not compute", error_trace="# goes to stderr")
     ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    installer = DeployedWorkflows(ws, install_state, timedelta(seconds=1))
+    installer = DeployedWorkflows(ws, install_state)
     logger = logging.getLogger("databricks.labs.ucx.installer.workflows")
     logger.setLevel(logging.DEBUG)
     with pytest.raises(Unknown) as failure:
@@ -246,7 +246,7 @@ def test_run_workflow_run_id_not_found(ws, mocker, mock_installation_with_jobs):
     ws.jobs.get_run_output.return_value = jobs.RunOutput(error="does not compute", error_trace="# goes to stderr")
     ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timedelta(seconds=1))
+    deployed = DeployedWorkflows(ws, install_state)
     with pytest.raises(NotFound):
         deployed.run_workflow("assessment")
 
@@ -279,7 +279,7 @@ def test_run_workflow_creates_failure_from_mapping(ws, mocker, mock_installation
         error="something: PermissionDenied: does not compute", error_trace="# goes to stderr"
     )
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timedelta(seconds=1))
+    deployed = DeployedWorkflows(ws, install_state)
     with pytest.raises(PermissionDenied) as failure:
         deployed.run_workflow("assessment")
 
@@ -324,7 +324,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
     )
     ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("does not compute")
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timedelta(seconds=1))
+    deployed = DeployedWorkflows(ws, install_state)
     with pytest.raises(ManyError) as failure:
         deployed.run_workflow("assessment")
 
@@ -826,9 +826,9 @@ def test_repair_run(ws, mocker, mock_installation_with_jobs):
 
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
-    deployed.repair_run("assessment")
+    deployed.repair_run("assessment", timeout)
 
 
 def test_repair_run_success(ws, caplog, mock_installation_with_jobs):
@@ -847,9 +847,9 @@ def test_repair_run_success(ws, caplog, mock_installation_with_jobs):
     ws.jobs.list_runs.repair_run = None
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
-    deployed.repair_run("assessment")
+    deployed.repair_run("assessment", timeout)
 
     assert "job is not in FAILED state" in caplog.text
 
@@ -871,10 +871,10 @@ def test_repair_run_no_job_id(ws, mock_installation, caplog):
 
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
     with caplog.at_level('WARNING'):
-        deployed.repair_run("assessment")
+        deployed.repair_run("assessment", timeout)
         assert 'Skipping assessment: job does not exists hence skipping repair' in caplog.messages
 
 
@@ -884,10 +884,10 @@ def test_repair_run_no_job_run(ws, mock_installation_with_jobs, caplog):
 
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
     with caplog.at_level('WARNING'):
-        deployed.repair_run("assessment")
+        deployed.repair_run("assessment", timeout)
         assert "Skipping assessment: job is not initialized yet. Can't trigger repair run now" in caplog.messages
 
 
@@ -896,10 +896,10 @@ def test_repair_run_exception(ws, mock_installation_with_jobs, caplog):
 
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
     with caplog.at_level('WARNING'):
-        deployed.repair_run("assessment")
+        deployed.repair_run("assessment", timeout)
         assert "Skipping assessment: Workflow does not exists" in caplog.messages
 
 
@@ -920,9 +920,9 @@ def test_repair_run_result_state(ws, caplog, mock_installation_with_jobs):
 
     timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
 
-    deployed.repair_run("assessment")
+    deployed.repair_run("assessment", timeout)
     assert "Please try after sometime" in caplog.text
 
 
@@ -968,9 +968,8 @@ def test_latest_job_status_states(ws, mock_installation_with_jobs, state, expect
             start_time=1704114000000,
         )
     ]
-    timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.return_value = base
     status = deployed.latest_job_status()
     assert len(status) == 1
@@ -999,9 +998,8 @@ def test_latest_job_status_success_with_time(mock_datetime, ws, mock_installatio
             start_time=start_time,
         )
     ]
-    timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.return_value = base
     faked_now = datetime(2024, 1, 1, 14, 0, 0)
     mock_datetime.now.return_value = faked_now
@@ -1035,10 +1033,9 @@ def test_latest_job_status_list(ws):
         ],
         [],  # the last job has no runs
     ]
-    timeout = timedelta(seconds=1)
     installation = MockInstallation({'state.json': {'resources': {'jobs': {"job1": "1", "job2": "2", "job3": "3"}}}})
     install_state = InstallState.from_installation(installation)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.side_effect = iter(runs)
     status = deployed.latest_job_status()
     assert len(status) == 3
@@ -1051,9 +1048,8 @@ def test_latest_job_status_list(ws):
 
 
 def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs):
-    timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.return_value = ""
     status = deployed.latest_job_status()
     assert len(status) == 1
@@ -1061,9 +1057,8 @@ def test_latest_job_status_no_job_run(ws, mock_installation_with_jobs):
 
 
 def test_latest_job_status_exception(ws, mock_installation_with_jobs):
-    timeout = timedelta(seconds=1)
     install_state = InstallState.from_installation(mock_installation_with_jobs)
-    deployed = DeployedWorkflows(ws, install_state, timeout)
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.side_effect = InvalidParameterValue("Workflow does not exists")
     status = deployed.latest_job_status()
     assert len(status) == 0
@@ -1580,7 +1575,7 @@ def test_validate_step(ws, result_state, expected):
         }
     )
     install_state = InstallState.from_installation(installation)
-    deployed = DeployedWorkflows(ws, install_state, timedelta(seconds=1))
+    deployed = DeployedWorkflows(ws, install_state)
     ws.jobs.list_runs.return_value = [
         BaseRun(
             job_id=123,

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -32,7 +31,6 @@ def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
         ws,
         wheels,
         PRODUCT_INFO,
-        timedelta(seconds=10),
         [],
     )
     return WorkspaceInstallation(

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -70,7 +70,7 @@ def test_run_workflow(mock_installation) -> None:
     """Check that run_workflow starts a workflow and waits for it to complete."""
     ws = create_autospec(WorkspaceClient)
     install_state = InstallState.from_installation(mock_installation)
-    workflows = DeployedWorkflows(ws, install_state, verify_timeout=timedelta(seconds=0))
+    workflows = DeployedWorkflows(ws, install_state)
     ws.jobs.run_now.return_value = Run(run_id=456)
     ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
         state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000
@@ -87,7 +87,7 @@ def test_run_workflow_skip_job_wait(mock_installation) -> None:
     """Check that run_workflow can start a workflow but return immediately instead of waiting for it to complete."""
     ws = create_autospec(WorkspaceClient)
     install_state = InstallState.from_installation(mock_installation)
-    workflows = DeployedWorkflows(ws, install_state, verify_timeout=timedelta(seconds=0))
+    workflows = DeployedWorkflows(ws, install_state)
     ws.jobs.run_now.return_value = Run(run_id=456)
 
     run_id = workflows.run_workflow("test", skip_job_wait=True)
@@ -101,7 +101,7 @@ def test_run_workflow_operation_failed(mock_installation) -> None:
     """Check that run_workflow handles a failing workflow due to an OperationFailed error, including log replication."""
     ws = create_autospec(WorkspaceClient)
     install_state = InstallState.from_installation(mock_installation)
-    workflows = DeployedWorkflows(ws, install_state, verify_timeout=timedelta(seconds=0))
+    workflows = DeployedWorkflows(ws, install_state)
     ws.jobs.run_now.return_value = Run(run_id=456)
     ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = OperationFailed("Simulated workflow failure")
     ws.jobs.get_run.return_value = Run(
@@ -124,7 +124,7 @@ def test_run_workflow_timeout(mock_installation) -> None:
     """Check that run_workflow can handle a workflow takes longer than the timeout, including log replication."""
     ws = create_autospec(WorkspaceClient)
     install_state = InstallState.from_installation(mock_installation)
-    workflows = DeployedWorkflows(ws, install_state, verify_timeout=timedelta(seconds=0))
+    workflows = DeployedWorkflows(ws, install_state)
     ws.jobs.run_now.return_value = Run(run_id=456)
     ws.jobs.wait_get_run_job_terminated_or_skipped.side_effect = TimeoutError("Simulated timeout")
 

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -25,7 +25,7 @@ def test_deployed_workflows_handles_log_folder_does_not_exists(mock_installation
     # Raise the error when the result is iterated over, NOT when the method is called.
     ws.workspace.list.return_value = ResourceDoesNotExistIter()
     install_state = InstallState.from_installation(mock_installation)
-    deployed_workflows = DeployedWorkflows(ws, install_state, timedelta(minutes=2))
+    deployed_workflows = DeployedWorkflows(ws, install_state)
 
     deployed_workflows.relay_logs("test")
 

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -55,7 +55,6 @@ def test_workflows_deployment_creates_jobs_with_remove_after_tag(mock_installati
         ws,
         wheels,
         product_info,
-        verify_timeout=timedelta(minutes=5),
         tasks=tasks,
     )
     try:


### PR DESCRIPTION
## Changes
Since the attribute is not used except in the repair_run method, refactoring accordingly.

### Linked issues
Resolves #2383 


### Tests
- [ ] manually tested
- [x] modified unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
