### PR TITLE
Fix test failure: `test_running_real_remove_backup_groups_job`

### DIFF
--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -183,6 +183,8 @@ def test_running_real_remove_backup_groups_job(ws: WorkspaceClient, installation
 
     installation_ctx.deployed_workflows.run_workflow("remove-workspace-local-backup-groups")
 
+    assert installation_ctx.deployed_workflows.validate_step("remove-workspace-local-backup-groups")
+
     # Group deletion is eventually consistent. Although the group manager tries to wait for convergence, parts of the
     # API internals have a 60s timeout. As such we should wait at least that long before concluding deletion has not
     # happened.

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -186,10 +186,10 @@ def test_running_real_remove_backup_groups_job(ws: WorkspaceClient, installation
     # Group deletion is eventually consistent. Although the group manager tries to wait for convergence, parts of the
     # API internals have a 60s timeout. As such we should wait at least that long before concluding deletion has not
     # happened.
-    # Note: If you are adjusting this, also look at: test_running_real_remove_backup_groups_job
+    # Note: If you are adjusting this, also look at: test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only
     @retried(on=[KeyError], timeout=timedelta(minutes=3))
     def get_group(group_id: str) -> NoReturn:
-        _ = ws.groups.get(group_id)
+        ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
     with pytest.raises(NotFound):

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -152,7 +152,7 @@ def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(
     # Note: If you are adjusting this, also look at: test_running_real_remove_backup_groups_job
     @retried(on=[KeyError], timeout=timedelta(seconds=90))
     def get_group(group_id: str) -> NoReturn:
-        _ = ws.groups.get(group_id)
+        ws.groups.get(group_id)
         raise KeyError(f"Group is not deleted: {group_id}")
 
     with pytest.raises(NotFound):


### PR DESCRIPTION
## Changes
Verify the "remove-workspace-local-backup-groups" finished successfully before checking the group was deleted

### Linked issues
(Hopefully) Resolves #2691. The eventual consistency of the groups API makes testing difficult.

### Tests

- [x] modified integration tests: `test_running_real_remove_backup_groups_job`
