### PR TITLE
Fix failing solution accelerator verification tests

### DIFF
--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -202,6 +202,7 @@ class LocalCheckoutContext(WorkspaceContext):
     def local_code_linter(self):
         session_state = CurrentSessionState()
         return LocalCodeLinter(
+            self.notebook_loader,
             self.file_loader,
             self.folder_loader,
             self.path_lookup,

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -207,6 +207,7 @@ def test_lint_local_code(simple_ctx):
     path_to_scan = Path(ucx_path, "src")
     # TODO: LocalCheckoutContext has to move into GlobalContext because of this hack
     linter = LocalCodeLinter(
+        light_ctx.notebook_loader,
         light_ctx.file_loader,
         light_ctx.folder_loader,
         light_ctx.path_lookup,

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -121,7 +121,7 @@ def local_code_linter(mock_path_lookup, migration_index):
         mock_path_lookup,
     )
     return LocalCodeLinter(
-        file_loader, folder_loader, mock_path_lookup, session_state, resolver, lambda: LinterContext(migration_index)
+        notebook_loader, file_loader, folder_loader, mock_path_lookup, session_state, resolver, lambda: LinterContext(migration_index)
     )
 
 
@@ -194,6 +194,7 @@ site_packages = locate_site_packages()
     "path", [Path("/Users/eric.vergnaud/development/ucx/.venv/lib/python3.10/site-packages/spacy/pipe_analysis.py")]
 )
 def test_known_issues(path: Path, migration_index):
+    notebook_loader = NotebookLoader()
     file_loader = FileLoader()
     notebook_loader = NotebookLoader()
     folder_loader = FolderLoader(notebook_loader, file_loader)
@@ -205,6 +206,7 @@ def test_known_issues(path: Path, migration_index):
     pip_resolver = PythonLibraryResolver(allow_list)
     resolver = DependencyResolver(pip_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup)
     linter = LocalCodeLinter(
+        notebook_loader,
         file_loader,
         folder_loader,
         path_lookup,

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -121,7 +121,13 @@ def local_code_linter(mock_path_lookup, migration_index):
         mock_path_lookup,
     )
     return LocalCodeLinter(
-        notebook_loader, file_loader, folder_loader, mock_path_lookup, session_state, resolver, lambda: LinterContext(migration_index)
+        notebook_loader,
+        file_loader,
+        folder_loader,
+        mock_path_lookup,
+        session_state,
+        resolver,
+        lambda: LinterContext(migration_index),
     )
 
 


### PR DESCRIPTION
## Changes
LocalCodeLinter is unable to normalize python code at notebook cell level
This PR fixes the issue

### Linked issues
None

### Functionality
None

### Tests
- [x] manually tested running `make solacc` on files that fail in CI
