### PR TITLE
Rename: (table) migration status classes

### DIFF
--- a/src/databricks/labs/ucx/account/aggregate.py
+++ b/src/databricks/labs/ucx/account/aggregate.py
@@ -12,7 +12,7 @@ from databricks.labs.blueprint.installation import NotInstalled
 
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableMigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.hive_metastore.locations import LocationTrie
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.source_code.base import CurrentSessionState

--- a/src/databricks/labs/ucx/account/aggregate.py
+++ b/src/databricks/labs/ucx/account/aggregate.py
@@ -12,7 +12,7 @@ from databricks.labs.blueprint.installation import NotInstalled
 
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, MigrationStatus
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.hive_metastore.locations import LocationTrie
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.source_code.base import CurrentSessionState
@@ -70,9 +70,9 @@ class AccountAggregate:
             try:
                 # use already existing code to replace tables in the query, assuming that UCX database is in HMS
                 inventory_database = ctx.config.inventory_database
-                stub_index = MigrationIndex(
+                stub_index = TableMigrationIndex(
                     [
-                        MigrationStatus(
+                        TableMigrationStatus(
                             src_schema=inventory_database,
                             src_table=table_name,
                             dst_catalog='hive_metastore',

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -35,9 +35,9 @@ from databricks.labs.ucx.hive_metastore.grants import (
     ACLMigrator,
 )
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.hive_metastore.table_migrate import (
-    MigrationStatusRefresher,
+    TableMigrationStatusRefresher,
     TablesMigrator,
 )
 from databricks.labs.ucx.hive_metastore.table_move import TableMove
@@ -331,7 +331,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def migration_status_refresher(self):
-        return MigrationStatusRefresher(
+        return TableMigrationStatusRefresher(
             self.workspace_client,
             self.sql_backend,
             self.inventory_database,
@@ -424,7 +424,7 @@ class GlobalContext(abc.ABC):
             self.workspace_client,
             self.dependency_resolver,
             self.path_lookup,
-            MigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
+            TableMigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
             self.config.include_job_ids,
         )
 

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -35,7 +35,7 @@ from databricks.labs.ucx.hive_metastore.grants import (
     ACLMigrator,
 )
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.hive_metastore.table_migrate import (
     TableMigrationStatusRefresher,
     TablesMigrator,

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.azure.credentials import StorageCredentialManager, Serv
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.files import LocalFileMigrator, LocalCodeLinter

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.azure.credentials import StorageCredentialManager, Serv
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.files import LocalFileMigrator, LocalCodeLinter
@@ -189,7 +189,7 @@ class LocalCheckoutContext(WorkspaceContext):
             index = self.tables_migrator.index()
         except NotFound:
             logger.warning("Metastore does not seem to exist yet. Skipping loading of migration status.")
-            index = MigrationIndex([])
+            index = TableMigrationIndex([])
         if session_state is None:
             session_state = CurrentSessionState()
         return LinterContext(index, session_state)

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -38,7 +38,7 @@ from databricks.labs.ucx.hive_metastore.locations import (
     Mounts,
 )
 from databricks.labs.ucx.hive_metastore.mapping import TableToMigrate, Rule
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.hive_metastore.tables import Table, TablesCrawler
 from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 from databricks.labs.ucx.workspace_access.groups import GroupManager
@@ -784,7 +784,7 @@ class ACLMigrator:
         self,
         tables_crawler: TablesCrawler,
         workspace_info: WorkspaceInfo,
-        migration_status_refresher: MigrationStatusRefresher,
+        migration_status_refresher: TableMigrationStatusRefresher,
         migrate_grants: MigrateGrants,
     ):
         self._table_crawler = tables_crawler

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -38,7 +38,7 @@ from databricks.labs.ucx.hive_metastore.locations import (
     Mounts,
 )
 from databricks.labs.ucx.hive_metastore.mapping import TableToMigrate, Rule
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.hive_metastore.tables import Table, TablesCrawler
 from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 from databricks.labs.ucx.workspace_access.groups import GroupManager

--- a/src/databricks/labs/ucx/hive_metastore/migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/migration_status.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class MigrationStatus:
+class TableMigrationStatus:
     src_schema: str
     src_table: str
     dst_catalog: str | None = None
@@ -27,7 +27,7 @@ class MigrationStatus:
         return f"{self.dst_catalog}.{self.dst_schema}.{self.dst_table}".lower()
 
     @classmethod
-    def from_json(cls, raw: dict[str, str]) -> "MigrationStatus":
+    def from_json(cls, raw: dict[str, str]) -> "TableMigrationStatus":
         return cls(
             src_schema=raw['src_schema'],
             src_table=raw['src_table'],
@@ -49,15 +49,15 @@ class TableView:
         return f"{self.catalog}.{self.schema}.{self.name}".lower()
 
 
-class MigrationIndex:
-    def __init__(self, tables: list[MigrationStatus]):
+class TableMigrationIndex:
+    def __init__(self, tables: list[TableMigrationStatus]):
         self._index = {(ms.src_schema, ms.src_table): ms for ms in tables}
 
     def is_migrated(self, schema: str, table: str) -> bool:
         """Check if a table is migrated."""
         return self.get(schema, table) is not None
 
-    def get(self, schema: str, table: str) -> MigrationStatus | None:
+    def get(self, schema: str, table: str) -> TableMigrationStatus | None:
         """Get the migration status for a table. If the table is not migrated, return None."""
         dst = self._index.get((schema.lower(), table.lower()))
         if not dst or not dst.dst_table:
@@ -68,14 +68,19 @@ class MigrationIndex:
         return self._index.keys()
 
 
-class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
+class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
+    """Crawler to capture the migration status of tables.
+
+    Migrated tables have a property set to mark them as such; this crawler scans all tables and examines the properties
+    for the presence of the marker.
+    """
     def __init__(self, ws: WorkspaceClient, sbe: SqlBackend, schema, table_crawler: TablesCrawler):
-        super().__init__(sbe, "hive_metastore", schema, "migration_status", MigrationStatus)
+        super().__init__(sbe, "hive_metastore", schema, "migration_status", TableMigrationStatus)
         self._ws = ws
         self._table_crawler = table_crawler
 
-    def index(self) -> MigrationIndex:
-        return MigrationIndex(list(self.snapshot()))
+    def index(self) -> TableMigrationIndex:
+        return TableMigrationIndex(list(self.snapshot()))
 
     def get_seen_tables(self) -> dict[str, str]:
         seen_tables: dict[str, str] = {}
@@ -111,14 +116,14 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
         logger.info(f"{schema}.{table} is set as not migrated")
         return False
 
-    def _crawl(self) -> Iterable[MigrationStatus]:
+    def _crawl(self) -> Iterable[TableMigrationStatus]:
         all_tables = self._table_crawler.snapshot()
         reverse_seen = {v: k for k, v in self.get_seen_tables().items()}
         timestamp = datetime.datetime.now(datetime.timezone.utc).timestamp()
         for table in all_tables:
             src_schema = table.database.lower()
             src_table = table.name.lower()
-            table_migration_status = MigrationStatus(
+            table_migration_status = TableMigrationStatus(
                 src_schema=src_schema,
                 src_table=src_table,
                 update_ts=str(timestamp),
@@ -134,9 +139,9 @@ class MigrationStatusRefresher(CrawlerBase[MigrationStatus]):
                     )
             yield table_migration_status
 
-    def _try_fetch(self) -> Iterable[MigrationStatus]:
+    def _try_fetch(self) -> Iterable[TableMigrationStatus]:
         for row in self._fetch(f"SELECT * FROM {escape_sql_identifier(self.full_name)}"):
-            yield MigrationStatus(*row)
+            yield TableMigrationStatus(*row)
 
     def _iter_schemas(self):
         for catalog in self._ws.catalogs.list():

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.hive_metastore.mapping import (
     TableMapping,
     TableToMigrate,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.hive_metastore.tables import (
     MigrationCount,
     Table,
@@ -40,7 +40,7 @@ class TablesMigrator:
         ws: WorkspaceClient,
         backend: SqlBackend,
         table_mapping: TableMapping,
-        migration_status_refresher: MigrationStatusRefresher,
+        migration_status_refresher: TableMigrationStatusRefresher,
         migrate_grants: MigrateGrants,
     ):
         self._tc = table_crawler

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -17,7 +17,7 @@ from databricks.labs.ucx.hive_metastore.mapping import (
     TableMapping,
     TableToMigrate,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.hive_metastore.tables import (
     MigrationCount,
     Table,

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -74,6 +74,7 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
     Migrated tables have a property set to mark them as such; this crawler scans all tables and examines the properties
     for the presence of the marker.
     """
+
     def __init__(self, ws: WorkspaceClient, sbe: SqlBackend, schema, table_crawler: TablesCrawler):
         super().__init__(sbe, "hive_metastore", schema, "migration_status", TableMigrationStatus)
         self._ws = ws

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -69,10 +69,10 @@ class TableMigrationIndex:
 
 
 class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
-    """Crawler to capture the migration status of tables.
+    """Crawler to capture the migration status of tables (and views).
 
-    Migrated tables have a property set to mark them as such; this crawler scans all tables and examines the properties
-    for the presence of the marker.
+    Migrated tables have a property set to mark them as such; this crawler scans all tables and views, examining the
+    properties for the presence of the marker.
     """
 
     def __init__(self, ws: WorkspaceClient, sbe: SqlBackend, schema, table_crawler: TablesCrawler):

--- a/src/databricks/labs/ucx/hive_metastore/view_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/view_migrate.py
@@ -6,7 +6,7 @@ from functools import cached_property
 import sqlglot
 from sqlglot import ParseError, expressions
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, TableView
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableView
 from databricks.labs.ucx.hive_metastore.mapping import TableToMigrate
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter
@@ -52,7 +52,7 @@ class ViewToMigrate(TableToMigrate):
                     aliases.add(expression.alias_or_name)
         return aliases
 
-    def sql_migrate_view(self, index: MigrationIndex) -> str:
+    def sql_migrate_view(self, index: TableMigrationIndex) -> str:
         from_table = FromTableSqlLinter(index, CurrentSessionState(self.src.database))
         assert self.src.view_text is not None, 'Expected a view text'
         migrated_select = from_table.apply(self.src.view_text)
@@ -83,9 +83,14 @@ class ViewToMigrate(TableToMigrate):
 
 class ViewsMigrationSequencer:
 
-    def __init__(self, tables_to_migrate: Collection[TableToMigrate], *, migration_index: MigrationIndex | None = None):
+    def __init__(
+        self,
+        tables_to_migrate: Collection[TableToMigrate],
+        *,
+        migration_index: TableMigrationIndex | None = None,
+    ):
         self._tables = tables_to_migrate  # Also contains views to migrate
-        self._index = migration_index or MigrationIndex([])
+        self._index = migration_index or TableMigrationIndex([])
 
     @cached_property
     def _views(self) -> dict[ViewToMigrate, TableView]:

--- a/src/databricks/labs/ucx/hive_metastore/view_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/view_migrate.py
@@ -6,7 +6,7 @@ from functools import cached_property
 import sqlglot
 from sqlglot import ParseError, expressions
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableView
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableView
 from databricks.labs.ucx.hive_metastore.mapping import TableToMigrate
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -64,7 +64,7 @@ from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, Mount
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatus
 from databricks.labs.ucx.hive_metastore.table_size import TableSize
 from databricks.labs.ucx.hive_metastore.tables import Table, TableError
 from databricks.labs.ucx.hive_metastore.udfs import Udf

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -64,7 +64,7 @@ from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, Mount
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatus
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatus
 from databricks.labs.ucx.hive_metastore.table_size import TableSize
 from databricks.labs.ucx.hive_metastore.tables import Table, TableError
 from databricks.labs.ucx.hive_metastore.udfs import Udf
@@ -115,7 +115,7 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
             functools.partial(table, "permissions", Permissions),
             functools.partial(table, "submit_runs", SubmitRunInfo),
             functools.partial(table, "policies", PolicyInfo),
-            functools.partial(table, "migration_status", MigrationStatus),
+            functools.partial(table, "migration_status", TableMigrationStatus),
             functools.partial(table, "workflow_problems", JobProblem),
             functools.partial(table, "udfs", Udf),
             functools.partial(table, "logs", LogRecord),

--- a/src/databricks/labs/ucx/recon/migration_recon.py
+++ b/src/databricks/labs/ucx/recon/migration_recon.py
@@ -10,7 +10,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.recon.base import (
     DataComparator,
     SchemaComparator,
@@ -40,7 +40,7 @@ class MigrationRecon(CrawlerBase[ReconResult]):
         self,
         sbe: SqlBackend,
         schema: str,
-        migration_status_refresher: MigrationStatusRefresher,
+        migration_status_refresher: TableMigrationStatusRefresher,
         table_mapping: TableMapping,
         schema_comparator: SchemaComparator,
         data_comparator: DataComparator,

--- a/src/databricks/labs/ucx/recon/migration_recon.py
+++ b/src/databricks/labs/ucx/recon/migration_recon.py
@@ -10,7 +10,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore.mapping import TableMapping
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.recon.base import (
     DataComparator,
     SchemaComparator,

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -18,7 +18,7 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.service import compute, jobs
 
 from databricks.labs.ucx.assessment.crawlers import runtime_version_tuple
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.mixins.cached_workspace_path import WorkspaceCache
 from databricks.labs.ucx.source_code.base import CurrentSessionState, LocatedAdvice
 from databricks.labs.ucx.source_code.graph import (
@@ -319,7 +319,7 @@ class WorkflowLinter:
         ws: WorkspaceClient,
         resolver: DependencyResolver,
         path_lookup: PathLookup,
-        migration_index: MigrationIndex,
+        migration_index: TableMigrationIndex,
         include_job_ids: list[int] | None = None,
     ):
         self._ws = ws
@@ -423,7 +423,7 @@ class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
         path_lookup: PathLookup,
         key: str,
         session_state: CurrentSessionState,
-        migration_index: MigrationIndex,
+        migration_index: TableMigrationIndex,
     ):
         super().__init__(graph, linted_paths, path_lookup)
         self._key = key

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -18,7 +18,7 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.service import compute, jobs
 
 from databricks.labs.ucx.assessment.crawlers import runtime_version_tuple
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.mixins.cached_workspace_path import WorkspaceCache
 from databricks.labs.ucx.source_code.base import CurrentSessionState, LocatedAdvice
 from databricks.labs.ucx.source_code.graph import (

--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from databricks.labs.blueprint.entrypoint import get_logger
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import DependencyProblem
 from databricks.labs.ucx.source_code.linters.context import LinterContext
@@ -166,7 +166,7 @@ class KnownList:
 
     @classmethod
     def _analyze_file(cls, known_distributions, library_root, dist_info, module_path):
-        empty_index = MigrationIndex([])
+        empty_index = TableMigrationIndex([])
         relative_path = module_path.relative_to(library_root)
         module_ref = relative_path.as_posix().replace('/', '.')
         for suffix in ('.py', '.__init__'):

--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from databricks.labs.blueprint.entrypoint import get_logger
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import DependencyProblem
 from databricks.labs.ucx.source_code.linters.context import LinterContext

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Fixer,
     Linter,

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -22,7 +22,11 @@ from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinte
 
 
 class LinterContext:
-    def __init__(self, index: TableMigrationIndex | None = None, session_state: CurrentSessionState | None = None):
+    def __init__(
+        self,
+        index: TableMigrationIndex | None = None,
+        session_state: CurrentSessionState | None = None,
+    ):
         self._index = index
         session_state = CurrentSessionState() if not session_state else session_state
 

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Fixer,
     Linter,
@@ -22,7 +22,7 @@ from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinte
 
 
 class LinterContext:
-    def __init__(self, index: MigrationIndex | None = None, session_state: CurrentSessionState | None = None):
+    def __init__(self, index: TableMigrationIndex | None = None, session_state: CurrentSessionState | None = None):
         self._index = index
         session_state = CurrentSessionState() if not session_state else session_state
 

--- a/src/databricks/labs/ucx/source_code/linters/from_table.py
+++ b/src/databricks/labs/ucx/source_code/linters/from_table.py
@@ -1,7 +1,7 @@
 import logging
 from sqlglot import parse as parse_sql
 from sqlglot.expressions import Table, Expression, Use, Create
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState, SqlLinter, Fixer
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ class FromTableSqlLinter(SqlLinter, Fixer):
     SQL queries.
     """
 
-    def __init__(self, index: MigrationIndex, session_state: CurrentSessionState):
+    def __init__(self, index: TableMigrationIndex, session_state: CurrentSessionState):
         """
         Initializes the FromTableLinter class.
 
@@ -30,7 +30,7 @@ class FromTableSqlLinter(SqlLinter, Fixer):
                 schema.table                 -> Table(catalog='', db='schema', this='table')
                 table                               -> Table(catalog='', db='', this='table')
         """
-        self._index: MigrationIndex = index
+        self._index: TableMigrationIndex = index
         self._session_state: CurrentSessionState = session_state
 
     @property

--- a/src/databricks/labs/ucx/source_code/linters/from_table.py
+++ b/src/databricks/labs/ucx/source_code/linters/from_table.py
@@ -1,7 +1,7 @@
 import logging
 from sqlglot import parse as parse_sql
 from sqlglot.expressions import Table, Expression, Use, Create
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState, SqlLinter, Fixer
 
 logger = logging.getLogger(__name__)

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 from astroid import Attribute, Call, Const, Name, NodeNG  # type: ignore
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,
@@ -42,12 +42,12 @@ class _TableNameMatcher(ABC):
 
     @abstractmethod
     def lint(
-        self, from_table: FromTableSqlLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSqlLinter, index: TableMigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         """raises Advices by linting the code"""
 
     @abstractmethod
-    def apply(self, from_table: FromTableSqlLinter, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSqlLinter, index: TableMigrationIndex, node: Call) -> None:
         """applies recommendations"""
 
     def _get_table_arg(self, node: Call):
@@ -83,7 +83,7 @@ class _TableNameMatcher(ABC):
 class SparkCallMatcher(_TableNameMatcher):
 
     def lint(
-        self, from_table: FromTableSqlLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSqlLinter, index: TableMigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
         table_name = table_arg.as_string().strip("'").strip('"')
@@ -105,7 +105,7 @@ class SparkCallMatcher(_TableNameMatcher):
                 node=node,
             )
 
-    def apply(self, from_table: FromTableSqlLinter, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSqlLinter, index: TableMigrationIndex, node: Call) -> None:
         table_arg = self._get_table_arg(node)
         assert isinstance(table_arg, Const)
         dst = self._find_dest(index, table_arg.value, from_table.schema)
@@ -113,7 +113,7 @@ class SparkCallMatcher(_TableNameMatcher):
             table_arg.value = dst.destination()
 
     @staticmethod
-    def _find_dest(index: MigrationIndex, value: str, schema: str):
+    def _find_dest(index: TableMigrationIndex, value: str, schema: str):
         parts = value.split(".")
         # Ensure that unqualified table references use the current schema
         if len(parts) == 1:
@@ -130,7 +130,7 @@ class ReturnValueMatcher(_TableNameMatcher):
         )
 
     def lint(
-        self, from_table: FromTableSqlLinter, index: MigrationIndex, session_state: CurrentSessionState, node: Call
+        self, from_table: FromTableSqlLinter, index: TableMigrationIndex, session_state: CurrentSessionState, node: Call
     ) -> Iterator[Advice]:
         assert isinstance(node.func, Attribute)  # always true, avoids a pylint warning
         yield Advisory.from_node(
@@ -139,7 +139,7 @@ class ReturnValueMatcher(_TableNameMatcher):
             node=node,
         )
 
-    def apply(self, from_table: FromTableSqlLinter, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSqlLinter, index: TableMigrationIndex, node: Call) -> None:
         # No transformations to apply
         return
 
@@ -156,7 +156,11 @@ class DirectFilesystemAccessMatcher(_TableNameMatcher):
         )
 
     def lint(
-        self, from_table: FromTableSqlLinter, index: MigrationIndex, session_state: CurrentSessionState, node: NodeNG
+        self,
+        from_table: FromTableSqlLinter,
+        index: TableMigrationIndex,
+        session_state: CurrentSessionState,
+        node: NodeNG,
     ) -> Iterator[Advice]:
         table_arg = self._get_table_arg(node)
         for inferred in InferredValue.infer_from_node(table_arg):
@@ -171,7 +175,7 @@ class DirectFilesystemAccessMatcher(_TableNameMatcher):
                     node=node,
                 )
 
-    def apply(self, from_table: FromTableSqlLinter, index: MigrationIndex, node: Call) -> None:
+    def apply(self, from_table: FromTableSqlLinter, index: TableMigrationIndex, node: Call) -> None:
         # No transformations to apply
         return
 
@@ -280,7 +284,7 @@ class SparkTableNamePyLinter(PythonLinter, Fixer):
 
     _spark_matchers = SparkTableNameMatchers()
 
-    def __init__(self, from_table: FromTableSqlLinter, index: MigrationIndex, session_state):
+    def __init__(self, from_table: FromTableSqlLinter, index: TableMigrationIndex, session_state):
         self._from_table = from_table
         self._index = index
         self._session_state = session_state

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 
 from astroid import Attribute, Call, Const, Name, NodeNG  # type: ignore
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,

--- a/src/databricks/labs/ucx/source_code/lsp.py
+++ b/src/databricks/labs/ucx/source_code/lsp.py
@@ -12,10 +12,7 @@ from urllib.parse import parse_qsl
 from databricks.labs.blueprint.logger import install_logger
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.table_migration_status import (
-    TableMigrationStatus,
-)
-from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,

--- a/src/databricks/labs/ucx/source_code/lsp.py
+++ b/src/databricks/labs/ucx/source_code/lsp.py
@@ -13,9 +13,9 @@ from databricks.labs.blueprint.logger import install_logger
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.hive_metastore.migration_status import (
-    MigrationStatus,
+    TableMigrationStatus,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,
@@ -329,12 +329,12 @@ if __name__ == '__main__':
     install_logger()
     logging.root.setLevel('DEBUG')
     languages = LinterContext(
-        MigrationIndex(
+        TableMigrationIndex(
             [
-                MigrationStatus(
+                TableMigrationStatus(
                     src_schema='old', src_table='things', dst_catalog='brand', dst_schema='new', dst_table='stuff'
                 ),
-                MigrationStatus(
+                TableMigrationStatus(
                     src_schema='other',
                     src_table='matters',
                     dst_catalog='some',

--- a/src/databricks/labs/ucx/source_code/lsp.py
+++ b/src/databricks/labs/ucx/source_code/lsp.py
@@ -12,10 +12,10 @@ from urllib.parse import parse_qsl
 from databricks.labs.blueprint.logger import install_logger
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import (
+from databricks.labs.ucx.hive_metastore.table_migration_status import (
     TableMigrationStatus,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -6,7 +6,7 @@ from pylsp.config.config import Config  # type: ignore
 from pylsp.workspace import Document  # type: ignore
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableMigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.lsp import Diagnostic

--- a/src/databricks/labs/ucx/source_code/lsp_plugin.py
+++ b/src/databricks/labs/ucx/source_code/lsp_plugin.py
@@ -6,7 +6,7 @@ from pylsp.config.config import Config  # type: ignore
 from pylsp.workspace import Document  # type: ignore
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex, MigrationStatus
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.lsp import Diagnostic
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def pylsp_lint(config: Config, document: Document) -> list[dict]:
     cfg = config.plugin_settings('pylsp_ucx', document_path=document.uri)
 
-    migration_index = MigrationIndex([MigrationStatus.from_json(st) for st in cfg.get('migration_index', [])])
+    migration_index = TableMigrationIndex([TableMigrationStatus.from_json(st) for st in cfg.get('migration_index', [])])
 
     session_state = CurrentSessionState(
         data_security_mode=CurrentSessionState.parse_security_mode(cfg.get('dataSecurityMode', None)),

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -11,7 +11,7 @@ from astroid import AstroidSyntaxError, Module, NodeNG  # type: ignore
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Failure,
@@ -131,7 +131,7 @@ class NotebookLinter:
     @classmethod
     def from_source(
         cls,
-        index: MigrationIndex,
+        index: TableMigrationIndex,
         path_lookup: PathLookup,
         session_state: CurrentSessionState,
         source: str,

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -11,7 +11,7 @@ from astroid import AstroidSyntaxError, Module, NodeNG  # type: ignore
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Failure,

--- a/src/databricks/labs/ucx/source_code/redash.py
+++ b/src/databricks/labs/ucx/source_code/redash.py
@@ -8,7 +8,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import Dashboard, LegacyQuery, UpdateQueryRequestQuery
 from databricks.sdk.errors.platform import DatabricksError
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class Redash:
     MIGRATED_TAG = "Migrated by UCX"
 
-    def __init__(self, index: MigrationIndex, ws: WorkspaceClient, installation: Installation):
+    def __init__(self, index: TableMigrationIndex, ws: WorkspaceClient, installation: Installation):
         self._index = index
         self._ws = ws
         self._installation = installation

--- a/src/databricks/labs/ucx/source_code/redash.py
+++ b/src/databricks/labs/ucx/source_code/redash.py
@@ -8,7 +8,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import Dashboard, LegacyQuery, UpdateQueryRequestQuery
 from databricks.sdk.errors.platform import DatabricksError
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter
 

--- a/tests/integration/source_code/solacc.py
+++ b/tests/integration/source_code/solacc.py
@@ -9,7 +9,7 @@ from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.contexts.workspace_cli import LocalCheckoutContext
 from databricks.labs.ucx.framework.utils import run_command
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import LocatedAdvice
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 
@@ -91,7 +91,7 @@ def lint_one(file: Path, ctx: LocalCheckoutContext, unparsed: Path | None) -> tu
 def lint_all(file_to_lint: str | None):
     ws = WorkspaceClient(host='...', token='...')
     ctx = LocalCheckoutContext(ws).replace(
-        linter_context_factory=lambda session_state: LinterContext(MigrationIndex([]), session_state)
+        linter_context_factory=lambda session_state: LinterContext(TableMigrationIndex([]), session_state)
     )
     parseable = 0
     not_computed = 0

--- a/tests/integration/source_code/solacc.py
+++ b/tests/integration/source_code/solacc.py
@@ -9,7 +9,7 @@ from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.contexts.workspace_cli import LocalCheckoutContext
 from databricks.labs.ucx.framework.utils import run_command
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import LocatedAdvice
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -18,7 +18,7 @@ from databricks.sdk.service.compute import Library, PythonPyPiLibrary
 from databricks.sdk.service.pipelines import NotebookLibrary
 from databricks.sdk.service.workspace import ImportFormat, Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.mixins.fixtures import get_purge_suffix, factory
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import Dependency
@@ -188,7 +188,7 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
 def test_lint_local_code(simple_ctx):
     # no need to connect
     session_state = CurrentSessionState()
-    linter_context = LinterContext(MigrationIndex([]), session_state)
+    linter_context = LinterContext(TableMigrationIndex([]), session_state)
     light_ctx = simple_ctx
     ucx_path = Path(__file__).parent.parent.parent.parent
     path_to_scan = Path(ucx_path, "src")

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -18,7 +18,7 @@ from databricks.sdk.service.compute import Library, PythonPyPiLibrary
 from databricks.sdk.service.pipelines import NotebookLibrary
 from databricks.sdk.service.workspace import ImportFormat, Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.mixins.fixtures import get_purge_suffix, factory
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import Dependency

--- a/tests/unit/contexts/test_application.py
+++ b/tests/unit/contexts/test_application.py
@@ -4,7 +4,7 @@ import pytest
 
 from databricks.labs.ucx.contexts.application import GlobalContext
 from databricks.labs.ucx.contexts.workspace_cli import LocalCheckoutContext
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrator
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from tests.unit import mock_workspace_client
@@ -29,6 +29,6 @@ def test_local_context_attributes_not_none(attribute: str):
     ctx = LocalCheckoutContext(client)
     tables_migrator = create_autospec(TablesMigrator)
     tables_migrator.index.return_value = None
-    ctx.replace(languages=LinterContext(MigrationIndex([])), tables_migrator=tables_migrator)
+    ctx.replace(languages=LinterContext(TableMigrationIndex([])), tables_migrator=tables_migrator)
     assert hasattr(ctx, attribute)
     assert getattr(ctx, attribute) is not None

--- a/tests/unit/contexts/test_application.py
+++ b/tests/unit/contexts/test_application.py
@@ -4,7 +4,7 @@ import pytest
 
 from databricks.labs.ucx.contexts.application import GlobalContext
 from databricks.labs.ucx.contexts.workspace_cli import LocalCheckoutContext
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.hive_metastore.table_migrate import TablesMigrator
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from tests.unit import mock_workspace_client

--- a/tests/unit/hive_metastore/test_migrate_acls.py
+++ b/tests/unit/hive_metastore/test_migrate_acls.py
@@ -6,7 +6,7 @@ from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.account.workspaces import WorkspaceInfo
 from databricks.labs.ucx.hive_metastore.grants import MigrateGrants, ACLMigrator, Grant
-from databricks.labs.ucx.hive_metastore.migration_status import (
+from databricks.labs.ucx.hive_metastore.table_migration_status import (
     TableMigrationStatusRefresher,
     TableMigrationIndex,
 )

--- a/tests/unit/hive_metastore/test_migrate_acls.py
+++ b/tests/unit/hive_metastore/test_migrate_acls.py
@@ -7,8 +7,8 @@ from databricks.sdk import WorkspaceClient
 from databricks.labs.ucx.account.workspaces import WorkspaceInfo
 from databricks.labs.ucx.hive_metastore.grants import MigrateGrants, ACLMigrator, Grant
 from databricks.labs.ucx.hive_metastore.migration_status import (
-    MigrationStatusRefresher,
-    MigrationIndex,
+    TableMigrationStatusRefresher,
+    TableMigrationIndex,
 )
 from databricks.labs.ucx.hive_metastore.tables import TablesCrawler, Table
 from databricks.labs.ucx.workspace_access.groups import GroupManager, MigratedGroup
@@ -36,7 +36,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, ws_info, caplog):
     table_crawler.snapshot.return_value = [src]
 
     workspace_info = ws_info
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
 
     migrate_grants = create_autospec(MigrateGrants)
     acl_migrate = ACLMigrator(
@@ -59,10 +59,10 @@ def test_migrate_acls_hms_fed_proper_queries(ws, ws_info, caplog):
     workspace_info = ws_info
     migrate_grants = create_autospec(MigrateGrants)
 
-    migration_index = create_autospec(MigrationIndex)
+    migration_index = create_autospec(TableMigrationIndex)
     migration_index.is_migrated.return_value = True
 
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
     migration_status_refresher.get_seen_tables.return_value = {
         "ucx_default.db1_dst.managed_dbfs": "hive_metastore.db1_src.managed_dbfs",
     }

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -19,7 +19,7 @@ from databricks.labs.ucx.hive_metastore.mapping import (
 from databricks.labs.ucx.hive_metastore.table_migrate import (
     TablesMigrator,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import (
+from databricks.labs.ucx.hive_metastore.table_migration_status import (
     TableMigrationStatusRefresher,
     TableMigrationIndex,
     TableMigrationStatus,

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -20,9 +20,9 @@ from databricks.labs.ucx.hive_metastore.table_migrate import (
     TablesMigrator,
 )
 from databricks.labs.ucx.hive_metastore.migration_status import (
-    MigrationStatusRefresher,
-    MigrationIndex,
-    MigrationStatus,
+    TableMigrationStatusRefresher,
+    TableMigrationIndex,
+    TableMigrationStatus,
     TableView,
 )
 from databricks.labs.ucx.hive_metastore.tables import (
@@ -51,7 +51,7 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs", "managed_mnt", "managed_other"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -102,7 +102,7 @@ def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["dbfs_parquet"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -138,7 +138,7 @@ def test_migrate_dbfs_root_tables_should_be_skipped_when_upgrading_external(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(crawler_backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -160,7 +160,7 @@ def test_migrate_external_tables_should_produce_proper_queries(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(crawler_backend, "inventory_database")
     table_mapping = mock_table_mapping(["external_src"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -191,7 +191,7 @@ def test_migrate_external_table_failed_sync(ws, caplog):
     crawler_backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(crawler_backend, "inventory_database")
     table_mapping = mock_table_mapping(["external_src"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -296,7 +296,7 @@ def test_migrate_external_hiveserde_table_in_place(
     )
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["external_hiveserde"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     mount_crawler = create_autospec(Mounts)
     mount_crawler.snapshot.return_value = [Mount('/mnt/test', 's3://test/folder')]
     migrate_grants = create_autospec(MigrateGrants)
@@ -348,7 +348,7 @@ def test_migrate_external_tables_ctas_should_produce_proper_queries(ws, what, te
     backend = MockBackend()
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping([test_table])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     mounts_crawler = create_autospec(Mounts)
     mounts_crawler.snapshot.return_value = [Mount('/mnt/test', 's3://test/folder')]
     migrate_grants = create_autospec(MigrateGrants)
@@ -393,7 +393,7 @@ def test_migrate_already_upgraded_table_should_produce_no_queries(ws):
             Rule("workspace", "cat1", "db1_src", "schema1", "external_src", "dest1"),
         )
     ]
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -416,7 +416,7 @@ def test_migrate_unsupported_format_table_should_produce_no_queries(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(crawler_backend, "inventory_database")
     table_mapping = mock_table_mapping(["external_src_unsupported"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -441,14 +441,14 @@ def test_migrate_view_should_produce_proper_queries(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs", "view"])
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
     migration_status_refresher.get_seen_tables.return_value = {
         "ucx_default.db1_dst.managed_dbfs": "hive_metastore.db1_src.managed_dbfs"
     }
-    migration_index = MigrationIndex(
+    migration_index = TableMigrationIndex(
         [
-            MigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
-            MigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
+            TableMigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
+            TableMigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
         ]
     )
     migration_status_refresher.index.return_value = migration_index
@@ -489,14 +489,14 @@ def test_migrate_view_with_columns(ws):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs", "view"])
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
     migration_status_refresher.get_seen_tables.return_value = {
         "ucx_default.db1_dst.managed_dbfs": "hive_metastore.db1_src.managed_dbfs"
     }
-    migration_index = MigrationIndex(
+    migration_index = TableMigrationIndex(
         [
-            MigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
-            MigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
+            TableMigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
+            TableMigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
         ]
     )
     migration_status_refresher.index.return_value = migration_index
@@ -602,7 +602,7 @@ def get_table_migrator(backend: SqlBackend) -> TablesMigrator:
     ]
     table_crawler.snapshot.return_value = test_tables
     table_mapping = mock_table_mapping()
-    migration_status_refresher = MigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)  # pylint: disable=mock-no-usage
     table_migrate = TablesMigrator(
         table_crawler,
@@ -668,7 +668,7 @@ def test_no_migrated_tables(ws):
     table_mapping.load.return_value = [
         Rule("workspace", "catalog_1", "db1", "db1", "managed", "managed"),
     ]
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -709,7 +709,7 @@ def test_empty_revert_report(ws):
     table_crawler = create_autospec(TablesCrawler)
     ws.tables.list.side_effect = []
     table_mapping = mock_table_mapping()
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -741,7 +741,7 @@ def test_is_upgraded(ws):
         Table("hive_metastore", "schema1", "table2", "MANAGED", "DELTA"),
     ]
     table_mapping = mock_table_mapping()
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -821,10 +821,10 @@ def test_table_status():
             properties={"upgraded_from": "hive_metastore.schema1.table2"},
         ),
     ]
-    table_status_crawler = MigrationStatusRefresher(client, backend, "ucx", table_crawler)
+    table_status_crawler = TableMigrationStatusRefresher(client, backend, "ucx", table_crawler)
     snapshot = list(table_status_crawler.snapshot())
     assert snapshot == [
-        MigrationStatus(
+        TableMigrationStatus(
             src_schema='schema1',
             src_table='table1',
             dst_catalog='cat1',
@@ -832,7 +832,7 @@ def test_table_status():
             dst_table='table1',
             update_ts='0',
         ),
-        MigrationStatus(
+        TableMigrationStatus(
             src_schema='schema1',
             src_table='table2',
             dst_catalog=None,
@@ -840,7 +840,7 @@ def test_table_status():
             dst_table=None,
             update_ts='0',
         ),
-        MigrationStatus(
+        TableMigrationStatus(
             src_schema='schema1',
             src_table='table3',
             dst_catalog=None,
@@ -857,7 +857,7 @@ def test_table_status_reset():
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = create_autospec(TablesCrawler)
     client = create_autospec(WorkspaceClient)
-    table_status_crawler = MigrationStatusRefresher(client, backend, "ucx", table_crawler)
+    table_status_crawler = TableMigrationStatusRefresher(client, backend, "ucx", table_crawler)
     table_status_crawler.reset()
     assert backend.queries == [
         "TRUNCATE TABLE `hive_metastore`.`ucx`.`migration_status`",
@@ -915,7 +915,7 @@ def test_table_status_seen_tables(caplog):
         ],
         NotFound(),
     ]
-    table_status_crawler = MigrationStatusRefresher(client, backend, "ucx", table_crawler)
+    table_status_crawler = TableMigrationStatusRefresher(client, backend, "ucx", table_crawler)
     seen_tables = table_status_crawler.get_seen_tables()
     assert seen_tables == {
         'cat1.schema1.table1': 'hive_metastore.schema1.table1',
@@ -936,10 +936,10 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
     src = Table('hive_metastore', 'db1_src', 'managed_dbfs', 'TABLE', 'DELTA', "/foo/bar/test")
     table_crawler.snapshot.return_value = [src]
     table_mapping = mock_table_mapping(["managed_dbfs"])
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
 
     migrate_grants = create_autospec(MigrateGrants)
-    migration_index = create_autospec(MigrationIndex)
+    migration_index = create_autospec(TableMigrationIndex)
     migration_index.is_migrated.return_value = False
     migration_status_refresher.index.return_value = migration_index
     sql_backend = MockBackend()
@@ -1002,12 +1002,12 @@ def test_migrate_views_should_be_properly_sequenced(ws):
             Rule("workspace", "catalog", "db1_src", "db1_dst", "t2_src", "t2_dst"),
         ),
     ]
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
     migration_status_refresher.get_seen_tables.return_value = {
         "ucx_default.db1_dst.managed_dbfs": "hive_metastore.db1_src.managed_dbfs"
     }
-    migration_index = create_autospec(MigrationIndex)
-    migration_index.get.return_value = MigrationStatus(
+    migration_index = create_autospec(TableMigrationIndex)
+    migration_index.get.return_value = TableMigrationStatus(
         src_schema="db1_src",
         src_table="t1_src",
         dst_catalog="catalog",
@@ -1056,7 +1056,7 @@ def test_table_in_mount_mapping_with_table_owner():
         )
     ]
     table_crawler = TablesCrawler(backend, "inventory_database")
-    migration_status_refresher = MigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -1099,7 +1099,7 @@ def test_table_in_mount_mapping_with_partition_information():
         )
     ]
     table_crawler = TablesCrawler(backend, "inventory_database")
-    migration_status_refresher = MigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(client, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -1124,14 +1124,14 @@ def test_migrate_view_failed(ws, caplog):
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs", "view"])
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
     migration_status_refresher.get_seen_tables.return_value = {
         "ucx_default.db1_dst.managed_dbfs": "hive_metastore.db1_src.managed_dbfs"
     }
-    migration_index = MigrationIndex(
+    migration_index = TableMigrationIndex(
         [
-            MigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
-            MigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
+            TableMigrationStatus("db1_src", "managed_dbfs", "ucx_default", "db1_dst", "new_managed_dbfs"),
+            TableMigrationStatus("db1_src", "view_src", "ucx_default", "db1_dst", "view_dst"),
         ]
     )
     migration_status_refresher.index.return_value = migration_index
@@ -1157,7 +1157,7 @@ def test_migrate_dbfs_root_tables_failed(ws, caplog):
     backend = MockBackend(fails_on_first=errors, rows={})
     table_crawler = TablesCrawler(backend, "inventory_database")
     table_mapping = mock_table_mapping(["managed_dbfs"])
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     migrate_grants = create_autospec(MigrateGrants)
     table_migrate = TablesMigrator(
         table_crawler,
@@ -1219,11 +1219,11 @@ def test_refresh_migration_status_published_remained_tables(caplog):
         ),
     ]
     table_mapping = mock_table_mapping()
-    migration_status_refresher = create_autospec(MigrationStatusRefresher)
-    migration_index = MigrationIndex(
+    migration_status_refresher = create_autospec(TableMigrationStatusRefresher)
+    migration_index = TableMigrationIndex(
         [
-            MigrationStatus("schema1", "table1", "ucx_default", "db1_dst", "dst_table1"),
-            MigrationStatus("schema1", "table2", "ucx_default", "db1_dst", "dst_table2"),
+            TableMigrationStatus("schema1", "table1", "ucx_default", "db1_dst", "dst_table1"),
+            TableMigrationStatus("schema1", "table2", "ucx_default", "db1_dst", "dst_table2"),
         ]
     )
     migration_status_refresher.index.return_value = migration_index

--- a/tests/unit/hive_metastore/test_view_migrate.py
+++ b/tests/unit/hive_metastore/test_view_migrate.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 import pytest
 
 from databricks.labs.ucx.hive_metastore.mapping import Rule, TableToMigrate
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex, TableMigrationStatus
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.hive_metastore.view_migrate import ViewsMigrationSequencer, ViewToMigrate
 

--- a/tests/unit/recon/test_migration_recon.py
+++ b/tests/unit/recon/test_migration_recon.py
@@ -5,7 +5,7 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.hive_metastore import TablesCrawler
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.recon.base import TableIdentifier
 from databricks.labs.ucx.recon.data_comparator import StandardDataComparator
 from databricks.labs.ucx.recon.data_profiler import StandardDataProfiler
@@ -75,7 +75,7 @@ def test_migrate_recon_should_produce_proper_queries(
     }
     backend = MockBackend(fails_on_first=errors, rows=rows)
     table_crawler = TablesCrawler(backend, "inventory_database")
-    migration_status_refresher = MigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
+    migration_status_refresher = TableMigrationStatusRefresher(ws, backend, "inventory_database", table_crawler)
     metadata_retriever = DatabricksTableMetadataRetriever(backend)
     data_profiler = StandardDataProfiler(backend, metadata_retriever)
     migration_recon = MigrationRecon(

--- a/tests/unit/recon/test_migration_recon.py
+++ b/tests/unit/recon/test_migration_recon.py
@@ -5,7 +5,7 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.hive_metastore import TablesCrawler
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationStatusRefresher
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.recon.base import TableIdentifier
 from databricks.labs.ucx.recon.data_comparator import StandardDataComparator
 from databricks.labs.ucx.recon.data_profiler import StandardDataProfiler

--- a/tests/unit/source_code/conftest.py
+++ b/tests/unit/source_code/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 
 from databricks.labs.ucx.hive_metastore.migration_status import (
-    MigrationStatus,
+    TableMigrationStatus,
 )
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.graph import DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader
@@ -14,36 +14,44 @@ from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolv
 
 @pytest.fixture
 def empty_index():
-    return MigrationIndex([])
+    return TableMigrationIndex([])
 
 
 @pytest.fixture
 def migration_index():
-    return MigrationIndex(
+    return TableMigrationIndex(
         [
-            MigrationStatus('old', 'things', dst_catalog='brand', dst_schema='new', dst_table='stuff'),
-            MigrationStatus('other', 'matters', dst_catalog='some', dst_schema='certain', dst_table='issues'),
+            TableMigrationStatus('old', 'things', dst_catalog='brand', dst_schema='new', dst_table='stuff'),
+            TableMigrationStatus('other', 'matters', dst_catalog='some', dst_schema='certain', dst_table='issues'),
         ]
     )
 
 
 @pytest.fixture
 def extended_test_index():
-    return MigrationIndex(
+    return TableMigrationIndex(
         [
-            MigrationStatus('old', 'things', dst_catalog='brand', dst_schema='new', dst_table='stuff'),
-            MigrationStatus('other', 'matters', dst_catalog='some', dst_schema='certain', dst_table='issues'),
-            MigrationStatus('old', 'stuff', dst_catalog='brand', dst_schema='new', dst_table='things'),
-            MigrationStatus('other', 'issues', dst_catalog='some', dst_schema='certain', dst_table='matters'),
-            MigrationStatus('default', 'testtable', dst_catalog='cata', dst_schema='nondefault', dst_table='table'),
-            MigrationStatus('different_db', 'testtable', dst_catalog='cata2', dst_schema='newspace', dst_table='table'),
-            MigrationStatus('old', 'testtable', dst_catalog='cata3', dst_schema='newspace', dst_table='table'),
-            MigrationStatus('default', 'people', dst_catalog='cata4', dst_schema='nondefault', dst_table='newpeople'),
-            MigrationStatus(
+            TableMigrationStatus('old', 'things', dst_catalog='brand', dst_schema='new', dst_table='stuff'),
+            TableMigrationStatus('other', 'matters', dst_catalog='some', dst_schema='certain', dst_table='issues'),
+            TableMigrationStatus('old', 'stuff', dst_catalog='brand', dst_schema='new', dst_table='things'),
+            TableMigrationStatus('other', 'issues', dst_catalog='some', dst_schema='certain', dst_table='matters'),
+            TableMigrationStatus(
+                'default', 'testtable', dst_catalog='cata', dst_schema='nondefault', dst_table='table'
+            ),
+            TableMigrationStatus(
+                'different_db', 'testtable', dst_catalog='cata2', dst_schema='newspace', dst_table='table'
+            ),
+            TableMigrationStatus('old', 'testtable', dst_catalog='cata3', dst_schema='newspace', dst_table='table'),
+            TableMigrationStatus(
+                'default', 'people', dst_catalog='cata4', dst_schema='nondefault', dst_table='newpeople'
+            ),
+            TableMigrationStatus(
                 'something', 'persons', dst_catalog='cata4', dst_schema='newsomething', dst_table='persons'
             ),
-            MigrationStatus('whatever', 'kittens', dst_catalog='cata4', dst_schema='felines', dst_table='toms'),
-            MigrationStatus('whatever', 'numbers', dst_catalog='cata4', dst_schema='counting', dst_table='numbers'),
+            TableMigrationStatus('whatever', 'kittens', dst_catalog='cata4', dst_schema='felines', dst_table='toms'),
+            TableMigrationStatus(
+                'whatever', 'numbers', dst_catalog='cata4', dst_schema='counting', dst_table='numbers'
+            ),
         ]
     )
 

--- a/tests/unit/source_code/conftest.py
+++ b/tests/unit/source_code/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 
-from databricks.labs.ucx.hive_metastore.migration_status import (
-    TableMigrationStatus,
-)
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex, TableMigrationStatus
 from databricks.labs.ucx.source_code.graph import DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.source_code.known import KnownList
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.linters.files import (
     LocalFileMigrator,
     FileLoader,

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.source_code.known import KnownList
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.linters.files import (
     LocalFileMigrator,
     FileLoader,
@@ -28,21 +28,21 @@ from tests.unit import locate_site_packages, _samples_path
 
 
 def test_notebook_migrator_ignores_unsupported_extensions():
-    languages = LinterContext(MigrationIndex([]))
+    languages = LinterContext(TableMigrationIndex([]))
     migrator = NotebookMigrator(languages)
     path = Path('unsupported.ext')
     assert not migrator.apply(path)
 
 
 def test_file_migrator_fix_ignores_unsupported_extensions():
-    languages = LinterContext(MigrationIndex([]))
+    languages = LinterContext(TableMigrationIndex([]))
     migrator = LocalFileMigrator(lambda: languages)
     path = Path('unsupported.ext')
     assert not migrator.apply(path)
 
 
 def test_file_migrator_fix_ignores_unsupported_language():
-    languages = LinterContext(MigrationIndex([]))
+    languages = LinterContext(TableMigrationIndex([]))
     migrator = LocalFileMigrator(lambda: languages)
     migrator._extensions[".py"] = None  # pylint: disable=protected-access
     path = Path('unsupported.py')
@@ -66,7 +66,7 @@ def test_file_migrator_supported_language_no_diagnostics():
 
 
 def test_notebook_migrator_supported_language_no_diagnostics(mock_path_lookup):
-    languages = LinterContext(MigrationIndex([]))
+    languages = LinterContext(TableMigrationIndex([]))
     migrator = NotebookMigrator(languages)
     path = mock_path_lookup.resolve(Path("root1.run.py"))
     assert not migrator.apply(path)

--- a/tests/unit/source_code/linters/test_linters.py
+++ b/tests/unit/source_code/linters/test_linters.py
@@ -1,11 +1,11 @@
 import pytest
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Fixer, Linter
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 
-index = MigrationIndex([])
+index = TableMigrationIndex([])
 
 
 def test_linter_returns_correct_analyser_for_python():

--- a/tests/unit/source_code/linters/test_linters.py
+++ b/tests/unit/source_code/linters/test_linters.py
@@ -1,7 +1,7 @@
 import pytest
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Fixer, Linter
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 

--- a/tests/unit/source_code/test_functional.py
+++ b/tests/unit/source_code/test_functional.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Advice, CurrentSessionState, is_a_notebook
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver
 from databricks.labs.ucx.source_code.linters.context import LinterContext
@@ -110,7 +110,7 @@ class Functional:
         self.language = CellLanguage.PYTHON if path.suffix.endswith("py") else CellLanguage.SQL
 
     def verify(
-        self, path_lookup: PathLookup, dependency_resolver: DependencyResolver, migration_index: MigrationIndex
+        self, path_lookup: PathLookup, dependency_resolver: DependencyResolver, migration_index: TableMigrationIndex
     ) -> None:
         expected_problems = list(self._expected_problems())
         actual_advices = list(self._lint(path_lookup, dependency_resolver, migration_index))
@@ -134,7 +134,7 @@ class Functional:
         # TODO: output annotated file with comments for quick fixing
 
     def _lint(
-        self, path_lookup: PathLookup, dependency_resolver: DependencyResolver, migration_index: MigrationIndex
+        self, path_lookup: PathLookup, dependency_resolver: DependencyResolver, migration_index: TableMigrationIndex
     ) -> Iterable[Advice]:
         session_state = self._test_session_state()
         print(str(session_state))

--- a/tests/unit/source_code/test_functional.py
+++ b/tests/unit/source_code/test_functional.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import Advice, CurrentSessionState, is_a_notebook
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver
 from databricks.labs.ucx.source_code.linters.context import LinterContext

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -1,6 +1,6 @@
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.notebooks.sources import NotebookLinter
 

--- a/tests/unit/source_code/test_notebook_linter.py
+++ b/tests/unit/source_code/test_notebook_linter.py
@@ -1,10 +1,10 @@
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.hive_metastore.migration_status import MigrationIndex
+from databricks.labs.ucx.hive_metastore.migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.notebooks.sources import NotebookLinter
 
-index = MigrationIndex([])
+index = TableMigrationIndex([])
 
 
 def test_notebook_linter_name(mock_path_lookup):


### PR DESCRIPTION
## Changes

This is a refactoring PR that renames some of the classes used for tracking the state of table migration. This is partly to avoid confusion with the upcoming migration progress code, but also to better reflect the scope of responsibility. 

### Linked issues

Relates to #2074.

### Functionality

- Functionality is not intended to change. The existing `migration_status` table has been left alone.

### Tests

- Existing unit and integration tests.
