### PR TITLE
Crawler snapshots: allow refreshing

### DIFF
--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -146,9 +146,3 @@ class CrawlerBase(ABC, Generic[Result]):
     def _update_snapshot(self, items: Sequence[Result], mode: Literal["append", "overwrite"] = "append") -> None:
         logger.debug(f"[{self.full_name}] found {len(items)} new records for {self._table}")
         self._backend.save_table(self.full_name, items, self._klass, mode=mode)
-
-    def _append_records(self, items: Sequence[Result]):
-        self._update_snapshot(items, mode="append")
-
-    def _overwrite_records(self, items: Sequence[Result]):
-        self._update_snapshot(items, mode="overwrite")

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -138,7 +138,7 @@ class CrawlerBase(ABC, Generic[Result]):
                     return cached_results
             except NotFound:
                 pass
-        logger.debug(f"[{self.full_name}] crawling new batch for {self._table}")
+        logger.debug(f"[{self.full_name}] crawling new set of snapshot data for {self._table}")
         loaded_records = list(loader())
         self._update_snapshot(loaded_records, mode="overwrite")
         return loaded_records

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -134,7 +134,7 @@ class CrawlerBase(ABC, Generic[Result]):
             logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
             try:
                 cached_results = list(fetcher())
-                if len(cached_results) > 0:
+                if cached_results:
                     return cached_results
             except NotFound:
                 pass

--- a/src/databricks/labs/ucx/framework/crawlers.py
+++ b/src/databricks/labs/ucx/framework/crawlers.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
-from typing import ClassVar, Generic, Protocol, TypeVar
+from typing import ClassVar, Generic, Literal, Protocol, TypeVar
 
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk.errors import NotFound
@@ -91,8 +91,8 @@ class CrawlerBase(ABC, Generic[Result]):
             return None
         return cls._valid(name)
 
-    def snapshot(self) -> Iterable[Result]:
-        return self._snapshot(self._try_fetch, self._crawl)
+    def snapshot(self, *, force_refresh: bool = False) -> Iterable[Result]:
+        return self._snapshot(self._try_fetch, self._crawl, force_refresh=force_refresh)
 
     @abstractmethod
     def _try_fetch(self) -> Iterable[Result]:
@@ -110,7 +110,7 @@ class CrawlerBase(ABC, Generic[Result]):
             Iterable[Result]: Records that capture the results of crawling the environment.
         """
 
-    def _snapshot(self, fetcher: ResultFn, loader: ResultFn) -> list[Result]:
+    def _snapshot(self, fetcher: ResultFn, loader: ResultFn, *, force_refresh: bool) -> list[Result]:
         """
         Tries to load dataset of records with `fetcher` function, otherwise automatically creates
         a table with the schema defined in the class of the first row and executes `loader` function
@@ -119,26 +119,36 @@ class CrawlerBase(ABC, Generic[Result]):
         Args:
             fetcher: A function to fetch existing data.
             loader: A function to load new data.
+            force_refresh: Whether existing data should be ignored and forcibly replaced with data from the loader.
 
         Exceptions:
-        - If a runtime error occurs during fetching (other than "TABLE_OR_VIEW_NOT_FOUND"), the original error is
-          re-raised.
+        - Any errors raised by the fetcher are passed through, except for NotFound (usually due to
+          TABLE_OR_VIEW_NOT_FOUND) which is suppressed. All errors raised by the loader are passed through.
 
         Returns:
-        list[Result]: A list of data records, either fetched or loaded.
+            list[Result]: A list of data records, either fetched or loaded.
         """
-        logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
-        try:
-            cached_results = list(fetcher())
-            if len(cached_results) > 0:
-                return cached_results
-        except NotFound:
-            pass
+        if force_refresh:
+            logger.debug(f"[{self.full_name}] ignoring any existing {self._table} inventory; refresh is forced.")
+        else:
+            logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
+            try:
+                cached_results = list(fetcher())
+                if len(cached_results) > 0:
+                    return cached_results
+            except NotFound:
+                pass
         logger.debug(f"[{self.full_name}] crawling new batch for {self._table}")
         loaded_records = list(loader())
-        self._append_records(loaded_records)
+        self._update_snapshot(loaded_records, mode="overwrite")
         return loaded_records
 
-    def _append_records(self, items: Sequence[Result]):
+    def _update_snapshot(self, items: Sequence[Result], mode: Literal["append", "overwrite"] = "append") -> None:
         logger.debug(f"[{self.full_name}] found {len(items)} new records for {self._table}")
-        self._backend.save_table(self.full_name, items, self._klass, mode="append")
+        self._backend.save_table(self.full_name, items, self._klass, mode=mode)
+
+    def _append_records(self, items: Sequence[Result]):
+        self._update_snapshot(items, mode="append")
+
+    def _overwrite_records(self, items: Sequence[Result]):
+        self._update_snapshot(items, mode="overwrite")

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -205,9 +205,9 @@ class GrantsCrawler(CrawlerBase[Grant]):
         self._udf = udf
         self._include_databases = include_databases
 
-    def snapshot(self) -> Iterable[Grant]:
+    def snapshot(self, *, force_refresh: bool = False) -> Iterable[Grant]:
         try:
-            return super().snapshot()
+            return super().snapshot(force_refresh=force_refresh)
         except Exception as e:  # pylint: disable=broad-exception-caught
             log_fn = logger.warning if CLUSTER_WITHOUT_ACL_FRAGMENT in repr(e) else logger.error
             log_fn(f"Couldn't fetch grants snapshot: {e}")

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 import os
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
 from typing import ClassVar, Optional
@@ -359,11 +359,6 @@ class TablesInMounts(CrawlerBase[Table]):
             irrelevant_patterns.update(exclude_paths_in_mount)
         self._fiter_paths = irrelevant_patterns
 
-    def snapshot(self) -> list[Table]:
-        updated_records = self._crawl()
-        self._overwrite_records(updated_records)
-        return updated_records
-
     def _crawl(self) -> list[Table]:
         logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
         cached_results = []
@@ -393,11 +388,7 @@ class TablesInMounts(CrawlerBase[Table]):
             seen[rec.location] = rec.key
         return seen
 
-    def _overwrite_records(self, items: Sequence[Table]):
-        logger.debug(f"[{self.full_name}] found {len(items)} new records for {self._table}")
-        self._backend.save_table(self.full_name, items, Table, mode="overwrite")
-
-    def _crawl_tables(self, table_paths_from_assessment: dict[str, str]):
+    def _crawl_tables(self, table_paths_from_assessment: dict[str, str]) -> list[Table]:
         all_mounts = self._mounts_crawler.snapshot()
         all_tables = []
         for mount in all_mounts:

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -359,6 +359,14 @@ class TablesInMounts(CrawlerBase[Table]):
             irrelevant_patterns.update(exclude_paths_in_mount)
         self._fiter_paths = irrelevant_patterns
 
+    def snapshot(self, *, force_refresh: bool = True) -> list[Table]:
+        # TODO: Figure out what this should do (and refactor); non-trivial due to it overwriting the static table data.
+        if not force_refresh:
+            logger.warning("The tables-in-mounts crawler always refreshes, and overwrites the static table inventory.")
+        updated_records = self._crawl()
+        self._overwrite_records(updated_records)
+        return updated_records
+
     def _crawl(self) -> list[Table]:
         logger.debug(f"[{self.full_name}] fetching {self._table} inventory")
         cached_results = []

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -123,9 +123,9 @@ class ScanTablesInMounts(Workflow):
     @job_task
     def scan_tables_in_mounts_experimental(self, ctx: RuntimeContext):
         """[EXPERIMENTAL] This workflow scans for Delta tables inside all mount points
-        captured during the assessment. It will store the results under the `tables` table
-        located under the assessment."""
-        ctx.tables_in_mounts.snapshot()
+        captured during the assessment. It will store the results in the `tables` table,
+        replacing any existing content that might be present."""
+        ctx.tables_in_mounts.snapshot(force_refresh=True)
 
     @job_task(job_cluster="table_migration", depends_on=[scan_tables_in_mounts_experimental])
     def update_migration_status(self, ctx: RuntimeContext):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -160,7 +160,7 @@ class StaticTablesCrawler(TablesCrawler):
             for _ in tables
         ]
 
-    def snapshot(self) -> list[Table]:
+    def snapshot(self, *, force_refresh: bool = False) -> list[Table]:
         return self._tables
 
 
@@ -169,7 +169,7 @@ class StaticServicePrincipalCrawler(AzureServicePrincipalCrawler):
         super().__init__(*args)
         self._spn_infos = spn_infos
 
-    def snapshot(self) -> list[AzureServicePrincipalInfo]:
+    def snapshot(self, *, force_refresh: bool = False) -> list[AzureServicePrincipalInfo]:
         return self._spn_infos
 
 
@@ -184,7 +184,7 @@ class StaticMountCrawler(Mounts):
         super().__init__(sb, workspace_client, inventory_database)
         self._mounts = mounts
 
-    def snapshot(self) -> list[Mount]:
+    def snapshot(self, *, force_refresh: bool = False) -> list[Mount]:
         return self._mounts
 
 

--- a/tests/unit/assessment/test_clusters.py
+++ b/tests/unit/assessment/test_clusters.py
@@ -93,7 +93,7 @@ def test_cluster_without_owner_should_have_empty_creator_name():
     ws = mock_workspace_client(cluster_ids=['simplest-autoscale'])
     mockbackend = MockBackend()
     ClustersCrawler(ws, mockbackend, "ucx").snapshot()
-    result = mockbackend.rows_written_for("hive_metastore.ucx.clusters", "append")
+    result = mockbackend.rows_written_for("hive_metastore.ucx.clusters", "overwrite")
     assert result == [
         Row(
             cluster_id="simplest-autoscale",

--- a/tests/unit/assessment/test_init_scripts.py
+++ b/tests/unit/assessment/test_init_scripts.py
@@ -92,7 +92,7 @@ def test_init_script_without_config_should_have_empty_creator_name():
     mockbackend = MockBackend()
     crawler = GlobalInitScriptCrawler(mock_ws, mockbackend, schema="ucx")
     crawler.snapshot()
-    result = mockbackend.rows_written_for("hive_metastore.ucx.global_init_scripts", "append")
+    result = mockbackend.rows_written_for("hive_metastore.ucx.global_init_scripts", "overwrite")
 
     assert result == [
         Row(script_id="222", success=1, failures="[]", script_name="newscript", enabled=False, created_by=None),

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -63,7 +63,7 @@ def test_job_crawler_with_no_owner_should_have_empty_creator_name():
     ws = mock_workspace_client(job_ids=['no-tasks'])
     sql_backend = MockBackend()
     JobsCrawler(ws, sql_backend, "ucx").snapshot()
-    result = sql_backend.rows_written_for("hive_metastore.ucx.jobs", "append")
+    result = sql_backend.rows_written_for("hive_metastore.ucx.jobs", "overwrite")
     assert result == [Row(job_id='9001', success=1, failures='[]', job_name='No Tasks', creator=None)]
 
 
@@ -119,7 +119,7 @@ def test_job_run_crawler(jobruns_ids, cluster_ids, run_ids, failures):
     ws = mock_workspace_client(jobruns_ids=jobruns_ids, cluster_ids=cluster_ids)
     sql_backend = MockBackend()
     SubmitRunsCrawler(ws, sql_backend, "ucx", 10).snapshot()
-    result = sql_backend.rows_written_for("hive_metastore.ucx.submit_runs", "append")
+    result = sql_backend.rows_written_for("hive_metastore.ucx.submit_runs", "overwrite")
     assert len(result) == 1
     assert result[0].run_ids == run_ids
     assert result[0].failures == failures

--- a/tests/unit/assessment/test_pipelines.py
+++ b/tests/unit/assessment/test_pipelines.py
@@ -49,7 +49,7 @@ def test_pipeline_without_owners_should_have_empty_creator_name():
     ws.dbfs.read().data = "JXNoCmVjaG8gIj0="
     mockbackend = MockBackend()
     PipelinesCrawler(ws, mockbackend, "ucx").snapshot()
-    result = mockbackend.rows_written_for("hive_metastore.ucx.pipelines", "append")
+    result = mockbackend.rows_written_for("hive_metastore.ucx.pipelines", "overwrite")
 
     assert result == [
         Row(

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -127,6 +127,8 @@ def test_snapshot_force_refresh_replaces_prior_data() -> None:
 
     cb.snapshot(force_refresh=True)
 
+    mock_fetcher.assert_not_called()
+    mock_loader.assert_called_once()
     assert [Row(first="second", second=None)] == mock_backend.rows_written_for("a.b.c", mode="overwrite")
 
 

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -105,7 +105,7 @@ def test_snapshot_doesnt_crawl_if_previous_crawl_yielded_data() -> None:
 
 
 def test_snapshot_crawls_if_refresh_forced() -> None:
-    """Check that existing data is used (with no crawl) if the fetcher can load the snapshot data."""
+    """Check that a crawl happens (without even checking existing data) if a refresh is forced."""
     mock_backend = MockBackend()
     mock_fetcher = Mock(return_value=[Baz(first="first")])
     mock_loader = Mock(return_value=[Baz(first="second")])
@@ -119,6 +119,7 @@ def test_snapshot_crawls_if_refresh_forced() -> None:
 
 
 def test_snapshot_force_refresh_replaces_prior_data() -> None:
+    """Check that when refreshing the new data replaces (via overwrite) any existing data."""
     mock_backend = MockBackend()
     mock_fetcher = Mock(side_effect=RuntimeError("never called"))
     mock_loader = Mock(return_value=[Baz(first="second")])

--- a/tests/unit/framework/test_crawlers.py
+++ b/tests/unit/framework/test_crawlers.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
+from unittest.mock import Mock
 
 import pytest
 from databricks.labs.lsql import Row
@@ -61,17 +62,84 @@ def test_full_name():
     assert cb.full_name == "a.b.c"
 
 
-def test_snapshot_appends_to_existing_table():
+def test_snapshot_crawls_when_no_prior_crawl() -> None:
+    """Check that the crawler is invoked when the fetcher reports that the inventory doesn't exist."""
+    mock_backend = MockBackend()
+    mock_fetcher = Mock(side_effect=NotFound(".. TABLE_OR_VIEW_NOT_FOUND .."))
+    mock_loader = Mock(return_value=[Baz(first="first")])
+    cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, fetcher=mock_fetcher, loader=mock_loader)
+
+    result = cb.snapshot()
+
+    mock_fetcher.assert_called_once()
+    mock_loader.assert_called_once()
+    assert [Baz(first="first")] == result
+
+
+def test_snapshot_crawls_when_prior_crawl_yielded_no_data() -> None:
+    """Check that the crawler is invoked when the fetcher reports that the inventory exists but doesn't contain data."""
+    mock_backend = MockBackend()
+    mock_fetcher = Mock(return_value=[])
+    mock_loader = Mock(return_value=[Baz(first="first")])
+    cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, fetcher=mock_fetcher, loader=mock_loader)
+
+    result = cb.snapshot()
+
+    mock_fetcher.assert_called_once()
+    mock_loader.assert_called_once()
+    assert [Baz(first="first")] == result
+
+
+def test_snapshot_doesnt_crawl_if_previous_crawl_yielded_data() -> None:
+    """Check that existing data is used (with no crawl) if the fetcher can load the snapshot data."""
+    mock_backend = MockBackend()
+    mock_fetcher = Mock(return_value=[Baz(first="first")])
+    mock_loader = Mock(return_value=[Baz(first="second")])
+    cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, fetcher=mock_fetcher, loader=mock_loader)
+
+    result = cb.snapshot()
+
+    mock_fetcher.assert_called_once()
+    mock_loader.assert_not_called()
+    assert [Baz(first="first")] == result
+
+
+def test_snapshot_crawls_if_refresh_forced() -> None:
+    """Check that existing data is used (with no crawl) if the fetcher can load the snapshot data."""
+    mock_backend = MockBackend()
+    mock_fetcher = Mock(return_value=[Baz(first="first")])
+    mock_loader = Mock(return_value=[Baz(first="second")])
+    cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, fetcher=mock_fetcher, loader=mock_loader)
+
+    result = cb.snapshot(force_refresh=True)
+
+    mock_fetcher.assert_not_called()
+    mock_loader.assert_called_once()
+    assert [Baz(first="second")] == result
+
+
+def test_snapshot_force_refresh_replaces_prior_data() -> None:
+    mock_backend = MockBackend()
+    mock_fetcher = Mock(side_effect=RuntimeError("never called"))
+    mock_loader = Mock(return_value=[Baz(first="second")])
+    cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, fetcher=mock_fetcher, loader=mock_loader)
+
+    cb.snapshot(force_refresh=True)
+
+    assert [Row(first="second", second=None)] == mock_backend.rows_written_for("a.b.c", mode="overwrite")
+
+
+def test_snapshot_updates_existing_table() -> None:
     mock_backend = MockBackend()
     cb = _CrawlerFixture[Baz](mock_backend, "a", "b", "c", Baz, loader=lambda: [Baz(first="first")])
 
     result = cb.snapshot()
 
     assert [Baz(first="first")] == result
-    assert [Row(first="first", second=None)] == mock_backend.rows_written_for("a.b.c", "append")
+    assert [Row(first="first", second=None)] == mock_backend.rows_written_for("a.b.c", "overwrite")
 
 
-def test_snapshot_appends_to_new_table():
+def test_snapshot_updates_new_table() -> None:
     mock_backend = MockBackend()
 
     def fetcher():
@@ -85,10 +153,10 @@ def test_snapshot_appends_to_new_table():
     result = cb.snapshot()
 
     assert [Foo(first="first", second=True)] == result
-    assert [Row(first="first", second=True)] == mock_backend.rows_written_for("a.b.c", "append")
+    assert [Row(first="first", second=True)] == mock_backend.rows_written_for("a.b.c", "overwrite")
 
 
-def test_snapshot_wrong_error():
+def test_snapshot_wrong_error() -> None:
     sql_backend = MockBackend()
 
     def fetcher():

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -329,7 +329,7 @@ def test_mount_listing_multiple_folders():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert results == [
         Table("hive_metastore", "mounted_test_mount", "table1", "EXTERNAL", "DELTA", "adls://bucket/table1"),
         Table("hive_metastore", "mounted_test_mount", "table2", "EXTERNAL", "PARQUET", "adls://bucket/table2"),
@@ -368,7 +368,7 @@ def test_mount_listing_sub_folders():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert results == [
         Table(
             "hive_metastore",
@@ -409,7 +409,7 @@ def test_partitioned_parquet_layout():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert results == [
         Table(
             "hive_metastore",
@@ -466,7 +466,7 @@ def test_partitioned_delta():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert len(results) == 2
     assert results[0].table_format == "DELTA"
     assert results[0].is_partitioned
@@ -499,7 +499,8 @@ def test_filtering_irrelevant_paths():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts, exclude_paths_in_mount=["$_azuretempfolder"]).snapshot()
+    crawler = TablesInMounts(backend, client, "test", mounts, exclude_paths_in_mount=["$_azuretempfolder"])
+    results = crawler.snapshot(force_refresh=True)
     assert results == [
         Table("hive_metastore", "mounted_test_mount", "table1", "EXTERNAL", "DELTA", "adls://bucket/table1"),
     ]
@@ -532,7 +533,8 @@ def test_filter_irrelevant_mounts():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts, include_mounts=["/mnt/test_mount"]).snapshot()
+    crawler = TablesInMounts(backend, client, "test", mounts, include_mounts=["/mnt/test_mount"])
+    results = crawler.snapshot(force_refresh=True)
 
     assert results == [
         Table("hive_metastore", "mounted_test_mount", "table1", "EXTERNAL", "DELTA", "/mnt/test_mount/table1"),
@@ -569,7 +571,7 @@ def test_historical_data_should_be_overwritten():
         }
     )
     mounts = Mounts(backend, client, "test")
-    TablesInMounts(backend, client, "test", mounts).snapshot()
+    TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert backend.rows_written_for("hive_metastore.test.tables", "overwrite") == [
         Row(
             catalog='hive_metastore',
@@ -624,9 +626,8 @@ def test_mount_include_paths():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(
-        backend, client, "test", mounts, include_paths_in_mount=["dbfs:/mnt/test_mount/table2/"]
-    ).snapshot()
+    crawler = TablesInMounts(backend, client, "test", mounts, include_paths_in_mount=["dbfs:/mnt/test_mount/table2/"])
+    results = crawler.snapshot(force_refresh=True)
     assert results == [
         Table("hive_metastore", "mounted_test_mount", "table2", "EXTERNAL", "PARQUET", "adls://bucket/table2"),
     ]
@@ -663,7 +664,7 @@ def test_mount_listing_csv_json():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert results == [
         Table(
             "hive_metastore",
@@ -713,7 +714,7 @@ def test_mount_listing_seen_tables():
         }
     )
     mounts = Mounts(backend, client, "test")
-    results = TablesInMounts(backend, client, "test", mounts).snapshot()
+    results = TablesInMounts(backend, client, "test", mounts).snapshot(force_refresh=True)
     assert len(results) == 3
     assert results[0].location == "adls://bucket/table1"
     assert results[1].location == "dbfs:/mnt/test_mount/table2"

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -92,7 +92,7 @@ def test_mounts_inventory_should_contain_mounts_without_encryption_type():
         Row(name="mp_1", source="path_1"),
         Row(name="mp_2", source="path_2"),
         Row(name="mp_3", source="path_3"),
-    ] == backend.rows_written_for("hive_metastore.test.mounts", "append")
+    ] == backend.rows_written_for("hive_metastore.test.mounts", "overwrite")
 
 
 def test_mounts_inventory_should_contain_deduped_mounts_without_encryption_type():
@@ -111,7 +111,7 @@ def test_mounts_inventory_should_contain_deduped_mounts_without_encryption_type(
     assert [
         Row(name="mp_1", source="path_1"),
         Row(name="mp_2", source="path_2"),
-    ] == backend.rows_written_for("hive_metastore.test.mounts", "append")
+    ] == backend.rows_written_for("hive_metastore.test.mounts", "overwrite")
 
 
 def test_mounts_inventory_should_contain_deduped_mounts_without_variable_volume_names():
@@ -136,7 +136,7 @@ def test_mounts_inventory_should_contain_deduped_mounts_without_variable_volume_
         Row(name="mp_1", source="path_1"),
         Row(name="mp_2", source="path_2"),
     ]
-    assert expected == backend.rows_written_for("hive_metastore.test.mounts", "append")
+    assert expected == backend.rows_written_for("hive_metastore.test.mounts", "overwrite")
 
 
 def test_external_locations():

--- a/tests/unit/workspace_access/test_manager.py
+++ b/tests/unit/workspace_access/test_manager.py
@@ -53,7 +53,7 @@ def test_snapshot_crawl_fallback(mocker) -> None:
     permission_manager.snapshot()
 
     assert [Row(object_id="a", object_type="b", raw="c")] == sql_backend.rows_written_for(
-        "hive_metastore.test_database.permissions", "append"
+        "hive_metastore.test_database.permissions", "overwrite"
     )
 
 
@@ -72,7 +72,7 @@ def test_manager_snapshot_crawl_ignore_disabled_features(mock_backend, mocker):
     permission_manager.snapshot()
 
     assert [Row(object_id="a", object_type="b", raw="c")] == mock_backend.rows_written_for(
-        "hive_metastore.test_database.permissions", "append"
+        "hive_metastore.test_database.permissions", "overwrite"
     )
 
 


### PR DESCRIPTION
## Changes

This PR updates the crawler internals so that when requesting a snapshot a refresh can be forced. In addition, the default semantics for crawlers have been updated so that they use an overwrite operation to write the data rather than appending (with the assumption that the table is already empty).

### Linked issues

- Progresses: #2074
- Resolves: #2576
- Closes: #2597

### Functionality

- modifies all existing crawlers

### Tests

- updated unit tests
- existing integration tests
