### PR TITLE
Fix test failure: `test_table_migration_job_refreshes_migration_status[regular-migrate-tables]`

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -80,8 +80,8 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
         self._ws = ws
         self._table_crawler = table_crawler
 
-    def index(self) -> TableMigrationIndex:
-        return TableMigrationIndex(list(self.snapshot()))
+    def index(self, *, force_refresh: bool = False) -> TableMigrationIndex:
+        return TableMigrationIndex(list(self.snapshot(force_refresh=force_refresh)))
 
     def get_seen_tables(self) -> dict[str, str]:
         seen_tables: dict[str, str] = {}

--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -1,4 +1,6 @@
 import pytest
+from databricks.labs.lsql.backends import DataclassInstance, MockBackend
+
 from databricks.labs.ucx.hive_metastore.workflows import (
     TableMigration,
     MigrateExternalTablesCTAS,
@@ -53,6 +55,26 @@ def test_migrate_ctas_views(run_workflow):
     ctx.workspace_client.catalogs.list.assert_called()
 
 
+class MockBackendFriend(MockBackend):
+    """A wrapper class to change the return type on :meth:`rows_written_for`."""
+
+    def rows_written_for(self, full_name: str, mode: str) -> list[DataclassInstance] | None:
+        """Retrieve the rows written for a table name given a mode.
+
+        Additionally to the logic of the parent class, differentiate between no rows (empty list) and no match (None).
+        """
+        rows: list[DataclassInstance] = []
+        found_write_match = False
+        for stub_full_name, stub_rows, stub_mode in self._save_table:
+            if not (stub_full_name == full_name and stub_mode == mode):
+                continue
+            found_write_match = True
+            rows += stub_rows
+        if len(rows) == 0 and not found_write_match:
+            return None
+        return rows
+
+
 @pytest.mark.parametrize(
     "workflow",
     [
@@ -65,6 +87,6 @@ def test_migrate_ctas_views(run_workflow):
 )
 def test_update_migration_status(run_workflow, workflow):
     """Migration status is refreshed by deleting and showing new tables"""
-    ctx = run_workflow(getattr(workflow, "update_migration_status"))
-    assert "TRUNCATE TABLE `hive_metastore`.`ucx`.`migration_status`" in ctx.sql_backend.queries
+    ctx = run_workflow(getattr(workflow, "update_migration_status"), replace={"sql_backend": MockBackendFriend()})
+    assert ctx.sql_backend.rows_written_for("hive_metastore.ucx.migration_status", "overwrite") is not None
     assert "SHOW DATABASES" in ctx.sql_backend.queries

--- a/tests/unit/hive_metastore/test_workflows.py
+++ b/tests/unit/hive_metastore/test_workflows.py
@@ -1,5 +1,4 @@
 import pytest
-from databricks.labs.lsql.backends import DataclassInstance, MockBackend
 
 from databricks.labs.ucx.hive_metastore.workflows import (
     TableMigration,


### PR DESCRIPTION
## Changes
Reuse the `force_refresh` flag on the `snapshot` introduced in #2566 to make sure the migration status is up-to-date.

### Linked issues
Resolves #2621
Resolves #2537

### Tests

- [x] modified unit tests
