### PR TITLE
Let `create-uber-principal` command run on collection of workspaces

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -163,14 +163,17 @@ commands:
         description: AWS Profile to use for authentication
 
   - name: create-uber-principal
-    description: For azure cloud, creates a service principal and gives STORAGE BLOB READER access on all the storage account
-      used by tables in the workspace and stores the spn info in the UCX cluster policy. For aws,
-      it identifies all s3 buckets used by the Instance Profiles configured in the workspace.
+    description: |
+      For azure cloud, creates a service principal and gives `STORAGE_BLOB_READER` access on all the storage account
+      used by tables in the workspace and stores the service principal information in the UCX cluster policy.
+      For aws, indentify all s3 buckets used by the Instance Profiles configured in the workspace.
     flags:
       - name: subscription-id
         description: Subscription to scan storage account in
       - name: aws-profile
         description: AWS Profile to use for authentication
+      - name: run-as-collection
+        description: Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: validate-groups-membership
     description: Validate groups to check if the groups at account level and workspace level have different memberships

--- a/src/databricks/labs/ucx/azure/access.py
+++ b/src/databricks/labs/ucx/azure/access.py
@@ -373,7 +373,7 @@ class AzureResourcePermissions:
             )
             raise error
 
-    def create_uber_principal(self, prompts: Prompts):
+    def create_uber_principal(self, prompts: Prompts) -> None:
         config = self._installation.load(WorkspaceConfig)
         inventory_database = config.inventory_database
         display_name = f"unity-catalog-migration-{inventory_database}-{self._ws.get_workspace_id()}"

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -313,11 +313,11 @@ def create_uber_principal(
         workspace_contexts = [ctx]
     else:
         workspace_contexts = _get_workspace_contexts(w, a, run_as_collection, **named_parameters)
-    for ctx in workspace_contexts:
-        if ctx.is_azure:
-            ctx.azure_resource_permissions.create_uber_principal(prompts)
-        if ctx.is_aws:
-            ctx.aws_resource_permissions.create_uber_principal(prompts)
+    for workspace_context in workspace_contexts:
+        if workspace_context.is_azure:
+            workspace_context.azure_resource_permissions.create_uber_principal(prompts)
+        if workspace_context.is_aws:
+            workspace_context.aws_resource_permissions.create_uber_principal(prompts)
         else:
             raise ValueError("Unsupported cloud provider")
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -298,8 +298,8 @@ def alias(
 
 @ucx.command
 def create_uber_principal(
-    prompts: Prompts,
     w: WorkspaceClient,
+    prompts: Prompts,
     ctx: WorkspaceContext | None = None,
     run_as_collection: bool = False,
     a: AccountClient | None = None,

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -316,7 +316,7 @@ def create_uber_principal(
     for workspace_context in workspace_contexts:
         if workspace_context.is_azure:
             workspace_context.azure_resource_permissions.create_uber_principal(prompts)
-        if workspace_context.is_aws:
+        elif workspace_context.is_aws:
             workspace_context.aws_resource_permissions.create_uber_principal(prompts)
         else:
             raise ValueError("Unsupported cloud provider")

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -119,8 +119,6 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def is_azure(self) -> bool:
-        if self.is_aws:
-            return False
         return self.connect_config.is_azure
 
     @cached_property

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -132,7 +132,7 @@ class WorkspaceContext(CliContext):
         return run_command
 
     @cached_property
-    def aws_profile(self):
+    def aws_profile(self) -> str:
         aws_profile = self.named_parameters.get("aws_profile")
         if not aws_profile:
             aws_profile = os.getenv("AWS_DEFAULT_PROFILE")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -567,12 +567,12 @@ def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws):
         create_uber_principal(ws, prompts, ctx=ctx)
 
 
-def test_create_master_principal_no_subscription(ws):
+def test_create_uber_principal_raises_value_error_if_azure_subscription_id_is_missing(ws):
     ws.config.auth_type = "azure-cli"
     ws.config.is_azure = True
     prompts = MockPrompts({})
     ctx = WorkspaceContext(ws)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Please enter subscription id to scan storage accounts in."):
         create_uber_principal(ws, prompts, ctx=ctx, subscription_id="")
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -569,12 +569,14 @@ def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws):
 
 
 def test_create_azure_uber_principal_raises_value_error_if_subscription_id_is_missing(ws) -> None:
-    ws.config.auth_type = "azure-cli"
-    ws.config.is_azure = True
-    prompts = MockPrompts({})
-    ctx = WorkspaceContext(ws)
+    ctx = WorkspaceContext(ws).replace(
+        is_azure=True,
+        is_aws=False,
+        azure_cli_authenticated=True,
+    )
+    prompts = MockPrompts({"Enter a name for the uber service principal to be created": "test"})
     with pytest.raises(ValueError, match="Please enter subscription id to scan storage accounts in."):
-        create_uber_principal(ws, prompts, ctx=ctx, subscription_id="")
+        create_uber_principal(ws, prompts, ctx=ctx)
 
 
 def test_create_azure_uber_principal_calls_workspace_id_and_storage_accounts(ws) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -559,11 +559,12 @@ def test_migrate_credentials_limit_aws(ws, acc_client):
         migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
 
 
-def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws):
-    ws.config.is_azure = False
-    ws.config.is_aws = False
+def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws) -> None:
+    ctx = WorkspaceContext(ws).replace(
+        is_azure=False,
+        is_aws=False,
+    )
     prompts = MockPrompts({})
-    ctx = WorkspaceContext(ws)
     with pytest.raises(ValueError, match="Unsupported cloud provider"):
         create_uber_principal(ws, prompts, ctx=ctx)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -87,7 +87,7 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
                 },
                 'installed_workspace_ids': installed_workspace_ids,
                 'policy_id': '01234567A8BCDEF9',
-                # Exit Azure's `create_uber_principal` early by setting the uber service principal in the configuration
+                # Exit Azure's `create_uber_principal` early by setting the uber service principal id
                 # to isolate cli testing as much as possible to the cli commands and not the invoked ucx functionality.
                 'uber_spn_id': '0123456789',
             }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -558,12 +558,12 @@ def test_migrate_credentials_limit_aws(ws, acc_client):
         migrate_credentials(ws, prompts, ctx=ctx, a=acc_client)
 
 
-def test_create_master_principal_not_azure(ws):
+def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws):
     ws.config.is_azure = False
     ws.config.is_aws = False
     prompts = MockPrompts({})
     ctx = WorkspaceContext(ws)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unsupported cloud provider"):
         create_uber_principal(ws, prompts, ctx=ctx)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -615,6 +615,16 @@ def test_create_azure_uber_principal_runs_as_collection_requests_workspace_ids(w
         workspace_client.get_workspace_id.assert_called()
 
 
+def test_create_aws_uber_principal_raises_value_error_if_aws_profile_is_missing(ws) -> None:
+    ctx = WorkspaceContext(ws).replace(
+        is_azure=False,
+        is_aws=True,
+    )
+    prompts = MockPrompts({})
+    with pytest.raises(ValueError, match="AWS Profile is not specified. .*"):
+        create_uber_principal(ws, prompts, ctx=ctx)
+
+
 def test_migrate_locations_raises_value_error_for_unsupported_cloud_provider(ws) -> None:
     ctx = WorkspaceContext(ws).replace(is_azure=False, is_aws=False)
     with pytest.raises(ValueError, match="Unsupported cloud provider"):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -87,6 +87,8 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
                 },
                 'installed_workspace_ids': installed_workspace_ids,
                 'policy_id': '01234567A8BCDEF9',
+                # Exit Azure's `create_uber_principal` early by setting the uber service principal in the configuration
+                # to isolate cli testing as much as possible to the cli commands and not the invoked ucx functionality.
                 'uber_spn_id': '0123456789',
             }
         ),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -568,7 +568,7 @@ def test_create_uber_principal_raises_value_error_for_unsupported_cloud(ws):
         create_uber_principal(ws, prompts, ctx=ctx)
 
 
-def test_create_uber_principal_raises_value_error_if_azure_subscription_id_is_missing(ws):
+def test_create_azure_uber_principal_raises_value_error_if_subscription_id_is_missing(ws) -> None:
     ws.config.auth_type = "azure-cli"
     ws.config.is_azure = True
     prompts = MockPrompts({})

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -698,17 +698,6 @@ def test_migrate_locations_azure_run_as_collection(workspace_clients, acc_client
 
 
 def test_migrate_locations_aws(ws, caplog) -> None:
-    successful_return = """
-    {
-        "UserId": "uu@mail.com",
-        "Account": "1234",
-        "Arn": "arn:aws:sts::1234:assumed-role/AWSVIEW/uu@mail.com"
-    }
-    """
-
-    def successful_call(_):
-        return 0, successful_return, ""
-
     ctx = WorkspaceContext(ws).replace(
         is_aws=True,
         is_azure=False,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -584,13 +584,11 @@ def test_create_azure_uber_principal_raises_value_error_if_subscription_id_is_mi
 
 
 def test_create_azure_uber_principal_calls_workspace_id(ws) -> None:
-    azurerm = create_autospec(AzureResources)
     ctx = WorkspaceContext(ws).replace(
         is_azure=True,
         is_aws=False,
         azure_cli_authenticated=True,
         azure_subscription_id="id",
-        azure_resources=azurerm,
     )
     prompts = MockPrompts({"Enter a name for the uber service principal to be created": "test"})
 
@@ -604,7 +602,13 @@ def test_create_azure_uber_principal_runs_as_collection_requests_workspace_ids(w
         ws.config.auth_type = "azure-cli"
     prompts = MockPrompts({"Enter a name for the uber service principal to be created": "test"})
 
-    create_uber_principal(workspace_clients[0], prompts, run_as_collection=True, a=acc_client, subscription_id="test",)
+    create_uber_principal(
+        workspace_clients[0],
+        prompts,
+        run_as_collection=True,
+        a=acc_client,
+        subscription_id="test",
+    )
 
     for workspace_client in workspace_clients:
         workspace_client.get_workspace_id.assert_called()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -598,8 +598,9 @@ def test_create_azure_uber_principal_calls_workspace_id(ws) -> None:
 
 
 def test_create_azure_uber_principal_runs_as_collection_requests_workspace_ids(workspace_clients, acc_client) -> None:
-    for ws in workspace_clients:
-        ws.config.auth_type = "azure-cli"
+    for workspace_client in workspace_clients:
+        # Setting the auth as follows as we (currently) do not support injecting multiple workspace contexts
+        workspace_client.config.auth_type = "azure-cli"
     prompts = MockPrompts({"Enter a name for the uber service principal to be created": "test"})
 
     create_uber_principal(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -581,7 +581,7 @@ def test_create_azure_uber_principal_raises_value_error_if_subscription_id_is_mi
         create_uber_principal(ws, prompts, ctx=ctx)
 
 
-def test_create_azure_uber_principal_calls_workspace_id_and_storage_accounts() -> None:
+def test_create_azure_uber_principal_calls_workspace_id(ws) -> None:
     azurerm = create_autospec(AzureResources)
     ctx = WorkspaceContext(ws).replace(
         is_azure=True,
@@ -595,7 +595,6 @@ def test_create_azure_uber_principal_calls_workspace_id_and_storage_accounts() -
     create_uber_principal(ws, prompts, ctx=ctx)
 
     ws.get_workspace_id.assert_called_once()
-    azurerm.storage_accounts.assert_called_once()
 
 
 def test_create_azure_uber_principal_runs_as_collection_requests_workspace_ids(workspace_clients, acc_client) -> None:


### PR DESCRIPTION
## Changes
Let `create-uber-principal` command run on a collection of workspaces.

### Linked issues

Resolves #2605

### Functionality

- [x] modified existing command: `databricks labs ucx create-uber-principal`

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] ~added integration tests~ : Covering after #2507
