### PR TITLE
Assessment: crawl UDFs as a task in parallel to tables instead of implicitly during grants

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -19,11 +19,19 @@ class Assessment(Workflow):
         stored is then used in the subsequent tasks and workflows to, for example,  find all Hive Metastore tables that
         cannot easily be migrated to Unity Catalog."""
 
+    @job_task
+    def crawl_udfs(self, ctx: RuntimeContext):
+        """Iterates over all UDFs in the Hive Metastore of the current workspace and persists their metadata in the
+        Delta table named `$inventory_database.udfs`. (The `inventory_database` is set in the configuration file.)
+        This inventory is currently used when scanning securable objects for issues with grants that cannot be migrated
+        to Unit Catalog."""
+        ctx.udfs_crawler.snapshot()
+
     @job_task(job_cluster="tacl")
     def setup_tacl(self, ctx: RuntimeContext):
         """(Optimization) Starts `tacl` job cluster in parallel to crawling tables."""
 
-    @job_task(depends_on=[crawl_tables, setup_tacl], job_cluster="tacl")
+    @job_task(depends_on=[crawl_tables, crawl_udfs, setup_tacl], job_cluster="tacl")
     def crawl_grants(self, ctx: RuntimeContext):
         """Scans all securable objects for permissions that have been assigned: this include database-level permissions,
         as well permissions directly configured on objects in the (already gathered) table and UDF inventories. The

--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -22,9 +22,8 @@ class Assessment(Workflow):
     @job_task
     def crawl_udfs(self, ctx: RuntimeContext):
         """Iterates over all UDFs in the Hive Metastore of the current workspace and persists their metadata in the
-        Delta table named `$inventory_database.udfs`. (The `inventory_database` is set in the configuration file.)
-        This inventory is currently used when scanning securable objects for issues with grants that cannot be migrated
-        to Unit Catalog."""
+        table named `$inventory_database.udfs`. This inventory is currently used when scanning securable objects for
+        issues with grants that cannot be migrated to Unit Catalog."""
         ctx.udfs_crawler.snapshot()
 
     @job_task(job_cluster="tacl")


### PR DESCRIPTION
## Changes

This PR updates the way UDFs are crawled/scanned during the `assessment` workflow:

 - Prior to this PR the UDFs are crawled/scanned implicitly by the `GrantsCrawler`: it requests a snapshot from the `UDFSCrawler` but that hasn't executed prior to this point in the workflow.
 - With this PR, the UDFs are crawled/scanned as their own task in parallel with tables before grants crawling commences.

### Linked issues

Progresses #2574, where grants and UDFs need to be refreshable but only once within a given workflow run.

### Functionality

- modified existing workflow: `assessment`

### Tests

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
