### PR TITLE
Clone solacc repos 1 by 1 and delete them once linting is done

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -97,7 +97,8 @@ class LocatedAdvice:
         if default is not None:
             path = default
         path = path.relative_to(base)
-        return f"./{path.as_posix()}:{advice.start_line}:{advice.start_col}: [{advice.code}] {advice.message}"
+        # increment start_line because it is 0-based whereas IDEs are usually 1-based
+        return f"./{path.as_posix()}:{advice.start_line+1}:{advice.start_col}: [{advice.code}] {advice.message}"
 
 
 class Advisory(Advice):


### PR DESCRIPTION
## Changes
Current implementation clones all `solacc` repos at once, occupying 1.5g which brings us close to limits in CI
This PR fixes that by cloning repos 1 by 1 and deleting them once linting is done

### Linked issues
None

### Functionality
None

### Tests
- [x] manually tested
