### PR TITLE
Document: clarify that the `assessment` job is not intended to be re-run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ which can be used for further analysis and decision-making through the [assessme
 
 After UCX assessment workflow is executed, the assessment dashboard will be populated with findings and common recommendations. See [this guide](docs/assessment.md) for more details.
 
-The UCX assessment workflow is intended to only be run once; re-running it is not supported. If the inventory and findings for a workspace need to be updated then UCX should first be [uninstalled](#uninstall-ucx) and reinstalled.
+The UCX assessment workflow is intended to only run once; re-running it is not supported. If the inventory and findings for a workspace need to be updated then first reinstall UCX by [uninstalling](#uninstall-ucx) and [installing](#install-ucx) it again.
 
 [[back to top](#databricks-labs-ucx)]
 

--- a/README.md
+++ b/README.md
@@ -362,8 +362,6 @@ It identifies incompatible entities and provides information necessary for plann
 the assessment workflow can be executed in parallel or sequentially, depending on the dependencies specified in the `@task` decorators.
 The output of each task is stored in Delta tables in the `$inventory_database` schema, that you specify during [installation](#install-ucx),
 which can be used for further analysis and decision-making through the [assessment report](docs/assessment.md).
-The assessment workflow can be executed multiple times to ensure that all incompatible entities are identified and accounted
-for before starting the migration process.
 
 1. `crawl_tables`: This task scans all tables in the Hive Metastore of the current workspace and persists their metadata in a Delta table named `$inventory_database.tables`. This metadata includes information such as the database name, table name, table type, and table location. This task is used for assessing which tables cannot be easily migrated to Unity Catalog.
 2. `crawl_grants`: This task scans the Delta table named `$inventory_database.tables` and issues a `SHOW GRANTS` statement for every object to retrieve the permissions assigned to it. The permissions include information such as the principal, action type, and the table it applies to. This task persists the permissions in the Delta table `$inventory_database.grants`.
@@ -379,6 +377,8 @@ for before starting the migration process.
 ![report](docs/assessment-report.png)
 
 After UCX assessment workflow is executed, the assessment dashboard will be populated with findings and common recommendations. See [this guide](docs/assessment.md) for more details.
+
+The UCX assessment workflow is intended to only be run once; re-running it is not supported. If the inventory and findings for a workspace need to be updated then UCX should first be [uninstalled](#uninstall-ucx) and reinstalled.
 
 [[back to top](#databricks-labs-ucx)]
 


### PR DESCRIPTION
## Changes

Following on from some discussions yesterday, this PR updates the project document to clarify that the `assessment` job is only intended to be run once and should not be re-run to refresh the inventory and/or findings. The intent is that UCX should be reinstalled first if the assessment needs to be re-run.

### Linked issues

As part of #2074 a new (daily) job will be introduced that refreshes parts of the inventory; however the `assessment` job will remain as-is. (These documentation changes are intended to reflect the status quo.)

### Functionality

- updated user documentation
