### PR TITLE
Fix schema collision in `test_migrate_table_in_mount`

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -662,11 +662,11 @@ def test_migrate_table_in_mount(
     table_path = make_random(4).lower()
     src_schema = make_schema(
         catalog_name="hive_metastore",
-        name=f"mounted_{env_or_skip("TEST_MOUNT_NAME")}_{table_path}",
+        name=f"mounted_{env_or_skip('TEST_MOUNT_NAME')}_{table_path}",
     )
     src_external_table = runtime_ctx.make_table(
         schema_name=src_schema.name,
-        external_delta=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{table_path}',
+        external_delta=f"dbfs:/mnt/{env_or_skip('TEST_MOUNT_NAME')}/a/b/{table_path}",
     )
     table_in_mount_location = f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{table_path}"
     # TODO: Remove this hack below

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -659,16 +659,16 @@ def test_migrate_table_in_mount(
         connect=ws.config,
     )
     runtime_ctx = runtime_ctx.replace(config=config)
-    tbl_path = make_random(4).lower()
+    table_path = make_random(4).lower()
     src_schema = make_schema(
         catalog_name="hive_metastore",
-        name=f"mounted_{env_or_skip("TEST_MOUNT_NAME")}_{tbl_path}",
+        name=f"mounted_{env_or_skip("TEST_MOUNT_NAME")}_{table_path}",
     )
     src_external_table = runtime_ctx.make_table(
         schema_name=src_schema.name,
-        external_delta=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{tbl_path}',
+        external_delta=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{table_path}',
     )
-    table_in_mount_location = f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{tbl_path}"
+    table_in_mount_location = f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{table_path}"
     # TODO: Remove this hack below
     # This is done because we have to create the external table in a mount point, but TablesInMounts() has to use the adls/ path
     # Otherwise, if we keep the dbfs:/ path, the entire logic of TablesInMounts won't work

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -660,8 +660,12 @@ def test_migrate_table_in_mount(
     )
     runtime_ctx = runtime_ctx.replace(config=config)
     tbl_path = make_random(4).lower()
+    src_schema = make_schema(
+        catalog_name="hive_metastore",
+        name=f"mounted_{env_or_skip("TEST_MOUNT_NAME")}_{tbl_path}",
+    )
     src_external_table = runtime_ctx.make_table(
-        schema_name=make_schema(catalog_name="hive_metastore", name=f'mounted_{env_or_skip("TEST_MOUNT_NAME")}').name,
+        schema_name=src_schema.name,
         external_delta=f'dbfs:/mnt/{env_or_skip("TEST_MOUNT_NAME")}/a/b/{tbl_path}',
     )
     table_in_mount_location = f"abfss://things@labsazurethings.dfs.core.windows.net/a/b/{tbl_path}"
@@ -678,7 +682,7 @@ def test_migrate_table_in_mount(
             Rule(
                 "workspace",
                 dst_catalog.name,
-                f'mounted_{env_or_skip("TEST_MOUNT_NAME")}',
+                src_schema.name,
                 dst_schema.name,
                 table_in_mount_location,
                 src_external_table.name,


### PR DESCRIPTION
## Changes
Fix schema collision in `test_migrate_table_in_mount` by suffixing a random name

### Linked issues
Resolves #2569

### Tests

- [ ] modified integration tests: `test_migrate_table_in_mount`
