### PR TITLE
Let `migrate-acls` command run as collection

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -267,6 +267,8 @@ commands:
     flags:
       - name: dashboard-id
         description: (Optional) DBSQL dashboard ID to migrate. If no dashboard ID is provided, all DBSQL dashboards in the workspace will be migrated.
+      - name: run-as-collection
+        description: (Optional) Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: revert-dbsql-dashboards
     description: Revert DBSQL dashboards that have been migrated to their original state before the migration.

--- a/labs.yml
+++ b/labs.yml
@@ -248,8 +248,11 @@ commands:
 
   - name: migrate-tables
     description: |
-      Trigger the migrate-tables workflow and, optionally, migrate-external-hiveserde-tables-in-place-experimental
-      workflow and migrate-external-tables-ctas workflow.
+      Trigger the `migrate-tables` workflow and, optionally, `migrate-external-hiveserde-tables-in-place-experimental`
+      workflow and `migrate-external-tables-ctas workflow`.
+    flags:
+      - name: run-as-collection
+        description: Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: migrate-acls
     description: |

--- a/labs.yml
+++ b/labs.yml
@@ -178,6 +178,9 @@ commands:
       Workspace Group Name\tMembers Count\tAccount Group Name\tMembers Count\tDifference
       {{range .}}{{.wf_group_name}}\t{{.wf_group_members_count}}\t{{.acc_group_name}}\t{{.acc_group_members_count}}\t{{.group_members_difference}}
       {{end}}
+    flags:
+    - name: run-as-collection
+      description: (Optional) Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: migrate-credentials
     description: Migrate credentials for storage access to UC storage credential

--- a/labs.yml
+++ b/labs.yml
@@ -250,12 +250,14 @@ commands:
 
   - name: migrate-acls
     description: |
-      Migrate ACLs from legacy metastore to UC metastore.
+      Migrate access control lists from legacy metastore to UC metastore.
     flags:
       - name: target-catalog
         description: (Optional) Target catalog to migrate ACLs to. Used for HMS-FED ACLs migration.
       - name: hms-fed
         description: (Optional) Migrate HMS-FED ACLs. If not provided, HMS ACLs will be migrated for migrated tables.
+      - name: run-as-collection
+        description: (Optional) Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: migrate-dbsql-dashboards
     description: Migrate DBSQL dashboards by replacing legacy HMS tables in DBSQL queries with the corresponding new UC tables.

--- a/labs.yml
+++ b/labs.yml
@@ -208,6 +208,8 @@ commands:
         description: Subscription to scan storage account in
       - name: aws-profile
         description: AWS Profile to use for authentication
+      - name: run-as-collection
+        description: Run the command for the collection of workspaces with ucx installed. Default is False.
 
   - name: create-catalogs-schemas
     description: Create UC external catalogs and schemas based on the destinations created from create_table_mapping command.

--- a/src/databricks/labs/ucx/aws/locations.py
+++ b/src/databricks/labs/ucx/aws/locations.py
@@ -27,7 +27,7 @@ class AWSExternalLocationsMigration:
         self._aws_resource_permissions = aws_resource_permissions
         self._principal_acl = principal_acl
 
-    def run(self):
+    def run(self) -> None:
         """
         For each path find out the role that has access to it
         Find out the credential that is pointing to this path
@@ -36,7 +36,10 @@ class AWSExternalLocationsMigration:
         credential_dict = self._get_existing_credentials_dict()
         external_locations = self._external_locations.snapshot()
         existing_external_locations = self._ws.external_locations.list()
-        existing_paths = [external_location.url for external_location in existing_external_locations]
+        existing_paths = []
+        for external_location in existing_external_locations:
+            if external_location.url is not None:
+                existing_paths.append(external_location.url)
         compatible_roles = self._aws_resource_permissions.load_uc_compatible_roles()
         missing_paths = self._identify_missing_external_locations(external_locations, existing_paths, compatible_roles)
         for path, role_arn in missing_paths:

--- a/src/databricks/labs/ucx/azure/locations.py
+++ b/src/databricks/labs/ucx/azure/locations.py
@@ -182,7 +182,7 @@ class ExternalLocationsMigration:
             logger.warning(f"Skip unsupported location: {url}")
         return supported_urls
 
-    def run(self):
+    def run(self) -> list[str]:
         # list missing external locations in UC
         _, missing_locations = self._hms_locations.match_table_external_locations()
         # Extract the location URLs from the missing locations

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -541,16 +541,24 @@ def migrate_tables(w: WorkspaceClient, prompts: Prompts, *, ctx: WorkspaceContex
 
 
 @ucx.command
-def migrate_acls(w: WorkspaceClient, *, ctx: WorkspaceContext | None = None, **named_parameters):
+def migrate_acls(
+    w: WorkspaceClient,
+    *,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+    **named_parameters,
+):
     """
     Migrate the ACLs for migrated tables and view. Can work with hms federation or other table migration scenarios.
     """
-    if ctx is None:
-        ctx = WorkspaceContext(w)
-    ctx.acl_migrator.migrate_acls(
-        target_catalog=named_parameters.get("target_catalog"),
-        hms_fed=named_parameters.get("hms_fed", False),
-    )
+    if ctx:
+        workspace_contexts = [ctx]
+    else:
+        workspace_contexts = _get_workspace_contexts(w, a, run_as_collection, **named_parameters)
+    target_catalog, hms_fed = named_parameters.get("target_catalog"), named_parameters.get("hms_fed", False)
+    for workspace_context in workspace_contexts:
+        workspace_context.acl_migrator.migrate_acls(target_catalog=target_catalog, hms_fed=hms_fed)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -571,10 +571,20 @@ def migrate_acls(
 
 
 @ucx.command
-def migrate_dbsql_dashboards(w: WorkspaceClient, dashboard_id: str | None = None):
+def migrate_dbsql_dashboards(
+    w: WorkspaceClient,
+    dashboard_id: str | None = None,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+) -> None:
     """Migrate table references in DBSQL Dashboard queries"""
-    ctx = WorkspaceContext(w)
-    ctx.redash.migrate_dashboards(dashboard_id)
+    if ctx:
+        workspace_contexts = [ctx]
+    else:
+        workspace_contexts = _get_workspace_contexts(w, a, run_as_collection)
+    for workspace_context in workspace_contexts:
+        workspace_context.redash.migrate_dashboards(dashboard_id)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -203,11 +203,20 @@ def repair_run(w: WorkspaceClient, step):
 
 
 @ucx.command
-def validate_groups_membership(w: WorkspaceClient):
+def validate_groups_membership(
+    w: WorkspaceClient,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+) -> None:
     """Validate the groups to see if the groups at account level and workspace level has different membership"""
-    ctx = WorkspaceContext(w)
-    mismatch_groups = ctx.group_manager.validate_group_membership()
-    print(json.dumps(mismatch_groups))
+    if ctx:
+        workspace_contexts = [ctx]
+    else:
+        workspace_contexts = _get_workspace_contexts(w, a, run_as_collection)
+    for workspace_context in workspace_contexts:
+        mismatch_groups = workspace_context.group_manager.validate_group_membership()
+        print(json.dumps(mismatch_groups))
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -428,17 +428,27 @@ def migrate_credentials(
 
 
 @ucx.command
-def migrate_locations(w: WorkspaceClient, ctx: WorkspaceContext | None = None, **named_parameters):
+def migrate_locations(
+    w: WorkspaceClient,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+    **named_parameters,
+):
     """This command creates UC external locations. The candidate locations to be created are extracted from
     guess_external_locations task in the assessment job. You can run validate_external_locations command to check
     the candidate locations. Please make sure the credentials haven migrated before running this command. The command
     will only create the locations that have corresponded UC Storage Credentials.
     """
-    if not ctx:
-        ctx = WorkspaceContext(w, named_parameters)
-    if ctx.is_azure or ctx.is_aws:
-        return ctx.external_locations_migration.run()
-    raise ValueError("Unsupported cloud provider")
+    if ctx:
+        workspace_contexts = [ctx]
+    else:
+        workspace_contexts = _get_workspace_contexts(w, a, run_as_collection, **named_parameters)
+    for workspace_context in workspace_contexts:
+        if workspace_context.is_azure or workspace_context.is_aws:
+            workspace_context.external_locations_migration.run()
+        else:
+            raise ValueError("Unsupported cloud provider")
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -15,7 +15,7 @@ from databricks.labs.ucx.recon.data_profiler import StandardDataProfiler
 from databricks.labs.ucx.recon.metadata_retriever import DatabricksTableMetadataRetriever
 from databricks.labs.ucx.recon.migration_recon import MigrationRecon
 from databricks.labs.ucx.recon.schema_comparator import StandardSchemaComparator
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawlers
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
 from databricks.sdk import AccountClient, WorkspaceClient, core
 from databricks.sdk.errors import ResourceDoesNotExist
@@ -54,6 +54,7 @@ from databricks.labs.ucx.source_code.linters.files import FileLoader, FolderLoad
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.graph import DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
+from databricks.labs.ucx.source_code.queries import QueryLinter
 from databricks.labs.ucx.source_code.redash import Redash
 from databricks.labs.ucx.workspace_access import generic, redash
 from databricks.labs.ucx.workspace_access.groups import GroupManager
@@ -426,13 +427,21 @@ class GlobalContext(abc.ABC):
             self.dependency_resolver,
             self.path_lookup,
             TableMigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
-            self.directfs_access_crawlers,
+            self.directfs_access_crawler_for_paths,
             self.config.include_job_ids,
         )
 
     @cached_property
-    def directfs_access_crawlers(self):
-        return DirectFsAccessCrawlers(self.sql_backend, self.inventory_database)
+    def query_linter(self):
+        return QueryLinter(self.workspace_client, self.directfs_access_crawler_for_queries)
+
+    @cached_property
+    def directfs_access_crawler_for_paths(self):
+        return DirectFsAccessCrawler.for_paths(self.sql_backend, self.inventory_database)
+
+    @cached_property
+    def directfs_access_crawler_for_queries(self):
+        return DirectFsAccessCrawler.for_queries(self.sql_backend, self.inventory_database)
 
     @cached_property
     def redash(self):

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -202,6 +202,7 @@ class LocalCheckoutContext(WorkspaceContext):
     def local_code_linter(self):
         session_state = CurrentSessionState()
         return LocalCodeLinter(
+            self.notebook_loader,
             self.file_loader,
             self.folder_loader,
             self.path_lookup,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -75,7 +75,7 @@ from databricks.labs.ucx.installer.policy import ClusterPolicyInstaller
 from databricks.labs.ucx.installer.workflows import WorkflowsDeployment
 from databricks.labs.ucx.recon.migration_recon import ReconResult
 from databricks.labs.ucx.runtime import Workflows
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccess
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessInPath, DirectFsAccessInQuery
 from databricks.labs.ucx.source_code.jobs import JobProblem
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.generic import WorkspaceObjectInfo
@@ -121,9 +121,8 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
             functools.partial(table, "udfs", Udf),
             functools.partial(table, "logs", LogRecord),
             functools.partial(table, "recon_results", ReconResult),
-            functools.partial(
-                table, "directfs_in_paths", DirectFsAccess
-            ),  # directfs_in_queries will be added in upcoming PR
+            functools.partial(table, "directfs_in_paths", DirectFsAccessInPath),
+            functools.partial(table, "directfs_in_queries", DirectFsAccessInQuery),
         ],
     )
     deployer.deploy_view("grant_detail", "queries/views/grant_detail.sql")
@@ -132,7 +131,7 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
     deployer.deploy_view("misc_patterns", "queries/views/misc_patterns.sql")
     deployer.deploy_view("code_patterns", "queries/views/code_patterns.sql")
     deployer.deploy_view("reconciliation_results", "queries/views/reconciliation_results.sql")
-    # direct_file_system_access view will be added in upcoming PR
+    deployer.deploy_view("directfs", "queries/views/directfs.sql")
 
 
 def extract_major_minor(version_string):

--- a/src/databricks/labs/ucx/queries/views/directfs.sql
+++ b/src/databricks/labs/ucx/queries/views/directfs.sql
@@ -1,0 +1,27 @@
+SELECT
+    path,
+    is_read,
+    is_write,
+    source_id,
+    source_timestamp,
+    source_lineage,
+    assessment_start_timestamp,
+    assessment_end_timestamp,
+    job_id,
+    job_name,
+    task_key
+FROM $inventory.directfs_in_paths
+UNION ALL
+SELECT
+    path,
+    is_read,
+    is_write,
+    source_id,
+    source_timestamp,
+    source_lineage,
+    assessment_start_timestamp,
+    assessment_end_timestamp,
+    NULL as job_id,
+    NULL as job_name,
+    null as task_key
+FROM $inventory.directfs_in_queries

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import codecs
+import dataclasses
 import locale
 import logging
 from abc import abstractmethod, ABC
@@ -41,25 +42,6 @@ class Advice:
     end_line: int
     end_col: int
 
-    def replace(
-        self,
-        *,
-        code: str | None = None,
-        message: str | None = None,
-        start_line: int | None = None,
-        start_col: int | None = None,
-        end_line: int | None = None,
-        end_col: int | None = None,
-    ) -> Advice:
-        return type(self)(
-            code=code if code is not None else self.code,
-            message=message if message is not None else self.message,
-            start_line=start_line if start_line is not None else self.start_line,
-            start_col=start_col if start_col is not None else self.start_col,
-            end_line=end_line if end_line is not None else self.end_line,
-            end_col=end_col if end_col is not None else self.end_col,
-        )
-
     def as_advisory(self) -> 'Advisory':
         return Advisory(**self.__dict__)
 
@@ -89,7 +71,8 @@ class Advice:
 
     def replace_from_node(self, node: NodeNG) -> Advice:
         # Astroid lines are 1-based.
-        return self.replace(
+        return dataclasses.replace(
+            self,
             start_line=(node.lineno or 1) - 1,
             start_col=node.col_offset,
             end_line=(node.end_lineno or 1) - 1,

--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 import itertools
 import logging
 from dataclasses import dataclass
@@ -95,7 +96,8 @@ class DependencyGraph:
         return MaybeGraph(
             child_graph,
             [
-                problem.replace(
+                dataclasses.replace(
+                    problem,
                     source_path=dependency.path if problem.is_path_missing() else problem.source_path,
                 )
                 for problem in problems
@@ -473,7 +475,7 @@ class DependencyResolver:
             out_path = path if problem.is_path_missing() else problem.source_path
             if out_path.is_absolute() and out_path.is_relative_to(self._path_lookup.cwd):
                 out_path = out_path.relative_to(self._path_lookup.cwd)
-            adjusted_problems.append(problem.replace(source_path=out_path))
+            adjusted_problems.append(dataclasses.replace(problem, source_path=out_path))
         return adjusted_problems
 
     def __repr__(self):
@@ -496,26 +498,6 @@ class DependencyProblem:
 
     def is_path_missing(self):
         return self.source_path == Path(MISSING_SOURCE_PATH)
-
-    def replace(
-        self,
-        code: str | None = None,
-        message: str | None = None,
-        source_path: Path | None = None,
-        start_line: int | None = None,
-        start_col: int | None = None,
-        end_line: int | None = None,
-        end_col: int | None = None,
-    ) -> DependencyProblem:
-        return DependencyProblem(
-            code if code is not None else self.code,
-            message if message is not None else self.message,
-            source_path if source_path is not None else self.source_path,
-            start_line if start_line is not None else self.start_line,
-            start_col if start_col is not None else self.start_col,
-            end_line if end_line is not None else self.end_line,
-            end_col if end_col is not None else self.end_col,
-        )
 
     def as_advisory(self) -> 'Advisory':
         return Advisory(

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
@@ -27,7 +27,12 @@ from databricks.labs.ucx.source_code.base import (
     file_language,
     guess_encoding,
 )
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccess, LineageAtom, DirectFsAccessCrawlers
+from databricks.labs.ucx.source_code.directfs_access import (
+    DirectFsAccess,
+    LineageAtom,
+    DirectFsAccessCrawler,
+    DirectFsAccessInPath,
+)
 from databricks.labs.ucx.source_code.graph import (
     Dependency,
     DependencyGraph,
@@ -336,20 +341,20 @@ class WorkflowLinter:
         resolver: DependencyResolver,
         path_lookup: PathLookup,
         migration_index: TableMigrationIndex,
-        directfs_crawlers: DirectFsAccessCrawlers,
+        directfs_crawler: DirectFsAccessCrawler,
         include_job_ids: list[int] | None = None,
     ):
         self._ws = ws
         self._resolver = resolver
         self._path_lookup = path_lookup
         self._migration_index = migration_index
-        self._directfs_crawlers = directfs_crawlers
+        self._directfs_crawler = directfs_crawler
         self._include_job_ids = include_job_ids
 
     def refresh_report(self, sql_backend: SqlBackend, inventory_database: str):
         tasks = []
         all_jobs = list(self._ws.jobs.list())
-        logger.info(f"Preparing {len(all_jobs)} linting jobs...")
+        logger.info(f"Preparing {len(all_jobs)} linting tasks...")
         for job in all_jobs:
             if self._include_job_ids and job.job_id not in self._include_job_ids:
                 logger.info(f"Skipping job {job.job_id}...")
@@ -358,7 +363,7 @@ class WorkflowLinter:
         logger.info(f"Running {tasks} linting tasks in parallel...")
         job_results, errors = Threads.gather('linting workflows', tasks)
         job_problems: list[JobProblem] = []
-        job_dfsas: list[DirectFsAccess] = []
+        job_dfsas: list[DirectFsAccessInPath] = []
         for problems, dfsas in job_results:
             job_problems.extend(problems)
             job_dfsas.extend(dfsas)
@@ -369,11 +374,11 @@ class WorkflowLinter:
             JobProblem,
             mode='overwrite',
         )
-        self._directfs_crawlers.for_paths().dump_all(job_dfsas)
+        self._directfs_crawler.dump_all(job_dfsas)
         if len(errors) > 0:
             raise ManyError(errors)
 
-    def lint_job(self, job_id: int) -> tuple[list[JobProblem], list[DirectFsAccess]]:
+    def lint_job(self, job_id: int) -> tuple[list[JobProblem], list[DirectFsAccessInPath]]:
         try:
             job = self._ws.jobs.get(job_id)
         except NotFound:
@@ -388,9 +393,9 @@ class WorkflowLinter:
 
     _UNKNOWN = Path('<UNKNOWN>')
 
-    def _lint_job(self, job: jobs.Job) -> tuple[list[JobProblem], list[DirectFsAccess]]:
+    def _lint_job(self, job: jobs.Job) -> tuple[list[JobProblem], list[DirectFsAccessInPath]]:
         problems: list[JobProblem] = []
-        dfsas: list[DirectFsAccess] = []
+        dfsas: list[DirectFsAccessInPath] = []
         assert job.job_id is not None
         assert job.settings is not None
         assert job.settings.name is not None
@@ -458,12 +463,14 @@ class WorkflowLinter:
 
     def _collect_task_dfsas(
         self, task: jobs.Task, job: jobs.Job, graph: DependencyGraph, session_state: CurrentSessionState
-    ) -> Iterable[DirectFsAccess]:
+    ) -> Iterable[DirectFsAccessInPath]:
         collector = DfsaCollectorWalker(graph, set(), self._path_lookup, session_state)
         assert job.settings is not None  # as already done in _lint_job
         job_name = job.settings.name
         for dfsa in collector:
-            yield dfsa.replace_job_infos(job_id=job.job_id, job_name=job_name, task_key=task.task_key)
+            yield DirectFsAccessInPath(**asdict(dfsa)).replace_job_infos(
+                job_id=job.job_id, job_name=job_name, task_key=task.task_key
+            )
 
 
 class LintingWalker(DependencyGraphWalker[LocatedAdvice]):

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import re
 import shlex
@@ -105,8 +106,10 @@ class PythonCell(Cell):
         python_dependency_problems = analyzer.build_graph()
         # Position information for the Python code is within the code and needs to be mapped to the location within the parent nodebook.
         return [
-            problem.replace(
-                start_line=self.original_offset + problem.start_line, end_line=self.original_offset + problem.end_line
+            dataclasses.replace(
+                problem,
+                start_line=self.original_offset + problem.start_line,
+                end_line=self.original_offset + problem.end_line,
             )
             for problem in python_dependency_problems
         ]
@@ -177,7 +180,7 @@ class RunCell(Cell):
             start_line = self._original_offset + idx
             problems = parent.register_notebook(path, True)
             return [
-                problem.replace(start_line=start_line, start_col=0, end_line=start_line, end_col=len(line))
+                dataclasses.replace(problem, start_line=start_line, start_col=0, end_line=start_line, end_col=len(line))
                 for problem in problems
             ]
         start_line = self._original_offset

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import locale
 import logging
 from collections.abc import Iterable
@@ -173,7 +174,8 @@ class NotebookLinter:
                 linter = self._linter(cell.language.language)
                 advices = linter.lint(cell.original_code)
             for advice in advices:
-                yield advice.replace(
+                yield dataclasses.replace(
+                    advice,
                     start_line=advice.start_line + cell.original_offset,
                     end_line=advice.end_line + cell.original_offset,
                 )

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Iterable
 from pathlib import Path
@@ -48,7 +49,8 @@ class PythonCodeAnalyzer:
         for base_node in nodes:
             for problem in self._build_graph_from_node(base_node):
                 # Astroid line numbers are 1-based.
-                problem = problem.replace(
+                problem = dataclasses.replace(
+                    problem,
                     start_line=base_node.node.lineno - 1,
                     start_col=base_node.node.col_offset,
                     end_line=(base_node.node.end_lineno or 1) - 1,

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -1,0 +1,53 @@
+import logging
+from collections.abc import Iterable
+from dataclasses import asdict
+from datetime import datetime
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import ListQueryObjectsResponseQuery
+
+
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler, DirectFsAccessInQuery
+from databricks.labs.ucx.source_code.linters.directfs import DirectFsAccessSqlLinter
+
+logger = logging.getLogger(__name__)
+
+
+class QueryLinter:
+
+    def __init__(
+        self,
+        ws: WorkspaceClient,
+        directfs_crawler: DirectFsAccessCrawler,
+    ):
+        self._ws = ws
+        self._directfs_crawler = directfs_crawler
+
+    def collect_dfsas_from_queries(self) -> Iterable[DirectFsAccessInQuery]:
+        assessment_start = datetime.now()
+        queries_dfsas = self._collect_dfsas_from_queries()
+        assessment_end = datetime.now()
+        dfsas: list[DirectFsAccessInQuery] = []
+        for dfsa in queries_dfsas:
+            dfsas.append(
+                dfsa.replace_assessment_infos(assessment_start=assessment_start, assessment_end=assessment_end)
+            )
+        self._directfs_crawler.dump_all(dfsas)
+        return dfsas
+
+    def _collect_dfsas_from_queries(self) -> Iterable[DirectFsAccessInQuery]:
+        queries = self._ws.queries.list()
+        for query in queries:
+            yield from self._collect_dfsas_from_query(query)
+
+    @classmethod
+    def _collect_dfsas_from_query(cls, query: ListQueryObjectsResponseQuery) -> Iterable[DirectFsAccessInQuery]:
+        if query.query_text is None:
+            return
+        linter = DirectFsAccessSqlLinter()
+        source_id = query.display_name or "<anonymous>"
+        source_timestamp = datetime.now() if query.update_time is None else datetime.fromisoformat(query.update_time)
+        for dfsa in linter.collect_dfsas(query.query_text):
+            yield DirectFsAccessInQuery(**asdict(dfsa)).replace_source(
+                source_id=source_id, source_timestamp=source_timestamp
+            )

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -207,6 +207,7 @@ def test_lint_local_code(simple_ctx):
     path_to_scan = Path(ucx_path, "src")
     # TODO: LocalCheckoutContext has to move into GlobalContext because of this hack
     linter = LocalCodeLinter(
+        light_ctx.notebook_loader,
         light_ctx.file_loader,
         light_ctx.folder_loader,
         light_ctx.path_lookup,

--- a/tests/integration/source_code/test_queries.py
+++ b/tests/integration/source_code/test_queries.py
@@ -1,0 +1,42 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import Query, ListQueryObjectsResponseQuery
+
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler
+from databricks.labs.ucx.source_code.queries import QueryLinter
+
+
+@pytest.mark.parametrize(
+    "name, query, dfsa_paths, is_read, is_write",
+    [
+        ("simple", "SELECT * from dual", [], False, False),
+        (
+            "location",
+            "CREATE TABLE hive_metastore.indices_historical_data.sp_500 LOCATION 's3a://db-gtm-industry-solutions/data/fsi/capm/sp_500/'",
+            ["s3a://db-gtm-industry-solutions/data/fsi/capm/sp_500/"],
+            False,
+            True,
+        ),
+    ],
+)
+def test_query_linter_collects_dfsas_from_queries(
+    name,
+    query,
+    dfsa_paths,
+    is_read,
+    is_write,
+):
+    ws = create_autospec(WorkspaceClient)
+    crawlers = create_autospec(DirectFsAccessCrawler)
+    query = Query.from_dict({"parent_path": "workspace", "display_name": name, "query_text": query})
+    response = ListQueryObjectsResponseQuery.from_dict(query.as_dict())
+    ws.queries.list.return_value = iter([response])
+    linter = QueryLinter(ws, crawlers)
+    dfsas = linter.collect_dfsas_from_queries()
+    crawlers.assert_not_called()
+    assert set(dfsa.path for dfsa in dfsas) == set(dfsa_paths)
+    assert not any(dfsa for dfsa in dfsas if dfsa.is_read != is_read)
+    assert not any(dfsa for dfsa in dfsas if dfsa.is_write != is_write)

--- a/tests/unit/source_code/linters/test_files.py
+++ b/tests/unit/source_code/linters/test_files.py
@@ -121,7 +121,13 @@ def local_code_linter(mock_path_lookup, migration_index):
         mock_path_lookup,
     )
     return LocalCodeLinter(
-        file_loader, folder_loader, mock_path_lookup, session_state, resolver, lambda: LinterContext(migration_index)
+        notebook_loader,
+        file_loader,
+        folder_loader,
+        mock_path_lookup,
+        session_state,
+        resolver,
+        lambda: LinterContext(migration_index),
     )
 
 
@@ -194,6 +200,7 @@ site_packages = locate_site_packages()
     "path", [Path("/Users/eric.vergnaud/development/ucx/.venv/lib/python3.10/site-packages/spacy/pipe_analysis.py")]
 )
 def test_known_issues(path: Path, migration_index):
+    notebook_loader = NotebookLoader()
     file_loader = FileLoader()
     notebook_loader = NotebookLoader()
     folder_loader = FolderLoader(notebook_loader, file_loader)
@@ -205,6 +212,7 @@ def test_known_issues(path: Path, migration_index):
     pip_resolver = PythonLibraryResolver(allow_list)
     resolver = DependencyResolver(pip_resolver, notebook_resolver, import_resolver, import_resolver, path_lookup)
     linter = LocalCodeLinter(
+        notebook_loader,
         file_loader,
         folder_loader,
         path_lookup,

--- a/tests/unit/source_code/test_base.py
+++ b/tests/unit/source_code/test_base.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Advisory,
@@ -20,7 +22,7 @@ def test_message_initialization():
 def test_warning_initialization():
     warning = Advisory('code2', 'This is a warning', 1, 1, 2, 2)
 
-    copy_of = warning.replace(code='code3')
+    copy_of = dataclasses.replace(warning, code='code3')
     assert copy_of.code == 'code3'
     assert isinstance(copy_of, Advisory)
 

--- a/tests/unit/source_code/test_directfs_access.py
+++ b/tests/unit/source_code/test_directfs_access.py
@@ -2,25 +2,29 @@ from datetime import datetime
 
 from databricks.labs.lsql.backends import MockBackend
 
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccess, DirectFsAccessCrawlers, LineageAtom
+from databricks.labs.ucx.source_code.directfs_access import (
+    DirectFsAccessCrawler,
+    LineageAtom,
+    DirectFsAccessInPath,
+)
 
 
 def test_crawler_appends_dfsas():
     backend = MockBackend()
-    crawler = DirectFsAccessCrawlers(backend, "schema").for_paths()
+    crawler = DirectFsAccessCrawler.for_paths(backend, "schema")
     dfsas = list(
-        DirectFsAccess(
+        DirectFsAccessInPath(
             path=path,
             is_read=False,
             is_write=False,
             source_id="ID",
             source_timestamp=datetime.now(),
             source_lineage=[LineageAtom(object_type="LINEAGE", object_id="ID")],
+            assessment_start_timestamp=datetime.now(),
+            assessment_end_timestamp=datetime.now(),
             job_id=222,
             job_name="JOB",
             task_key="TASK",
-            assessment_start_timestamp=datetime.now(),
-            assessment_end_timestamp=datetime.now(),
         )
         for path in ("a", "b", "c")
     )

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -10,7 +10,7 @@ from databricks.sdk.service.pipelines import NotebookLibrary, GetPipelineRespons
 
 from databricks.labs.blueprint.paths import DBFSPath, WorkspacePath
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawlers
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler
 from databricks.labs.ucx.source_code.python_libraries import PythonLibraryResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.sdk import WorkspaceClient
@@ -238,8 +238,8 @@ def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_l
     expected_message = "Found job problems:\nUNKNOWN:-1 [library-install-failed] 'pip --disable-pip-version-check install unknown-library"
 
     ws = create_autospec(WorkspaceClient)
-    dfsas = create_autospec(DirectFsAccessCrawlers)
-    linter = WorkflowLinter(ws, dependency_resolver, mock_path_lookup, empty_index, dfsas)
+    crawler = create_autospec(DirectFsAccessCrawler)
+    linter = WorkflowLinter(ws, dependency_resolver, mock_path_lookup, empty_index, crawler)
 
     libraries = [compute.Library(pypi=compute.PythonPyPiLibrary(package="unknown-library-name"))]
     task = jobs.Task(task_key="test-task", libraries=libraries)
@@ -250,7 +250,7 @@ def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_l
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.source_code.jobs"):
         linter.lint_job(1234)
 
-    dfsas.assert_not_called()
+    crawler.assert_not_called()
     assert any(message.startswith(expected_message) for message in caplog.messages)
 
 

--- a/tests/unit/source_code/test_s3fs.py
+++ b/tests/unit/source_code/test_s3fs.py
@@ -1,3 +1,4 @@
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -126,7 +127,7 @@ def test_detect_s3fs_import(empty_index, source: str, expected: list[DependencyP
         pip_resolver, notebook_resolver, import_resolver, import_resolver, mock_path_lookup
     )
     maybe = dependency_resolver.build_local_file_dependency_graph(sample, CurrentSessionState())
-    assert maybe.problems == [_.replace(source_path=sample) for _ in expected]
+    assert maybe.problems == [dataclasses.replace(_, source_path=sample) for _ in expected]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -823,9 +823,21 @@ def test_create_missing_principal_azure(ws, caplog):
     assert str(failure.value) == "Unsupported cloud provider"
 
 
-def test_migrate_dbsql_dashboards(ws, caplog):
-    migrate_dbsql_dashboards(ws)
-    ws.dashboards.list.assert_called_once()
+@pytest.mark.parametrize("run_as_collection", [False, True])
+def test_migrate_dbsql_dashboards_list_dashboards(
+    run_as_collection,
+    workspace_clients,
+    acc_client,
+) -> None:
+    if not run_as_collection:
+        workspace_clients = [workspace_clients[0]]
+    migrate_dbsql_dashboards(
+        workspace_clients[0],
+        run_as_collection=run_as_collection,
+        a=acc_client,
+    )
+    for workspace_client in workspace_clients:
+        workspace_client.dashboards.list.assert_called_once()
 
 
 def test_revert_dbsql_dashboards(ws, caplog):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -742,30 +742,52 @@ def test_assign_metastore(acc_client, caplog):
         assign_metastore(acc_client, "123")
 
 
-def test_migrate_tables(ws):
-    ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
-        state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000
+@pytest.mark.parametrize("run_as_collection", [False, True])
+def test_migrate_tables_calls_migrate_table_job_run_now(
+    run_as_collection,
+    workspace_clients,
+    acc_client,
+) -> None:
+    if not run_as_collection:
+        workspace_clients = [workspace_clients[0]]
+    run = Run(
+        state=RunState(result_state=RunResultState.SUCCESS),
+        start_time=0,
+        end_time=1000,
+        run_duration=1000,
     )
-    prompts = MockPrompts({})
-    migrate_tables(ws, prompts)
-    ws.jobs.run_now.assert_called_with(456)
-    ws.jobs.wait_get_run_job_terminated_or_skipped.assert_called_once()
+    for workspace_client in workspace_clients:
+        workspace_client.jobs.wait_get_run_job_terminated_or_skipped.return_value = run
+
+    migrate_tables(workspace_clients[0], MockPrompts({}), run_as_collection=run_as_collection, a=acc_client)
+
+    for workspace_client in workspace_clients:
+        workspace_client.jobs.run_now.assert_called_with(456)
+        workspace_client.jobs.wait_get_run_job_terminated_or_skipped.assert_called_once()
 
 
-def test_migrate_external_hiveserde_tables_in_place(ws):
+def test_migrate_tables_calls_external_hiveserde_tables_job_run_now(ws) -> None:
+    # TODO: Test for running on a collection when context injection for multiple workspaces is supported.
     tables_crawler = create_autospec(TablesCrawler)
     table = Table(
-        catalog="hive_metastore", database="test", name="hiveserde", object_type="UNKNOWN", table_format="HIVE"
+        catalog="hive_metastore",
+        database="test",
+        name="hiveserde",
+        object_type="UNKNOWN",
+        table_format="HIVE",
     )
     tables_crawler.snapshot.return_value = [table]
     ctx = WorkspaceContext(ws).replace(tables_crawler=tables_crawler)
     ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
-        state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000
+        state=RunState(result_state=RunResultState.SUCCESS),
+        start_time=0,
+        end_time=1000,
+        run_duration=1000,
     )
 
     prompt = (
-        "Found 1 (.*) hiveserde tables, do you want to run the "
-        "migrate-external-hiveserde-tables-in-place-experimental workflow?"
+        "Found 1 (.*) hiveserde tables in https://localhost, do you want to run the "
+        "`migrate-external-hiveserde-tables-in-place-experimental` workflow?"
     )
     prompts = MockPrompts({prompt: "Yes"})
 
@@ -775,20 +797,28 @@ def test_migrate_external_hiveserde_tables_in_place(ws):
     ws.jobs.wait_get_run_job_terminated_or_skipped.call_count = 2
 
 
-def test_migrate_external_tables_ctas(ws):
+def test_migrate_tables_calls_external_tables_ctas_job_run_now(ws) -> None:
+    # TODO: Test for running on a collection when context injection for multiple workspaces is supported.
     tables_crawler = create_autospec(TablesCrawler)
     table = Table(
-        catalog="hive_metastore", database="test", name="externalctas", object_type="UNKNOWN", table_format="EXTERNAL"
+        catalog="hive_metastore",
+        database="test",
+        name="externalctas",
+        object_type="UNKNOWN",
+        table_format="EXTERNAL",
     )
     tables_crawler.snapshot.return_value = [table]
     ctx = WorkspaceContext(ws).replace(tables_crawler=tables_crawler)
     ws.jobs.wait_get_run_job_terminated_or_skipped.return_value = Run(
-        state=RunState(result_state=RunResultState.SUCCESS), start_time=0, end_time=1000, run_duration=1000
+        state=RunState(result_state=RunResultState.SUCCESS),
+        start_time=0,
+        end_time=1000,
+        run_duration=1000,
     )
 
     prompt = (
-        "Found 1 (.*) external tables which cannot be migrated using sync, do you want to run the "
-        "migrate-external-tables-ctas workflow?"
+        "Found 1 (.*) external tables which cannot be migrated using sync in https://localhost, do you want to run the "
+        "`migrate-external-tables-ctas` workflow?"
     )
 
     prompts = MockPrompts({prompt: "Yes"})

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -429,10 +429,21 @@ def test_save_storage_and_principal_gcp(ws):
         principal_prefix_access(ws, ctx=ctx)
 
 
-def test_migrate_acls_calls_workspace_id(ws) -> None:
-    ctx = WorkspaceContext(ws)
-    migrate_acls(ws, ctx=ctx)
-    ws.get_workspace_id.assert_called()
+@pytest.mark.parametrize("run_as_collection", [True, False])
+def test_migrate_acls_calls_workspace_id(
+    run_as_collection,
+    workspace_clients,
+    acc_client,
+) -> None:
+    if not run_as_collection:
+        workspace_clients = [workspace_clients[0]]
+    migrate_acls(
+        workspace_clients[0],
+        run_as_collection=run_as_collection,
+        a=acc_client,
+    )
+    for workspace_client in workspace_clients:
+        workspace_client.get_workspace_id.assert_called()
 
 
 def test_migrate_credentials_azure(ws, acc_client):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -407,9 +407,21 @@ def test_save_storage_and_principal_azure(ws, caplog, acc_client):
     azure_resource_permissions.save_spn_permissions.assert_called_once()
 
 
-def test_validate_groups_membership(ws):
-    validate_groups_membership(ws)
-    ws.groups.list.assert_called()
+@pytest.mark.parametrize("run_as_collection", [True, False])
+def test_validate_groups_membership_lists_groups(
+    run_as_collection,
+    workspace_clients,
+    acc_client,
+) -> None:
+    if not run_as_collection:
+        workspace_clients = [workspace_clients[0]]
+    validate_groups_membership(
+        workspace_clients[0],
+        run_as_collection=run_as_collection,
+        a=acc_client,
+    )
+    for workspace_client in workspace_clients:
+        workspace_client.groups.list.assert_called()
 
 
 def test_save_storage_and_principal_aws(ws, acc_client):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -39,6 +39,7 @@ from databricks.labs.ucx.cli import (
     join_collection,
     logs,
     manual_workspace_info,
+    migrate_acls,
     migrate_credentials,
     migrate_dbsql_dashboards,
     migrate_local_code,
@@ -99,6 +100,12 @@ def create_workspace_client_mock(workspace_id: int) -> WorkspaceClient:
                     }
                 }
             }
+        ),
+        '/Users/foo/.ucx/workspaces.json': json.dumps(
+            [
+                {'workspace_id': 123, 'workspace_name': '123'},
+                {'workspace_id': 456, 'workspace_name': '456'},
+            ]
         ),
         "/Users/foo/.ucx/uc_roles_access.csv": "role_arn,resource_type,privilege,resource_path\n"
         "arn:aws:iam::123456789012:role/role_name,s3,READ_FILES,s3://labsawsbucket/",
@@ -420,6 +427,12 @@ def test_save_storage_and_principal_gcp(ws):
     ctx = WorkspaceContext(ws)
     with pytest.raises(ValueError):
         principal_prefix_access(ws, ctx=ctx)
+
+
+def test_migrate_acls_calls_workspace_id(ws) -> None:
+    ctx = WorkspaceContext(ws)
+    migrate_acls(ws, ctx=ctx)
+    ws.get_workspace_id.assert_called()
 
 
 def test_migrate_credentials_azure(ws, acc_client):


### PR DESCRIPTION
## Changes
Let `migrate-acls` command to run as collection

### Linked issues

Resolves #2611

### Functionality

- [x] modified existing command: `databricks labs ucx migrate-acls`

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] ~added integration tests~ : Covering after #2507
