### PR TITLE
Fix infinite recursion when visiting a dependency graph

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -208,13 +208,9 @@ class DependencyGraph:
 
             def __init__(self):
                 self._visited_pairs: set[tuple[Path, Path]] = set()
-                self._depth = 0
 
             def visit(self, graph: DependencyGraph) -> bool:
                 path = graph.dependency.path
-                self._depth += 1
-                if self._depth > 20:
-                    pass
                 if visited is not None:
                     if path in visited:
                         return False

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -174,13 +174,6 @@ class DependencyGraph:
     def local_dependencies(self) -> set[Dependency]:
         return {child.dependency for child in self._dependencies.values()}
 
-    @property
-    def all_paths(self) -> set[Path]:
-        # TODO: remove this public method, as it'll throw false positives
-        # for package imports, like certifi. a WorkflowTask is also a dependency,
-        # but it does not exist on a filesystem
-        return {d.path for d in self.all_dependencies}
-
     def all_relative_names(self) -> set[str]:
         """This method is intended to simplify testing"""
         return self._relative_names(self.all_dependencies)

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -32,6 +32,7 @@ def test_graph_visits_package_with_recursive_imports():
     graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
     container = maybe.dependency.load(path_lookup)
     container.build_dependency_graph(graph)
+    assert len(graph.all_dependencies) > 10
     # visit the graph without a 'visited' set
     roots = graph.root_dependencies
     assert roots

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
-from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph, WrappingLoader, Dependency
+from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph
 from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
-from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver, LocalFile
+from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, NotebookResolver
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
+from databricks.sdk.service.workspace import Language
+
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph
+from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph, WrappingLoader, Dependency
 from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
-from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver
+from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver, LocalFile
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, NotebookResolver
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
@@ -18,19 +20,20 @@ def test_graph_visits_package_with_recursive_imports():
                 return UNKNOWN
             return super().module_compatibility(name)
 
-    root_path = Path("../../unit/source_code/samples/import-sqlglot.py").resolve()
     allow_list = TestKnownList()
     library_resolver = PythonLibraryResolver(allow_list)
     notebook_resolver = NotebookResolver(NotebookLoader())
     import_resolver = ImportFileResolver(FileLoader(), allow_list)
-    path_lookup = PathLookup.from_sys_path(root_path.parent)
+    path_lookup = PathLookup.from_sys_path(Path(__file__).parent)
     dependency_resolver = DependencyResolver(
         library_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup
     )
-    maybe = dependency_resolver.resolve_file(path_lookup, root_path)
-    assert maybe.dependency
-    graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
-    container = maybe.dependency.load(path_lookup)
+    root_path = Path(__file__).parent.parent.parent / "unit" / "source_code" / "samples" / "import-sqlglot.py"
+    assert root_path.is_file()
+    container = LocalFile(root_path, "from sqlglot import Expression\n", Language.PYTHON)
+    loader = WrappingLoader(container)
+    dependency = Dependency(loader, root_path, False)
+    graph = DependencyGraph(dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
     container.build_dependency_graph(graph)
     assert len(graph.all_dependencies) > 10
     # visit the graph without a 'visited' set

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -30,10 +30,10 @@ def test_graph_visits_package_with_recursive_imports():
     )
     root_path = Path(__file__).parent.parent.parent / "unit" / "source_code" / "samples" / "import-sqlglot.py"
     assert root_path.is_file()
-    container = LocalFile(root_path, "from sqlglot import Expression\n", Language.PYTHON)
-    loader = WrappingLoader(container)
-    dependency = Dependency(loader, root_path, False)
-    graph = DependencyGraph(dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
+    maybe = dependency_resolver.resolve_file(path_lookup, root_path)
+    assert maybe.dependency
+    graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
+    container = maybe.dependency.load(path_lookup)
     container.build_dependency_graph(graph)
     assert len(graph.all_dependencies) > 10
     # visit the graph without a 'visited' set

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from databricks.labs.ucx.source_code.base import CurrentSessionState
+from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph
+from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
+from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver
+from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, NotebookResolver
+from databricks.labs.ucx.source_code.path_lookup import PathLookup
+from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
+
+
+def test_graph_visits_package_with_recursive_imports():
+    # we need a populated KnownList for this test to run in a reasonable time
+    # but sqlglot should be unknown since it exhibits the problematic recursion
+    class TestKnownList(KnownList):
+        def module_compatibility(self, name: str) -> Compatibility:
+            if name.startswith("sqlglot"):
+                return UNKNOWN
+            return super().module_compatibility(name)
+
+    root_path = Path("../../unit/source_code/samples/import-sqlglot.py").resolve()
+    allow_list = TestKnownList()
+    library_resolver = PythonLibraryResolver(allow_list)
+    notebook_resolver = NotebookResolver(NotebookLoader())
+    import_resolver = ImportFileResolver(FileLoader(), allow_list)
+    path_lookup = PathLookup.from_sys_path(root_path.parent)
+    dependency_resolver = DependencyResolver(
+        library_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup
+    )
+    maybe = dependency_resolver.resolve_file(path_lookup, root_path)
+    assert maybe.dependency
+    graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
+    container = maybe.dependency.load(path_lookup)
+    container.build_dependency_graph(graph)
+    # visit the graph without a 'visited' set
+    roots = graph.root_dependencies
+    assert roots

--- a/tests/unit/source_code/samples/import-sqlglot.py
+++ b/tests/unit/source_code/samples/import-sqlglot.py
@@ -1,0 +1,1 @@
+from sqlglot import Expression

--- a/tests/unit/source_code/test_graph.py
+++ b/tests/unit/source_code/test_graph.py
@@ -208,5 +208,6 @@ def test_graph_visits_package_with_recursive_imports(mock_path_lookup):
     graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
     container = maybe.dependency.load(path_lookup)
     container.build_dependency_graph(graph)
+    # visit the graph without a 'visited' set
     roots = graph.root_dependencies
     assert roots

--- a/tests/unit/source_code/test_graph.py
+++ b/tests/unit/source_code/test_graph.py
@@ -38,7 +38,8 @@ def test_folder_loads_content(mock_path_lookup, simple_dependency_resolver):
     graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
     container = dependency.load(mock_path_lookup)
     container.build_dependency_graph(graph)
-    assert len(graph.all_paths) == 4
+    all_paths = [d.path for d in graph.all_dependencies]
+    assert len(all_paths) == 4
 
 
 def test_root_dependencies_returns_only_files(mock_path_lookup, simple_dependency_resolver):

--- a/tests/unit/source_code/test_graph.py
+++ b/tests/unit/source_code/test_graph.py
@@ -6,8 +6,9 @@ from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver, FolderLoader
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver, InheritedContext
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookResolver, NotebookLoader
+from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
-from databricks.labs.ucx.source_code.known import KnownList
+from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
 
 
 def test_dependency_graph_registers_library(mock_path_lookup):
@@ -181,3 +182,30 @@ def test_graph_builds_inherited_context(mock_path_lookup, simple_dependency_reso
     assert inference_context.tree is not None
     assert inference_context.tree.has_global("some_table_name")
     assert not inference_context.tree.has_global("other_table_name")
+
+
+def test_graph_visits_package_with_recursive_imports(mock_path_lookup):
+    # we need a populated KnownList for this test to run in a reasonable time
+    # but sqlglot should be unknown since it exhibits the problematic recursion
+    class TestKnownList(KnownList):
+        def module_compatibility(self, name: str) -> Compatibility:
+            if name.startswith("sqlglot"):
+                return UNKNOWN
+            return super().module_compatibility(name)
+
+    root_path = mock_path_lookup.resolve(Path("import-sqlglot.py"))
+    allow_list = TestKnownList()
+    library_resolver = PythonLibraryResolver(allow_list)
+    notebook_resolver = NotebookResolver(NotebookLoader())
+    import_resolver = ImportFileResolver(FileLoader(), allow_list)
+    path_lookup = PathLookup.from_sys_path(root_path.parent)
+    dependency_resolver = DependencyResolver(
+        library_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup
+    )
+    maybe = dependency_resolver.resolve_file(path_lookup, root_path)
+    assert maybe.dependency
+    graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
+    container = maybe.dependency.load(path_lookup)
+    container.build_dependency_graph(graph)
+    roots = graph.root_dependencies
+    assert roots

--- a/tests/unit/source_code/test_graph.py
+++ b/tests/unit/source_code/test_graph.py
@@ -6,9 +6,8 @@ from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver, FolderLoader
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver, InheritedContext
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookResolver, NotebookLoader
-from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
-from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
+from databricks.labs.ucx.source_code.known import KnownList
 
 
 def test_dependency_graph_registers_library(mock_path_lookup):
@@ -183,5 +182,3 @@ def test_graph_builds_inherited_context(mock_path_lookup, simple_dependency_reso
     assert inference_context.tree is not None
     assert inference_context.tree.has_global("some_table_name")
     assert not inference_context.tree.has_global("other_table_name")
-
-

--- a/tests/unit/source_code/test_graph.py
+++ b/tests/unit/source_code/test_graph.py
@@ -185,29 +185,3 @@ def test_graph_builds_inherited_context(mock_path_lookup, simple_dependency_reso
     assert not inference_context.tree.has_global("other_table_name")
 
 
-def test_graph_visits_package_with_recursive_imports(mock_path_lookup):
-    # we need a populated KnownList for this test to run in a reasonable time
-    # but sqlglot should be unknown since it exhibits the problematic recursion
-    class TestKnownList(KnownList):
-        def module_compatibility(self, name: str) -> Compatibility:
-            if name.startswith("sqlglot"):
-                return UNKNOWN
-            return super().module_compatibility(name)
-
-    root_path = mock_path_lookup.resolve(Path("import-sqlglot.py"))
-    allow_list = TestKnownList()
-    library_resolver = PythonLibraryResolver(allow_list)
-    notebook_resolver = NotebookResolver(NotebookLoader())
-    import_resolver = ImportFileResolver(FileLoader(), allow_list)
-    path_lookup = PathLookup.from_sys_path(root_path.parent)
-    dependency_resolver = DependencyResolver(
-        library_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup
-    )
-    maybe = dependency_resolver.resolve_file(path_lookup, root_path)
-    assert maybe.dependency
-    graph = DependencyGraph(maybe.dependency, None, dependency_resolver, path_lookup, CurrentSessionState())
-    container = maybe.dependency.load(path_lookup)
-    container.build_dependency_graph(graph)
-    # visit the graph without a 'visited' set
-    roots = graph.root_dependencies
-    assert roots

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -146,7 +146,8 @@ def test_notebook_builds_leaf_dependency_graph(mock_path_lookup) -> None:
     assert container is not None
     problems = container.build_dependency_graph(graph)
     assert not problems
-    assert graph.all_paths == {mock_path_lookup.cwd / "leaf1.py"}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / "leaf1.py"}
 
 
 def get_status_side_effect(*args) -> ObjectInfo:
@@ -164,7 +165,8 @@ def test_notebook_builds_depth1_dependency_graph(mock_path_lookup) -> None:
     assert container is not None
     problems = container.build_dependency_graph(graph)
     assert not problems
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in paths}
 
 
 def test_notebook_builds_depth2_dependency_graph(mock_path_lookup) -> None:
@@ -177,7 +179,8 @@ def test_notebook_builds_depth2_dependency_graph(mock_path_lookup) -> None:
     assert container is not None
     problems = container.build_dependency_graph(graph)
     assert not problems
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in paths}
 
 
 def test_notebook_builds_dependency_graph_avoiding_duplicates(mock_path_lookup) -> None:
@@ -191,7 +194,8 @@ def test_notebook_builds_dependency_graph_avoiding_duplicates(mock_path_lookup) 
     problems = container.build_dependency_graph(graph)
     assert not problems
     # if visited once only, set and list will have same len
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in paths}
 
 
 def test_notebook_builds_cyclical_dependency_graph(mock_path_lookup) -> None:
@@ -204,7 +208,8 @@ def test_notebook_builds_cyclical_dependency_graph(mock_path_lookup) -> None:
     assert container is not None
     problems = container.build_dependency_graph(graph)
     assert not problems
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in paths}
 
 
 def test_notebook_builds_python_dependency_graph(mock_path_lookup) -> None:
@@ -217,7 +222,8 @@ def test_notebook_builds_python_dependency_graph(mock_path_lookup) -> None:
     assert container is not None
     problems = container.build_dependency_graph(graph)
     assert not problems
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in paths}
 
 
 def test_notebook_builds_python_dependency_graph_with_loop(mock_path_lookup) -> None:
@@ -230,7 +236,8 @@ def test_notebook_builds_python_dependency_graph_with_loop(mock_path_lookup) -> 
     assert container is not None
     container.build_dependency_graph(graph)
     expected_paths = [path, "leaf1.py", "leaf2.py", "leaf3.py"]
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in expected_paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in expected_paths}
 
 
 def test_notebook_builds_python_dependency_graph_with_fstring_loop(mock_path_lookup) -> None:
@@ -243,7 +250,8 @@ def test_notebook_builds_python_dependency_graph_with_fstring_loop(mock_path_loo
     assert container is not None
     container.build_dependency_graph(graph)
     expected_paths = [path, "leaf1.py", "leaf3.py"]
-    assert graph.all_paths == {mock_path_lookup.cwd / path for path in expected_paths}
+    all_paths = set(d.path for d in graph.all_dependencies)
+    assert all_paths == {mock_path_lookup.cwd / path for path in expected_paths}
 
 
 def test_detects_multiple_calls_to_dbutils_notebook_run_in_python_code() -> None:

--- a/tests/unit/source_code/test_path_lookup_simulation.py
+++ b/tests/unit/source_code/test_path_lookup_simulation.py
@@ -54,7 +54,8 @@ def test_locates_notebooks(source: list[str], expected: int, mock_path_lookup):
     maybe = dependency_resolver.build_notebook_dependency_graph(notebook_path, CurrentSessionState())
     assert not maybe.problems
     assert maybe.graph is not None
-    assert len(maybe.graph.all_paths) == expected
+    all_paths = [d.path for d in maybe.graph.all_dependencies]
+    assert len(all_paths) == expected
 
 
 @pytest.mark.parametrize(
@@ -119,7 +120,8 @@ sys.path.append('{child_dir_path.as_posix()}')
         maybe = resolver.build_notebook_dependency_graph(parent_file_path, CurrentSessionState())
         assert not maybe.problems
         assert maybe.graph is not None
-        assert len(maybe.graph.all_paths) == 2
+        all_paths = [d.path for d in maybe.graph.all_dependencies]
+        assert len(all_paths) == 2
 
 
 def test_locates_files_with_absolute_path():


### PR DESCRIPTION
## Changes
When visiting a dependency graph, infinite recursion can happen.
For example, many files in sqlglot package import sqlglot itself
When visiting the graph with a 'visited' set, this is naturally prevented.
However, when computing dependency roots, we can't have a 'visited' set.
This PR fixes the issue by only visiting once parent/child pairs 

### Linked issues
Progresses #2350 (PR #https://github.com/databrickslabs/ucx/pull/2526 blocked by this bug)

### Functionality
None

### Tests
- [x] added unit tests

n.b. this PR also drops a test method to avoid a pylint `too-many-methods` error
