### PR TITLE
Remove installing on workspace log message in `_get_installer`

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -729,7 +729,6 @@ class AccountInstaller(AccountContext):
 
     def _get_installer(self, workspace: Workspace) -> WorkspaceInstaller:
         workspace_client = self.account_client.get_workspace_client(workspace)
-        logger.info(f"Installing UCX on workspace {workspace.deployment_name}")
         return WorkspaceInstaller(workspace_client).replace(product_info=self.product_info, prompts=self.prompts)
 
     def install_on_account(self):


### PR DESCRIPTION
## Changes
No installation happens in `_get_installer`; the message is confusing (to users) as it prints ucx is installing when it is not