### PR TITLE
Limit resources to assess in integration tests that run the `assessment` workflow

### DIFF
--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -86,7 +86,7 @@ class RuntimeContext(GlobalContext):
     @cached_property
     def tables_crawler(self):
         # TODO: Update tables crawler inheritance to specify return type hint
-        return FasterTableScanCrawler(self.sql_backend, self.inventory_database)
+        return FasterTableScanCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
 
     @cached_property
     def tables_in_mounts(self) -> TablesInMounts:

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime as dt
 
 from databricks.labs.lsql.backends import CommandExecutionBackend
 from databricks.sdk.service.iam import PermissionLevel
@@ -8,18 +7,28 @@ from databricks.sdk.service.iam import PermissionLevel
 def test_running_real_assessment_job_ext_hms(
     ws,
     installation_ctx,
-    product_info,
     env_or_skip,
     make_cluster_policy,
     make_cluster_policy_permissions,
-    populate_for_linting,
-):
+) -> None:
     cluster_id = env_or_skip('TEST_EXT_HMS_CLUSTER_ID')
+    ws_group, _ = installation_ctx.make_ucx_group(wait_for_provisioning=True)
+    # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
+    cluster_policy = make_cluster_policy()
+    make_cluster_policy_permissions(
+        object_id=cluster_policy.policy_id,
+        permission_level=PermissionLevel.CAN_USE,
+        group_name=ws_group.display_name,
+    )
+    installation_ctx.make_linting_resources()
+    source_schema = installation_ctx.make_schema(catalog_name="hive_metastore")
+    installation_ctx.make_table(schema_name=source_schema.name)
     ext_hms_ctx = installation_ctx.replace(
         sql_backend=CommandExecutionBackend(ws, cluster_id),
         config_transform=lambda wc: dataclasses.replace(
             wc,
             override_clusters=None,
+            include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
         ),
         extend_prompts={
             r"Instance pool id to be set.*": env_or_skip("TEST_INSTANCE_POOL_ID"),
@@ -28,26 +37,12 @@ def test_running_real_assessment_job_ext_hms(
             r"Choose a cluster policy": "0",
         },
     )
-    ws_group_a, _ = ext_hms_ctx.make_ucx_group(wait_for_provisioning=True)
-
-    cluster_policy = make_cluster_policy()
-    make_cluster_policy_permissions(
-        object_id=cluster_policy.policy_id,
-        permission_level=PermissionLevel.CAN_USE,
-        group_name=ws_group_a.display_name,
-    )
-    ext_hms_ctx.__dict__['include_object_permissions'] = [f"cluster-policies:{cluster_policy.policy_id}"]
     ext_hms_ctx.workspace_installation.run()
 
-    populate_for_linting(installation_ctx.installation)
-
-    # Under ideal circumstances this can take 10-16 minutes (depending on whether there are compute instances available
-    # via the integration pool). Allow some margin to reduce spurious failures.
-    ext_hms_ctx.deployed_workflows.run_workflow("assessment", max_wait=dt.timedelta(minutes=25))
-
-    # assert the workflow is successful. the tasks on sql warehouse will fail so skip checking them
-    assert ext_hms_ctx.deployed_workflows.validate_step("assessment")
+    workflow = "assessment"
+    ext_hms_ctx.deployed_workflows.run_workflow(workflow)
+    assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     after = ext_hms_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
-    assert ws_group_a.display_name in after, f"Group {ws_group_a.display_name} not found in cluster policy"
-    assert after[ws_group_a.display_name] == PermissionLevel.CAN_USE
+    assert ws_group.display_name in after, f"Group {ws_group.display_name} not found in cluster policy"
+    assert after[ws_group.display_name] == PermissionLevel.CAN_USE

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -12,6 +12,14 @@ def test_running_real_assessment_job_ext_hms(
     make_cluster_policy_permissions,
 ) -> None:
     cluster_id = env_or_skip('TEST_EXT_HMS_CLUSTER_ID')
+    ws_group, _ = installation_ctx.make_ucx_group(wait_for_provisioning=True)
+    # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
+    cluster_policy = make_cluster_policy()
+    make_cluster_policy_permissions(
+        object_id=cluster_policy.policy_id,
+        permission_level=PermissionLevel.CAN_USE,
+        group_name=ws_group.display_name,
+    )
     ext_hms_ctx = installation_ctx.replace(
         sql_backend=CommandExecutionBackend(ws, cluster_id),
         config_transform=lambda wc: dataclasses.replace(
@@ -25,14 +33,6 @@ def test_running_real_assessment_job_ext_hms(
             r".*connect to the external metastore?.*": "yes",
             r"Choose a cluster policy": "0",
         },
-    )
-    ws_group, _ = ext_hms_ctx.make_ucx_group(wait_for_provisioning=True)
-    # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
-    cluster_policy = make_cluster_policy()
-    make_cluster_policy_permissions(
-        object_id=cluster_policy.policy_id,
-        permission_level=PermissionLevel.CAN_USE,
-        group_name=ws_group.display_name,
     )
     ext_hms_ctx.make_linting_resources()
     source_schema = ext_hms_ctx.make_schema(catalog_name="hive_metastore")

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -11,14 +11,20 @@ def test_running_real_assessment_job(
     make_cluster_policy,
     make_cluster_policy_permissions,
     make_dashboard,
-    populate_for_linting,
 ) -> None:
     ws_group, _ = installation_ctx.make_ucx_group()
+    # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
     cluster_policy = make_cluster_policy()
     make_cluster_policy_permissions(
         object_id=cluster_policy.policy_id,
         permission_level=PermissionLevel.CAN_USE,
         group_name=ws_group.display_name,
+    )
+    installation_ctx = installation_ctx.replace(
+        config_transform=lambda wc: dataclasses.replace(
+            wc,
+            include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
+        ),
     )
 
     source_schema = installation_ctx.make_schema(catalog_name="hive_metastore")
@@ -27,28 +33,17 @@ def test_running_real_assessment_job(
     tmp_table = installation_ctx.make_table(schema_name=source_schema.name, ctas="SELECT 2+2 AS four")
     view = installation_ctx.make_table(schema_name=source_schema.name, ctas="SELECT 2+2 AS four", view=True)
     non_delta = installation_ctx.make_table(schema_name=source_schema.name, non_delta=True)
-    installation_ctx = installation_ctx.replace(
-        config_transform=lambda wc: dataclasses.replace(
-            wc,
-            include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
-            include_databases=[source_schema.name],
-        ),
-    )
+    installation_ctx.make_linting_resources()
     installation_ctx.workspace_installation.run()
-    populate_for_linting(installation_ctx.installation)
 
     workflow = "assessment"
     installation_ctx.deployed_workflows.run_workflow(workflow)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     after = installation_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
-
     assert after[ws_group.display_name] == PermissionLevel.CAN_USE
 
-    tables = set[str]()
-    for table in installation_ctx.tables_crawler.snapshot():
-        tables.add(table.name)
-
+    tables = set(table.name for table in installation_ctx.tables_crawler.snapshot())
     expected_tables = {managed_table.name, external_table.name, tmp_table.name, view.name, non_delta.name}
     assert len(tables) == len(expected_tables)
     assert set(tables) == expected_tables

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -42,8 +42,9 @@ def test_running_real_assessment_job(
     installation_ctx.workspace_installation.run()
     populate_for_linting(installation_ctx.installation)
 
-    installation_ctx.deployed_workflows.run_workflow("assessment", max_wait=timedelta(minutes=25))
-    assert installation_ctx.deployed_workflows.validate_step("assessment")
+    workflow = "assessment"
+    installation_ctx.deployed_workflows.run_workflow(workflow, max_wait=timedelta(minutes=25))
+    assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     after = installation_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
 

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -11,7 +11,6 @@ def test_running_real_assessment_job(
     make_cluster_policy,
     make_cluster_policy_permissions,
     make_dashboard,
-    inventory_schema,
     populate_for_linting,
 ) -> None:
     ws_group, _ = installation_ctx.make_ucx_group()

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -43,7 +43,7 @@ def test_running_real_assessment_job(
     populate_for_linting(installation_ctx.installation)
 
     workflow = "assessment"
-    installation_ctx.deployed_workflows.run_workflow(workflow, max_wait=timedelta(minutes=25))
+    installation_ctx.deployed_workflows.run_workflow(workflow)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     after = installation_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -10,7 +10,6 @@ from databricks.labs.ucx.hive_metastore import TablesCrawler
 # pylint: disable=too-many-locals
 @retried(on=[NotFound, InvalidParameterValue])
 def test_running_real_assessment_job(
-    ws,
     installation_ctx,
     make_cluster_policy,
     make_cluster_policy_permissions,
@@ -18,7 +17,7 @@ def test_running_real_assessment_job(
     sql_backend,
     inventory_schema,
     populate_for_linting,
-):
+) -> None:
     ws_group, _ = installation_ctx.make_ucx_group()
     cluster_policy = make_cluster_policy()
     make_cluster_policy_permissions(

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -33,10 +33,10 @@ def test_running_real_assessment_job(
     view = installation_ctx.make_table(schema_name=source_schema.name, ctas="SELECT 2+2 AS four", view=True)
     non_delta = installation_ctx.make_table(schema_name=source_schema.name, non_delta=True)
     installation_ctx = installation_ctx.replace(
-        config_transform = lambda wc: dataclasses.replace(
+        config_transform=lambda wc: dataclasses.replace(
             wc,
             include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
-            include_databases=[source_schema.name]
+            include_databases=[source_schema.name],
         ),
     )
     installation_ctx.workspace_installation.run()

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -7,7 +7,6 @@ from databricks.sdk.service.iam import PermissionLevel
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 
 
-# pylint: disable=too-many-locals
 @retried(on=[NotFound, InvalidParameterValue])
 def test_running_real_assessment_job(
     installation_ctx,

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -36,6 +36,7 @@ def test_running_real_assessment_job(
         config_transform = lambda wc: dataclasses.replace(
             wc,
             include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
+            include_databases=[source_schema.name]
         ),
     )
     installation_ctx.workspace_installation.run()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-import io
 import json
 from collections.abc import Callable, Generator
 import functools
@@ -10,15 +9,12 @@ from datetime import timedelta
 from functools import cached_property
 import shutil
 import subprocess
-from pathlib import Path
 
 import pytest  # pylint: disable=wrong-import-order
-import yaml
 from databricks.labs.blueprint.commands import CommandExecutor
 from databricks.labs.blueprint.entrypoint import is_in_debug
 from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.parallel import Threads
-from databricks.labs.blueprint.paths import WorkspacePath
 from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.lsql.backends import SqlBackend
@@ -28,10 +24,9 @@ from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service import iam, jobs
 from databricks.sdk.service.catalog import FunctionInfo, SchemaInfo, TableInfo
-from databricks.sdk.service.compute import ClusterSpec
 from databricks.sdk.service.dashboards import Dashboard as SDKDashboard
 from databricks.sdk.service.iam import Group
-from databricks.sdk.service.jobs import SparkPythonTask
+from databricks.sdk.service.jobs import Job, SparkPythonTask
 from databricks.sdk.service.sql import Dashboard, WidgetPosition, WidgetOptions, LegacyQuery
 
 from databricks.labs.ucx.__about__ import __version__
@@ -454,14 +449,20 @@ class CommonUtils:
         return self._ws
 
 
-class MockRuntimeContext(CommonUtils, RuntimeContext):
-    def __init__(
+class MockRuntimeContext(
+    CommonUtils, RuntimeContext
+):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         make_catalog_fixture,
         make_schema_fixture,
         make_table_fixture,
         make_udf_fixture,
         make_group_fixture,
+        make_job_fixture,
+        make_notebook_fixture,
+        make_query_fixture,
+        make_dashboard_fixture,
         env_or_skip_fixture,
         ws_fixture,
         make_random_fixture,
@@ -478,12 +479,18 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
         self._make_schema = make_schema_fixture
         self._make_udf = make_udf_fixture
         self._make_group = make_group_fixture
+        self._make_job = make_job_fixture
+        self._make_notebook = make_notebook_fixture
+        self._make_query = make_query_fixture
+        self._make_dashboard = make_dashboard_fixture
         self._env_or_skip = env_or_skip_fixture
         self._tables: list[TableInfo] = []
         self._schemas: list[SchemaInfo] = []
         self._groups: list[Group] = []
         self._udfs: list[FunctionInfo] = []
         self._grants: list[Grant] = []
+        self._jobs: list[Job] = []
+        self._dashboards: list[Dashboard] = []
         # TODO: add methods to pre-populate the following:
         self._spn_infos: list[AzureServicePrincipalInfo] = []
 
@@ -550,6 +557,15 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
         self._grants.append(grant)
         return grant
 
+    def make_linting_resources(self) -> None:
+        """Make resources to lint."""
+        notebook_job = self._make_job(content="spark.read.parquet('dbfs://mnt/notebook/')")
+        file_job = self._make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
+        query = self._make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
+        dashboard = self._make_dashboard(query=query)
+        self._jobs.extend([notebook_job, file_job])
+        self._dashboards.append(dashboard)
+
     def add_table(self, table: TableInfo):
         self._tables.append(table)
 
@@ -563,6 +579,8 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
             renamed_group_prefix=f'tmp-{self.inventory_database}-',
             include_group_names=self.created_groups,
             include_databases=self.created_databases,
+            include_job_ids=self.created_jobs,
+            include_dashboard_ids=self.created_dashboards,
         )
 
     @cached_property
@@ -668,6 +686,22 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
         return created_groups
 
     @cached_property
+    def created_jobs(self) -> list[int]:
+        created_jobs = []
+        for job in self._jobs:
+            if job.job_id is not None:
+                created_jobs.append(job.job_id)
+        return created_jobs
+
+    @cached_property
+    def created_dashboards(self) -> list[str]:
+        created_dashboards = []
+        for dashboard in self._dashboards:
+            if dashboard.id is not None:
+                created_dashboards.append(dashboard.id)
+        return created_dashboards
+
+    @cached_property
     def azure_service_principal_crawler(self) -> StaticServicePrincipalCrawler:
         return StaticServicePrincipalCrawler(
             self._spn_infos,
@@ -704,7 +738,7 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
 
 
 @pytest.fixture
-def runtime_ctx(
+def runtime_ctx(  # pylint: disable=too-many-arguments
     ws,
     sql_backend,
     make_catalog,
@@ -712,6 +746,10 @@ def runtime_ctx(
     make_table,
     make_udf,
     make_group,
+    make_job,
+    make_notebook,
+    make_query,
+    make_dashboard,
     env_or_skip,
     make_random,
 ) -> MockRuntimeContext:
@@ -721,6 +759,10 @@ def runtime_ctx(
         make_table,
         make_udf,
         make_group,
+        make_job,
+        make_notebook,
+        make_query,
+        make_dashboard,
         env_or_skip,
         ws,
         make_random,
@@ -851,6 +893,10 @@ class MockInstallationContext(MockRuntimeContext):
         make_random_fixture,
         make_acc_group_fixture,
         make_user_fixture,
+        make_job_fixture,
+        make_notebook_fixture,
+        make_query_fixture,
+        make_dashboard_fixture,
         ws_fixture,
         watchdog_purge_suffix,
     ):
@@ -860,6 +906,10 @@ class MockInstallationContext(MockRuntimeContext):
             make_table_fixture,
             make_udf_fixture,
             make_group_fixture,
+            make_job_fixture,
+            make_notebook_fixture,
+            make_query_fixture,
+            make_dashboard_fixture,
             env_or_skip_fixture,
             ws_fixture,
             make_random_fixture,
@@ -950,6 +1000,8 @@ class MockInstallationContext(MockRuntimeContext):
             renamed_group_prefix=self.renamed_group_prefix,
             include_group_names=self.created_groups,
             include_databases=self.created_databases,
+            include_job_ids=self.created_jobs,
+            include_dashboard_ids=self.created_dashboards,
             include_object_permissions=self.include_object_permissions,
             warehouse_id=self._env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"),
             ucx_catalog=self.ucx_catalog,
@@ -1033,6 +1085,10 @@ def installation_ctx(  # pylint: disable=too-many-arguments
     make_random,
     make_acc_group,
     make_user,
+    make_job,
+    make_notebook,
+    make_query,
+    make_dashboard,
     watchdog_purge_suffix,
 ) -> Generator[MockInstallationContext, None, None]:
     ctx = MockInstallationContext(
@@ -1045,6 +1101,10 @@ def installation_ctx(  # pylint: disable=too-many-arguments
         make_random,
         make_acc_group,
         make_user,
+        make_job,
+        make_notebook,
+        make_query,
+        make_dashboard,
         ws,
         watchdog_purge_suffix,
     )
@@ -1253,71 +1313,3 @@ def pytest_ignore_collect(path):
     except ValueError as err:
         logger.debug(f"pytest_ignore_collect: error: {err}")
         return False
-
-
-@pytest.fixture
-def create_file_job(ws, make_random, watchdog_remove_after, watchdog_purge_suffix, log_workspace_link):
-
-    def create(installation, **_kwargs):
-        # create args
-        data = {"name": f"dummy-{make_random(4)}"}
-        # create file to run
-        file_name = f"dummy_{make_random(4)}_{watchdog_purge_suffix}"
-        file_path = WorkspacePath(ws, installation.install_folder()) / file_name
-        file_path.write_text("spark.read.parquet('dbfs://mnt/foo/bar')")
-        task = jobs.Task(
-            task_key=make_random(4),
-            description=make_random(4),
-            new_cluster=ClusterSpec(
-                num_workers=1,
-                node_type_id=ws.clusters.select_node_type(local_disk=True, min_memory_gb=16),
-                spark_version=ws.clusters.select_spark_version(latest=True),
-            ),
-            spark_python_task=SparkPythonTask(python_file=str(file_path)),
-            timeout_seconds=0,
-        )
-        data["tasks"] = [task]
-        # add RemoveAfter tag for job cleanup
-        data["tags"] = [{"key": "RemoveAfter", "value": watchdog_remove_after}]
-        job = ws.jobs.create(**data)
-        log_workspace_link(data["name"], f'job/{job.job_id}', anchor=False)
-        return job
-
-    yield from factory("job", create, lambda item: ws.jobs.delete(item.job_id))
-
-
-@pytest.fixture
-def populate_for_linting(
-    ws,
-    make_random,
-    make_job,
-    make_notebook,
-    make_query,
-    make_dashboard,
-    create_file_job,
-    watchdog_purge_suffix,
-):
-
-    def create_notebook_job(installation):
-        path = Path(installation.install_folder()) / f"dummy_{make_random(4)}_{watchdog_purge_suffix}"
-        notebook_text = "spark.read.parquet('dbfs://mnt/foo1/bar1')"
-        notebook_path = make_notebook(path=path, content=io.BytesIO(notebook_text.encode("utf-8")))
-        return make_job(notebook_path=notebook_path)
-
-    def populate_workspace(installation):
-        # keep linting scope to minimum to avoid test timeouts
-        file_job = create_file_job(installation=installation)
-        notebook_job = create_notebook_job(installation=installation)
-        query = make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
-        dashboard = make_dashboard(query=query)
-        # can't use installation.load(WorkspaceConfig)/installation.save() because they populate empty credentials
-        config_path = WorkspacePath(ws, installation.install_folder()) / "config.yml"
-        text = config_path.read_text()
-        config = yaml.safe_load(text)
-        config["include_job_ids"] = [file_job.job_id, notebook_job.job_id]
-        config["include_dashboard_ids"] = [dashboard.id]
-        text = yaml.dump(config)
-        config_path.unlink()
-        config_path.write_text(text)
-
-    return populate_workspace

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,7 @@ from databricks.labs.pytester.fixtures.baseline import factory
 from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
-from databricks.sdk.service import iam, jobs
+from databricks.sdk.service import iam
 from databricks.sdk.service.catalog import FunctionInfo, SchemaInfo, TableInfo
 from databricks.sdk.service.dashboards import Dashboard as SDKDashboard
 from databricks.sdk.service.iam import Group

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -9,12 +9,18 @@ from ..conftest import MockInstallationContext
 @retried(on=[NotFound, InvalidParameterValue], timeout=dt.timedelta(minutes=12))
 def test_running_real_migration_progress_job(installation_ctx: MockInstallationContext) -> None:
     """Ensure that the migration-progress workflow can complete successfully."""
+    # Limit the resources crawled by the assessment
+    source_schema = installation_ctx.make_schema()
+    installation_ctx.make_table(schema_name=source_schema.name)
+    installation_ctx.make_linting_resources()
+    installation_ctx.make_group()
+
     installation_ctx.workspace_installation.run()
 
     # The assessment workflow is a prerequisite for migration-progress: it needs to successfully complete before we can
     # test the migration-progress workflow.
     workflow = "assessment"
-    installation_ctx.deployed_workflows.run_workflow(workflow, max_wait=dt.timedelta(minutes=25))
+    installation_ctx.deployed_workflows.run_workflow(workflow)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     # After the assessment, a user (maybe) installs the progress tracking


### PR DESCRIPTION
## Changes
Scope resources to run the assessment workflow for in integration tests to shorten the time it takes for the assessment to run:

<img width="1582" alt="Screenshot 2024-10-04 at 17 45 52" src="https://github.com/user-attachments/assets/8ee12e89-1068-45f4-a5de-c2da121a6101">

- Move the populate for linting logic to the context
- Set the `include_job_ids` to the job ids created by the populate for linting logic
- Set the `include_dashboard_ids` to the dashboard ids created by the populate for linting logic
- Move the create job based on Python file fixture to [pytester](https://github.com/databrickslabs/pytester/pull/60)

### Linked issues

Resolves #2637
Resolves #2849

### Tests

- [x] modified integration tests: 
       - `test_running_real_assessment_job`
       - `test_running_real_assessment_job_ext_hms`
       - `test_running_real_migration_progress_job`
