### PR TITLE
Add and populate UCX `workflow_runs` table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
       * [`table-migrated-to-uc`](#table-migrated-to-uc)
       * [`to-json-in-shared-clusters`](#to-json-in-shared-clusters)
       * [`unsupported-magic-line`](#unsupported-magic-line)
-  * [(EXPERIMENTAL) Migration Progress Workflow](#experimental-migration-progress-workflow)
+  * [[EXPERIMENTAL] Migration Progress Workflow](#experimental-migration-progress-workflow)
 * [Utility commands](#utility-commands)
   * [`logs` command](#logs-command)
   * [`ensure-assessment-run` command](#ensure-assessment-run-command)
@@ -997,7 +997,7 @@ This message indicates the code that could not be analysed by UCX. User must che
 
 ## [EXPERIMENTAL] Migration Progress Workflow
 
-The `migration-process-experimental` workflow updates a subset of the inventory tables to track migration status of
+The `migration-progress-experimental` workflow updates a subset of the inventory tables to track migration status of
 workspace resources that need to be migrated. Besides updating the inventory tables, this workflow tracks the migration
 progress by updating the following [UCX catalog](#create-ucx-catalog-command) tables:
 
@@ -1044,8 +1044,8 @@ databricks labs ucx update-migration-progress
 ```
 
 This command runs the [(experimental) migration progress workflow](#experimental-migration-progress-workflow) to update
-the migration status of worksapce resources that need to be migrated. It does this by triggering
-the `migration-process-experimental` workflow to run on a workspace and waiting for
+the migration status of workspace resources that need to be migrated. It does this by triggering
+the `migration-progress-experimental` workflow to run on a workspace and waiting for
 it to complete.
 
 Workflows and their status can be listed with the [`workflows` command](#workflows-commandr), while failed workflows can

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
       * [`table-migrated-to-uc`](#table-migrated-to-uc)
       * [`to-json-in-shared-clusters`](#to-json-in-shared-clusters)
       * [`unsupported-magic-line`](#unsupported-magic-line)
+  * [(EXPERIMENTAL) Migration Progress Workflow](#experimental-migration-progress-workflow)
 * [Utility commands](#utility-commands)
   * [`logs` command](#logs-command)
   * [`ensure-assessment-run` command](#ensure-assessment-run-command)
@@ -126,7 +127,7 @@ See [contributing instructions](CONTRIBUTING.md) to help improve this project.
   * [`revert-cluster-remap` command](#revert-cluster-remap-command)
   * [`upload` command](#upload-command)
   * [`download` command](#download-command)
-  * [`join-collection` command](#join-collection command)
+  * [`join-collection` command](#join-collection-command)
   * [collection eligible command](#collection-eligible-command)
 * [Common Challenges and the Solutions](#common-challenges-and-the-solutions)
     * [Network Connectivity Issues](#network-connectivity-issues)
@@ -994,6 +995,19 @@ This message indicates the code that could not be analysed by UCX. User must che
 
 [[back to top](#databricks-labs-ucx)]
 
+## [EXPERIMENTAL] Migration Progress Workflow
+
+The `migration-process-experimental` workflow updates a subset of the inventory tables to track migration status of
+workspace resources that need to be migrated. Besides updating the inventory tables, this workflow tracks the migration
+progress by updating the following [UCX catalog](#create-ucx-catalog-command) tables:
+
+- `workflow_runs`: Tracks the status of the workflow runs.
+
+_Note: A subset of the inventory is updated, *not* the complete inventory that is initially gathered by
+the [assessment workflow](#assessment-workflow)._
+
+[[back to top](#databricks-labs-ucx)]
+
 # Utility commands
 
 ## `logs` command
@@ -1029,13 +1043,10 @@ listed with the [`workflows` command](#workflows-command).
 databricks labs ucx update-migration-progress
 ```
 
-This command updates a subset of the inventory tables that are used to track workspace resources that need to be
-migrated. It does this by triggering the `migration-process-experimental` workflow to run on a workspace and waiting for
-it to complete. This can be used to ensure that dashboards and associated reporting are updated to reflect the current
-state of the workspace.
-
-_Note: Only a subset of the inventory is updated, *not* the complete inventory that is initially gathered by
-the [assessment workflow](#assessment-workflow)._
+This command runs the [(experimental) migration progress workflow](#experimental-migration-progress-workflow) to update
+the migration status of worksapce resources that need to be migrated. It does this by triggering
+the `migration-process-experimental` workflow to run on a workspace and waiting for
+it to complete.
 
 Workflows and their status can be listed with the [`workflows` command](#workflows-commandr), while failed workflows can
 be fixed with the [`repair-run` command](#repair-run-command).

--- a/README.md
+++ b/README.md
@@ -1029,11 +1029,16 @@ listed with the [`workflows` command](#workflows-command).
 databricks labs ucx update-migration-progress
 ```
 
-This command updates a subset of the inventory tables that are used to track workspace resources that need to be migrated. It does this by triggering the `migration-process-experimental` workflow to run on a workspace and waiting for it to complete. This can be used to ensure that dashboards and associated reporting are updated to reflect the current state of the workspace.
+This command updates a subset of the inventory tables that are used to track workspace resources that need to be
+migrated. It does this by triggering the `migration-process-experimental` workflow to run on a workspace and waiting for
+it to complete. This can be used to ensure that dashboards and associated reporting are updated to reflect the current
+state of the workspace.
 
-_Note: Only a subset of the inventory is updated, *not* the complete inventory that is initially gathered by the [assessment workflow](#assessment-workflow)._
+_Note: Only a subset of the inventory is updated, *not* the complete inventory that is initially gathered by
+the [assessment workflow](#assessment-workflow)._
 
-Workflows and their status can be listed with the [`workflows` command](#workflows-commandr), while failed workflows can be fixed with the [`repair-run` command](#repair-run-command).
+Workflows and their status can be listed with the [`workflows` command](#workflows-commandr), while failed workflows can
+be fixed with the [`repair-run` command](#repair-run-command).
 
 [[back to top](#databricks-labs-ucx)]
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -611,7 +611,7 @@ def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceConte
     """
     workspace_context = ctx or WorkspaceContext(w)
     workspace_context.catalog_schema.create_ucx_catalog(prompts)
-    workspace_context.history_installation.run()
+    workspace_context.progress_tracking_installer.run()
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -611,6 +611,7 @@ def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceConte
     """
     workspace_context = ctx or WorkspaceContext(w)
     workspace_context.catalog_schema.create_ucx_catalog(prompts)
+    workspace_context.history_installation.run()
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -611,7 +611,7 @@ def create_ucx_catalog(w: WorkspaceClient, prompts: Prompts, ctx: WorkspaceConte
     """
     workspace_context = ctx or WorkspaceContext(w)
     workspace_context.catalog_schema.create_ucx_catalog(prompts)
-    workspace_context.progress_tracking_installer.run()
+    workspace_context.progress_tracking_installation.run()
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -120,4 +120,5 @@ class RuntimeContext(GlobalContext):
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),
             workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),
+            workflow_start_time=self.named_parameters["workflow_start_time"],
         )

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -116,7 +116,6 @@ class RuntimeContext(GlobalContext):
         return WorkflowRunRecorder(
             self.workspace_client,
             self.sql_backend,
-            workflow_name=self.named_parameters["job_name"],
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),
             workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -16,6 +16,7 @@ from databricks.labs.ucx.hive_metastore import TablesInMounts
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
 from databricks.labs.ucx.hive_metastore.tables import FasterTableScanCrawler
 from databricks.labs.ucx.installer.logs import TaskRunWarningRecorder
+from databricks.labs.ucx.progress.workflow_runs import WorkflowRunRecorder
 
 
 class RuntimeContext(GlobalContext):
@@ -108,4 +109,15 @@ class RuntimeContext(GlobalContext):
             self.sql_backend,
             self.inventory_database,
             int(self.named_parameters.get("attempt", "0")),
+        )
+
+    @cached_property
+    def workflow_run_recorder(self):
+        return WorkflowRunRecorder(
+            self.workspace_client,
+            self.sql_backend,
+            workflow_name=self.named_parameters["job_name"],
+            workflow_id=int(self.named_parameters["job_id"]),
+            workflow_run_id=int(self.named_parameters["parent_run_id"]),
+            workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),
         )

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -121,5 +121,5 @@ class RuntimeContext(GlobalContext):
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),
             workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),
-            workflow_start_time=self.named_parameters["workflow_start_time"],
+            workflow_start_time=self.named_parameters["start_time"],
         )

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -116,6 +116,7 @@ class RuntimeContext(GlobalContext):
         return WorkflowRunRecorder(
             self.workspace_client,
             self.sql_backend,
+            self.config.ucx_catalog,
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),
             workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -114,9 +114,9 @@ class RuntimeContext(GlobalContext):
     @cached_property
     def workflow_run_recorder(self):
         return WorkflowRunRecorder(
-            self.workspace_client,
             self.sql_backend,
             self.config.ucx_catalog,
+            workspace_id=int(self.named_parameters["workspace_id"]),
             workflow_name=self.named_parameters["workflow"],
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -112,7 +112,7 @@ class RuntimeContext(GlobalContext):
         )
 
     @cached_property
-    def workflow_run_recorder(self):
+    def workflow_run_recorder(self) -> WorkflowRunRecorder:
         return WorkflowRunRecorder(
             self.sql_backend,
             self.config.ucx_catalog,

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -117,6 +117,7 @@ class RuntimeContext(GlobalContext):
             self.workspace_client,
             self.sql_backend,
             self.config.ucx_catalog,
+            workflow_name=self.named_parameters["workflow"],
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),
             workflow_run_attempt=int(self.named_parameters.get("attempt", 0)),

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -116,7 +116,7 @@ class RuntimeContext(GlobalContext):
         return WorkflowRunRecorder(
             self.sql_backend,
             self.config.ucx_catalog,
-            workspace_id=int(self.named_parameters["workspace_id"]),
+            workspace_id=self.workspace_client.get_workspace_id(),
             workflow_name=self.named_parameters["workflow"],
             workflow_id=int(self.named_parameters["job_id"]),
             workflow_run_id=int(self.named_parameters["parent_run_id"]),

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -18,7 +18,7 @@ from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
-from databricks.labs.ucx.progress.install import ProgressTrackingInstaller
+from databricks.labs.ucx.progress.install import ProgressTrackingInstallation
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.files import LocalFileMigrator, LocalCodeLinter
@@ -181,8 +181,8 @@ class WorkspaceContext(CliContext):
         return NotebookLoader()
 
     @cached_property
-    def progress_tracking_installer(self) -> ProgressTrackingInstaller:
-        return ProgressTrackingInstaller(self.sql_backend, self.config.ucx_catalog)
+    def progress_tracking_installation(self) -> ProgressTrackingInstallation:
+        return ProgressTrackingInstallation(self.sql_backend, self.config.ucx_catalog)
 
 
 class LocalCheckoutContext(WorkspaceContext):

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -18,6 +18,7 @@ from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
+from databricks.labs.ucx.progress.install import HistoryInstallation
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.files import LocalFileMigrator, LocalCodeLinter
@@ -178,6 +179,10 @@ class WorkspaceContext(CliContext):
     @cached_property
     def notebook_loader(self) -> NotebookLoader:
         return NotebookLoader()
+
+    @cached_property
+    def history_installation(self) -> HistoryInstallation:
+        return HistoryInstallation(self.sql_backend, self.config.ucx_catalog)
 
 
 class LocalCheckoutContext(WorkspaceContext):

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -18,7 +18,7 @@ from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureAPIClient, AzureResources
 from databricks.labs.ucx.contexts.application import CliContext
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
-from databricks.labs.ucx.progress.install import HistoryInstallation
+from databricks.labs.ucx.progress.install import ProgressTrackingInstaller
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.linters.files import LocalFileMigrator, LocalCodeLinter
@@ -181,8 +181,8 @@ class WorkspaceContext(CliContext):
         return NotebookLoader()
 
     @cached_property
-    def history_installation(self) -> HistoryInstallation:
-        return HistoryInstallation(self.sql_backend, self.config.ucx_catalog)
+    def progress_tracking_installer(self) -> ProgressTrackingInstaller:
+        return ProgressTrackingInstaller(self.sql_backend, self.config.ucx_catalog)
 
 
 class LocalCheckoutContext(WorkspaceContext):

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -1,4 +1,3 @@
-import datetime as dt
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
@@ -66,7 +65,6 @@ def parse_args(*argv) -> dict[str, str]:
 class Workflow:
     def __init__(self, name: str):
         self._name = name
-        self._start_time = dt.datetime.now()
 
     @property
     def name(self):

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
@@ -65,6 +66,7 @@ def parse_args(*argv) -> dict[str, str]:
 class Workflow:
     def __init__(self, name: str):
         self._name = name
+        self._start_time = dt.datetime.now()
 
     @property
     def name(self):

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -55,9 +55,12 @@ logger = logging.getLogger(__name__)
 
 TEST_RESOURCE_PURGE_TIMEOUT = timedelta(hours=1)
 TEST_NIGHTLY_CI_RESOURCES_PURGE_TIMEOUT = timedelta(hours=3)  # Buffer for debugging nightly integration test runs
+# See https://docs.databricks.com/en/jobs/parameter-value-references.html#supported-value-references
 EXTRA_TASK_PARAMS = {
     "job_id": "{{job_id}}",
+    "job_name": "{{job.name}}",
     "run_id": "{{run_id}}",
+    "start_time": "{{job.start_time.iso_datetime}}",
     "attempt": "{{job.repair_count}}",
     "parent_run_id": "{{parent_run_id}}",
 }

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -62,7 +62,6 @@ EXTRA_TASK_PARAMS = {
     "start_time": "{{job.start_time.iso_datetime}}",
     "attempt": "{{job.repair_count}}",
     "parent_run_id": "{{parent_run_id}}",
-    "workspace_id": "{{workspace.id}}",
 }
 DEBUG_NOTEBOOK = """# Databricks notebook source
 # MAGIC %md
@@ -113,8 +112,7 @@ main(f'--config=/Workspace{config_file}',
      f'--run_id=' + dbutils.widgets.get('run_id'),
      f'--start_time=' + dbutils.widgets.get('start_time'),
      f'--attempt=' + dbutils.widgets.get('attempt'),
-     f'--parent_run_id=' + dbutils.widgets.get('parent_run_id'),
-     f'--workspace_id=' + dbutils.widgets.get('workspace_id'))
+     f'--parent_run_id=' + dbutils.widgets.get('parent_run_id'))
 """
 
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -58,7 +58,6 @@ TEST_NIGHTLY_CI_RESOURCES_PURGE_TIMEOUT = timedelta(hours=3)  # Buffer for debug
 # See https://docs.databricks.com/en/jobs/parameter-value-references.html#supported-value-references
 EXTRA_TASK_PARAMS = {
     "job_id": "{{job_id}}",
-    "job_name": "{{job.name}}",
     "run_id": "{{run_id}}",
     "start_time": "{{job.start_time.iso_datetime}}",
     "attempt": "{{job.repair_count}}",

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -62,6 +62,7 @@ EXTRA_TASK_PARAMS = {
     "start_time": "{{job.start_time.iso_datetime}}",
     "attempt": "{{job.repair_count}}",
     "parent_run_id": "{{parent_run_id}}",
+    "workspace_id": "{{workspace.id}}",
 }
 DEBUG_NOTEBOOK = """# Databricks notebook source
 # MAGIC %md

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -111,8 +111,10 @@ main(f'--config=/Workspace{config_file}',
      f'--task=' + dbutils.widgets.get('task'),
      f'--job_id=' + dbutils.widgets.get('job_id'),
      f'--run_id=' + dbutils.widgets.get('run_id'),
+     f'--start_time=' + dbutils.widgets.get('start_time'),
      f'--attempt=' + dbutils.widgets.get('attempt'),
-     f'--parent_run_id=' + dbutils.widgets.get('parent_run_id'))
+     f'--parent_run_id=' + dbutils.widgets.get('parent_run_id'),
+     f'--workspace_id=' + dbutils.widgets.get('workspace_id'))
 """
 
 

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -7,7 +7,7 @@ from databricks.labs.ucx.progress.workflow_runs import WorkflowRun
 logger = logging.getLogger(__name__)
 
 
-class ProgressTrackingInstaller:
+class ProgressTrackingInstallation:
     """Install resources for UCX's progress tracking."""
 
     _SCHEMA = "multiworkspace"

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -41,7 +41,7 @@ class HistoryInstallation:
     def run(self) -> None:
         self._create_schema()
         self._create_table("records", Record)
-        logger.info(f"Installation completed successfully!")
+        logger.info("Installation completed successfully!")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
     def _create_schema(self) -> None:

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -39,7 +39,7 @@ class WorkflowRun:
 class ProgressTrackingInstaller:
     """Install resources for UCX's progress tracking."""
 
-    _SCHEMA = "history"
+    _SCHEMA = "multiworkspace"
 
     def __init__(self, sql_backend: SqlBackend, ucx_catalog: str) -> None:
         # `mod` is required parameter, but it's not used in this context.

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import logging
-from dataclasses import dataclass
 
 from databricks.labs.lsql.backends import Dataclass, SqlBackend
 from databricks.sdk.errors import InternalError
@@ -10,20 +9,6 @@ from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Record:
-    workspace_id: int  # The workspace id
-    run_id: int  # The workflow run id that crawled the objects
-    run_start_time: dt.datetime  # The workflow run timestamp that crawled the objects
-    object_type: str  # The object type, e.g. TABLE, VIEW. Forms a composite key together with object_id
-    object_id: str  # The object id, e.g. hive_metastore.database.table. Forms a composite key together with object_id
-    object_data: str  # The object data; the attributes of the corresponding ucx data class, e.g. table name, table ...
-    failures: list  # The failures indicating the object is not UC compatible
-    owner: str  # The object owner
-    ucx_version: str  # The ucx semantic version
-    snapshot_id: int  # An identifier for the snapshot
 
 
 class HistoryInstallation:
@@ -40,7 +25,6 @@ class HistoryInstallation:
 
     def run(self) -> None:
         self._create_schema()
-        self._create_table("records", Record)
         logger.info("Installation completed successfully!")
 
     @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -47,4 +47,5 @@ class HistoryInstallation:
 
     def run(self) -> None:
         self._schema_deployer.deploy_schema()
+        self._schema_deployer.deploy_table("workflow_runs", WorkflowRun)
         logger.info("Installation completed successfully!")

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -1,40 +1,21 @@
-import datetime as dt
 import logging
 
-from databricks.labs.lsql.backends import Dataclass, SqlBackend
-from databricks.sdk.errors import InternalError
-from databricks.sdk.retries import retried
-
-from databricks.labs.ucx.framework.utils import escape_sql_identifier
+from databricks.labs.lsql.backends import SqlBackend
+from databricks.labs.lsql.deployment import SchemaDeployer
 
 
 logger = logging.getLogger(__name__)
 
 
 class HistoryInstallation:
-    """Install resources for UCX's artifacts history.
-
-    `InternalError` are retried on create statements for resilience on sporadic Databricks issues.
-    """
+    """Install resources for UCX's artifacts history."""
 
     _SCHEMA = "history"
 
     def __init__(self, sql_backend: SqlBackend, ucx_catalog: str) -> None:
-        self._backend = sql_backend
-        self._ucx_catalog = ucx_catalog
+        # `mod` is required parameter, but it's not used in this context.
+        self._schema_deployer = SchemaDeployer(sql_backend, self._SCHEMA, mod=None, catalog=ucx_catalog)
 
     def run(self) -> None:
-        self._create_schema()
+        self._schema_deployer.deploy_schema()
         logger.info("Installation completed successfully!")
-
-    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
-    def _create_schema(self) -> None:
-        schema = f"{self._ucx_catalog}.{self._SCHEMA}"
-        logger.info(f"Creating {schema} database...")
-        self._backend.execute(f"CREATE SCHEMA IF NOT EXISTS {escape_sql_identifier(schema, maxsplit=1)}")
-
-    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
-    def _create_table(self, name: str, klass: Dataclass) -> None:
-        full_name = f"{self._ucx_catalog}.{self._SCHEMA}.{name}"
-        logger.info(f"Create {full_name} table ...")
-        self._backend.create_table(escape_sql_identifier(full_name), klass)

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -36,8 +36,8 @@ class WorkflowRun:
     """The workflow run final status"""
 
 
-class HistoryInstallation:
-    """Install resources for UCX's artifacts history."""
+class ProgressTrackingInstaller:
+    """Install resources for UCX's progress tracking."""
 
     _SCHEMA = "history"
 

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -1,39 +1,10 @@
-import datetime as dt
 import logging
-from dataclasses import dataclass
 
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.lsql.deployment import SchemaDeployer
-
+from databricks.labs.ucx.progress.workflow_runs import WorkflowRun
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, kw_only=True)
-class WorkflowRun:
-    started_at: dt.datetime
-    """The timestamp of the workflow run start."""
-
-    finished_at: dt.datetime
-    """The timestamp of the workflow run end."""
-
-    workspace_id: int
-    """The workspace id in which the workflow ran."""
-
-    workflow_name: str
-    """The workflow name that ran."""
-
-    workflow_id: int
-    """"The workflow id of the workflow that ran."""
-
-    workflow_run_id: int
-    """The workflow run id."""
-
-    run_as: str
-    """The identity the workflow was run as`"""
-
-    status: str
-    """The workflow run final status"""
 
 
 class ProgressTrackingInstaller:

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -1,10 +1,39 @@
+import datetime as dt
 import logging
+from dataclasses import dataclass
 
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.labs.lsql.deployment import SchemaDeployer
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class WorkflowRun:
+    started_at: dt.datetime
+    """The timestamp of the workflow run start."""
+
+    finished_at: dt.datetime
+    """The timestamp of the workflow run end."""
+
+    workspace_id: int
+    """The workspace id in which the workflow ran."""
+
+    workflow_name: str
+    """The workflow name that ran."""
+
+    workflow_id: int
+    """"The workflow id of the workflow that ran."""
+
+    workflow_run_id: int
+    """The workflow run id."""
+
+    run_as: str
+    """The identity the workflow was run as`"""
+
+    status: str
+    """The workflow run final status"""
 
 
 class HistoryInstallation:

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -1,0 +1,56 @@
+import datetime as dt
+import logging
+from dataclasses import dataclass
+
+from databricks.labs.lsql.backends import Dataclass, SqlBackend
+from databricks.sdk.errors import InternalError
+from databricks.sdk.retries import retried
+
+from databricks.labs.ucx.framework.utils import escape_sql_identifier
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Record:
+    workspace_id: int  # The workspace id
+    run_id: int  # The workflow run id that crawled the objects
+    run_start_time: dt.datetime  # The workflow run timestamp that crawled the objects
+    object_type: str  # The object type, e.g. TABLE, VIEW. Forms a composite key together with object_id
+    object_id: str  # The object id, e.g. hive_metastore.database.table. Forms a composite key together with object_id
+    object_data: str  # The object data; the attributes of the corresponding ucx data class, e.g. table name, table ...
+    failures: list  # The failures indicating the object is not UC compatible
+    owner: str  # The object owner
+    ucx_version: str  # The ucx semantic version
+    snapshot_id: int  # An identifier for the snapshot
+
+
+class HistoryInstallation:
+    """Install resources for UCX's artifacts history.
+
+    `InternalError` are retried on create statements for resilience on sporadic Databricks issues.
+    """
+
+    _SCHEMA = "history"
+
+    def __init__(self, sql_backend: SqlBackend, ucx_catalog: str) -> None:
+        self._backend = sql_backend
+        self._ucx_catalog = ucx_catalog
+
+    def run(self) -> None:
+        self._create_schema()
+        self._create_table("records", Record)
+        logger.info(f"Installation completed successfully!")
+
+    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
+    def _create_schema(self) -> None:
+        schema = f"{self._ucx_catalog}.{self._SCHEMA}"
+        logger.info(f"Creating {schema} database...")
+        self._backend.execute(f"CREATE SCHEMA IF NOT EXISTS {escape_sql_identifier(schema, maxsplit=1)}")
+
+    @retried(on=[InternalError], timeout=dt.timedelta(minutes=1))
+    def _create_table(self, name: str, klass: Dataclass) -> None:
+        full_name = f"{self._ucx_catalog}.{self._SCHEMA}.{name}"
+        logger.info(f"Create {full_name} table ...")
+        self._backend.create_table(escape_sql_identifier(full_name), klass)

--- a/src/databricks/labs/ucx/progress/install.py
+++ b/src/databricks/labs/ucx/progress/install.py
@@ -13,7 +13,7 @@ class ProgressTrackingInstallation:
     _SCHEMA = "multiworkspace"
 
     def __init__(self, sql_backend: SqlBackend, ucx_catalog: str) -> None:
-        # `mod` is required parameter, but it's not used in this context.
+        # `mod` is a required parameter, though, it's not used in this context without views.
         self._schema_deployer = SchemaDeployer(sql_backend, self._SCHEMA, mod=None, catalog=ucx_catalog)
 
     def run(self) -> None:

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -43,7 +43,6 @@ class WorkflowRunRecorder:
         ws: WorkspaceClient,
         sql_backend: SqlBackend,
         *,
-        workflow_name: str,
         workflow_id: int,
         workflow_run_id: int,
         workflow_run_attempt: int,
@@ -53,18 +52,21 @@ class WorkflowRunRecorder:
         self._sql_backend = sql_backend
         self._full_table_name = f"{catalog}.multiworkspace.workflow_runs"
         self._workflow_start_time = workflow_start_time
-        self._workflow_name = workflow_name
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id
         self._workflow_run_attempt = workflow_run_attempt
 
-    def record(self) -> None:
-        """Record a workflow run in the database."""
+    def record(self, *, workflow_name: str) -> None:
+        """Record a workflow run in the database.
+
+        Args:
+            workflow_name (str): The UCX internal workflow name.
+        """
         workflow_run = WorkflowRun(
             started_at=dt.datetime.fromisoformat(self._workflow_start_time),
             finished_at=dt.datetime.now(),
             workspace_id=self._ws.get_workspace_id(),
-            workflow_name=self._workflow_name,
+            workflow_name=workflow_name,
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -3,7 +3,6 @@ import logging
 from dataclasses import dataclass
 
 from databricks.labs.lsql.backends import SqlBackend
-from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -73,7 +73,7 @@ class WorkflowRunRecorder:
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,
-            run_as="UNKOWN",  # TODO Update this
+            run_as="UNKNOWN",  # TODO Update this
         )
         try:
             self._sql_backend.save_table(

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -46,6 +46,7 @@ class WorkflowRunRecorder:
         sql_backend: SqlBackend,
         ucx_catalog: str,
         *,
+        workflow_name,
         workflow_id: int,
         workflow_run_id: int,
         workflow_run_attempt: int,
@@ -54,22 +55,19 @@ class WorkflowRunRecorder:
         self._ws = ws
         self._sql_backend = sql_backend
         self._full_table_name = f"{ucx_catalog}.multiworkspace.workflow_runs"
+        self._workflow_name = workflow_name
         self._workflow_start_time = workflow_start_time
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id
         self._workflow_run_attempt = workflow_run_attempt
 
-    def record(self, *, workflow_name: str) -> None:
-        """Record a workflow run in the database.
-
-        Args:
-            workflow_name (str): The UCX internal workflow name.
-        """
+    def record(self) -> None:
+        """Record a workflow run in the database."""
         workflow_run = WorkflowRun(
             started_at=dt.datetime.fromisoformat(self._workflow_start_time),
             finished_at=dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0),
             workspace_id=self._ws.get_workspace_id(),
-            workflow_name=workflow_name,
+            workflow_name=self._workflow_name,
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -39,19 +39,19 @@ class WorkflowRunRecorder:
 
     def __init__(
         self,
-        ws: WorkspaceClient,
         sql_backend: SqlBackend,
         ucx_catalog: str,
         *,
+        workspace_id: int,
         workflow_name,
         workflow_id: int,
         workflow_run_id: int,
         workflow_run_attempt: int,
         workflow_start_time: str,
     ):
-        self._ws = ws
         self._sql_backend = sql_backend
         self._full_table_name = f"{ucx_catalog}.multiworkspace.workflow_runs"
+        self._workspace_id = workspace_id
         self._workflow_name = workflow_name
         self._workflow_start_time = workflow_start_time
         self._workflow_id = workflow_id
@@ -63,7 +63,7 @@ class WorkflowRunRecorder:
         workflow_run = WorkflowRun(
             started_at=dt.datetime.fromisoformat(self._workflow_start_time),
             finished_at=dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0),
-            workspace_id=self._ws.get_workspace_id(),
+            workspace_id=self._workspace_id,
             workflow_name=self._workflow_name,
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -52,10 +52,10 @@ class WorkflowRunRecorder:
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id
 
-    def record(self) -> None:
+    def record(self, *, start_time: dt.datetime) -> None:
         """Record a workflow run in the database."""
         workflow_run = WorkflowRun(
-            started_at=dt.datetime.now(),  # TODO: Update this
+            started_at=start_time,
             finished_at=dt.datetime.now(),
             workspace_id=self._ws.get_workspace_id(),
             workflow_name=self._workflow_name,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -39,6 +39,7 @@ class WorkflowRunRecorder:
         self,
         ws: WorkspaceClient,
         sql_backend: SqlBackend,
+        ucx_catalog: str,
         *,
         workflow_id: int,
         workflow_run_id: int,
@@ -47,7 +48,7 @@ class WorkflowRunRecorder:
     ):
         self._ws = ws
         self._sql_backend = sql_backend
-        self._full_table_name = f"{catalog}.multiworkspace.workflow_runs"
+        self._full_table_name = f"{ucx_catalog}.multiworkspace.workflow_runs"
         self._workflow_start_time = workflow_start_time
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -25,6 +25,9 @@ class WorkflowRun:
     workflow_run_id: int
     """The workflow run id."""
 
+    workflow_run_attempt: int
+    """The workflow run attempt."""
+
     run_as: str
     """The identity the workflow was run as`"""
 
@@ -43,7 +46,7 @@ class WorkflowRunRecorder:
         workflow_name: str,
         workflow_id: int,
         workflow_run_id: int,
-        attempt: int,
+        workflow_run_attempt: int,
     ):
         self._ws = ws
         self._sql_backend = sql_backend
@@ -51,6 +54,7 @@ class WorkflowRunRecorder:
         self._workflow_name = workflow_name
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id
+        self._workflow_run_attempt = workflow_run_attempt
 
     def record(self, *, start_time: dt.datetime) -> None:
         """Record a workflow run in the database."""
@@ -61,6 +65,7 @@ class WorkflowRunRecorder:
             workflow_name=self._workflow_name,
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
+            workflow_run_attempt=self._workflow_run_attempt,
             run_as="UNKOWN",  # TODO Update this,
             status="RUNNING",  # Always RUNNING as it is called during a running workflow
         )

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -51,7 +51,7 @@ class WorkflowRunRecorder:
     ):
         self._ws = ws
         self._sql_backend = sql_backend
-        self._full_table_name = f"{self._catalog}.multiworkspace.workflow_runs"
+        self._full_table_name = f"{catalog}.multiworkspace.workflow_runs"
         self._workflow_start_time = workflow_start_time
         self._workflow_name = workflow_name
         self._workflow_id = workflow_id

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -42,7 +42,7 @@ class WorkflowRunRecorder:
         ucx_catalog: str,
         *,
         workspace_id: int,
-        workflow_name,
+        workflow_name: str,
         workflow_id: int,
         workflow_run_id: int,
         workflow_run_attempt: int,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -1,0 +1,29 @@
+import datetime as dt
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class WorkflowRun:
+    started_at: dt.datetime
+    """The timestamp of the workflow run start."""
+
+    finished_at: dt.datetime
+    """The timestamp of the workflow run end."""
+
+    workspace_id: int
+    """The workspace id in which the workflow ran."""
+
+    workflow_name: str
+    """The workflow name that ran."""
+
+    workflow_id: int
+    """"The workflow id of the workflow that ran."""
+
+    workflow_run_id: int
+    """The workflow run id."""
+
+    run_as: str
+    """The identity the workflow was run as`"""
+
+    status: str
+    """The workflow run final status"""

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -47,19 +47,21 @@ class WorkflowRunRecorder:
         workflow_id: int,
         workflow_run_id: int,
         workflow_run_attempt: int,
+        workflow_start_time: str,
     ):
         self._ws = ws
         self._sql_backend = sql_backend
         self._full_table_name = f"{self._catalog}.multiworkspace.workflow_runs"
+        self._workflow_start_time = workflow_start_time,
         self._workflow_name = workflow_name
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id
         self._workflow_run_attempt = workflow_run_attempt
 
-    def record(self, *, start_time: dt.datetime) -> None:
+    def record(self) -> None:
         """Record a workflow run in the database."""
         workflow_run = WorkflowRun(
-            started_at=start_time,
+            started_at=dt.datetime.fromisoformat(self._workflow_start_time),
             finished_at=dt.datetime.now(),
             workspace_id=self._ws.get_workspace_id(),
             workflow_name=self._workflow_name,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -52,7 +52,7 @@ class WorkflowRunRecorder:
         self._ws = ws
         self._sql_backend = sql_backend
         self._full_table_name = f"{self._catalog}.multiworkspace.workflow_runs"
-        self._workflow_start_time = workflow_start_time,
+        self._workflow_start_time = workflow_start_time
         self._workflow_name = workflow_name
         self._workflow_id = workflow_id
         self._workflow_run_id = workflow_run_id

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -58,7 +58,7 @@ class WorkflowRunRecorder:
         self._workflow_run_attempt = workflow_run_attempt
 
     def record(self) -> None:
-        """Record a workflow run in the database."""
+        """Record a workflow run."""
         workflow_run = WorkflowRun(
             started_at=dt.datetime.fromisoformat(self._workflow_start_time),
             finished_at=dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0),

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -31,9 +31,6 @@ class WorkflowRun:
     run_as: str
     """The identity the workflow was run as`"""
 
-    status: str
-    """The workflow run final status"""
-
 
 class WorkflowRunRecorder:
     """Record workflow runs in a database."""
@@ -71,7 +68,6 @@ class WorkflowRunRecorder:
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,
             run_as="UNKOWN",  # TODO Update this
-            status="RUNNING",  # Always RUNNING as it is called during a running workflow
         )
         self._sql_backend.save_table(
             self._full_table_name,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -67,7 +67,7 @@ class WorkflowRunRecorder:
         """
         workflow_run = WorkflowRun(
             started_at=dt.datetime.fromisoformat(self._workflow_start_time),
-            finished_at=dt.datetime.now(),
+            finished_at=dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0),
             workspace_id=self._ws.get_workspace_id(),
             workflow_name=workflow_name,
             workflow_id=self._workflow_id,

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -33,9 +33,6 @@ class WorkflowRun:
     workflow_run_attempt: int
     """The workflow run attempt."""
 
-    run_as: str
-    """The identity the workflow was run as`"""
-
 
 class WorkflowRunRecorder:
     """Record workflow runs in a database."""
@@ -71,7 +68,6 @@ class WorkflowRunRecorder:
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,
-            run_as="UNKNOWN",  # TODO Update this
         )
         try:
             self._sql_backend.save_table(

--- a/src/databricks/labs/ucx/progress/workflow_runs.py
+++ b/src/databricks/labs/ucx/progress/workflow_runs.py
@@ -68,7 +68,7 @@ class WorkflowRunRecorder:
             workflow_id=self._workflow_id,
             workflow_run_id=self._workflow_run_id,
             workflow_run_attempt=self._workflow_run_attempt,
-            run_as="UNKOWN",  # TODO Update this,
+            run_as="UNKOWN",  # TODO Update this
             status="RUNNING",  # Always RUNNING as it is called during a running workflow
         )
         self._sql_backend.save_table(

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -111,3 +111,17 @@ class MigrationProgress(Workflow):
         The results of the scan are stored in the `$inventory.migration_status` inventory table.
         """
         ctx.migration_status_refresher.snapshot(force_refresh=True)
+
+    @job_task(
+        depends_on=[
+            crawl_grants,
+            assess_jobs,
+            assess_clusters,
+            assess_pipelines,
+            crawl_cluster_policies,
+            refresh_table_migration_status,
+        ]
+    )
+    def record_workflow_run(self, ctx: RuntimeContext) -> None:
+        """Record the workflow run (of this workflow."""
+        ctx.workflow_run_recorder.record()

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -123,5 +123,5 @@ class MigrationProgress(Workflow):
         ]
     )
     def record_workflow_run(self, ctx: RuntimeContext) -> None:
-        """Record the workflow run (of this workflow."""
+        """Record the workflow run of this workflow."""
         ctx.workflow_run_recorder.record()

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -124,4 +124,4 @@ class MigrationProgress(Workflow):
     )
     def record_workflow_run(self, ctx: RuntimeContext) -> None:
         """Record the workflow run of this workflow."""
-        ctx.workflow_run_recorder.record()
+        ctx.workflow_run_recorder.record(self._name)

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -124,4 +124,4 @@ class MigrationProgress(Workflow):
     )
     def record_workflow_run(self, ctx: RuntimeContext) -> None:
         """Record the workflow run of this workflow."""
-        ctx.workflow_run_recorder.record(self._name)
+        ctx.workflow_run_recorder.record()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -992,7 +992,6 @@ class MockInstallationContext(MockRuntimeContext):
     def progress_tracking_installation(self) -> ProgressTrackingInstallation:
         return ProgressTrackingInstallation(self.sql_backend, self.ucx_catalog)
 
-
     @cached_property
     def extend_prompts(self):
         return {}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -445,7 +445,7 @@ class CommonUtils:
 
     @cached_property
     def ucx_catalog(self) -> str:
-        return self._make_catalog(name=f"ucx-{self._make_random()}").name
+        return self._make_catalog(name=f"ucx_{self._make_random()}").name
 
     @cached_property
     def workspace_client(self) -> WorkspaceClient:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -748,6 +748,7 @@ class MockWorkspaceContext(CommonUtils, WorkspaceContext):
         return WorkspaceConfig(
             warehouse_id=self._env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"),
             inventory_database=self.inventory_database,
+            ucx_catalog=self.ucx_catalog,
             connect=self.workspace_client.config,
             renamed_group_prefix=f'tmp-{self.inventory_database}-',
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,7 @@ from databricks.labs.ucx.hive_metastore.mapping import Rule, TableMapping
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller, AccountInstaller
 from databricks.labs.ucx.installer.workflows import WorkflowsDeployment
-
+from databricks.labs.ucx.progress.install import ProgressTrackingInstallation
 from databricks.labs.ucx.runtime import Workflows
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, GroupManager
 
@@ -987,6 +987,11 @@ class MockInstallationContext(MockRuntimeContext):
             self.prompts,
             self.product_info,
         )
+
+    @cached_property
+    def progress_tracking_installation(self) -> ProgressTrackingInstallation:
+        return ProgressTrackingInstallation(self.sql_backend, self.ucx_catalog)
+
 
     @cached_property
     def extend_prompts(self):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -949,6 +949,7 @@ class MockInstallationContext(MockRuntimeContext):
             include_databases=self.created_databases,
             include_object_permissions=self.include_object_permissions,
             warehouse_id=self._env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"),
+            ucx_catalog=self.ucx_catalog,
         )
         workspace_config = self.config_transform(workspace_config)
         self.installation.save(workspace_config)

--- a/tests/integration/progress/test_install.py
+++ b/tests/integration/progress/test_install.py
@@ -1,0 +1,7 @@
+def test_progress_tracking_installer_creates_workflow_runs_table(az_cli_ctx) -> None:
+    az_cli_ctx.progress_tracking_installer.run()
+    query = (
+        f"SELECT 1 FROM tables WHERE table_catalog = '{az_cli_ctx.config.ucx_catalog}' "
+        "AND table_schema = 'multiworkspace' AND table_name = 'workflow_runs'"
+    )
+    assert any(az_cli_ctx.sql_backend.fetch(query, catalog="system", schema="information_schema"))

--- a/tests/integration/progress/test_install.py
+++ b/tests/integration/progress/test_install.py
@@ -1,5 +1,5 @@
 def test_progress_tracking_installer_creates_workflow_runs_table(az_cli_ctx) -> None:
-    az_cli_ctx.progress_tracking_installer.run()
+    az_cli_ctx.progress_tracking_installation.run()
     query = (
         f"SELECT 1 FROM tables WHERE table_catalog = '{az_cli_ctx.config.ucx_catalog}' "
         "AND table_schema = 'multiworkspace' AND table_name = 'workflow_runs'"

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -1,0 +1,14 @@
+def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> None:
+    az_cli_ctx.progress_tracking_installer.run()
+    query = f"SELECT 1 FROM {az_cli_ctx.ucx_catalog}.multiworkspace.workflow_runs"
+    assert not any(az_cli_ctx.sql_backend.fetch(query))
+
+    named_parameters = {
+        "job_id": "123",
+        "parent_run_id": "456",
+        "workflow_start_time": "2024-10-11T01:42:02.000000",
+    }
+    ctx = runtime_ctx.replace(named_parameters=named_parameters, ucx_catalog=az_cli_ctx.ucx_catalog)
+    ctx.workflow_run_recorder.record(workflow_name="test")
+
+    assert any(az_cli_ctx.sql_backend.fetch(query))

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -8,12 +8,13 @@ def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> 
 
     start_time = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0)
     named_parameters = {
+        "workflow": "test",
         "job_id": "123",
         "parent_run_id": "456",
         "workflow_start_time": start_time.isoformat(),
     }
     ctx = runtime_ctx.replace(named_parameters=named_parameters, ucx_catalog=az_cli_ctx.ucx_catalog)
-    ctx.workflow_run_recorder.record(workflow_name="test")
+    ctx.workflow_run_recorder.record()
 
     rows = list(az_cli_ctx.sql_backend.fetch(query))
     assert len(rows) == 1

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -9,7 +9,7 @@ def test_workflow_run_recorder_records_workflow_run(installation_ctx) -> None:
         "workflow": "test",
         "job_id": "123",
         "parent_run_id": "456",
-        "workflow_start_time": start_time.isoformat(),
+        "start_time": start_time.isoformat(),
     }
     ctx = installation_ctx.replace(named_parameters=named_parameters)
     ctx.progress_tracking_installation.run()

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -5,7 +5,6 @@ def test_workflow_run_recorder_records_workflow_run(installation_ctx) -> None:
     """Ensure that the workflow run recorder records a workflow run"""
     start_time = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0)
     named_parameters = {
-        "workspace_id": 123456789,
         "workflow": "test",
         "job_id": "123",
         "parent_run_id": "456",
@@ -23,7 +22,7 @@ def test_workflow_run_recorder_records_workflow_run(installation_ctx) -> None:
     assert len(rows) == 1
     assert rows[0].started_at == start_time
     assert start_time <= rows[0].finished_at <= dt.datetime.now(tz=dt.timezone.utc)
-    assert rows[0].workspace_id == 123456789
+    assert rows[0].workspace_id == installation_ctx.workspace_client.get_workspace_id()
     assert rows[0].workflow_name == "test"
     assert rows[0].workflow_id == 123
     assert rows[0].workflow_run_id == 456

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -22,7 +22,7 @@ def test_workflow_run_recorder_records_workflow_run(installation_ctx) -> None:
     rows = list(ctx.sql_backend.fetch(select_workflow_runs_query))
     assert len(rows) == 1
     assert rows[0].started_at == start_time
-    assert start_time < rows[0].finished_at < dt.datetime.now(tz=dt.timezone.utc)
+    assert start_time <= rows[0].finished_at <= dt.datetime.now(tz=dt.timezone.utc)
     assert rows[0].workspace_id == 123456789
     assert rows[0].workflow_name == "test"
     assert rows[0].workflow_id == 123

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -25,4 +25,3 @@ def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> 
     assert rows[0].workflow_id == 123
     assert rows[0].workflow_run_id == 456
     assert rows[0].workflow_run_attempt == 0
-    assert rows[0].run_as == "UNKNOWN"  # TODO: Update this

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -8,6 +8,7 @@ def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> 
 
     start_time = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0)
     named_parameters = {
+        "workspace_id": 123456789,
         "workflow": "test",
         "job_id": "123",
         "parent_run_id": "456",
@@ -20,7 +21,7 @@ def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> 
     assert len(rows) == 1
     assert rows[0].started_at == start_time
     assert start_time < rows[0].finished_at < dt.datetime.now(tz=dt.timezone.utc)
-    assert rows[0].workspace_id == ctx.workspace_client.get_workspace_id()
+    assert rows[0].workspace_id == 123456789
     assert rows[0].workflow_name == "test"
     assert rows[0].workflow_id == 123
     assert rows[0].workflow_run_id == 456

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -2,7 +2,7 @@ import datetime as dt
 
 
 def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> None:
-    az_cli_ctx.progress_tracking_installer.run()
+    az_cli_ctx.progress_tracking_installation.run()
     query = f"SELECT * FROM {az_cli_ctx.ucx_catalog}.multiworkspace.workflow_runs"
     assert not any(az_cli_ctx.sql_backend.fetch(query))
 

--- a/tests/integration/progress/test_workflow_runs.py
+++ b/tests/integration/progress/test_workflow_runs.py
@@ -1,11 +1,8 @@
 import datetime as dt
 
 
-def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> None:
-    az_cli_ctx.progress_tracking_installation.run()
-    query = f"SELECT * FROM {az_cli_ctx.ucx_catalog}.multiworkspace.workflow_runs"
-    assert not any(az_cli_ctx.sql_backend.fetch(query))
-
+def test_workflow_run_recorder_records_workflow_run(installation_ctx) -> None:
+    """Ensure that the workflow run recorder records a workflow run"""
     start_time = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0)
     named_parameters = {
         "workspace_id": 123456789,
@@ -14,10 +11,15 @@ def test_workflow_run_recorder_records_workflow_run(az_cli_ctx, runtime_ctx) -> 
         "parent_run_id": "456",
         "workflow_start_time": start_time.isoformat(),
     }
-    ctx = runtime_ctx.replace(named_parameters=named_parameters, ucx_catalog=az_cli_ctx.ucx_catalog)
+    ctx = installation_ctx.replace(named_parameters=named_parameters)
+    ctx.progress_tracking_installation.run()
+    select_workflow_runs_query = f"SELECT * FROM {ctx.ucx_catalog}.multiworkspace.workflow_runs"
+    # Be confident that we are not selecting any workflow runs before the to-be-tested code
+    assert not any(ctx.sql_backend.fetch(select_workflow_runs_query))
+
     ctx.workflow_run_recorder.record()
 
-    rows = list(az_cli_ctx.sql_backend.fetch(query))
+    rows = list(ctx.sql_backend.fetch(select_workflow_runs_query))
     assert len(rows) == 1
     assert rows[0].started_at == start_time
     assert start_time < rows[0].finished_at < dt.datetime.now(tz=dt.timezone.utc)

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -16,6 +16,9 @@ def test_running_real_migration_progress_job(installation_ctx: MockInstallationC
     installation_ctx.deployed_workflows.run_workflow("assessment")
     assert installation_ctx.deployed_workflows.validate_step("assessment")
 
+    # After the assessment, a user (maybe) installs the progress tracking
+    installation_ctx.progress_tracking_installation.run()
+
     # Run the migration-progress workflow until completion.
     installation_ctx.deployed_workflows.run_workflow("migration-progress-experimental")
     assert installation_ctx.deployed_workflows.validate_step("migration-progress-experimental")

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -19,3 +19,7 @@ def test_running_real_migration_progress_job(installation_ctx: MockInstallationC
     # Run the migration-progress workflow until completion.
     installation_ctx.deployed_workflows.run_workflow("migration-progress-experimental")
     assert installation_ctx.deployed_workflows.validate_step("migration-progress-experimental")
+
+    # Ensure that the migration-progress workflow populated the `workflow_runs` table.
+    query = f"SELECT 1 FROM {installation_ctx.ucx_catalog}.multiworkspace.workflow_runs"
+    assert any(installation_ctx.sql_backend.fetch(query))

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -25,4 +25,4 @@ def test_running_real_migration_progress_job(installation_ctx: MockInstallationC
 
     # Ensure that the migration-progress workflow populated the `workflow_runs` table.
     query = f"SELECT 1 FROM {installation_ctx.ucx_catalog}.multiworkspace.workflow_runs"
-    assert any(installation_ctx.sql_backend.fetch(query))
+    assert any(installation_ctx.sql_backend.fetch(query)), f"No workflow run captured: {query}"

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -4,4 +4,4 @@ from databricks.labs.ucx.progress.install import HistoryInstallation
 def test_history_installation_run_creates_history_schema(mock_backend) -> None:
     installation = HistoryInstallation(mock_backend, "ucx")
     installation.run()
-    assert mock_backend.queries[0] == "CREATE SCHEMA IF NOT EXISTS `ucx`.`history`"
+    assert mock_backend.queries[0] == "CREATE SCHEMA IF NOT EXISTS ucx.history"

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -4,4 +4,4 @@ from databricks.labs.ucx.progress.install import HistoryInstallation
 def test_history_installation_run_creates_history_schema(mock_backend) -> None:
     installation = HistoryInstallation(mock_backend, "ucx")
     installation.run()
-    assert "CREATE SCHEMA IF NOT EXISTS `ucx`.`history`" == mock_backend.queries[0]
+    assert mock_backend.queries[0] == "CREATE SCHEMA IF NOT EXISTS `ucx`.`history`"

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -1,14 +1,14 @@
-from databricks.labs.ucx.progress.install import HistoryInstallation
+from databricks.labs.ucx.progress.install import ProgressTrackingInstaller
 
 
-def test_history_installation_run_creates_history_schema(mock_backend) -> None:
-    installation = HistoryInstallation(mock_backend, "ucx")
+def test_progress_tracking_installation_run_creates_progress_tracking_schema(mock_backend) -> None:
+    installation = ProgressTrackingInstaller(mock_backend, "ucx")
     installation.run()
     assert "CREATE SCHEMA IF NOT EXISTS ucx.history" in mock_backend.queries[0]
 
 
-def test_history_installation_run_creates_workflow_runs_table(mock_backend) -> None:
-    installation = HistoryInstallation(mock_backend, "ucx")
+def test_progress_tracking_installation_run_creates_workflow_runs_table(mock_backend) -> None:
+    installation = ProgressTrackingInstaller(mock_backend, "ucx")
     installation.run()
     # Dataclass to schema conversion is tested within the lsql package
     assert any("CREATE TABLE IF NOT EXISTS" in query for query in mock_backend.queries)

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -4,7 +4,7 @@ from databricks.labs.ucx.progress.install import ProgressTrackingInstaller
 def test_progress_tracking_installation_run_creates_progress_tracking_schema(mock_backend) -> None:
     installation = ProgressTrackingInstaller(mock_backend, "ucx")
     installation.run()
-    assert "CREATE SCHEMA IF NOT EXISTS ucx.history" in mock_backend.queries[0]
+    assert "CREATE SCHEMA IF NOT EXISTS ucx.multiworkspace" in mock_backend.queries[0]
 
 
 def test_progress_tracking_installation_run_creates_workflow_runs_table(mock_backend) -> None:

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -5,3 +5,10 @@ def test_history_installation_run_creates_history_schema(mock_backend) -> None:
     installation = HistoryInstallation(mock_backend, "ucx")
     installation.run()
     assert "CREATE SCHEMA IF NOT EXISTS ucx.history" in mock_backend.queries[0]
+
+
+def test_history_installation_run_creates_workflow_runs_table(mock_backend) -> None:
+    installation = HistoryInstallation(mock_backend, "ucx")
+    installation.run()
+    # Dataclass to schema conversion is tested within the lsql package
+    assert any("CREATE TABLE IF NOT EXISTS" in query for query in mock_backend.queries)

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -4,4 +4,4 @@ from databricks.labs.ucx.progress.install import HistoryInstallation
 def test_history_installation_run_creates_history_schema(mock_backend) -> None:
     installation = HistoryInstallation(mock_backend, "ucx")
     installation.run()
-    assert mock_backend.queries[0] == "CREATE SCHEMA IF NOT EXISTS ucx.history"
+    assert "CREATE SCHEMA IF NOT EXISTS ucx.history" in mock_backend.queries[0]

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -1,14 +1,14 @@
-from databricks.labs.ucx.progress.install import ProgressTrackingInstaller
+from databricks.labs.ucx.progress.install import ProgressTrackingInstallation
 
 
 def test_progress_tracking_installation_run_creates_progress_tracking_schema(mock_backend) -> None:
-    installation = ProgressTrackingInstaller(mock_backend, "ucx")
+    installation = ProgressTrackingInstallation(mock_backend, "ucx")
     installation.run()
     assert "CREATE SCHEMA IF NOT EXISTS ucx.multiworkspace" in mock_backend.queries[0]
 
 
 def test_progress_tracking_installation_run_creates_workflow_runs_table(mock_backend) -> None:
-    installation = ProgressTrackingInstaller(mock_backend, "ucx")
+    installation = ProgressTrackingInstallation(mock_backend, "ucx")
     installation.run()
     # Dataclass to schema conversion is tested within the lsql package
     assert any("CREATE TABLE IF NOT EXISTS" in query for query in mock_backend.queries)

--- a/tests/unit/progress/test_install.py
+++ b/tests/unit/progress/test_install.py
@@ -1,0 +1,7 @@
+from databricks.labs.ucx.progress.install import HistoryInstallation
+
+
+def test_history_installation_run_creates_history_schema(mock_backend) -> None:
+    installation = HistoryInstallation(mock_backend, "ucx")
+    installation.run()
+    assert "CREATE SCHEMA IF NOT EXISTS `ucx`.`history`" == mock_backend.queries[0]

--- a/tests/unit/progress/test_workflow_runs.py
+++ b/tests/unit/progress/test_workflow_runs.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+from databricks.labs.ucx.progress.workflow_runs import WorkflowRunRecorder
+
+
+def test_workflow_run_record_records_workflow_run(mock_backend) -> None:
+    """Ensure that the workflow run recorder records a workflow run"""
+    start_time = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0)
+    workflow_run_recorder = WorkflowRunRecorder(
+        mock_backend,
+        ucx_catalog="ucx",
+        workspace_id=123456789,
+        workflow_name="workflow",
+        workflow_id=123,
+        workflow_run_id=456,
+        workflow_run_attempt=0,
+        workflow_start_time=start_time.isoformat(),
+    )
+
+    workflow_run_recorder.record()
+
+    rows = mock_backend.rows_written_for("ucx.multiworkspace.workflow_runs", "append")
+    assert len(rows) == 1
+    assert rows[0].started_at == start_time
+    assert start_time <= rows[0].finished_at <= dt.datetime.now(tz=dt.timezone.utc)
+    assert rows[0].workspace_id == 123456789
+    assert rows[0].workflow_name == "workflow"
+    assert rows[0].workflow_id == 123
+    assert rows[0].workflow_run_id == 456
+    assert rows[0].workflow_run_attempt == 0
+

--- a/tests/unit/progress/test_workflow_runs.py
+++ b/tests/unit/progress/test_workflow_runs.py
@@ -28,4 +28,3 @@ def test_workflow_run_record_records_workflow_run(mock_backend) -> None:
     assert rows[0].workflow_id == 123
     assert rows[0].workflow_run_id == 456
     assert rows[0].workflow_run_attempt == 0
-

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -900,7 +900,6 @@ def test_create_ucx_catalog_creates_history_schema_and_table(ws, mock_backend) -
     create_ucx_catalog(ws, prompts, ctx=WorkspaceContext(ws).replace(sql_backend=mock_backend))
 
     assert "CREATE SCHEMA" in mock_backend.queries[0]
-    assert "CREATE TABLE" in mock_backend.queries[1]
 
 
 @pytest.mark.parametrize("run_as_collection", [False, True])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -33,6 +33,7 @@ from databricks.labs.ucx.cli import (
     create_missing_principals,
     create_table_mapping,
     create_uber_principal,
+    create_ucx_catalog,
     download,
     ensure_assessment_run,
     installations,
@@ -888,7 +889,7 @@ def test_assign_metastore_logs_account_id_and_assigns_metastore(caplog, acc_clie
 def test_create_ucx_catalog_calls_create_catalog(ws) -> None:
     prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
 
-    create_catalogs_schemas(ws, prompts, ctx=WorkspaceContext(ws))
+    create_ucx_catalog(ws, prompts, ctx=WorkspaceContext(ws))
 
     ws.catalogs.create.assert_called_once()
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -894,6 +894,15 @@ def test_create_ucx_catalog_calls_create_catalog(ws) -> None:
     ws.catalogs.create.assert_called_once()
 
 
+def test_create_ucx_catalog_creates_history_schema_and_table(ws, mock_backend) -> None:
+    prompts = MockPrompts({"Please provide storage location url for catalog: .*": "metastore"})
+
+    create_ucx_catalog(ws, prompts, ctx=WorkspaceContext(ws).replace(sql_backend=mock_backend))
+
+    assert "CREATE SCHEMA" in mock_backend.queries[0]
+    assert "CREATE TABLE" in mock_backend.queries[1]
+
+
 @pytest.mark.parametrize("run_as_collection", [False, True])
 def test_migrate_tables_calls_migrate_table_job_run_now(
     run_as_collection,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -899,6 +899,7 @@ def test_create_ucx_catalog_creates_history_schema_and_table(ws, mock_backend) -
 
     create_ucx_catalog(ws, prompts, ctx=WorkspaceContext(ws).replace(sql_backend=mock_backend))
 
+    assert len(mock_backend.queries) > 0, "No queries executed on backend"
     assert "CREATE SCHEMA" in mock_backend.queries[0]
 
 


### PR DESCRIPTION
## Changes
Add and populate workflow runs table

### Linked issues

Resolves #2600 

### Functionality

- [x] added relevant user documentation
- [x] modified existing workflow: `migration-process-experimental`

### Tests

- [ ] manually tested
- [x] added unit tests
- [x] added integration tests

### TODO
- [ ] Handle concurrent writes, [see](https://github.com/databrickslabs/ucx/pull/2754#discussion_r1778259805)
- [x] Decide on getting workflow run status from `parse_log_task` --> only add it to the migration progress workflow for now
