### PR TITLE
Fix failing integration tests that perform a real assessment

### DIFF
--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -1,6 +1,5 @@
 import dataclasses
 import datetime as dt
-import io
 
 from databricks.labs.lsql.backends import CommandExecutionBackend
 from databricks.sdk.service.iam import PermissionLevel
@@ -9,12 +8,11 @@ from databricks.sdk.service.iam import PermissionLevel
 def test_running_real_assessment_job_ext_hms(
     ws,
     installation_ctx,
+    product_info,
     env_or_skip,
     make_cluster_policy,
     make_cluster_policy_permissions,
-    make_notebook,
-    make_job,
-    make_dashboard,
+    populate_for_linting,
 ):
     cluster_id = env_or_skip('TEST_EXT_HMS_CLUSTER_ID')
     ext_hms_ctx = installation_ctx.replace(
@@ -41,14 +39,10 @@ def test_running_real_assessment_job_ext_hms(
     ext_hms_ctx.__dict__['include_object_permissions'] = [f"cluster-policies:{cluster_policy.policy_id}"]
     ext_hms_ctx.workspace_installation.run()
 
+    populate_for_linting(installation_ctx.installation)
+
     # Under ideal circumstances this can take 10-16 minutes (depending on whether there are compute instances available
     # via the integration pool). Allow some margin to reduce spurious failures.
-    notebook_path = make_notebook(content=io.BytesIO(b"import xyz"))
-    job = make_job(notebook_path=notebook_path)
-    installation_ctx.config.include_job_ids = [job.job_id]
-
-    dashboard = make_dashboard()
-    installation_ctx.config.include_dashboard_ids = [dashboard.id]
     ext_hms_ctx.deployed_workflows.run_workflow("assessment", max_wait=dt.timedelta(minutes=25))
 
     # assert the workflow is successful. the tasks on sql warehouse will fail so skip checking them

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -1,4 +1,3 @@
-import io
 from datetime import timedelta
 
 from databricks.sdk.errors import NotFound, InvalidParameterValue
@@ -8,7 +7,11 @@ from databricks.sdk.service.iam import PermissionLevel
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=8))
 def test_running_real_assessment_job(
-    ws, installation_ctx, make_cluster_policy, make_cluster_policy_permissions, make_job, make_notebook, make_dashboard
+    ws,
+    installation_ctx,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
+    populate_for_linting,
 ):
     ws_group, _ = installation_ctx.make_ucx_group()
     cluster_policy = make_cluster_policy()
@@ -20,12 +23,7 @@ def test_running_real_assessment_job(
     installation_ctx.__dict__['include_object_permissions'] = [f"cluster-policies:{cluster_policy.policy_id}"]
     installation_ctx.workspace_installation.run()
 
-    notebook_path = make_notebook(content=io.BytesIO(b"import xyz"))
-    job = make_job(notebook_path=notebook_path)
-    installation_ctx.config.include_job_ids = [job.job_id]
-
-    dashboard = make_dashboard()
-    installation_ctx.config.include_dashboard_ids = [dashboard.id]
+    populate_for_linting(installation_ctx.installation)
 
     installation_ctx.deployed_workflows.run_workflow("assessment")
     assert installation_ctx.deployed_workflows.validate_step("assessment")


### PR DESCRIPTION
## Changes
Ensure 'assessment' workflow only runs minimal assessment in integration tests

### Linked issues
None

### Functionality
None

### Tests
- [x] changed integration tests
