### PR TITLE
Integration test reliability: update some tests to ensure they use unique group names

### DIFF
--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -33,7 +33,7 @@ def test_create_account_level_groups(
     make_random,
     clean_account_level_groups,
 ):
-    suffix = get_purge_suffix()
+    suffix = f"{make_random(4).lower()}-{get_purge_suffix()}"
     make_ucx_group(f"test_ucx_migrate_invalid-{suffix}", f"test_ucx_migrate_invalid-{suffix}")
 
     group_display_name = f"created_by_ucx_regular_group-{suffix}"

--- a/tests/integration/framework/test_fixtures.py
+++ b/tests/integration/framework/test_fixtures.py
@@ -26,8 +26,9 @@ def test_user(make_user):
     logger.info(f"created {make_user()}")
 
 
-def test_group(make_group, make_user):
-    logger.info(f'created {make_group(display_name="abc", members=[make_user().id])}')
+def test_group(make_group, make_user, make_random):
+    display_name = f"abc-{make_random(4)}"
+    logger.info(f'created {make_group(display_name=display_name, members=[make_user().id])}')
 
 
 def test_secret_scope(make_secret_scope):


### PR DESCRIPTION
## Changes

This PR updates two integration tests that were using a fixed name for the fixture objects that they create. These can sometimes (spuriously) fail due to concurrent test runs against the same infrastructure.

### Tests

 - updated integration tests