### PR TITLE
Fix test failure: `test_workspace_object_crawler`

### DIFF
--- a/tests/integration/assessment/test_assessment.py
+++ b/tests/integration/assessment/test_assessment.py
@@ -43,6 +43,7 @@ _SPARK_CONF = {
 def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backend):
     notebook = make_notebook()
     workspace_listing = WorkspaceListing(ws, sql_backend, inventory_schema)
+        start_path=str(notebook.parent),
     workspace_objects = {_.path: _ for _ in workspace_listing.snapshot()}
     assert str(notebook) in workspace_objects
     assert workspace_objects[str(notebook)].object_type == "NOTEBOOK"

--- a/tests/integration/assessment/test_assessment.py
+++ b/tests/integration/assessment/test_assessment.py
@@ -40,10 +40,16 @@ _SPARK_CONF = {
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backend):
+def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backend) -> None:
     notebook = make_notebook()
-    workspace_listing = WorkspaceListing(ws, sql_backend, inventory_schema)
+
+    workspace_listing = WorkspaceListing(
+        ws,
+        sql_backend,
+        inventory_schema,
         start_path=str(notebook.parent),
+    )
+
     workspace_objects = {_.path: _ for _ in workspace_listing.snapshot()}
     assert str(notebook) in workspace_objects
     assert workspace_objects[str(notebook)].object_type == "NOTEBOOK"

--- a/tests/integration/assessment/test_assessment.py
+++ b/tests/integration/assessment/test_assessment.py
@@ -44,6 +44,5 @@ def test_workspace_object_crawler(ws, make_notebook, inventory_schema, sql_backe
     notebook = make_notebook()
     workspace_listing = WorkspaceListing(ws, sql_backend, inventory_schema)
     workspace_objects = {_.path: _ for _ in workspace_listing.snapshot()}
-
-    assert notebook in workspace_objects
-    assert workspace_objects[notebook].object_type == "NOTEBOOK"
+    assert str(notebook) in workspace_objects
+    assert workspace_objects[str(notebook)].object_type == "NOTEBOOK"


### PR DESCRIPTION
## Changes
[Pytester](https://github.com/databrickslabs/pytester) adopted return type `WorkspacePath` for `make_notebook` Changes for `make_notebook` fixture applied in this PR

### Linked issues

Resolves #2670

### Tests

- [x] changed integration tests `test_workspace_object_crawler`
