### PR TITLE
Added ability to run create-missing-principals command as collection

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -157,6 +157,8 @@ commands:
         description: (Optional) IAM policy Name to be specified for the UC roles. (default:UC_POLICY)
       - name: single-role
         description: (Optional) Create a single role for all S3 locations. (default:False)
+      - name: run-as-collection
+        description: (Optional) boolean flag to indicate to run the cmd as a collection. Default is False.
 
   - name: delete-missing-principals
     description: For AWS, this command identifies all the UC roles that are created through the create-missing-principals

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -371,6 +371,8 @@ def create_missing_principals(
     w: WorkspaceClient,
     prompts: Prompts,
     ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
     single_role: bool = False,
     role_name="UC_ROLE",
     policy_name="UC_POLICY",
@@ -380,11 +382,17 @@ def create_missing_principals(
     For AWS, this command identifies all the S3 locations that are missing a UC compatible role and creates them.
     By default, it will create a  role per S3 location. Set the optional single_role parameter to True to create a single role for all S3 locations.
     """
-    if not ctx:
-        ctx = WorkspaceContext(w, named_parameters)
-    if ctx.is_aws:
-        return ctx.iam_role_creation.run(prompts, single_role=single_role, role_name=role_name, policy_name=policy_name)
-    raise ValueError("Unsupported cloud provider")
+    workspace_contexts = _get_workspace_contexts(w, a, run_as_collection, **named_parameters)
+    if ctx:
+        workspace_contexts = [ctx]
+    if w.config.is_aws:
+        for workspace_ctx in workspace_contexts:
+            logger.info(f"Running cmd for workspace {workspace_ctx.workspace_client.get_workspace_id()}")
+            workspace_ctx.iam_role_creation.run(
+                prompts, single_role=single_role, role_name=role_name, policy_name=policy_name
+            )
+    else:
+        raise ValueError("Unsupported cloud provider")
 
 
 @ucx.command


### PR DESCRIPTION
This PR enables create-missing-principals command to run as a collection.

Linked issues
https://github.com/databrickslabs/ucx/issues/1782

Resolves #2606 

### Functionality

- [ ] modified existing command: `databricks labs ucx ...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] added unit tests
- [ ] verified on staging environment (screenshot attached)