### PR TITLE
Add `create-ucx-catalog` cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,10 +1170,10 @@ databricks labs ucx assign-metastore --workspace-id <workspace-id> [--metastore-
 ```
 
 This command assigns a metastore to a workspace with `workspace-id`. If there is only a single metastore in the
-workspace region, the command automatically assigns to the workspace. If there are multiple metastores available, the
-command prompts for specification of the metastore (id) you want to assign to the workspace.
+workspace region, the command automatically assigns that metastore to the workspace. If there are multiple metastores
+available, the command prompts for specification of the metastore (id) you want to assign to the workspace.
 
-Finally, the command setups up the metastore with a UCX artifact catalog. The command prompts for the catalog name.
+Finally, the command sets up the metastore with a UCX artifact catalog. The command prompts for the catalog name.
 
 [[back to top](#databricks-labs-ucx)]
 
@@ -1186,7 +1186,8 @@ Please provide storage location url for catalog: ucx (default: metastore): ...
 16:13:01  INFO [d.l.u.hive_metastore.catalog_schema] Creating UC catalog: ucx
 ```
 
-Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
+Create and setup UCX artifact catalog. Amongst other things, the artifacts are used for tracking the migration progress
+across workspaces.
 
 # Table migration commands
 

--- a/README.md
+++ b/README.md
@@ -1169,7 +1169,7 @@ a region, and you want to see which ones are available for assignment.
 databricks labs ucx assign-metastore --workspace-id <workspace-id> [--metastore-id <metastore-id>]
 ```
 
-This command assigns a metastore to a workspace with `workspace-id`. If there is only a single metastore in the
+This command assigns a metastore to a workspace with `--workspace-id`. If there is only a single metastore in the
 workspace region, the command automatically assigns that metastore to the workspace. If there are multiple metastores
 available, the command prompts for specification of the metastore (id) you want to assign to the workspace.
 

--- a/README.md
+++ b/README.md
@@ -1609,7 +1609,7 @@ workspace information with the UCX installations. Once the workspace information
 databricks labs ucx create-ucx-catalog
 ```
 
-Create ucx catalog for tracking the migration progress (possibly) across multiple workspaces.
+Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
 
 ## `sync-workspace-info` command
 

--- a/README.md
+++ b/README.md
@@ -1173,8 +1173,6 @@ This command assigns a metastore to a workspace with `--workspace-id`. If there 
 workspace region, the command automatically assigns that metastore to the workspace. If there are multiple metastores
 available, the command prompts for specification of the metastore (id) you want to assign to the workspace.
 
-Finally, the command sets up the metastore with a UCX artifact catalog. The command prompts for the catalog name.
-
 [[back to top](#databricks-labs-ucx)]
 
 ## `create-ucx-catalog` command

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
 * [Metastore related commands](#metastore-related-commands)
   * [`show-all-metastores` command](#show-all-metastores-command)
   * [`assign-metastore` command](#assign-metastore-command)
+  * [`create-ucx-catalog` command](#create-ucx-catalog-command)
 * [Table migration commands](#table-migration-commands)
   * [`principal-prefix-access` command](#principal-prefix-access-command)
     * [Access for AWS S3 Buckets](#access-for-aws-s3-buckets)
@@ -115,7 +116,6 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
   * [`migrate-dbsql-dashboards` command](#migrate-dbsql-dashboards-command)
   * [`revert-dbsql-dashboards` command](#revert-dbsql-dashboards-command)
 * [Cross-workspace installations](#cross-workspace-installations)
-  * [`create-ucx-catalog` command](#create-ucx-catalog-command)
   * [`sync-workspace-info` command](#sync-workspace-info-command)
   * [`manual-workspace-info` command](#manual-workspace-info-command)
   * [`create-account-groups` command](#create-account-groups-command)
@@ -1173,6 +1173,17 @@ This command assigns a metastore to a workspace with `workspace-id`. If there is
 region, it will be automatically assigned to the workspace. If there are multiple metastores available, you need to specify
 the metastore id of the metastore you want to assign to the workspace.
 
+## `create-ucx-catalog` command
+
+```commandline
+databricks labs ucx create-ucx-catalog
+16:12:59  INFO [d.l.u.hive_metastore.catalog_schema] Validating UC catalog: ucx
+Please provide storage location url for catalog: ucx (default: metastore): ...
+16:13:01  INFO [d.l.u.hive_metastore.catalog_schema] Creating UC catalog: ucx
+```
+
+Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
+
 # Table migration commands
 
 These commands are vital part of [table migration process](#Table-Migration) process and require
@@ -1602,17 +1613,6 @@ workspace information with the UCX installations. Once the workspace information
 [`create-table-mapping` command](#create-table-mapping-command) to align your tables with the Unity Catalog.
 
 [[back to top](#databricks-labs-ucx)]
-
-## `create-ucx-catalog` command
-
-```commandline
-databricks labs ucx create-ucx-catalog
-16:12:59  INFO [d.l.u.hive_metastore.catalog_schema] Validating UC catalog: ucx
-Please provide storage location url for catalog: ucx (default: metastore): ...
-16:13:01  INFO [d.l.u.hive_metastore.catalog_schema] Creating UC catalog: ucx
-```
-
-Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
 
 ## `sync-workspace-info` command
 

--- a/README.md
+++ b/README.md
@@ -1607,6 +1607,9 @@ workspace information with the UCX installations. Once the workspace information
 
 ```commandline
 databricks labs ucx create-ucx-catalog
+16:12:59  INFO [d.l.u.hive_metastore.catalog_schema] Validating UC catalog: ucx
+Please provide storage location url for catalog: ucx (default: metastore): ...
+16:13:01  INFO [d.l.u.hive_metastore.catalog_schema] Creating UC catalog: ucx
 ```
 
 Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.

--- a/README.md
+++ b/README.md
@@ -1169,9 +1169,13 @@ a region, and you want to see which ones are available for assignment.
 databricks labs ucx assign-metastore --workspace-id <workspace-id> [--metastore-id <metastore-id>]
 ```
 
-This command assigns a metastore to a workspace with `workspace-id`. If there is only a single metastore in the workspace
-region, it will be automatically assigned to the workspace. If there are multiple metastores available, you need to specify
-the metastore id of the metastore you want to assign to the workspace.
+This command assigns a metastore to a workspace with `workspace-id`. If there is only a single metastore in the
+workspace region, the command automatically assigns to the workspace. If there are multiple metastores available, the
+command prompts for specification of the metastore (id) you want to assign to the workspace.
+
+Finally, the command setups up the metastore with a UCX artifact catalog. The command prompts for the catalog name.
+
+[[back to top](#databricks-labs-ucx)]
 
 ## `create-ucx-catalog` command
 

--- a/labs.yml
+++ b/labs.yml
@@ -237,9 +237,6 @@ commands:
       - name: run-as-collection
         description: Run the command for the collection of workspaces with ucx installed. Default is False.
 
-  - name: create-ucx-catalog
-    description: Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
-
   - name: cluster-remap
     description: Re-mapping the cluster to UC
 
@@ -272,6 +269,9 @@ commands:
         description: (Optional) If there are multiple metastores in the region, specify the metastore ID to assign
       - name: default-catalog
         description: (Optional) Default catalog to assign to the workspace. If not provided, it will be hive_metastore
+
+  - name: create-ucx-catalog
+    description: Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
 
   - name: migrate-tables
     description: |

--- a/labs.yml
+++ b/labs.yml
@@ -262,8 +262,8 @@ commands:
   - name: assign-metastore
     is_account_level: true
     description: |
-      Enable Unity Catalog features on a workspace by assigning a metastore to it. Also, a UCX catalog is created to
-      store UCX artifacts.
+      Enable Unity Catalog features on a workspace by assigning a metastore to it. Also, a UCX artifact catalog is
+      setup.
     flags:
       - name: workspace-id
         description: (Optional) Workspace ID to assign a metastore to
@@ -273,7 +273,7 @@ commands:
         description: (Optional) Default catalog to assign to the workspace. If not provided, it will be hive_metastore
 
   - name: create-ucx-catalog
-    description: Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces.
+    description: Create UCX artifact catalog
 
   - name: migrate-tables
     description: |

--- a/labs.yml
+++ b/labs.yml
@@ -261,9 +261,7 @@ commands:
 
   - name: assign-metastore
     is_account_level: true
-    description: |
-      Enable Unity Catalog features on a workspace by assigning a metastore to it. Also, a UCX artifact catalog is
-      setup.
+    description: Enable Unity Catalog features on a workspace by assigning a metastore to it.
     flags:
       - name: workspace-id
         description: Workspace ID to assign a metastore to

--- a/labs.yml
+++ b/labs.yml
@@ -261,7 +261,9 @@ commands:
 
   - name: assign-metastore
     is_account_level: true
-    description: Enable Unity Catalog features on a workspace by assign a metastore to it
+    description: |
+      Enable Unity Catalog features on a workspace by assigning a metastore to it. Also, a UCX catalog is created to
+      store UCX artifacts.
     flags:
       - name: workspace-id
         description: (Optional) Workspace ID to assign a metastore to

--- a/labs.yml
+++ b/labs.yml
@@ -266,7 +266,7 @@ commands:
       setup.
     flags:
       - name: workspace-id
-        description: (Optional) Workspace ID to assign a metastore to
+        description: Workspace ID to assign a metastore to
       - name: metastore-id
         description: (Optional) If there are multiple metastores in the region, specify the metastore ID to assign
       - name: default-catalog

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -35,7 +35,7 @@ class AccountMetastores:
             # search for all matching metastores
             metastore_choices = self._get_all_metastores(self._get_region(workspace_id))
             if len(metastore_choices) == 0:
-                raise ValueError(f"No matching metastore found for workspace {workspace_id}")
+                raise ValueError(f"No matching metastore found for workspace: {workspace_id}")
             # if there are multiple matches, prompt users to select one
             if len(metastore_choices) > 1:
                 metastore_id = prompts.choice_from_dict(

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -54,11 +54,11 @@ class AccountMetastores:
         if default_catalog is not None:
             self._set_default_catalog(workspace_id, default_catalog)
 
-    def _get_region(self, workspace_id: int) -> str:
+    def _get_region(self, workspace_id: int) -> str | None:
         workspace = self._ac.workspaces.get(workspace_id)
         if self._ac.config.is_aws:
-            return str(workspace.aws_region)
-        return str(workspace.location)
+            return workspace.aws_region
+        return workspace.location
 
     def _get_all_workspaces(self) -> dict[str, int]:
         output = dict[str, int]()

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -31,7 +31,7 @@ class AccountMetastores:
         metastore_id: str | None = None,
         default_catalog: str | None = None,
     ):
-        if not metastore_id:
+        if metastore_id is None:
             # search for all matching metastores
             metastore_choices = self._get_all_metastores(self._get_region(workspace_id))
             if len(metastore_choices) == 0:

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -28,6 +28,7 @@ class AccountMetastores:
         self,
         prompts: Prompts,
         workspace_id: int,
+        *,
         metastore_id: str | None = None,
         default_catalog: str | None = None,
     ):

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -27,15 +27,10 @@ class AccountMetastores:
     def assign_metastore(
         self,
         prompts: Prompts,
-        str_workspace_id: str | None = None,
+        workspace_id: int,
         metastore_id: str | None = None,
         default_catalog: str | None = None,
     ):
-        if not str_workspace_id:
-            workspace_choices = self._get_all_workspaces()
-            workspace_id = prompts.choice_from_dict("Please select a workspace:", workspace_choices)
-        else:
-            workspace_id = int(str_workspace_id)
         if not metastore_id:
             # search for all matching metastores
             metastore_choices = self._get_all_metastores(self._get_region(workspace_id))

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -43,8 +43,7 @@ class AccountMetastores:
                 )
             else:
                 metastore_id = list(metastore_choices.values())[0]
-        if metastore_id is not None:
-            self._ac.metastore_assignments.create(workspace_id, metastore_id)
+        self._ac.metastore_assignments.create(workspace_id, metastore_id)
         # set the default catalog using the default_namespace setting API
         if default_catalog is not None:
             self._set_default_catalog(workspace_id, default_catalog)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -594,12 +594,12 @@ def assign_metastore(
 ):
     """Assign metastore to a workspace"""
     if not workspace_id:
-        logger.error("--workspace_id is a required parameter.")
+        logger.error("--workspace-id is a required parameter.")
         return
     try:
         workspace_id_casted = int(workspace_id)
     except ValueError as e:
-        logger.error("--workspace_id should be an integer.", exc_info=e)
+        logger.error("--workspace-id should be an integer.", exc_info=e)
         return
     ctx = ctx or AccountContext(a, named_parameters={"workspace_id": workspace_id})
     logger.info(f"Account ID: {ctx.account_client.config.account_id}")

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -600,7 +600,10 @@ def assign_metastore(
 
 @ucx.command
 def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None) -> None:
-    """Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces."""
+    """Create and setup UCX artifact catalog
+
+    Amongst other things, the artifacts are used for tracking the migration progress across workspaces.
+    """
     workspace_context = ctx or WorkspaceContext(w)
     workspace_context.catalog_schema.create_ucx_catalog(prompts)
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -590,10 +590,11 @@ def assign_metastore(
     workspace_id: str | None = None,
     metastore_id: str | None = None,
     default_catalog: str | None = None,
+    ctx: AccountContext | None = None,
 ):
     """Assign metastore to a workspace"""
-    logger.info(f"Account ID: {a.config.account_id}")
-    ctx = AccountContext(a)
+    ctx = ctx or AccountContext(a)
+    logger.info(f"Account ID: {ctx.account_client.config.account_id}")
     ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)
     ctx.catalog_schema.create_ucx_catalog(ctx.prompts)
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -528,13 +528,6 @@ def create_catalogs_schemas(
 
 
 @ucx.command
-def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None) -> None:
-    """Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces."""
-    workspace_context = ctx or WorkspaceContext(w)
-    workspace_context.catalog_schema.create_ucx_catalog(prompts)
-
-
-@ucx.command
 def cluster_remap(w: WorkspaceClient, prompts: Prompts):
     """Re-mapping the cluster to UC"""
     logger.info("Remapping the Clusters to UC")
@@ -602,6 +595,13 @@ def assign_metastore(
     logger.info(f"Account ID: {a.config.account_id}")
     ctx = AccountContext(a)
     ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)
+
+
+@ucx.command
+def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceContext | None = None) -> None:
+    """Create UCX catalog for tracking the migration progress (possibly) across multiple workspaces."""
+    workspace_context = ctx or WorkspaceContext(w)
+    workspace_context.catalog_schema.create_ucx_catalog(prompts)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -595,6 +595,7 @@ def assign_metastore(
     logger.info(f"Account ID: {a.config.account_id}")
     ctx = AccountContext(a)
     ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)
+    ctx.catalog_schema.create_ucx_catalog(ctx.prompts)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -596,6 +596,11 @@ def assign_metastore(
     if not workspace_id:
         logger.error("--workspace_id is a required parameter.")
         return None
+    try:
+        workspace_id = int(workspace_id)
+    except ValueError as e:
+        logger.error("--workspace_id should be an integer.", exc_info=e)
+        return None
     ctx = ctx or AccountContext(a)
     logger.info(f"Account ID: {ctx.account_client.config.account_id}")
     ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -593,6 +593,9 @@ def assign_metastore(
     ctx: AccountContext | None = None,
 ):
     """Assign metastore to a workspace"""
+    if not workspace_id:
+        logger.error("--workspace_id is a required parameter.")
+        return None
     ctx = ctx or AccountContext(a)
     logger.info(f"Account ID: {ctx.account_client.config.account_id}")
     ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -593,20 +593,14 @@ def assign_metastore(
     ctx: AccountContext | None = None,
 ):
     """Assign metastore to a workspace"""
-    if not workspace_id:
-        logger.error("--workspace-id is a required parameter.")
-        return
-    try:
-        workspace_id_casted = int(workspace_id)
-    except ValueError as e:
-        logger.error("--workspace-id should be an integer.", exc_info=e)
-        return
-    ctx = ctx or AccountContext(a, named_parameters={"workspace_id": workspace_id})
-    logger.info(f"Account ID: {ctx.account_client.config.account_id}")
+    logger.info(f"Account ID: {a.config.account_id}")
+    ctx = ctx or AccountContext(a)
     ctx.account_metastores.assign_metastore(
-        ctx.prompts, workspace_id_casted, metastore_id=metastore_id, default_catalog=default_catalog
+        ctx.prompts,
+        workspace_id,
+        metastore_id=metastore_id,
+        default_catalog=default_catalog,
     )
-    ctx.catalog_schema.create_ucx_catalog(ctx.prompts)
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -595,15 +595,15 @@ def assign_metastore(
     """Assign metastore to a workspace"""
     if not workspace_id:
         logger.error("--workspace_id is a required parameter.")
-        return None
+        return
     try:
-        workspace_id = int(workspace_id)
+        workspace_id_casted = int(workspace_id)
     except ValueError as e:
         logger.error("--workspace_id should be an integer.", exc_info=e)
-        return None
-    ctx = ctx or AccountContext(a)
+        return
+    ctx = ctx or AccountContext(a, named_parameters={"workspace_id": workspace_id})
     logger.info(f"Account ID: {ctx.account_client.config.account_id}")
-    ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id, metastore_id, default_catalog)
+    ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id_casted, metastore_id, default_catalog)
     ctx.catalog_schema.create_ucx_catalog(ctx.prompts)
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -603,7 +603,9 @@ def assign_metastore(
         return
     ctx = ctx or AccountContext(a, named_parameters={"workspace_id": workspace_id})
     logger.info(f"Account ID: {ctx.account_client.config.account_id}")
-    ctx.account_metastores.assign_metastore(ctx.prompts, workspace_id_casted, metastore_id, default_catalog)
+    ctx.account_metastores.assign_metastore(
+        ctx.prompts, workspace_id_casted, metastore_id=metastore_id, default_catalog=default_catalog
+    )
     ctx.catalog_schema.create_ucx_catalog(ctx.prompts)
 
 

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -26,6 +26,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     num_threads: int | None = 10
     database_to_catalog_mapping: dict[str, str] | None = None
     default_catalog: str | None = "ucx_default"
+    ucx_catalog: str | None = "ucx"
     log_level: str | None = "INFO"
 
     # Starting path for notebooks and directories crawler

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -11,6 +11,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     __version__ = 2
 
     inventory_database: str
+    ucx_catalog: str | None = "ucx"  # Catalog to store UCX artifact tables (shared across workspaces)
     # Group name conversion parameters.
     workspace_group_regex: str | None = None
     workspace_group_replace: str | None = None
@@ -26,7 +27,6 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     num_threads: int | None = 10
     database_to_catalog_mapping: dict[str, str] | None = None
     default_catalog: str | None = "ucx_default"  # DEPRECATED: Keeping to avoid errors when loading old configurations
-    ucx_catalog: str | None = "ucx"
     log_level: str | None = "INFO"
 
     # Starting path for notebooks and directories crawler

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -25,7 +25,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     connect: Config | None = None
     num_threads: int | None = 10
     database_to_catalog_mapping: dict[str, str] | None = None
-    default_catalog: str | None = "ucx_default"
+    default_catalog: str | None = "ucx_default"  # DEPRECATED: Keeping to avoid errors when loading old configurations
     ucx_catalog: str | None = "ucx"
     log_level: str | None = "INFO"
 

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -11,7 +11,7 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     __version__ = 2
 
     inventory_database: str
-    ucx_catalog: str | None = "ucx"  # Catalog to store UCX artifact tables (shared across workspaces)
+    ucx_catalog: str = "ucx"  # Catalog to store UCX artifact tables (shared across workspaces)
     # Group name conversion parameters.
     workspace_group_regex: str | None = None
     workspace_group_replace: str | None = None

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -1,8 +1,7 @@
 from functools import cached_property
 from os import environ
 
-from databricks.sdk import AccountClient
-
+from databricks.sdk import AccountClient, WorkspaceClient
 
 from databricks.labs.ucx.account.aggregate import AccountAggregate
 from databricks.labs.ucx.account.metastores import AccountMetastores
@@ -18,6 +17,14 @@ class AccountContext(CliContext):
     @cached_property
     def account_client(self) -> AccountClient:
         return self._ac
+
+    @cached_property
+    def workspace_client(self) -> WorkspaceClient:
+        """Return any workspace client available"""
+        workspace_clients = self.account_workspaces.workspace_clients()
+        if len(workspace_clients) == 0:
+            return super().workspace_client
+        return workspace_clients[0]
 
     @cached_property
     def workspace_ids(self):

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 from os import environ
 
-from databricks.sdk import AccountClient, WorkspaceClient
+from databricks.sdk import AccountClient, Workspace, WorkspaceClient
 
 from databricks.labs.ucx.account.aggregate import AccountAggregate
 from databricks.labs.ucx.account.metastores import AccountMetastores
@@ -21,10 +21,12 @@ class AccountContext(CliContext):
     @cached_property
     def workspace_client(self) -> WorkspaceClient:
         """The first workspace client available"""
-        workspace_clients = self.account_workspaces.workspace_clients()
-        if len(workspace_clients) == 0:
-            return super().workspace_client
-        return workspace_clients[0]
+        workspace_id = self.named_parameters.get("workspace_id")
+        if workspace_id is not None:
+            workspace_id = int(workspace_id)
+        workspace = Workspace(workspace_id=workspace_id)
+        workspace_client = self.account_workspaces.client_for(workspace)
+        return workspace_client
 
     @cached_property
     def workspace_ids(self):

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -23,8 +23,10 @@ class AccountContext(CliContext):
         """The first workspace client available"""
         workspace_id = self.named_parameters.get("workspace_id")
         if workspace_id is not None:
-            workspace_id = int(workspace_id)
-        workspace = Workspace(workspace_id=workspace_id)
+            workspace_id_casted = int(workspace_id)
+        else:
+            workspace_id_casted = None
+        workspace = Workspace(workspace_id=workspace_id_casted)
         workspace_client = self.account_workspaces.client_for(workspace)
         return workspace_client
 

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -1,13 +1,12 @@
 from functools import cached_property
 from os import environ
 
-from databricks.sdk import AccountClient, WorkspaceClient
+from databricks.sdk import AccountClient
 
 from databricks.labs.ucx.account.aggregate import AccountAggregate
 from databricks.labs.ucx.account.metastores import AccountMetastores
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.contexts.application import CliContext
-from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 
 
 class AccountContext(CliContext):
@@ -18,16 +17,6 @@ class AccountContext(CliContext):
     @cached_property
     def account_client(self) -> AccountClient:
         return self._ac
-
-    @cached_property
-    def workspace_client(self) -> WorkspaceClient:
-        """The workspace client when workspace_id is provided."""
-        workspace_id = self.named_parameters.get("workspace_id")
-        if workspace_id is None:
-            raise ValueError(f"Missing workspace id to create workspace client: {self.named_parameters}")
-        workspace = self._ac.workspaces.get(int(workspace_id))
-        workspace_client = self.account_workspaces.client_for(workspace)
-        return workspace_client
 
     @cached_property
     def workspace_ids(self):
@@ -48,8 +37,3 @@ class AccountContext(CliContext):
     @cached_property
     def account_metastores(self):
         return AccountMetastores(self.account_client)
-
-    @cached_property
-    def catalog_schema(self):
-        # TODO: Split `CatalogSchema` into `Catalogs` and `Schemas` https://github.com/databrickslabs/ucx/issues/2735
-        return CatalogSchema(self.workspace_client, self.config.ucx_catalog)

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -22,11 +22,9 @@ class AccountContext(CliContext):
     def workspace_client(self) -> WorkspaceClient:
         """The workspace client when workspace_id is provided."""
         workspace_id = self.named_parameters.get("workspace_id")
-        if workspace_id is not None:
-            workspace_id_casted = int(workspace_id)
-        else:
-            workspace_id_casted = None
-        workspace = Workspace(workspace_id=workspace_id_casted)
+        if workspace_id is None:
+            raise ValueError(f"Missing workspace id to create workspace client: {self.named_parameters}")
+        workspace = self._ac.workspaces.get(int(workspace_id))
         workspace_client = self.account_workspaces.client_for(workspace)
         return workspace_client
 

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -20,7 +20,7 @@ class AccountContext(CliContext):
 
     @cached_property
     def workspace_client(self) -> WorkspaceClient:
-        """The first workspace client available"""
+        """The workspace client when workspace_id is provided."""
         workspace_id = self.named_parameters.get("workspace_id")
         if workspace_id is not None:
             workspace_id_casted = int(workspace_id)

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -20,7 +20,7 @@ class AccountContext(CliContext):
 
     @cached_property
     def workspace_client(self) -> WorkspaceClient:
-        """Return any workspace client available"""
+        """The first workspace client available"""
         workspace_clients = self.account_workspaces.workspace_clients()
         if len(workspace_clients) == 0:
             return super().workspace_client

--- a/src/databricks/labs/ucx/contexts/account_cli.py
+++ b/src/databricks/labs/ucx/contexts/account_cli.py
@@ -1,12 +1,13 @@
 from functools import cached_property
 from os import environ
 
-from databricks.sdk import AccountClient, Workspace, WorkspaceClient
+from databricks.sdk import AccountClient, WorkspaceClient
 
 from databricks.labs.ucx.account.aggregate import AccountAggregate
 from databricks.labs.ucx.account.metastores import AccountMetastores
 from databricks.labs.ucx.account.workspaces import AccountWorkspaces
 from databricks.labs.ucx.contexts.application import CliContext
+from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 
 
 class AccountContext(CliContext):
@@ -47,3 +48,8 @@ class AccountContext(CliContext):
     @cached_property
     def account_metastores(self):
         return AccountMetastores(self.account_client)
+
+    @cached_property
+    def catalog_schema(self):
+        # TODO: Split `CatalogSchema` into `Catalogs` and `Schemas` https://github.com/databrickslabs/ucx/issues/2735
+        return CatalogSchema(self.workspace_client, self.config.ucx_catalog)

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -354,6 +354,7 @@ class GlobalContext(abc.ABC):
             self.principal_acl,
             self.sql_backend,
             self.grants_crawler,
+            self.config.ucx_catalog,
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -17,7 +17,6 @@ from databricks.labs.ucx.azure.credentials import StorageCredentialManager, Serv
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
-from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
@@ -179,13 +178,6 @@ class WorkspaceContext(CliContext):
     @cached_property
     def notebook_loader(self) -> NotebookLoader:
         return NotebookLoader()
-
-    @cached_property
-    def catalog_schema(self) -> CatalogSchema:
-        # TODO: Split `CatalogSchema` into `Catalogs` and `Schemas` https://github.com/databrickslabs/ucx/issues/2735
-        return CatalogSchema(
-            self.workspace_client, self.config.ucx_catalog, self.principal_acl, self.table_mapping, self.sql_backend
-        )
 
 
 class LocalCheckoutContext(WorkspaceContext):

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -17,6 +17,7 @@ from databricks.labs.ucx.azure.credentials import StorageCredentialManager, Serv
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
+from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
@@ -178,6 +179,13 @@ class WorkspaceContext(CliContext):
     @cached_property
     def notebook_loader(self) -> NotebookLoader:
         return NotebookLoader()
+
+    @cached_property
+    def catalog_schema(self) -> CatalogSchema:
+        # TODO: Split `CatalogSchema` into `Catalogs` and `Schemas` https://github.com/databrickslabs/ucx/issues/2735
+        return CatalogSchema(
+            self.workspace_client, self.config.ucx_catalog, self.principal_acl, self.table_mapping, self.sql_backend
+        )
 
 
 class LocalCheckoutContext(WorkspaceContext):

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 
 class CatalogSchema:
-    UCX_CATALOG = "ucx"
 
     def __init__(
         self,
@@ -47,10 +46,10 @@ class CatalogSchema:
                 The properties to pass to the catalog. If None, no properties are passed.
         """
         try:
-            self._create_catalog_validate(self.UCX_CATALOG, prompts, properties=properties)
+            self._create_catalog_validate(self._ucx_catalog, prompts, properties=properties)
         except BadRequest as e:
             if "already exists" in str(e):
-                logger.warning(f"Catalog '{self.UCX_CATALOG}' already exists. Skipping.")
+                logger.warning(f"Catalog '{self._ucx_catalog}' already exists. Skipping.")
                 return
             raise
 

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -27,6 +27,7 @@ class CatalogSchema:
         principal_grants: PrincipalACL,
         sql_backend: SqlBackend,
         grants_crawler: GrantsCrawler,
+        ucx_catalog: str,
     ):
         self._ws = ws
         self._table_mapping = table_mapping
@@ -34,6 +35,7 @@ class CatalogSchema:
         self._principal_grants = principal_grants
         self._backend = sql_backend
         self._hive_grants_crawler = grants_crawler
+        self._ucx_catalog = ucx_catalog
 
     def create_ucx_catalog(self, prompts: Prompts, *, properties: dict[str, str] | None = None) -> None:
         """Create the UCX catalog.

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -218,7 +218,7 @@ class CatalogSchema:
                 return True
         return False
 
-    def _create_catalog(self, catalog: str, catalog_storage: str, *, properties: dict[str, str] | None = None) -> None:
+    def _create_catalog(self, catalog: str, catalog_storage: str, *, properties: dict[str, str] | None) -> None:
         logger.info(f"Creating UC catalog: {catalog}")
         if catalog_storage == "metastore":
             self._ws.catalogs.create(catalog, comment="Created by UCX", properties=properties)

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -145,7 +145,7 @@ class CatalogSchema:
         attempts = 3
         while True:
             catalog_storage = prompts.question(
-                f"Please provide storage location url for catalog: {catalog}.", default="metastore"
+                f"Please provide storage location url for catalog: {catalog}", default="metastore"
             )
             if self._validate_location(catalog_storage):
                 break

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -226,21 +226,15 @@ class WorkspaceInstaller(WorkspaceContext):
 
     def _prompt_for_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
-        default_workspace_config = WorkspaceConfig(inventory_database="ucx")
+        default_database = "ucx"
         # if a workspace is configured to use external hive metastore, the majority of the time that metastore will be
         # shared with other workspaces. we need to add the suffix to ensure uniqueness of the inventory database
         if self.policy_installer.has_ext_hms():
             default_database = f"ucx_{self.workspace_client.get_workspace_id()}"
         inventory_database = self.prompts.question(
-            "Inventory Database stored in hive_metastore",
-            default=default_workspace_config.inventory_database,
-            valid_regex=r"^\w+$",
+            "Inventory Database stored in hive_metastore", default=default_database, valid_regex=r"^\w+$"
         )
-        ucx_catalog = self.prompts.question(
-            "Catalog to store UCX artifacts in",
-            default=default_workspace_config.ucx_catalog,
-            valid_regex=r"^\w+$",
-        )
+        ucx_catalog = self.prompts.question("Catalog to store UCX artifacts in", default="ucx", valid_regex=r"^\w+$")
         log_level = self.prompts.question("Log level", default="INFO").upper()
         num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))
         configure_groups = ConfigureGroups(self.prompts)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -226,13 +226,15 @@ class WorkspaceInstaller(WorkspaceContext):
 
     def _prompt_for_new_installation(self) -> WorkspaceConfig:
         logger.info("Please answer a couple of questions to configure Unity Catalog migration")
-        default_database = "ucx"
+        default_workspace_config = WorkspaceConfig(inventory_database="ucx")
         # if a workspace is configured to use external hive metastore, the majority of the time that metastore will be
         # shared with other workspaces. we need to add the suffix to ensure uniqueness of the inventory database
         if self.policy_installer.has_ext_hms():
             default_database = f"ucx_{self.workspace_client.get_workspace_id()}"
         inventory_database = self.prompts.question(
-            "Inventory Database stored in hive_metastore", default=default_database, valid_regex=r"^\w+$"
+            "Inventory Database stored in hive_metastore",
+            default=default_workspace_config.inventory_database,
+            valid_regex=r"^\w+$",
         )
         log_level = self.prompts.question("Log level", default="INFO").upper()
         num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -236,6 +236,11 @@ class WorkspaceInstaller(WorkspaceContext):
             default=default_workspace_config.inventory_database,
             valid_regex=r"^\w+$",
         )
+        ucx_catalog = self.prompts.question(
+            "Catalog to store UCX artifacts in",
+            default=default_workspace_config.ucx_catalog,
+            valid_regex=r"^\w+$",
+        )
         log_level = self.prompts.question("Log level", default="INFO").upper()
         num_threads = int(self.prompts.question("Number of threads", default="8", valid_number=True))
         configure_groups = ConfigureGroups(self.prompts)
@@ -250,6 +255,7 @@ class WorkspaceInstaller(WorkspaceContext):
         )
         return WorkspaceConfig(
             inventory_database=inventory_database,
+            ucx_catalog=ucx_catalog,
             workspace_group_regex=configure_groups.workspace_group_regex,
             workspace_group_replace=configure_groups.workspace_group_replace,
             account_group_regex=configure_groups.account_group_regex,

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -49,13 +49,13 @@ class QueryLinter:
 
     def refresh_report(self, sql_backend: SqlBackend, inventory_database: str):
         assessment_start = datetime.now(timezone.utc)
+        dashboard_ids = self._dashboard_ids_in_scope()
+        logger.info(f"Running {len(dashboard_ids)} linting tasks...")
         linted_queries: set[str] = set()
-        all_dashboards = list(self._ws.dashboards.list())
-        logger.info(f"Running {len(all_dashboards)} linting tasks...")
         all_problems: list[QueryProblem] = []
         all_dfsas: list[DirectFsAccess] = []
         # first lint and collect queries from dashboards
-        for dashboard_id in self._dashboard_ids_in_scope():
+        for dashboard_id in dashboard_ids:
             dashboard = self._ws.dashboards.get(dashboard_id=dashboard_id)
             problems, dfsas = self._lint_and_collect_from_dashboard(dashboard, linted_queries)
             all_problems.extend(problems)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -442,6 +442,10 @@ class CommonUtils:
         return self._make_schema(catalog_name="hive_metastore").name
 
     @cached_property
+    def ucx_catalog(self) -> str:
+        return self._make_catalog(name=f"ucx-{self._make_random()}").name
+
+    @cached_property
     def workspace_client(self) -> WorkspaceClient:
         return self._ws
 
@@ -550,6 +554,7 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
         return WorkspaceConfig(
             warehouse_id=self._env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"),
             inventory_database=self.inventory_database,
+            ucx_catalog=self.ucx_catalog,
             connect=self.workspace_client.config,
             renamed_group_prefix=f'tmp-{self.inventory_database}-',
             include_group_names=self.created_groups,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -374,7 +374,15 @@ class StaticMountCrawler(Mounts):
 
 
 class CommonUtils:
-    def __init__(self, make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture):
+    def __init__(
+        self,
+        make_catalog_fixture,
+        make_schema_fixture,
+        env_or_skip_fixture,
+        ws_fixture,
+        make_random_fixture,
+    ):
+        self._make_catalog = make_catalog_fixture
         self._make_schema = make_schema_fixture
         self._env_or_skip = env_or_skip_fixture
         self._ws = ws_fixture
@@ -441,15 +449,22 @@ class CommonUtils:
 class MockRuntimeContext(CommonUtils, RuntimeContext):
     def __init__(
         self,
-        make_table_fixture,
+        make_catalog_fixture,
         make_schema_fixture,
+        make_table_fixture,
         make_udf_fixture,
         make_group_fixture,
         env_or_skip_fixture,
         ws_fixture,
         make_random_fixture,
     ) -> None:
-        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture)
+        super().__init__(
+            make_catalog_fixture,
+            make_schema_fixture,
+            env_or_skip_fixture,
+            ws_fixture,
+            make_random_fixture,
+        )
         RuntimeContext.__init__(self)
         self._make_table = make_table_fixture
         self._make_schema = make_schema_fixture
@@ -673,16 +688,18 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
 def runtime_ctx(
     ws,
     sql_backend,
-    make_table,
+    make_catalog,
     make_schema,
+    make_table,
     make_udf,
     make_group,
     env_or_skip,
     make_random,
 ) -> MockRuntimeContext:
     ctx = MockRuntimeContext(
-        make_table,
+        make_catalog,
         make_schema,
+        make_table,
         make_udf,
         make_group,
         env_or_skip,
@@ -695,12 +712,19 @@ def runtime_ctx(
 class MockWorkspaceContext(CommonUtils, WorkspaceContext):
     def __init__(
         self,
+        make_catalog_fixture,
         make_schema_fixture,
         env_or_skip_fixture,
         ws_fixture,
         make_random_fixture,
     ):
-        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture)
+        super().__init__(
+            make_catalog_fixture,
+            make_schema_fixture,
+            env_or_skip_fixture,
+            ws_fixture,
+            make_random_fixture,
+        )
         WorkspaceContext.__init__(self, ws_fixture)
 
     @cached_property
@@ -798,8 +822,9 @@ class MockInstallationContext(MockRuntimeContext):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        make_table_fixture,
+        make_catalog_fixture,
         make_schema_fixture,
+        make_table_fixture,
         make_udf_fixture,
         make_group_fixture,
         env_or_skip_fixture,
@@ -810,8 +835,9 @@ class MockInstallationContext(MockRuntimeContext):
         watchdog_purge_suffix,
     ):
         super().__init__(
-            make_table_fixture,
+            make_catalog_fixture,
             make_schema_fixture,
+            make_table_fixture,
             make_udf_fixture,
             make_group_fixture,
             env_or_skip_fixture,
@@ -973,8 +999,9 @@ class MockInstallationContext(MockRuntimeContext):
 def installation_ctx(  # pylint: disable=too-many-arguments
     ws,
     sql_backend,
-    make_table,
+    make_catalog,
     make_schema,
+    make_table,
     make_udf,
     make_group,
     env_or_skip,
@@ -984,8 +1011,9 @@ def installation_ctx(  # pylint: disable=too-many-arguments
     watchdog_purge_suffix,
 ) -> Generator[MockInstallationContext, None, None]:
     ctx = MockInstallationContext(
-        make_table,
+        make_catalog,
         make_schema,
+        make_table,
         make_udf,
         make_group,
         env_or_skip,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -769,8 +769,8 @@ class MockLocalAzureCli(MockWorkspaceContext):
 
 
 @pytest.fixture
-def az_cli_ctx(ws, env_or_skip, make_schema, sql_backend):
-    ctx = MockLocalAzureCli(make_schema, env_or_skip, ws)
+def az_cli_ctx(ws, env_or_skip, make_catalog, make_schema, make_random, sql_backend):
+    ctx = MockLocalAzureCli(make_catalog, make_schema, env_or_skip, ws, make_random)
     return ctx.replace(sql_backend=sql_backend)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -374,10 +374,11 @@ class StaticMountCrawler(Mounts):
 
 
 class CommonUtils:
-    def __init__(self, make_schema_fixture, env_or_skip_fixture, ws_fixture):
+    def __init__(self, make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture):
         self._make_schema = make_schema_fixture
         self._env_or_skip = env_or_skip_fixture
         self._ws = ws_fixture
+        self._make_random = make_random_fixture
 
     def with_dummy_resource_permission(self):
         # TODO: in most cases (except prepared_principal_acl) it's just a sign of a bad logic, fix it
@@ -446,8 +447,9 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
         make_group_fixture,
         env_or_skip_fixture,
         ws_fixture,
+        make_random_fixture,
     ) -> None:
-        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture)
+        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture)
         RuntimeContext.__init__(self)
         self._make_table = make_table_fixture
         self._make_schema = make_schema_fixture
@@ -668,8 +670,25 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
 
 
 @pytest.fixture
-def runtime_ctx(ws, sql_backend, make_table, make_schema, make_udf, make_group, env_or_skip) -> MockRuntimeContext:
-    ctx = MockRuntimeContext(make_table, make_schema, make_udf, make_group, env_or_skip, ws)
+def runtime_ctx(
+    ws,
+    sql_backend,
+    make_table,
+    make_schema,
+    make_udf,
+    make_group,
+    env_or_skip,
+    make_random,
+) -> MockRuntimeContext:
+    ctx = MockRuntimeContext(
+        make_table,
+        make_schema,
+        make_udf,
+        make_group,
+        env_or_skip,
+        ws,
+        make_random,
+    )
     return ctx.replace(workspace_client=ws, sql_backend=sql_backend)
 
 
@@ -679,8 +698,9 @@ class MockWorkspaceContext(CommonUtils, WorkspaceContext):
         make_schema_fixture,
         env_or_skip_fixture,
         ws_fixture,
+        make_random_fixture,
     ):
-        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture)
+        super().__init__(make_schema_fixture, env_or_skip_fixture, ws_fixture, make_random_fixture)
         WorkspaceContext.__init__(self, ws_fixture)
 
     @cached_property
@@ -796,8 +816,8 @@ class MockInstallationContext(MockRuntimeContext):
             make_group_fixture,
             env_or_skip_fixture,
             ws_fixture,
+            make_random_fixture,
         )
-        self._make_random = make_random_fixture
         self._make_acc_group = make_acc_group_fixture
         self._make_user = make_user_fixture
         self._watchdog_purge_suffix = watchdog_purge_suffix

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -32,6 +32,7 @@ def test_create_ucx_catalog_creates_catalog(
     ws,
     runtime_ctx,
     make_random,
+    watchdog_remove_after,
     clean_up_test_catalogs,
 ) -> None:
     _ = clean_up_test_catalogs
@@ -39,7 +40,7 @@ def test_create_ucx_catalog_creates_catalog(
 
     catalog_name = f"{TEST_CATALOG_PREFIX}-{make_random(5)}"
     runtime_ctx.catalog_schema.UCX_CATALOG = catalog_name
-    runtime_ctx.catalog_schema.create_ucx_catalog(prompts)
+    runtime_ctx.catalog_schema.create_ucx_catalog(prompts, properties={"RemoveAfter": watchdog_remove_after})
 
     @retried(on=[KeyError], timeout=timedelta(seconds=20))
     def get_catalog(catalog_name: str) -> CatalogInfo:

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -41,8 +41,8 @@ def test_create_ucx_catalog_creates_catalog(
     runtime_ctx.catalog_schema.create_ucx_catalog(prompts, properties={"RemoveAfter": watchdog_remove_after})
 
     @retried(on=[KeyError], timeout=timedelta(seconds=20))
-    def get_catalog(catalog_name: str) -> CatalogInfo:
-        return ws.catalogs.get(catalog_name)
+    def get_catalog(name: str) -> CatalogInfo:
+        return ws.catalogs.get(name)
 
     assert get_catalog(catalog_name)
 
@@ -57,7 +57,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
 ):
     if not ws.config.is_azure:
         pytest.skip("only works in azure test env")
-    ctx, _, schema_name, catalog_name = prepared_principal_acl
+    ctx, _, schema_name, catalog_name_ = prepared_principal_acl
 
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
     user = make_user()
@@ -71,7 +71,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
     schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name_)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments
@@ -82,7 +82,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
 def test_create_catalog_schema_with_principal_acl_aws(
     ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, env_or_skip
 ):
-    ctx, _, schema_name, catalog_name = prepared_principal_acl
+    ctx, _, schema_name, catalog_name_ = prepared_principal_acl
 
     cluster = make_cluster(
         single_node=True,
@@ -100,7 +100,7 @@ def test_create_catalog_schema_with_principal_acl_aws(
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
     schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name_)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -41,7 +41,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
 ):
     if not ws.config.is_azure:
         pytest.skip("only works in azure test env")
-    ctx, _, schema_name, catalog_name_ = prepared_principal_acl
+    ctx, _, schema_name, catalog_name = prepared_principal_acl
 
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
     user = make_user()
@@ -55,7 +55,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
     schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name_)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments
@@ -66,7 +66,7 @@ def test_create_catalog_schema_with_principal_acl_azure(
 def test_create_catalog_schema_with_principal_acl_aws(
     ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, env_or_skip
 ):
-    ctx, _, schema_name, catalog_name_ = prepared_principal_acl
+    ctx, _, schema_name, catalog_name = prepared_principal_acl
 
     cluster = make_cluster(
         single_node=True,
@@ -84,7 +84,7 @@ def test_create_catalog_schema_with_principal_acl_aws(
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
     schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name_)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -36,7 +36,7 @@ def test_create_ucx_catalog_creates_catalog(
     catalog_name,
 ) -> None:
     prompts = MockPrompts({f"Please provide storage location url for catalog: {catalog_name}": "metastore"})
-    runtime_ctx.catalog_schema.UCX_CATALOG = catalog_name
+    runtime_ctx.catalog_schema._ucx_catalog = catalog_name
 
     runtime_ctx.catalog_schema.create_ucx_catalog(prompts, properties={"RemoveAfter": watchdog_remove_after})
 

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import timedelta
-from typing import Iterator
+from collections.abc import Iterator
 
 import pytest
 from databricks.labs.blueprint.tui import MockPrompts
@@ -23,7 +23,7 @@ def clean_up_test_catalogs(ws) -> Iterator[None]:
     yield
     for catalog in ws.catalogs.list():
         if catalog.name.startswith(TEST_CATALOG_PREFIX):
-            logger.info("Deleting catalog: {catalog.name}")
+            logger.info(f"Deleting catalog: {catalog.name}")
             ws.catalogs.delete(catalog.name, force=True)
 
 

--- a/tests/unit/account/test_metastores.py
+++ b/tests/unit/account/test_metastores.py
@@ -57,11 +57,11 @@ def test_assign_metastore(acc_client):
     account_metastores = AccountMetastores(acc_client)
     prompts = MockPrompts({"Multiple metastores found, please select one*": "0"})
 
-    account_metastores.assign_metastore(prompts, 123457, "", "")
+    account_metastores.assign_metastore(prompts, 123457)
     acc_client.metastore_assignments.create.assert_called_with(123457, "123")
 
     # multiple metastores & default catalog name, need to choose one
-    account_metastores.assign_metastore(prompts, 123456, "", "main")
+    account_metastores.assign_metastore(prompts, 123456, default_catalog="main")
     acc_client.metastore_assignments.create.assert_called_with(123456, "123")
     ws.settings.default_namespace.update.assert_called_with(
         allow_missing=True,
@@ -71,7 +71,7 @@ def test_assign_metastore(acc_client):
 
     # default catalog not found, still get etag
     ws.settings.default_namespace.get.side_effect = NotFound(details=[{"metadata": {"etag": "not_found"}}])
-    account_metastores.assign_metastore(prompts, 123456, "", "main")
+    account_metastores.assign_metastore(prompts, 123456, default_catalog="main")
     acc_client.metastore_assignments.create.assert_called_with(123456, "123")
     ws.settings.default_namespace.update.assert_called_with(
         allow_missing=True,

--- a/tests/unit/account/test_metastores.py
+++ b/tests/unit/account/test_metastores.py
@@ -37,7 +37,7 @@ def test_show_all_metastores(acc_client, caplog):
     assert "metastore_use - 124" in caplog.messages
 
 
-def test_assign_metastore(acc_client):
+def test_assign_metastore(acc_client) -> None:
     acc_client.metastores.list.return_value = [
         MetastoreInfo(name="metastore_usw_1", metastore_id="123", region="us-west-2"),
         MetastoreInfo(name="metastore_usw_2", metastore_id="124", region="us-west-2"),
@@ -59,6 +59,12 @@ def test_assign_metastore(acc_client):
 
     account_metastores.assign_metastore(prompts, 123457)
     acc_client.metastore_assignments.create.assert_called_with(123457, "123")
+    ws.settings.default_namespaces.update.assert_not_called()
+
+    # Empty default catalog should not call default name spaces
+    account_metastores.assign_metastore(prompts, 123457, default_catalog="")
+    acc_client.metastore_assignments.create.assert_called_with(123457, "123")
+    ws.settings.default_namespaces.update.assert_not_called()
 
     # multiple metastores & default catalog name, need to choose one
     account_metastores.assign_metastore(prompts, 123456, default_catalog="main")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -111,5 +111,5 @@ def mock_notebook_resolver():
 
 
 @pytest.fixture
-def mock_backend():
+def mock_backend() -> MockBackend:
     return MockBackend()

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -118,12 +118,12 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
     principal_acl.get_interactive_cluster_grants.return_value = grants
     hive_acl.snapshot.return_value = hive_grants
 
-    return CatalogSchema(ws, table_mapping, principal_acl, backend, hive_acl)
+    return CatalogSchema(ws, table_mapping, principal_acl, backend, hive_acl, "ucx")
 
 
 def test_create_ucx_catalog_creates_ucx_catalog() -> None:
     ws = create_autospec(WorkspaceClient)
-    mock_prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
+    mock_prompts = MockPrompts({"Please provide storage location url for catalog: ucx": "metastore"})
 
     catalog_schema = prepare_test(ws)
     catalog_schema.create_ucx_catalog(mock_prompts)
@@ -133,7 +133,7 @@ def test_create_ucx_catalog_creates_ucx_catalog() -> None:
 
 def test_create_ucx_catalog_skips_when_ucx_catalogs_exists(caplog) -> None:
     ws = create_autospec(WorkspaceClient)
-    mock_prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
+    mock_prompts = MockPrompts({"Please provide storage location url for catalog: ucx": "metastore"})
     catalog_schema = prepare_test(ws)
 
     def raise_catalog_exists(catalog: str, *_, **__) -> None:

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -144,7 +144,7 @@ def test_create_ucx_catalog_skips_when_ucx_catalogs_exists(caplog) -> None:
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.hive_metastore.catalog_schema"):
         catalog_schema.create_ucx_catalog(mock_prompts)
-    assert "Catalog 'ucx' already exists. Skipping" in caplog.text
+    assert "Catalog 'ucx' already exists. Skipping." in caplog.text
 
 
 @pytest.mark.parametrize("location", ["s3://foo/bar", "s3://foo/bar/test", "s3://foo/bar/test/baz"])

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -353,7 +353,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
         (r"Max workers for auto-scale.*", "20", {"max_workers": 20}),
     ],
 )
-def test_save_config_should_overwrite_value(
+def test_configure_sets_expected_workspace_configuration_values(
     ws,
     mock_installation,
     prompt_question,

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1102,10 +1102,10 @@ def test_save_config_should_overwrite_value(
 ) -> None:
     prompts = MockPrompts(
         {
-            prompt_question: prompt_answer,
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
             r"Choose how to map the workspace groups.*": "2",  # specify names
             r".*": "",
+            prompt_question: prompt_answer,
         }
     )
     ws.workspace.get_status = not_found

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -384,7 +384,6 @@ def test_configure_sets_expected_workspace_configuration_values(
             prompt_question: prompt_answer,
         }
     )
-    ws.workspace.get_status = not_found
     install = WorkspaceInstaller(ws).replace(prompts=prompts, installation=mock_installation, product_info=PRODUCT_INFO)
 
     install.configure()

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1105,7 +1105,6 @@ def test_save_config_should_overwrite_value(
             prompt_question: prompt_answer,
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
             r"Choose how to map the workspace groups.*": "2",  # specify names
-            r"Reconciliation threshold, in percentage.*": "5",
             r".*": "",
         }
     )

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -333,7 +333,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
     )
 
 
-def test_save_config(ws, mock_installation):
+def test_save_config(ws, mock_installation) -> None:
     ws.workspace.get_status = not_found
     ws.warehouses.list = lambda **_: [
         EndpointInfo(name="abc", id="abc", warehouse_type=EndpointInfoWarehouseType.PRO, state=State.RUNNING)
@@ -362,6 +362,7 @@ def test_save_config(ws, mock_installation):
             'version': 2,
             'default_catalog': 'ucx_default',
             'inventory_database': 'ucx',
+            'ucx_catalog': 'ucx',
             'log_level': 'INFO',
             'num_days_submit_runs_history': 30,
             'num_threads': 8,
@@ -398,7 +399,7 @@ def test_corrupted_config(ws, mock_installation, caplog):
     assert 'Existing installation at ~/mock is corrupted' in caplog.text
 
 
-def test_save_config_strip_group_names(ws, mock_installation):
+def test_save_config_strip_group_names(ws, mock_installation) -> None:
     prompts = MockPrompts(
         {
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
@@ -422,6 +423,7 @@ def test_save_config_strip_group_names(ws, mock_installation):
         {
             'version': 2,
             'default_catalog': 'ucx_default',
+            'ucx_catalog': 'ucx',
             'include_group_names': ['g1', 'g2', 'g99'],
             'inventory_database': 'ucx',
             'log_level': 'INFO',
@@ -438,7 +440,7 @@ def test_save_config_strip_group_names(ws, mock_installation):
     )
 
 
-def test_create_cluster_policy(ws, mock_installation):
+def test_create_cluster_policy(ws, mock_installation) -> None:
     ws.cluster_policies.list.return_value = [
         Policy(
             policy_id="foo1",
@@ -470,6 +472,7 @@ def test_create_cluster_policy(ws, mock_installation):
         {
             'version': 2,
             'default_catalog': 'ucx_default',
+            'ucx_catalog': 'ucx',
             'include_group_names': ['g1', 'g2', 'g99'],
             'inventory_database': 'ucx',
             'log_level': 'INFO',
@@ -1083,7 +1086,7 @@ def test_open_config(ws, mocker, mock_installation):
     webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/config.yml')
 
 
-def test_save_config_should_include_databases(ws, mock_installation):
+def test_save_config_should_include_databases(ws, mock_installation) -> None:
     prompts = MockPrompts(
         {
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
@@ -1106,6 +1109,7 @@ def test_save_config_should_include_databases(ws, mock_installation):
         {
             'version': 2,
             'default_catalog': 'ucx_default',
+            'ucx_catalog': 'ucx',
             'include_databases': ['db1', 'db2'],
             'inventory_database': 'ucx',
             'log_level': 'INFO',
@@ -1237,7 +1241,7 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
     wheels.upload_to_wsfs.assert_called()
 
 
-def test_fresh_install(ws, mock_installation):
+def test_fresh_install(ws, mock_installation) -> None:
     prompts = MockPrompts(
         {
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
@@ -1265,6 +1269,7 @@ def test_fresh_install(ws, mock_installation):
             'version': 2,
             'default_catalog': 'ucx_default',
             'inventory_database': 'ucx',
+            'ucx_catalog': 'ucx',
             'log_level': 'INFO',
             'num_days_submit_runs_history': 30,
             'num_threads': 8,
@@ -1746,7 +1751,7 @@ def test_user_workspace_installer(mock_ws):
     assert workspace_installer.install_state.install_folder().startswith("/Users/")
 
 
-def test_save_config_ext_hms(ws, mock_installation):
+def test_save_config_ext_hms(ws, mock_installation) -> None:
     ws.get_workspace_id.return_value = 12345678
     cluster_policy = {
         "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {"value": "url"},
@@ -1786,6 +1791,7 @@ def test_save_config_ext_hms(ws, mock_installation):
         {
             'version': 2,
             'default_catalog': 'ucx_default',
+            'ucx_catalog': 'ucx',
             'include_databases': ['db1', 'db2'],
             'inventory_database': 'ucx_12345678',
             'log_level': 'INFO',

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -335,8 +335,15 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
 @pytest.mark.parametrize(
     "prompt_question,prompt_answer,workspace_config_overwrite",
     [
-        (r"Comma-separated list of databases to migrate.*", "db1,db2", {"include_databases": ["db1", "db2"]}),
+        ("Inventory Database stored in hive_metastore", "non_default", {"inventory_database": "non_default"}),
         ("Catalog to store UCX artifacts in", "ucx-test", {"ucx_catalog": "ucx-test"}),
+        ("Log level", "DEBUG", {"log_level": "DEBUG"}),
+        (r".*workspace group names.*", "g1, g2, g99", {"include_group_names": ["g1", "g2", "g99"]}),
+        ("Number of threads", "16", {"num_threads": 16}),
+        (r"Comma-separated list of databases to migrate.*", "db1,db2", {"include_databases": ["db1", "db2"]}),
+        (r"Does given workspace .* block Internet access?", "yes", {"upload_dependencies": True}),
+        ("Do you want to trigger assessment job after installation?", "yes", {"trigger_job": True}),
+        ("Reconciliation threshold, in percentage", "10", {"recon_tolerance_percent": 10}),
         (
             r"Parallelism for migrating.*",
             "1000",
@@ -344,7 +351,6 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
         ),
         (r"Min workers for auto-scale.*", "2", {"min_workers": 2}),
         (r"Max workers for auto-scale.*", "20", {"max_workers": 20}),
-        (r".*workspace group names.*", "g1, g2, g99", {"include_group_names": ["g1", "g2", "g99"]}),
     ],
 )
 def test_save_config_should_overwrite_value(

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1109,35 +1109,30 @@ def test_save_config_should_overwrite_value(
         }
     )
     ws.workspace.get_status = not_found
-    install = WorkspaceInstaller(ws).replace(
-        prompts=prompts,
-        installation=mock_installation,
-        product_info=PRODUCT_INFO,
-    )
+    install = WorkspaceInstaller(ws).replace(prompts=prompts, installation=mock_installation, product_info=PRODUCT_INFO)
+
     install.configure()
 
-    mock_installation.assert_file_written(
-        'config.yml',
-        {
-            **{
-                'version': 2,
-                'default_catalog': 'ucx_default',
-                'ucx_catalog': 'ucx',
-                'inventory_database': 'ucx',
-                'log_level': 'INFO',
-                'num_threads': 8,
-                'min_workers': 1,
-                'max_workers': 10,
-                'policy_id': 'foo',
-                'renamed_group_prefix': 'db-temp-',
-                'warehouse_id': 'abc',
-                'workspace_start_path': '/',
-                'num_days_submit_runs_history': 30,
-                'recon_tolerance_percent': 5,
-            },
-            **workspace_config_overwrite,
+    expected_config = {
+        **{
+            'version': 2,
+            'default_catalog': 'ucx_default',
+            'ucx_catalog': 'ucx',
+            'inventory_database': 'ucx',
+            'log_level': 'INFO',
+            'num_threads': 8,
+            'min_workers': 1,
+            'max_workers': 10,
+            'policy_id': 'foo',
+            'renamed_group_prefix': 'db-temp-',
+            'warehouse_id': 'abc',
+            'workspace_start_path': '/',
+            'num_days_submit_runs_history': 30,
+            'recon_tolerance_percent': 5,
         },
-    )
+        **workspace_config_overwrite,
+    }
+    mock_installation.assert_file_written('config.yml', expected_config)
 
 
 def test_triggering_assessment_wf(ws, mocker, mock_installation):

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1086,12 +1086,22 @@ def test_open_config(ws, mocker, mock_installation):
     webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/config.yml')
 
 
-def test_save_config_should_include_databases(ws, mock_installation) -> None:
+@pytest.mark.parametrize(
+    "prompt_question,prompt_answer,workspace_config_overwrite",
+    [(r"Comma-separated list of databases to migrate.*", "db1,db2", {"include_databases": ["db1", "db2"]})],
+)
+def test_save_config_should_overwrite_value(
+    ws,
+    mock_installation,
+    prompt_question,
+    prompt_answer,
+    workspace_config_overwrite,
+) -> None:
     prompts = MockPrompts(
         {
+            prompt_question: prompt_answer,
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
             r"Choose how to map the workspace groups.*": "2",  # specify names
-            r"Comma-separated list of databases to migrate.*": "db1,db2",
             r"Reconciliation threshold, in percentage.*": "5",
             r".*": "",
         }
@@ -1107,21 +1117,23 @@ def test_save_config_should_include_databases(ws, mock_installation) -> None:
     mock_installation.assert_file_written(
         'config.yml',
         {
-            'version': 2,
-            'default_catalog': 'ucx_default',
-            'ucx_catalog': 'ucx',
-            'include_databases': ['db1', 'db2'],
-            'inventory_database': 'ucx',
-            'log_level': 'INFO',
-            'num_threads': 8,
-            'min_workers': 1,
-            'max_workers': 10,
-            'policy_id': 'foo',
-            'renamed_group_prefix': 'db-temp-',
-            'warehouse_id': 'abc',
-            'workspace_start_path': '/',
-            'num_days_submit_runs_history': 30,
-            'recon_tolerance_percent': 5,
+            **{
+                'version': 2,
+                'default_catalog': 'ucx_default',
+                'ucx_catalog': 'ucx',
+                'inventory_database': 'ucx',
+                'log_level': 'INFO',
+                'num_threads': 8,
+                'min_workers': 1,
+                'max_workers': 10,
+                'policy_id': 'foo',
+                'renamed_group_prefix': 'db-temp-',
+                'warehouse_id': 'abc',
+                'workspace_start_path': '/',
+                'num_days_submit_runs_history': 30,
+                'recon_tolerance_percent': 5,
+            },
+            **workspace_config_overwrite,
         },
     )
 

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -1088,7 +1088,10 @@ def test_open_config(ws, mocker, mock_installation):
 
 @pytest.mark.parametrize(
     "prompt_question,prompt_answer,workspace_config_overwrite",
-    [(r"Comma-separated list of databases to migrate.*", "db1,db2", {"include_databases": ["db1", "db2"]})],
+    [
+        (r"Comma-separated list of databases to migrate.*", "db1,db2", {"include_databases": ["db1", "db2"]}),
+        ("Catalog to store UCX artifacts in", "ucx-test", {"ucx_catalog": "ucx-test"}),
+    ],
 )
 def test_save_config_should_overwrite_value(
     ws,

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -354,6 +354,22 @@ def test_save_config_should_overwrite_value(
     prompt_answer,
     workspace_config_overwrite,
 ) -> None:
+    workspace_config_default = {
+        "version": 2,
+        "default_catalog": "ucx_default",
+        "ucx_catalog": "ucx",
+        "inventory_database": "ucx",
+        "log_level": "INFO",
+        "num_threads": 8,
+        "min_workers": 1,
+        "max_workers": 10,
+        "policy_id": "foo",
+        "renamed_group_prefix": "db-temp-",
+        "warehouse_id": "abc",
+        "workspace_start_path": "/",
+        "num_days_submit_runs_history": 30,
+        "recon_tolerance_percent": 5,
+    }
     prompts = MockPrompts(
         {
             r".*PRO or SERVERLESS SQL warehouse.*": "1",
@@ -367,26 +383,8 @@ def test_save_config_should_overwrite_value(
 
     install.configure()
 
-    expected_config = {
-        **{
-            'version': 2,
-            'default_catalog': 'ucx_default',
-            'ucx_catalog': 'ucx',
-            'inventory_database': 'ucx',
-            'log_level': 'INFO',
-            'num_threads': 8,
-            'min_workers': 1,
-            'max_workers': 10,
-            'policy_id': 'foo',
-            'renamed_group_prefix': 'db-temp-',
-            'warehouse_id': 'abc',
-            'workspace_start_path': '/',
-            'num_days_submit_runs_history': 30,
-            'recon_tolerance_percent': 5,
-        },
-        **workspace_config_overwrite,
-    }
-    mock_installation.assert_file_written('config.yml', expected_config)
+    workspace_config_expected = {**workspace_config_default, **workspace_config_overwrite}
+    mock_installation.assert_file_written("config.yml", workspace_config_expected)
 
 
 def test_corrupted_config(ws, mock_installation, caplog):

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -33,3 +33,15 @@ def test_query_linter_collects_dfsas_from_queries(name, query, dfsa_paths, is_re
     assert set(dfsa.path for dfsa in dfsas) == set(dfsa_paths)
     assert all(dfsa.is_read == is_read for dfsa in dfsas)
     assert all(dfsa.is_write == is_write for dfsa in dfsas)
+
+
+def test_query_liner_refresh_report_writes_query_problems(migration_index, mock_backend) -> None:
+    ws = create_autospec(WorkspaceClient)
+    crawlers = create_autospec(DirectFsAccessCrawler)
+    linter = QueryLinter(ws, migration_index, crawlers, None)
+
+    linter.refresh_report(mock_backend, inventory_database="test")
+
+    assert mock_backend.has_rows_written_for("`test`.query_problems")
+    ws.dashboards.list.assert_called_once()
+    crawlers.assert_not_called()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -806,14 +806,6 @@ def test_create_catalogs_schemas_handles_existing(ws, caplog) -> None:
     assert "Schema 'test' in catalog 'test' already exists. Skipping." in caplog.messages
 
 
-def test_create_ucx_catalog_calls_create_catalog(ws) -> None:
-    prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
-
-    create_catalogs_schemas(ws, prompts, ctx=WorkspaceContext(ws))
-
-    ws.catalogs.create.assert_called_once()
-
-
 def test_cluster_remap(ws, caplog):
     prompts = MockPrompts({"Please provide the cluster id's as comma separated value from the above list.*": "1"})
     ws.clusters.get.return_value = ClusterDetails(cluster_id="123", cluster_name="test_cluster")
@@ -885,6 +877,14 @@ def test_show_all_metastores(acc_client, caplog):
 def test_assign_metastore(acc_client, caplog):
     with pytest.raises(ValueError):
         assign_metastore(acc_client, "123")
+
+
+def test_create_ucx_catalog_calls_create_catalog(ws) -> None:
+    prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
+
+    create_catalogs_schemas(ws, prompts, ctx=WorkspaceContext(ws))
+
+    ws.catalogs.create.assert_called_once()
 
 
 @pytest.mark.parametrize("run_as_collection", [False, True])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -874,9 +874,8 @@ def test_show_all_metastores(acc_client, caplog):
     assert 'Matching metastores are:' in caplog.messages
 
 
-def test_assign_metastore_assigns_metastore_and_creates_catalog(caplog, acc_client, ws, mock_backend) -> None:
-    prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
-    ctx = AccountContext(acc_client).replace(workspace_client=ws, sql_backend=mock_backend, prompts=prompts)
+def test_assign_metastore_logs_account_id_and_assigns_metastore(caplog, acc_client) -> None:
+    ctx = AccountContext(acc_client)
     acc_client.metastores.list.return_value = [MetastoreInfo(name="test", metastore_id="123")]
 
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.cli"):
@@ -884,7 +883,6 @@ def test_assign_metastore_assigns_metastore_and_creates_catalog(caplog, acc_clie
 
     assert "Account ID: 123" in caplog.messages
     acc_client.metastore_assignments.create.assert_called_once()
-    ws.catalogs.create.assert_called_once()
 
 
 def test_create_ucx_catalog_calls_create_catalog(ws) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -874,7 +874,7 @@ def test_show_all_metastores(acc_client, caplog):
     assert 'Matching metastores are:' in caplog.messages
 
 
-def test_assign_metastore(acc_client, caplog):
+def test_assign_metastore(acc_client) -> None:
     with pytest.raises(ValueError):
         assign_metastore(acc_client, "123")
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -874,13 +874,15 @@ def test_show_all_metastores(acc_client, caplog):
     assert 'Matching metastores are:' in caplog.messages
 
 
-def test_assign_metastore_assigns_metastore_and_creates_catalog(acc_client, ws, mock_backend) -> None:
+def test_assign_metastore_assigns_metastore_and_creates_catalog(caplog, acc_client, ws, mock_backend) -> None:
     prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
     ctx = AccountContext(acc_client).replace(workspace_client=ws, sql_backend=mock_backend, prompts=prompts)
     acc_client.metastores.list.return_value = [MetastoreInfo(name="test", metastore_id="123")]
 
-    assign_metastore(acc_client, "123", ctx=ctx)
+    with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.cli"):
+        assign_metastore(acc_client, "456", ctx=ctx)
 
+    assert "Account ID: 123"
     acc_client.metastore_assignments.create.assert_called_once()
     ws.catalogs.create.assert_called_once()
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -882,7 +882,7 @@ def test_assign_metastore_assigns_metastore_and_creates_catalog(caplog, acc_clie
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx.cli"):
         assign_metastore(acc_client, "456", ctx=ctx)
 
-    assert "Account ID: 123"
+    assert "Account ID: 123" in caplog.messages
     acc_client.metastore_assignments.create.assert_called_once()
     ws.catalogs.create.assert_called_once()
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,23 @@
+import dataclasses
+import pytest
+
 from databricks.labs.blueprint.installation import MockInstallation
 
 from databricks.labs.ucx.config import WorkspaceConfig
+
+
+@pytest.mark.parametrize(
+    "attribute,value",
+    [
+        ("ucx_catalog", "ucx"),
+        ("default_catalog", "default"),
+    ],
+)
+def test_config_attributes(attribute, value) -> None:
+    """Increase code coverage with this test"""
+    config = dataclasses.replace(WorkspaceConfig("test"), **{attribute: value})
+
+    assert getattr(config, attribute) == value
 
 
 def test_v1_migrate_zeroconf():


### PR DESCRIPTION
## Changes
Add `create-ucx-catalog` cli command to create the catalog (going to be) used for migration tracking (possibly) accross multiple workspaces.

### Linked issues

Resolves #2571

### Functionality

- [x] added relevant user documentation
- [x] added new CLI command: `create-ucx-catalog`

### Tests

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
