### PR TITLE
Fixes source table alias dissapearance during migrate_views

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/from_table.py
+++ b/src/databricks/labs/ucx/source_code/linters/from_table.py
@@ -99,7 +99,7 @@ class FromTableSqlLinter(SqlLinter, Fixer):
                 dst = self._index.get(src_schema, old_table.name)
                 if not dst:
                     continue
-                new_table = Table(catalog=dst.dst_catalog, db=dst.dst_schema, this=dst.dst_table)
+                new_table = Table(catalog=dst.dst_catalog, db=dst.dst_schema, this=dst.dst_table, alias=old_table.alias)
                 old_table.replace(new_table)
             new_sql = statement.sql('databricks')
             new_statements.append(new_sql)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -376,7 +376,7 @@ def test_migrate_view_alias_test(ws, sql_backend, runtime_ctx, make_catalog):
     assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
     view1_view_text = ws.tables.get(f"{dst_schema.full_name}.{src_view1.name}").view_definition
     assert (
-        view1_view_text == f"SELECT `A`.* FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}` AS A"
+        view1_view_text == f"SELECT `A`.* FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}` AS `A`"
     )
 
 

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -376,7 +376,7 @@ def test_migrate_view_alias_test(ws, sql_backend, runtime_ctx, make_catalog):
     assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
     view1_view_text = ws.tables.get(f"{dst_schema.full_name}.{src_view1.name}").view_definition
     assert (
-        view1_view_text == f"SELECT * FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}`"
+        view1_view_text == f"SELECT `A`.* FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}` AS A"
     )
 
 

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -340,6 +340,7 @@ def test_migrate_view(ws, sql_backend, runtime_ctx, make_catalog):
     view3_view_text = next(iter(sql_backend.fetch(f"SHOW CREATE TABLE {dst_schema.full_name}.view3")))["createtab_stmt"]
     assert "(col1,col2)" in view3_view_text.replace("\n", "").replace(" ", "").lower()
 
+
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_migrate_view_alias_test(ws, sql_backend, runtime_ctx, make_catalog):
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -376,7 +376,8 @@ def test_migrate_view_alias_test(ws, sql_backend, runtime_ctx, make_catalog):
     assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
     view1_view_text = ws.tables.get(f"{dst_schema.full_name}.{src_view1.name}").view_definition
     assert (
-        view1_view_text == f"SELECT `A`.* FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}` AS `A`"
+        view1_view_text
+        == f"SELECT `A`.* FROM `{dst_schema.catalog_name}`.`{dst_schema.name}`.`{src_managed_table.name}` AS `A`"
     )
 
 

--- a/tests/unit/hive_metastore/test_view_migrate.py
+++ b/tests/unit/hive_metastore/test_view_migrate.py
@@ -36,8 +36,9 @@ def test_view_to_migrate_sql_migrate_view_sql():
 
     assert sql == expected_query
 
+
 def test_view_with_alias_to_migrate_sql_migrate_view_sql():
-    expected_query = "CREATE OR REPLACE VIEW IF NOT EXISTS `cat1`.`schema1`.`dest_view1` AS SELECT `A`.* FROM `cat1`.`schema1`.`dest_table1` as `A`"
+    expected_query = "CREATE OR REPLACE VIEW IF NOT EXISTS `cat1`.`schema1`.`dest_view1` AS SELECT `A`.* FROM `cat1`.`schema1`.`dest_table1` AS `A`"
     view = Table(
         object_type="VIEW",
         table_format="VIEW",
@@ -59,6 +60,7 @@ def test_view_with_alias_to_migrate_sql_migrate_view_sql():
     sql = view_to_migrate.sql_migrate_view(migration_index)
 
     assert sql == expected_query
+
 
 @pytest.fixture(scope="session")
 def samples() -> dict[str, dict[str, str]]:


### PR DESCRIPTION
## Changes
The alias for the source table is disappearing while converting the create view sql from legacy hive metastore to uc catalog.

### Linked issues
Resolves #2661 

### Functionality

- [x] fixes sql conversion

### Tests
- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
