### PR TITLE
Fix failing integration test `test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace`

### DIFF
--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -61,7 +61,11 @@ def test_rename_groups(ws, make_ucx_group, sql_backend, inventory_schema):
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace(
-    caplog, ws, make_ucx_group, sql_backend, inventory_schema,
+    caplog,
+    ws,
+    make_ucx_group,
+    sql_backend,
+    inventory_schema,
 ):
     """The groups that already are reflected in the workspace should be skipped."""
     ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -67,7 +67,9 @@ def test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in
     ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
-    group_manager.reflect_account_groups_on_workspace()
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.workspace_access.groups"):
+        group_manager.reflect_account_groups_on_workspace()
+    assert f"Skipping {acc_group.display_name}: already in workspace" in caplog.text
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -60,10 +60,10 @@ def test_rename_groups(ws, make_ucx_group, sql_backend, inventory_schema):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_reflect_account_groups_on_workspace_recovers_when_group_already_exists(
-    ws, make_ucx_group, sql_backend, inventory_schema
+def test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace(
+    caplog, ws, make_ucx_group, sql_backend, inventory_schema,
 ):
-    ws_group, _ = make_ucx_group()
+    """The groups that already are reflected in the workspace should be skipped."""
     ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -64,6 +64,7 @@ def test_reflect_account_groups_on_workspace_recovers_when_group_already_exists(
     ws, make_ucx_group, sql_backend, inventory_schema
 ):
     ws_group, _ = make_ucx_group()
+    ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
     group_manager.reflect_account_groups_on_workspace()


### PR DESCRIPTION
## Changes
Fix failing integration test `test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace` by waiting for the groups used for testing to be provisioned (instead of in the process of being provisioned).

### Linked issues

Resolves #2559

### Tests

- [ ] modified integration tests `test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace`
