### PR TITLE
Fix failing integration test: `test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace`

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -557,11 +557,15 @@ class GroupManager(CrawlerBase[MigratedGroup]):
         tasks = []
         account_groups_in_account = self._account_groups_in_account()
         account_groups_in_workspace = self._account_groups_in_workspace()
+        workspace_groups_in_workspace = self._workspace_groups_in_workspace()
         groups_to_migrate = self.get_migration_state().groups
         logger.info(f"Starting to reflect {len(groups_to_migrate)} account groups into workspace for migration...")
         for migrated_group in groups_to_migrate:
             if migrated_group.name_in_account in account_groups_in_workspace:
                 logger.info(f"Skipping {migrated_group.name_in_account}: already in workspace")
+                continue
+            if migrated_group.name_in_account in workspace_groups_in_workspace:
+                logger.error(f"Skipping {migrated_group.name_in_account}: group already exists in workspace")
                 continue
             if migrated_group.name_in_account not in account_groups_in_account:
                 logger.warning(f"Skipping {migrated_group.name_in_account}: not in account")

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -60,20 +60,20 @@ def test_rename_groups(ws, make_ucx_group, sql_backend, inventory_schema):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_reflect_account_groups_on_workspace_skips_groups_that_already_exists_in_the_workspace(
+def test_reflect_account_groups_on_workspace_skips_account_groups_when_a_workspace_group_has_same_name(
     caplog,
     ws,
     make_ucx_group,
     sql_backend,
     inventory_schema,
 ):
-    """The groups that already are reflected in the workspace should be skipped."""
+    """We should warn about groups for which a workspace group with the same name already exists."""
     ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
-    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.workspace_access.groups"):
+    with caplog.at_level(logging.WARN, logger="databricks.labs.ucx.workspace_access.groups"):
         group_manager.reflect_account_groups_on_workspace()
-    assert f"Skipping {acc_group.display_name}: already in workspace" in caplog.text
+    assert f"Skipping {acc_group.display_name}: group already exists in workspace" in caplog.text
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -60,14 +60,14 @@ def test_rename_groups(ws, make_ucx_group, sql_backend, inventory_schema):
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_reflect_account_groups_on_workspace_skips_account_groups_when_a_workspace_group_has_same_name(
+def test_reflect_account_groups_on_workspace_warns_skipping_when_a_workspace_group_has_same_name(
     caplog,
     ws,
     make_ucx_group,
     sql_backend,
     inventory_schema,
 ):
-    """We should warn about groups for which a workspace group with the same name already exists."""
+    """Warn about groups for which a workspace group with the same name exists."""
     ws_group, acc_group = make_ucx_group(wait_for_provisioning=True)
 
     group_manager = GroupManager(sql_backend, ws, inventory_schema, [ws_group.display_name], "ucx-temp-")
@@ -77,14 +77,14 @@ def test_reflect_account_groups_on_workspace_skips_account_groups_when_a_workspa
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_reflect_account_groups_on_workspace_skips_account_groups_when_already_reflected_on_workspace(
+def test_reflect_account_groups_on_workspace_logs_skipping_groups_when_already_reflected_on_workspace(
     caplog,
     ws,
     make_acc_group,
     sql_backend,
     inventory_schema,
 ):
-    """We should skip groups which are already reflected on the workspace."""
+    """Log skipping groups which are reflected on the workspace already."""
     acc_group = make_acc_group(wait_for_provisioning=True)
 
     sql_backend.save_table(


### PR DESCRIPTION
## Changes
Also check for **workspace** groups to exists with the same name. Follow up on #2615

In hindsight, what might have happened before: the workspace group was not created before the account group was reflected in the workspace, thus the test passes. With the changes in PR #2615, we got more consistent behaviour because we wait for the workspace group to exists before running the to-be-tested code. However, the code did not handle that situation. This PR handles when a workspace group has the same name as an to-be-reflected-in-the-workspace account group

### Linked issues

Resolves #2623

### Functionality

- [x] modified existing workflow: `group-migration`

### Tests

- [x] modified integration tests: `test_reflect_account_groups_on_workspace_skips_account_groups_when_a_workspace_group_has_same_name`
