### PR TITLE
Handle `PermissionDenied` when listing accessible workspaces

### DIFF
--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -98,8 +98,18 @@ class AccountWorkspaces:
         return accessible_workspaces
 
     def can_administer(self, workspace: Workspace) -> bool:
+        """Evaluate if the user can administer a workspace.
+
+        A user can administer a workspace if the user can access the workspace and is a member of the workspace "admin"
+        group.
+
+        Args:
+            workspace (Workspace): The workspace to check if the user can administer.
+
+        Returns:
+            bool: True if the user can administer the workspace, False otherwise.
+        """
         try:
-            # check if user has access to workspace
             ws = self.client_for(workspace)
             current_user = ws.current_user.me()
         except (PermissionDenied, NotFound, ValueError) as e:
@@ -107,7 +117,6 @@ class AccountWorkspaces:
             return False
         if current_user.groups is None:
             return False
-        # check if user is a workspace admin
         if "admins" not in [g.display for g in current_user.groups]:
             logger.warning(
                 f"{workspace.deployment_name}: User {current_user.user_name} is not a workspace admin. Skipping..."

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -115,7 +115,7 @@ class AccountWorkspaces:
         except (PermissionDenied, NotFound, ValueError) as e:
             logger.warning(f"User cannot access workspace: {workspace.deployment_name}", exc_info=e)
             return False
-        if current_user.groups is None or "admins" not in [g.display for g in current_user.groups]:
+        if current_user.groups is None or "admins" not in {g.display for g in current_user.groups}:
             logger.warning(f"User '{current_user.user_name}' is not a workspace admin: {workspace.deployment_name}")
             return False
         return True

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -115,9 +115,7 @@ class AccountWorkspaces:
         except (PermissionDenied, NotFound, ValueError) as e:
             logger.warning(f"User cannot access workspace: {workspace.deployment_name}", exc_info=e)
             return False
-        if current_user.groups is None:
-            return False
-        if "admins" not in [g.display for g in current_user.groups]:
+        if current_user.groups is None or "admins" not in [g.display for g in current_user.groups]:
             logger.warning(f"User '{current_user.user_name}' is not a workspace admin: {workspace.deployment_name}")
             return False
         return True

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -102,8 +102,8 @@ class AccountWorkspaces:
             # check if user has access to workspace
             ws = self.client_for(workspace)
             current_user = ws.current_user.me()
-        except (PermissionDenied, NotFound, ValueError) as err:
-            logger.warning(f"{workspace.deployment_name}: Encounter error {err}. Skipping...")
+        except (PermissionDenied, NotFound, ValueError) as e:
+            logger.warning(f"User cannot access workspace: {workspace.deployment_name}", exc_info=e)
             return False
         if current_user.groups is None:
             return False

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -118,9 +118,7 @@ class AccountWorkspaces:
         if current_user.groups is None:
             return False
         if "admins" not in [g.display for g in current_user.groups]:
-            logger.warning(
-                f"{workspace.deployment_name}: User {current_user.user_name} is not a workspace admin. Skipping..."
-            )
+            logger.warning(f"User '{current_user.user_name}' is not a workspace admin: {workspace.deployment_name}")
             return False
         return True
 

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -100,7 +100,7 @@ class AccountWorkspaces:
     def can_administer(self, workspace: Workspace) -> bool:
         """Evaluate if the user can administer a workspace.
 
-        A user can administer a workspace if the user can access the workspace and is a member of the workspace "admin"
+        A user can administer a workspace if the user can access the workspace and is a member of the workspace "admins"
         group.
 
         Args:

--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -101,10 +101,10 @@ class AccountWorkspaces:
         try:
             # check if user has access to workspace
             ws = self.client_for(workspace)
+            current_user = ws.current_user.me()
         except (PermissionDenied, NotFound, ValueError) as err:
             logger.warning(f"{workspace.deployment_name}: Encounter error {err}. Skipping...")
             return False
-        current_user = ws.current_user.me()
         if current_user.groups is None:
             return False
         # check if user is a workspace admin

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -499,9 +499,10 @@ def test_get_accessible_workspaces():
 def test_account_workspaces_can_administer_handles_permission_error_for_current_user() -> None:
     acc, ws = create_autospec(AccountClient), create_autospec(WorkspaceClient)
     acc.get_workspace_client.return_value = ws
-    ws.current_user.me.side_effect = PermissionDenied("This API is disabled for users without the databricks-sql-access or workspace-access entitlements")
+    ws.current_user.me.side_effect = PermissionDenied(
+        "This API is disabled for users without the databricks-sql-access or workspace-access entitlements"
+    )
     workspace = Workspace()
     account_workspaces = AccountWorkspaces(acc)
 
     assert not account_workspaces.can_administer(workspace)
-

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -508,11 +508,12 @@ def test_account_workspaces_can_administer_when_user_in_admins_group() -> None:
     assert account_workspaces.can_administer(workspace)
 
 
-def test_account_workspaces_cannot_administer_when_user_not_in_admins_group(caplog) -> None:
+@pytest.mark.parametrize("groups", [[ComplexValue(display="not-admins")], None])
+def test_account_workspaces_cannot_administer_when_user_not_in_admins_group(caplog, groups) -> None:
     acc = create_autospec(AccountClient)
     ws = create_autospec(WorkspaceClient)
     acc.get_workspace_client.return_value = ws
-    ws.current_user.me.return_value = User(user_name="test", groups=[ComplexValue(display="not-admins")])
+    ws.current_user.me.return_value = User(user_name="test", groups=groups)
     account_workspaces = AccountWorkspaces(acc)
     workspace = Workspace(deployment_name="test")
 

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -523,6 +523,18 @@ def test_account_workspaces_cannot_administer_when_user_not_in_admins_group(capl
     assert "User 'test' is not a workspace admin: test" in caplog.messages
 
 
+def test_account_workspaces_can_administer_handles_not_found_error_for_get_workspace_client(caplog) -> None:
+    acc = create_autospec(AccountClient)
+    acc.get_workspace_client.side_effect = NotFound
+    account_workspaces = AccountWorkspaces(acc)
+    workspace = Workspace(deployment_name="test")
+
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.account.workspaces"):
+        can_administer = account_workspaces.can_administer(workspace)
+    assert not can_administer
+    assert "User cannot access workspace: test" in caplog.messages
+
+
 def test_account_workspaces_can_administer_handles_permission_denied_error_for_current_user(caplog) -> None:
     acc = create_autospec(AccountClient)
     ws = create_autospec(WorkspaceClient)

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -497,6 +497,17 @@ def test_get_accessible_workspaces():
     assert len(account_workspaces.get_accessible_workspaces()) == 1
 
 
+def test_account_workspaces_can_administer_when_user_in_admins_group() -> None:
+    acc = create_autospec(AccountClient)
+    ws = create_autospec(WorkspaceClient)
+    acc.get_workspace_client.return_value = ws
+    ws.current_user.me.return_value = User(groups=[ComplexValue(display="admins")])
+    account_workspaces = AccountWorkspaces(acc)
+    workspace = Workspace(deployment_name="test")
+
+    assert account_workspaces.can_administer(workspace)
+
+
 def test_account_workspaces_can_administer_handles_permission_denied_error_for_current_user(caplog) -> None:
     acc = create_autospec(AccountClient)
     ws = create_autospec(WorkspaceClient)
@@ -504,8 +515,8 @@ def test_account_workspaces_can_administer_handles_permission_denied_error_for_c
     ws.current_user.me.side_effect = PermissionDenied(
         "This API is disabled for users without the databricks-sql-access or workspace-access entitlements"
     )
-    workspace = Workspace(deployment_name="test")
     account_workspaces = AccountWorkspaces(acc)
+    workspace = Workspace(deployment_name="test")
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.account.workspaces"):
         can_administer = account_workspaces.can_administer(workspace)

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -498,7 +498,8 @@ def test_get_accessible_workspaces():
 
 
 def test_account_workspaces_can_administer_handles_permission_denied_error_for_current_user(caplog) -> None:
-    acc, ws = create_autospec(AccountClient), create_autospec(WorkspaceClient)
+    acc = create_autospec(AccountClient)
+    ws = create_autospec(WorkspaceClient)
     acc.get_workspace_client.return_value = ws
     ws.current_user.me.side_effect = PermissionDenied(
         "This API is disabled for users without the databricks-sql-access or workspace-access entitlements"

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -497,7 +497,7 @@ def test_get_accessible_workspaces():
     assert len(account_workspaces.get_accessible_workspaces()) == 1
 
 
-def test_account_workspaces_can_administer_handles_permission_error_for_current_user(caplog) -> None:
+def test_account_workspaces_can_administer_handles_permission_denied_error_for_current_user(caplog) -> None:
     acc, ws = create_autospec(AccountClient), create_autospec(WorkspaceClient)
     acc.get_workspace_client.return_value = ws
     ws.current_user.me.side_effect = PermissionDenied(


### PR DESCRIPTION
## Changes
Handle `PermissionDenied` when listing accessible workspaces

### Linked issues
Resolves #2732

### Functionality

- [ ] modified existing command: that user the accesible workspaces (most account level commands)

### Tests

- [ ] manually tested
- [ ] added unit tests