### PR TITLE
drop workspace path.stat() workaround

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from urllib import parse
 
 from databricks.labs.blueprint.parallel import ManyError, Threads
-from databricks.labs.blueprint.paths import DBFSPath, WorkspacePath
+from databricks.labs.blueprint.paths import DBFSPath
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
@@ -495,20 +495,6 @@ class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
             yield LocatedAdvice(advice, dependency.path)
 
 
-def _get_path_modified_datetime(path: Path) -> datetime:
-    if isinstance(path, WorkspacePath):
-        # TODO add stats method in blueprint, see https://github.com/databrickslabs/blueprint/issues/142
-        # pylint: disable=protected-access
-        unix_time = float(path._object_info.modified_at) / 1000.0 if path._object_info.modified_at else 0.0
-    elif isinstance(path, DBFSPath):
-        # TODO add stats method in blueprint, see https://github.com/databrickslabs/blueprint/issues/143
-        # pylint: disable=protected-access
-        unix_time = float(path._file_info.modification_time) / 1000.0 if path._file_info.modification_time else 0.0
-    else:
-        unix_time = path.stat().st_mtime
-    return datetime.fromtimestamp(unix_time, timezone.utc)
-
-
 class DfsaCollectorWalker(DependencyGraphWalker[DirectFsAccess]):
 
     def __init__(
@@ -539,7 +525,7 @@ class DfsaCollectorWalker(DependencyGraphWalker[DirectFsAccess]):
         self, source: str, language: CellLanguage, path: Path, inherited_tree: Tree | None
     ) -> Iterable[DirectFsAccess]:
         notebook = Notebook.parse(path, source, language.language)
-        src_timestamp = _get_path_modified_datetime(path)
+        src_timestamp = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
         src_id = str(path)
         for cell in notebook.cells:
             for dfsa in self._collect_from_source(cell.original_code, cell.language, path, inherited_tree):
@@ -561,7 +547,7 @@ class DfsaCollectorWalker(DependencyGraphWalker[DirectFsAccess]):
         if iterable is None:
             logger.warning(f"Language {language.name} not supported yet!")
             return
-        src_timestamp = _get_path_modified_datetime(path)
+        src_timestamp = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
         src_id = str(path)
         for dfsa in iterable:
             yield dfsa.replace_source(source_id=src_id, source_lineage=self.lineage, source_timestamp=src_timestamp)


### PR DESCRIPTION
## Changes
Blueprint 0.8.3 implements path.stat() for workspace paths.
This PR removes the corresponding workaround

### Linked issues
None

### Functionality
None

### Tests
- [x] ran unit tests
- [x] ran integration tests
