### PR TITLE
Drop replace methods with builtin

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import codecs
+import dataclasses
 import locale
 import logging
 from abc import abstractmethod, ABC
@@ -41,25 +42,6 @@ class Advice:
     end_line: int
     end_col: int
 
-    def replace(
-        self,
-        *,
-        code: str | None = None,
-        message: str | None = None,
-        start_line: int | None = None,
-        start_col: int | None = None,
-        end_line: int | None = None,
-        end_col: int | None = None,
-    ) -> Advice:
-        return type(self)(
-            code=code if code is not None else self.code,
-            message=message if message is not None else self.message,
-            start_line=start_line if start_line is not None else self.start_line,
-            start_col=start_col if start_col is not None else self.start_col,
-            end_line=end_line if end_line is not None else self.end_line,
-            end_col=end_col if end_col is not None else self.end_col,
-        )
-
     def as_advisory(self) -> 'Advisory':
         return Advisory(**self.__dict__)
 
@@ -89,7 +71,8 @@ class Advice:
 
     def replace_from_node(self, node: NodeNG) -> Advice:
         # Astroid lines are 1-based.
-        return self.replace(
+        return dataclasses.replace(
+            self,
             start_line=(node.lineno or 1) - 1,
             start_col=node.col_offset,
             end_line=(node.end_lineno or 1) - 1,

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 import itertools
 import logging
 from dataclasses import dataclass
@@ -95,7 +96,8 @@ class DependencyGraph:
         return MaybeGraph(
             child_graph,
             [
-                problem.replace(
+                dataclasses.replace(
+                    problem,
                     source_path=dependency.path if problem.is_path_missing() else problem.source_path,
                 )
                 for problem in problems
@@ -473,7 +475,7 @@ class DependencyResolver:
             out_path = path if problem.is_path_missing() else problem.source_path
             if out_path.is_absolute() and out_path.is_relative_to(self._path_lookup.cwd):
                 out_path = out_path.relative_to(self._path_lookup.cwd)
-            adjusted_problems.append(problem.replace(source_path=out_path))
+            adjusted_problems.append(dataclasses.replace(problem, source_path=out_path))
         return adjusted_problems
 
     def __repr__(self):
@@ -496,26 +498,6 @@ class DependencyProblem:
 
     def is_path_missing(self):
         return self.source_path == Path(MISSING_SOURCE_PATH)
-
-    def replace(
-        self,
-        code: str | None = None,
-        message: str | None = None,
-        source_path: Path | None = None,
-        start_line: int | None = None,
-        start_col: int | None = None,
-        end_line: int | None = None,
-        end_col: int | None = None,
-    ) -> DependencyProblem:
-        return DependencyProblem(
-            code if code is not None else self.code,
-            message if message is not None else self.message,
-            source_path if source_path is not None else self.source_path,
-            start_line if start_line is not None else self.start_line,
-            start_col if start_col is not None else self.start_col,
-            end_line if end_line is not None else self.end_line,
-            end_col if end_col is not None else self.end_col,
-        )
 
     def as_advisory(self) -> 'Advisory':
         return Advisory(

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import re
 import shlex
@@ -105,8 +106,10 @@ class PythonCell(Cell):
         python_dependency_problems = analyzer.build_graph()
         # Position information for the Python code is within the code and needs to be mapped to the location within the parent nodebook.
         return [
-            problem.replace(
-                start_line=self.original_offset + problem.start_line, end_line=self.original_offset + problem.end_line
+            dataclasses.replace(
+                problem,
+                start_line=self.original_offset + problem.start_line,
+                end_line=self.original_offset + problem.end_line,
             )
             for problem in python_dependency_problems
         ]
@@ -177,7 +180,7 @@ class RunCell(Cell):
             start_line = self._original_offset + idx
             problems = parent.register_notebook(path, True)
             return [
-                problem.replace(start_line=start_line, start_col=0, end_line=start_line, end_col=len(line))
+                dataclasses.replace(problem, start_line=start_line, start_col=0, end_line=start_line, end_col=len(line))
                 for problem in problems
             ]
         start_line = self._original_offset

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import locale
 import logging
 from collections.abc import Iterable
@@ -173,7 +174,8 @@ class NotebookLinter:
                 linter = self._linter(cell.language.language)
                 advices = linter.lint(cell.original_code)
             for advice in advices:
-                yield advice.replace(
+                yield dataclasses.replace(
+                    advice,
                     start_line=advice.start_line + cell.original_offset,
                     end_line=advice.end_line + cell.original_offset,
                 )

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Iterable
 from pathlib import Path
@@ -48,7 +49,8 @@ class PythonCodeAnalyzer:
         for base_node in nodes:
             for problem in self._build_graph_from_node(base_node):
                 # Astroid line numbers are 1-based.
-                problem = problem.replace(
+                problem = dataclasses.replace(
+                    problem,
                     start_line=base_node.node.lineno - 1,
                     start_col=base_node.node.col_offset,
                     end_line=(base_node.node.end_lineno or 1) - 1,

--- a/tests/unit/source_code/test_base.py
+++ b/tests/unit/source_code/test_base.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,
@@ -20,7 +22,7 @@ def test_message_initialization():
 def test_warning_initialization():
     warning = Advisory('code2', 'This is a warning', 1, 1, 2, 2)
 
-    copy_of = warning.replace(code='code3')
+    copy_of = dataclasses.replace(warning, code='code3')
     assert copy_of.code == 'code3'
     assert isinstance(copy_of, Advisory)
 

--- a/tests/unit/source_code/test_s3fs.py
+++ b/tests/unit/source_code/test_s3fs.py
@@ -1,3 +1,4 @@
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -126,7 +127,7 @@ def test_detect_s3fs_import(empty_index, source: str, expected: list[DependencyP
         pip_resolver, notebook_resolver, import_resolver, import_resolver, mock_path_lookup
     )
     maybe = dependency_resolver.build_local_file_dependency_graph(sample, CurrentSessionState())
-    assert maybe.problems == [_.replace(source_path=sample) for _ in expected]
+    assert maybe.problems == [dataclasses.replace(_, source_path=sample) for _ in expected]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes
Our code implements 'replace' methods on some dataclasses with no benefit over the builtin method.
This PR fixes that.

### Linked issues
None

### Functionality
None

### Tests
- [x] ran unit tests
