### PR TITLE
Simplify DirectFsAccess storage

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -75,7 +75,7 @@ from databricks.labs.ucx.installer.policy import ClusterPolicyInstaller
 from databricks.labs.ucx.installer.workflows import WorkflowsDeployment
 from databricks.labs.ucx.recon.migration_recon import ReconResult
 from databricks.labs.ucx.runtime import Workflows
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessInPath, DirectFsAccessInQuery
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccess
 from databricks.labs.ucx.source_code.jobs import JobProblem
 from databricks.labs.ucx.source_code.queries import QueryProblem
 from databricks.labs.ucx.workspace_access.base import Permissions
@@ -123,8 +123,8 @@ def deploy_schema(sql_backend: SqlBackend, inventory_schema: str):
             functools.partial(table, "udfs", Udf),
             functools.partial(table, "logs", LogRecord),
             functools.partial(table, "recon_results", ReconResult),
-            functools.partial(table, "directfs_in_paths", DirectFsAccessInPath),
-            functools.partial(table, "directfs_in_queries", DirectFsAccessInQuery),
+            functools.partial(table, "directfs_in_paths", DirectFsAccess),
+            functools.partial(table, "directfs_in_queries", DirectFsAccess),
         ],
     )
     deployer.deploy_view("grant_detail", "queries/views/grant_detail.sql")

--- a/src/databricks/labs/ucx/queries/views/directfs.sql
+++ b/src/databricks/labs/ucx/queries/views/directfs.sql
@@ -6,10 +6,7 @@ SELECT
     source_timestamp,
     source_lineage,
     assessment_start_timestamp,
-    assessment_end_timestamp,
-    job_id,
-    job_name,
-    task_key
+    assessment_end_timestamp
 FROM $inventory.directfs_in_paths
 UNION ALL
 SELECT
@@ -20,8 +17,5 @@ SELECT
     source_timestamp,
     source_lineage,
     assessment_start_timestamp,
-    assessment_end_timestamp,
-    NULL as job_id,
-    NULL as job_name,
-    null as task_key
+    assessment_end_timestamp
 FROM $inventory.directfs_in_queries

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -465,9 +465,13 @@ class WorkflowLinter:
         self, job: jobs.Job, task: jobs.Task, graph: DependencyGraph, session_state: CurrentSessionState
     ) -> Iterable[DirectFsAccess]:
         # walker doesn't register lineage for job/task
+        job_id = str(job.job_id)
+        job_name = job.settings.name if job.settings and job.settings.name else "<anonymous>"
         for dfsa in DfsaCollectorWalker(graph, set(), self._path_lookup, session_state):
-            atoms = [ LineageAtom(object_type="job", object_id=str(job.job_id), other={"name": job.settings.name}),
-                      LineageAtom(object_type="task", object_id=task.task_key) ]
+            atoms = [
+                LineageAtom(object_type="job", object_id=job_id, other={"name": job_name}),
+                LineageAtom(object_type="task", object_id=task.task_key),
+            ]
             yield dataclasses.replace(dfsa, source_lineage=atoms + dfsa.source_lineage)
 
 

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
@@ -28,10 +28,9 @@ from databricks.labs.ucx.source_code.base import (
     guess_encoding,
 )
 from databricks.labs.ucx.source_code.directfs_access import (
-    DirectFsAccess,
     LineageAtom,
     DirectFsAccessCrawler,
-    DirectFsAccessInPath,
+    DirectFsAccess,
 )
 from databricks.labs.ucx.source_code.graph import (
     Dependency,
@@ -363,7 +362,7 @@ class WorkflowLinter:
         logger.info(f"Running {tasks} linting tasks in parallel...")
         job_results, errors = Threads.gather('linting workflows', tasks)
         job_problems: list[JobProblem] = []
-        job_dfsas: list[DirectFsAccessInPath] = []
+        job_dfsas: list[DirectFsAccess] = []
         for problems, dfsas in job_results:
             job_problems.extend(problems)
             job_dfsas.extend(dfsas)
@@ -378,7 +377,7 @@ class WorkflowLinter:
         if len(errors) > 0:
             raise ManyError(errors)
 
-    def lint_job(self, job_id: int) -> tuple[list[JobProblem], list[DirectFsAccessInPath]]:
+    def lint_job(self, job_id: int) -> tuple[list[JobProblem], list[DirectFsAccess]]:
         try:
             job = self._ws.jobs.get(job_id)
         except NotFound:
@@ -393,9 +392,9 @@ class WorkflowLinter:
 
     _UNKNOWN = Path('<UNKNOWN>')
 
-    def _lint_job(self, job: jobs.Job) -> tuple[list[JobProblem], list[DirectFsAccessInPath]]:
+    def _lint_job(self, job: jobs.Job) -> tuple[list[JobProblem], list[DirectFsAccess]]:
         problems: list[JobProblem] = []
-        dfsas: list[DirectFsAccessInPath] = []
+        dfsas: list[DirectFsAccess] = []
         assert job.job_id is not None
         assert job.settings is not None
         assert job.settings.name is not None
@@ -421,7 +420,7 @@ class WorkflowLinter:
                 )
                 problems.append(job_problem)
             assessment_start = datetime.now()
-            task_dfsas = self._collect_task_dfsas(task, job, graph, session_state)
+            task_dfsas = self._collect_task_dfsas(graph, session_state)
             assessment_end = datetime.now()
             for dfsa in task_dfsas:
                 dfsa = dfsa.replace_assessment_infos(assessment_start=assessment_start, assessment_end=assessment_end)
@@ -462,15 +461,9 @@ class WorkflowLinter:
         yield from walker
 
     def _collect_task_dfsas(
-        self, task: jobs.Task, job: jobs.Job, graph: DependencyGraph, session_state: CurrentSessionState
-    ) -> Iterable[DirectFsAccessInPath]:
-        collector = DfsaCollectorWalker(graph, set(), self._path_lookup, session_state)
-        assert job.settings is not None  # as already done in _lint_job
-        job_name = job.settings.name
-        for dfsa in collector:
-            yield DirectFsAccessInPath(**asdict(dfsa)).replace_job_infos(
-                job_id=job.job_id, job_name=job_name, task_key=task.task_key
-            )
+        self, graph: DependencyGraph, session_state: CurrentSessionState
+    ) -> Iterable[DirectFsAccess]:
+        yield from DfsaCollectorWalker(graph, set(), self._path_lookup, session_state)
 
 
 class LintingWalker(DependencyGraphWalker[LocatedAdvice]):

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import Dashboard, LegacyQuery
@@ -46,7 +46,7 @@ class QueryLinter:
         self._directfs_crawler = directfs_crawler
 
     def refresh_report(self, sql_backend: SqlBackend, inventory_database: str):
-        assessment_start = datetime.now()
+        assessment_start = datetime.now(timezone.utc)
         linted_queries: set[str] = set()
         all_dashboards = list(self._ws.dashboards.list())
         logger.info(f"Running {len(all_dashboards)} linting tasks...")
@@ -79,7 +79,7 @@ class QueryLinter:
             mode='overwrite',
         )
         # dump dfsas
-        assessment_end = datetime.now()
+        assessment_end = datetime.now(timezone.utc)
         all_dfsas = [
             dataclasses.replace(
                 dfsa, assessment_start_timestamp=assessment_start, assessment_end_timestamp=assessment_end

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -13,7 +13,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler, DirectFsAccessInQuery, LineageAtom
+from databricks.labs.ucx.source_code.directfs_access import DirectFsAccessCrawler, DirectFsAccess, LineageAtom
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.directfs import DirectFsAccessSqlLinter
 from databricks.labs.ucx.source_code.redash import Redash
@@ -51,7 +51,7 @@ class QueryLinter:
         all_dashboards = list(self._ws.dashboards.list())
         logger.info(f"Running {len(all_dashboards)} linting tasks...")
         all_problems: list[QueryProblem] = []
-        all_dfsas: list[DirectFsAccessInQuery] = []
+        all_dfsas: list[DirectFsAccess] = []
         # first lint and collect queries from dashboards
         for dashboard in all_dashboards:
             if not dashboard.id:
@@ -90,10 +90,10 @@ class QueryLinter:
 
     def _lint_and_collect_from_dashboard(
         self, dashboard: Dashboard, linted_queries: set[str]
-    ) -> tuple[Iterable[QueryProblem], Iterable[DirectFsAccessInQuery]]:
+    ) -> tuple[Iterable[QueryProblem], Iterable[DirectFsAccess]]:
         dashboard_queries = Redash.get_queries_from_dashboard(dashboard)
         query_problems: list[QueryProblem] = []
-        query_dfsas: list[DirectFsAccessInQuery] = []
+        query_dfsas: list[DirectFsAccess] = []
         dashboard_id = dashboard.id or "<no-id>"
         dashboard_parent = dashboard.parent or "<orphan>"
         dashboard_name = dashboard.name or "<anonymous>"
@@ -145,7 +145,7 @@ class QueryLinter:
             )
 
     @classmethod
-    def collect_dfsas_from_query(cls, query: LegacyQuery) -> Iterable[DirectFsAccessInQuery]:
+    def collect_dfsas_from_query(cls, query: LegacyQuery) -> Iterable[DirectFsAccess]:
         if query.query is None:
             return
         linter = DirectFsAccessSqlLinter()
@@ -154,7 +154,7 @@ class QueryLinter:
         source_timestamp = cls._read_timestamp(query.updated_at)
         source_lineage = [LineageAtom(object_type="QUERY", object_id=source_id, other={"query_name": source_name})]
         for dfsa in linter.collect_dfsas(query.query):
-            yield DirectFsAccessInQuery(**asdict(dfsa)).replace_source(
+            yield DirectFsAccess(**asdict(dfsa)).replace_source(
                 source_id=source_id, source_timestamp=source_timestamp, source_lineage=source_lineage
             )
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -165,7 +165,9 @@ display(spark.read.parquet("/mnt/something"))
         assert dfsa.assessment_start_timestamp > yesterday
         assert dfsa.assessment_end_timestamp > yesterday
         assert str(j.job_id) in [atom.object_id for atom in dfsa.source_lineage]
-        assert j.settings.name in [atom.other.get("name", None) for atom in dfsa.source_lineage if atom.other is not None]
+        assert j.settings.name in [
+            atom.other.get("name", None) for atom in dfsa.source_lineage if atom.other is not None
+        ]
         assert all(task_key in [atom.object_id for atom in dfsa.source_lineage] for task_key in task_keys)
 
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -3,7 +3,7 @@ import logging
 import shutil
 from collections.abc import Callable
 from dataclasses import replace
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
 from io import StringIO
 from pathlib import Path
 from unittest.mock import create_autospec
@@ -157,15 +157,16 @@ display(spark.read.parquet("/mnt/something"))
 
     assert len(dfsas) == 2
     task_keys = set(task.task_key for task in j.settings.tasks)
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
     for dfsa in dfsas:
         assert dfsa.source_id != DirectFsAccess.UNKNOWN
-        assert dfsa.source_lineage != DirectFsAccess.UNKNOWN
-        assert dfsa.source_timestamp != -1
-        assert dfsa.job_id == j.job_id
-        assert dfsa.job_name == j.settings.name
-        assert dfsa.task_key in task_keys
-        assert dfsa.assessment_start_timestamp != -1
-        assert dfsa.assessment_end_timestamp != -1
+        assert len(dfsa.source_lineage)
+        assert dfsa.source_timestamp > yesterday
+        assert dfsa.assessment_start_timestamp > yesterday
+        assert dfsa.assessment_end_timestamp > yesterday
+        assert str(j.job_id) in [atom.object_id for atom in dfsa.source_lineage]
+        assert j.settings.name in [atom.other.get("name", None) for atom in dfsa.source_lineage if atom.other is not None]
+        assert all(task_key in [atom.object_id for atom in dfsa.source_lineage] for task_key in task_keys)
 
 
 def test_workflow_linter_lints_job_with_import_pypi_library(

--- a/tests/unit/source_code/test_directfs_access.py
+++ b/tests/unit/source_code/test_directfs_access.py
@@ -5,7 +5,7 @@ from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.ucx.source_code.directfs_access import (
     DirectFsAccessCrawler,
     LineageAtom,
-    DirectFsAccessInPath,
+    DirectFsAccess,
 )
 
 
@@ -13,7 +13,7 @@ def test_crawler_appends_dfsas():
     backend = MockBackend()
     crawler = DirectFsAccessCrawler.for_paths(backend, "schema")
     dfsas = list(
-        DirectFsAccessInPath(
+        DirectFsAccess(
             path=path,
             is_read=False,
             is_write=False,
@@ -22,9 +22,6 @@ def test_crawler_appends_dfsas():
             source_lineage=[LineageAtom(object_type="LINEAGE", object_id="ID")],
             assessment_start_timestamp=datetime.now(),
             assessment_end_timestamp=datetime.now(),
-            job_id=222,
-            job_name="JOB",
-            task_key="TASK",
         )
         for path in ("a", "b", "c")
     )


### PR DESCRIPTION
## Changes
Current code implements DirectFsAccessInPath with fields conveying data already present in the source_lineage field.
This PR simplifies the code by dropping this specialization

### Linked issues
Relates to #2350

### Functionality
- [x] modified existing table: `directfs_in_paths` (not in prod yet)

### Tests
- [x] ran unit tests
- [x] ran integration tests
