### PR TITLE
Harden configuration reading

### DIFF
--- a/src/databricks/labs/ucx/assessment/secrets.py
+++ b/src/databricks/labs/ucx/assessment/secrets.py
@@ -30,7 +30,12 @@ class SecretsMixin:
             )
             return None
 
-    def _get_value_from_config_key(self, config: dict, key: str, get_secret: bool = True) -> str | None:
+    def _get_value_from_config_key(
+        self,
+        config: dict[str, str | dict[str, str]],
+        key: str,
+        get_secret: bool = True,
+    ) -> str | None:
         """Get a config value based on its key, with some special handling:
         If the key is prefixed with spark_conf, i.e. this is in a cluster policy, the actual value is nested
         If the value is of format {{secret_scope/secret}}, we extract that as well

--- a/src/databricks/labs/ucx/assessment/secrets.py
+++ b/src/databricks/labs/ucx/assessment/secrets.py
@@ -41,7 +41,9 @@ class SecretsMixin:
         If the value is of format {{secret_scope/secret}}, we extract that as well
         """
         if re.search("spark_conf", key):
-            value = config.get(key, {}).get("value", "")
+            value = config.get(key, {})
+            if isinstance(value, dict):
+                value = value.get("value", "")
         else:
             value = config.get(key, "")
         # retrieve from secret scope if used

--- a/src/databricks/labs/ucx/assessment/secrets.py
+++ b/src/databricks/labs/ucx/assessment/secrets.py
@@ -32,7 +32,7 @@ class SecretsMixin:
 
     def _get_value_from_config_key(
         self,
-        config: dict[str, str | dict[str, str]],
+        config: dict,
         key: str,
         get_secret: bool = True,
     ) -> str | None:

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -7,6 +7,7 @@ from databricks.labs.ucx.assessment.secrets import SecretsMixin
     "key,expected",
     [
         ("spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL", "url"),
+        ("NonExistentKey", ""),
     ]
 )
 def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -18,4 +18,6 @@ def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:
     }
     secrets_mixin = SecretsMixin()
 
-    assert secrets_mixin._get_value_from_config_key(config, key) == expected
+    value = secrets_mixin._get_value_from_config_key(config, key)
+
+    assert value == expected

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -1,0 +1,19 @@
+import pytest
+
+from databricks.labs.ucx.assessment.secrets import SecretsMixin
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL", "url"),
+    ]
+)
+def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:
+    config = {
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {"value": "url"},
+    }
+    secrets_mixin = SecretsMixin()
+
+    assert secrets_mixin._get_value_from_config_key(config, key) == expected
+

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.assessment.secrets import SecretsMixin
     ],
 )
 def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:
-    config: dict[str, str | dict[str, str]] = {
+    config = {
         "spark_conf.invalid": "{'should_not': 'be_string'}",
         "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {"value": "url"},
     }

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -8,13 +8,14 @@ from databricks.labs.ucx.assessment.secrets import SecretsMixin
     [
         ("spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL", "url"),
         ("NonExistentKey", ""),
-    ]
+        ("spark_conf.invalid", ""),
+    ],
 )
 def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:
-    config = {
+    config: dict[str, str | dict[str, str]] = {
+        "spark_conf.invalid": "{'should_not': 'be_string'}",
         "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {"value": "url"},
     }
     secrets_mixin = SecretsMixin()
 
     assert secrets_mixin._get_value_from_config_key(config, key) == expected
-

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.assessment.secrets import SecretsMixin
     [
         ("spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL", "url"),
         ("NonExistentKey", ""),
-        ("spark_conf.invalid", ""),
+        ("spark_conf.invalid", "{'should_not': 'be_string'}"),
     ],
 )
 def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:

--- a/tests/unit/assessment/test_secrets.py
+++ b/tests/unit/assessment/test_secrets.py
@@ -18,6 +18,6 @@ def test_secrets_mixin_gets_value_from_config_key(key, expected) -> None:
     }
     secrets_mixin = SecretsMixin()
 
-    value = secrets_mixin._get_value_from_config_key(config, key)
+    value = secrets_mixin._get_value_from_config_key(config, key)  # pylint: disable=protected-access
 
     assert value == expected


### PR DESCRIPTION
## Changes
Harden configuration reading by verifying the type before reading the "value" using `.get`

### Linked issues

Resolves #2581 (hopefully the second get is the issue, type hinting should cover that, but who knows)

### Functionality

- [x] modified existing workflow: `assessment`

### Tests

- [x] added unit tests