### PR TITLE
Let `validate-external-locations` command run as collection

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -76,7 +76,11 @@ commands:
         description: boolean flag to indicate to run the cmd as a collection. Default is False.
 
   - name: validate-external-locations
-    description: validates and provides mapping to external table to external location and shared generation tf scripts
+    description: |
+      Validates external locations and provides Terraform script that maps external locations to external table.
+    flags:
+     - name: run-as-collection
+       description: Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: repair-run
     description: Repair Run the Failed Job

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -171,12 +171,24 @@ def create_table_mapping(
 
 
 @ucx.command
-def validate_external_locations(w: WorkspaceClient, prompts: Prompts):
+def validate_external_locations(
+    w: WorkspaceClient,
+    prompts: Prompts,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+):
     """validates and provides mapping to external table to external location and shared generation tf scripts"""
-    ctx = WorkspaceContext(w)
-    path = ctx.external_locations.save_as_terraform_definitions_on_workspace(ctx.installation)
-    if path and prompts.confirm(f"external_locations.tf file written to {path}. Do you want to open it?"):
-        webbrowser.open(f"{w.config.host}/#workspace{path}")
+    if ctx:
+        workspace_contexts = [ctx]
+    else:
+        workspace_contexts = _get_workspace_contexts(w, a, run_as_collection)
+    for workspace_context in workspace_contexts:
+        path = workspace_context.external_locations.save_as_terraform_definitions_on_workspace(
+            workspace_context.installation
+        )
+        if path and prompts.confirm(f"external_locations.tf file written to {path}. Do you want to open it?"):
+            webbrowser.open(f"{w.config.host}/#workspace{path}")
 
 
 @ucx.command

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -277,6 +277,18 @@ def test_validate_external_locations(ws):
     ws.statement_execution.execute_statement.assert_called()
 
 
+def test_validate_external_locations_runs_as_collection(workspace_clients, acc_client) -> None:
+    validate_external_locations(
+        workspace_clients[0],
+        MockPrompts({}),
+        run_as_collection=True,
+        a=acc_client,
+    )
+
+    for workspace_client in workspace_clients:
+        workspace_client.statement_execution.execute_statement.assert_called()
+
+
 def test_ensure_assessment_run(ws, acc_client):
     ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
         state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -271,7 +271,7 @@ def test_create_table_mapping(ws, acc_client):
         create_table_mapping(ws, ctx, False, acc_client)
 
 
-def test_validate_external_locations(ws):
+def test_validate_external_locations(ws) -> None:
     validate_external_locations(ws, MockPrompts({}))
 
     ws.statement_execution.execute_statement.assert_called()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -272,8 +272,7 @@ def test_create_table_mapping(ws, acc_client):
 
 
 def test_validate_external_locations(ws) -> None:
-    validate_external_locations(ws, MockPrompts({}))
-
+    validate_external_locations(ws, MockPrompts({}), ctx=WorkspaceContext(ws))
     ws.statement_execution.execute_statement.assert_called()
 
 


### PR DESCRIPTION
## Changes
Let `validate-external-locations` command to run as collection

### Linked issues

Resolves #2607

### Functionality

- [x] modified existing command: `databricks labs ucx validate-external-locations`

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] ~added integration tests~ : Covering after #2507
