### PR TITLE
More escaping of SQL identifiers

### DIFF
--- a/src/databricks/labs/ucx/assessment/azure.py
+++ b/src/databricks/labs/ucx/assessment/azure.py
@@ -12,6 +12,7 @@ from databricks.labs.ucx.assessment.crawlers import azure_sp_conf_present_check,
 from databricks.labs.ucx.assessment.jobs import JobsMixin
 from databricks.labs.ucx.assessment.secrets import SecretsMixin
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
+from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 _STORAGE_ACCOUNT_PATTERN = r"(?:id|endpoint)(.*?)dfs"
 
@@ -45,7 +46,7 @@ class AzureServicePrincipalCrawler(CrawlerBase[AzureServicePrincipalInfo], JobsM
         self._ws = ws
 
     def _try_fetch(self) -> Iterable[AzureServicePrincipalInfo]:
-        for row in self._fetch(f"SELECT * FROM {self._catalog}.{self._schema}.{self._table}"):
+        for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield AzureServicePrincipalInfo(*row)
 
     def _crawl(self) -> Iterable[AzureServicePrincipalInfo]:

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -135,7 +135,7 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
             yield table_migration_status
 
     def _try_fetch(self) -> Iterable[MigrationStatus]:
-        for row in self._fetch(f"SELECT * FROM {self._catalog}.{self._schema}.{self._table}"):
+        for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
             yield MigrationStatus(*row)
 
     def _iter_schemas(self):

--- a/tests/unit/recon/test_migration_recon.py
+++ b/tests/unit/recon/test_migration_recon.py
@@ -47,7 +47,7 @@ def test_migrate_recon_should_produce_proper_queries(
     tgt_3 = TableIdentifier("catalog3", "schema3", "table3")
     errors = {}
     rows = {
-        'SELECT \\* FROM hive_metastore.inventory_database.migration_status': MIGRATION_STATUS[
+        'SELECT \\* FROM `hive_metastore`.`inventory_database`.`migration_status`': MIGRATION_STATUS[
             (src.schema, src.table, tgt.catalog, tgt.schema, tgt.table, "2021-01-01T00:00:00Z"),
             (src_2.schema, src_2.table, tgt_2.catalog, tgt_2.schema, tgt_2.table, "2021-01-01T00:00:00Z"),
             (src_3.schema, src_3.table, tgt_3.catalog, tgt_3.schema, tgt_3.table, "2021-01-01T00:00:00Z"),

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -62,7 +62,7 @@ def test_replace_installation():
         installation=mock_installation,
         sql_backend=MockBackend(
             rows={
-                r'some.azure_service_principals': spn_info_rows[
+                r'`some`.`azure_service_principals`': spn_info_rows[
                     ('first-application-id', 'foo', 'bar', 'tenant', 'ziyuanqintest'),
                     ('second-application-id', 'foo', 'bar', 'tenant', 'ziyuanqintest'),
                 ]


### PR DESCRIPTION
## Changes

Following on from #2485 and #2530, this PR updates the remaining SQL statements in the crawlers that weren't (yet) escaping the catalog/database/table identifiers.

### Linked issues

Follows #2485 and #2530.

### Tests

- updated unit tests
