### PR TITLE
Replace `greenlit` with unknown library in integration tests

### DIFF
--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -195,7 +195,7 @@ def test_workflow_linter_lints_job_with_import_pypi_library(simple_ctx, make_job
     simple_ctx = simple_ctx.replace(
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the project locally
     )
-    content = b"import pytest_asyncio"
+    content = "import pytest_asyncio"
     problem_message = "Could not locate import: pytest-asyncio"
     job_without_library = make_job(content=content)
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -192,18 +192,15 @@ display(spark.read.parquet("/mnt/something"))
 
 
 def test_workflow_linter_lints_job_with_import_pypi_library(simple_ctx, make_job) -> None:
-    simple_ctx = simple_ctx.replace(
-        path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the project locally
-    )
-    content = "import pytest_asyncio"
-    problem_message = "Could not locate import: pytest-asyncio"
+    content = "import dbt"
+    problem_message = "Could not locate import: dbt"
     job_without_library = make_job(content=content)
 
     problems, *_ = simple_ctx.workflow_linter.lint_job(job_without_library.job_id)
 
     assert len([problem for problem in problems if problem.message == problem_message]) == 1
 
-    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="pytest-asyncio"))
+    library = compute.Library(pypi=compute.PythonPyPiLibrary(package="dbt-core"))
     job_with_library = make_job(content=content, libraries=[library])
 
     problems, *_ = simple_ctx.workflow_linter.lint_job(job_with_library.job_id)

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -490,7 +490,7 @@ def test_job_spark_python_task_linter_unhappy_path(
     """The imported dependency is not defined."""
     entrypoint = make_directory()
 
-    make_notebook(path=f"{entrypoint}/notebook.py", content=b"import greenlet")
+    make_notebook(path=f"{entrypoint}/notebook.py", content=b"import foobar")
 
     new_cluster = make_cluster(single_node=True)
     task = jobs.Task(
@@ -504,7 +504,7 @@ def test_job_spark_python_task_linter_unhappy_path(
 
     problems, *_ = simple_ctx.workflow_linter.lint_job(j.job_id)
 
-    assert len([problem for problem in problems if problem.message == "Could not locate import: greenlet"]) == 1
+    assert len([problem for problem in problems if problem.message == "Could not locate import: foobar"]) == 1
 
 
 def test_workflow_linter_lints_python_wheel_task(simple_ctx, ws, make_job, make_random) -> None:

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -487,6 +487,7 @@ def test_job_spark_python_task_linter_unhappy_path(
     make_notebook,
     make_directory,
 ) -> None:
+    """The imported dependency is not defined."""
     entrypoint = make_directory()
 
     make_notebook(path=f"{entrypoint}/notebook.py", content=b"import greenlet")

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -464,30 +464,11 @@ def test_job_spark_python_task_linter_happy_path(
     assert len([problem for problem in problems if problem.message == "Could not locate import: greenlet"]) == 0
 
 
-def test_job_spark_python_task_linter_unhappy_path(
-    simple_ctx,
-    make_job,
-    make_random,
-    make_cluster,
-    make_notebook,
-    make_directory,
-) -> None:
+def test_job_spark_python_task_linter_unhappy_path(simple_ctx, make_job) -> None:
     """The imported dependency is not defined."""
-    entrypoint = make_directory()
+    job = make_job(content="import foobar", task_type=jobs.SparkPythonTask)
 
-    make_notebook(path=f"{entrypoint}/notebook.py", content=b"import foobar")
-
-    new_cluster = make_cluster(single_node=True)
-    task = jobs.Task(
-        task_key=make_random(4),
-        spark_python_task=jobs.SparkPythonTask(
-            python_file=f"{entrypoint}/notebook.py",
-        ),
-        existing_cluster_id=new_cluster.cluster_id,
-    )
-    j = make_job(tasks=[task])
-
-    problems, *_ = simple_ctx.workflow_linter.lint_job(j.job_id)
+    problems, *_ = simple_ctx.workflow_linter.lint_job(job.job_id)
 
     assert len([problem for problem in problems if problem.message == "Could not locate import: foobar"]) == 1
 


### PR DESCRIPTION
## Changes
`greenlit` library is added to the known list in #2830, thus not unknown anymore

### Linked issues
Resolves #2845
Resolves #2844

### Tests
- [x] modified integration tests: `test_job_spark_python_task_linter_unhappy_path`
