### PR TITLE
Documentation: table utilization updates

### DIFF
--- a/docs/table_persistence.md
+++ b/docs/table_persistence.md
@@ -14,6 +14,8 @@ Table Utilization:
 | permissions              | RW                  |                           | RW             | RO                      |              | RO             |                             |                 |
 | jobs                     | RW                  | RW                        |                |                         | RO           |                |                             |                 |
 | clusters                 | RW                  | RW                        |                |                         |              |                |                             |                 |
+| directfs_in_paths        | RW                  |                           |                |                         |              |                |                             | RW              |
+| directfs_in_queries      | RW                  |                           |                |                         |              |                |                             | RW              |
 | external_locations       | RW                  |                           |                | RO                      |              |                |                             |                 |
 | workspace                | RW                  |                           | RO             |                         | RO           |                |                             |                 |
 | workspace_objects        | RW                  |                           |                |                         |              |                |                             |                 |
@@ -26,7 +28,8 @@ Table Utilization:
 | submit_runs              | RW                  |                           |                |                         |              |                |                             |                 |
 | policies                 | RW                  | RW                        |                |                         |              |                |                             |                 |
 | migration_status         |                     | RW                        |                | RW                      |              | RW             |                             |                 |
-| workflow_problems        |                     |                           |                |                         |              |                |                             | RW              |
+| query_problems           | RW                  |                           |                |                         |              |                |                             | RW              |
+| workflow_problems        | RW                  |                           |                |                         |              |                |                             | RW              |
 | udfs                     | RW                  | RW                        | RO             |                         |              |                |                             |                 |
 | logs                     | RW                  |                           | RW             | RW                      |              | RW             | RW                          |                 |
 | recon_results            |                     |                           |                |                         |              |                | RW                          |                 |


### PR DESCRIPTION
## Changes

This PR adds updates the table utilization table:

 - Missing linter tables.
 - Since #2678 the assessment workflow also writes to `workflow_problems`.
