### PR TITLE
Bugfix: `test_running_real_remove_backup_groups_job`

### DIFF
--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -192,7 +192,7 @@ def test_running_real_remove_backup_groups_job(ws: WorkspaceClient, installation
         _ = ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
-    with pytest.raises(NotFound, match=f"Group with id {ws_group_a.id} not found."):
+    with pytest.raises(NotFound):
         get_group(ws_group_a.id)
 
 


### PR DESCRIPTION
## Changes

This PR updates an integration test that has started failing since the Databricks 0.32.0 release. In this test we check the error message associated with an expected failure, but the message changed with the new version of the SDK so the test now fails.

### Linked issues

Relates to #2541, affects #2546.

Triggered by upstream databricks/databricks-sdk-py#749.

### Tests

- updated integration test
