### PR TITLE
Update linter integration tests to ensure notebook source is linted

### DIFF
--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -34,10 +34,10 @@ from tests.unit.source_code.test_graph import _TestDependencyGraph
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
-def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_directory, make_job):
+def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_directory, make_job) -> None:
     # Deprecated file system path in call to: /mnt/things/e/f/g
     lint_problem = b"display(spark.read.csv('/mnt/things/e/f/g'))"
-    notebook = make_notebook(path=f"{make_directory()}/notebook.ipynb", content=lint_problem)
+    notebook = make_notebook(path=f"{make_directory()}/notebook.py", content=lint_problem)
     job = make_job(notebook_path=notebook)
     ctx = installation_ctx.replace(config_transform=lambda wc: replace(wc, include_job_ids=[job.job_id]))
     ctx.workspace_installation.run()
@@ -48,6 +48,8 @@ def test_running_real_workflow_linter_job(installation_ctx, make_notebook, make_
     if result['count'] == 0:
         installation_ctx.deployed_workflows.relay_logs("experimental-workflow-linter")
         assert False, "No workflow problems found"
+    dfsa_records = installation_ctx.directfs_access_crawler_for_paths.snapshot()
+    assert dfsa_records
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -88,7 +88,7 @@ def test_job_task_linter_library_not_installed_cluster(
     created_cluster = make_cluster(single_node=True)
     entrypoint = make_directory()
 
-    notebook = make_notebook(path=f"{entrypoint}/notebook.ipynb", content=b"import greenlet")
+    notebook = make_notebook(path=f"{entrypoint}/notebook.py", content=b"import greenlet")
 
     task = jobs.Task(
         task_key=make_random(4),
@@ -119,7 +119,7 @@ def test_job_task_linter_library_installed_cluster(
     libraries_api.install(created_cluster.cluster_id, [Library(pypi=PythonPyPiLibrary("greenlet"))])
     entrypoint = make_directory()
 
-    notebook = make_notebook(path=f"{entrypoint}/notebook.ipynb", content=b"import doesnotexist;import greenlet")
+    notebook = make_notebook(path=f"{entrypoint}/notebook.py", content=b"import doesnotexist;import greenlet")
 
     task = jobs.Task(
         task_key=make_random(4),
@@ -208,7 +208,7 @@ def test_workflow_linter_lints_job_with_import_pypi_library(
         path_lookup=PathLookup(Path("/non/existing/path"), []),  # Avoid finding the pytest you are running
     )
 
-    notebook = entrypoint / "notebook.ipynb"
+    notebook = entrypoint / "notebook.py"
     make_notebook(path=notebook, content=b"import greenlet")
 
     job_without_pytest_library = make_job(notebook_path=notebook)

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -40,15 +40,16 @@ def test_running_real_workflow_linter_job(installation_ctx, make_job) -> None:
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow("experimental-workflow-linter")
     ctx.deployed_workflows.validate_step("experimental-workflow-linter")
+
+    # This test merely tests that the workflows produces records of the expected types; record content is not checked.
     cursor = ctx.sql_backend.fetch(f"SELECT COUNT(*) AS count FROM {ctx.inventory_database}.workflow_problems")
     result = next(cursor)
     if result['count'] == 0:
         installation_ctx.deployed_workflows.relay_logs("experimental-workflow-linter")
         assert False, "No workflow problems found"
     dfsa_records = installation_ctx.directfs_access_crawler_for_paths.snapshot()
-    assert dfsa_records
     used_table_records = installation_ctx.used_tables_crawler_for_paths.snapshot()
-    assert used_table_records
+    assert dfsa_records and used_table_records
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -35,7 +35,7 @@ from tests.unit.source_code.test_graph import _TestDependencyGraph
 @retried(on=[NotFound], timeout=timedelta(minutes=5))
 def test_running_real_workflow_linter_job(installation_ctx, make_job) -> None:
     # Deprecated file system path in call to: /mnt/things/e/f/g
-    job = make_job(content=b"spark.read.table('a_table').write.csv('/mnt/things/e/f/g')")
+    job = make_job(content="spark.read.table('a_table').write.csv('/mnt/things/e/f/g')\n")
     ctx = installation_ctx.replace(config_transform=lambda wc: replace(wc, include_job_ids=[job.job_id]))
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow("experimental-workflow-linter")
@@ -57,7 +57,7 @@ def test_linter_from_context(simple_ctx, make_job) -> None:
     # This code is similar to test_running_real_workflow_linter_job, but it's executed on the caller side and is easier
     # to debug.
     # Ensure we have at least 1 job that fails
-    job = make_job(content=b"import xyz")
+    job = make_job(content="import xyz")
     simple_ctx.config.include_job_ids = [job.job_id]
     simple_ctx.workflow_linter.refresh_report(simple_ctx.sql_backend, simple_ctx.inventory_database)
 
@@ -77,7 +77,7 @@ def test_job_linter_no_problems(simple_ctx, make_job) -> None:
 
 
 def test_job_task_linter_library_not_installed_cluster(simple_ctx, make_job) -> None:
-    job = make_job(content=b"import library_not_found")
+    job = make_job(content="import library_not_found\n")
 
     problems, *_ = simple_ctx.workflow_linter.lint_job(job.job_id)
 

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -53,7 +53,7 @@ def test_running_real_workflow_linter_job(installation_ctx, make_job) -> None:
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_linter_from_context(simple_ctx, make_job):
+def test_linter_from_context(simple_ctx, make_job) -> None:
     # This code is similar to test_running_real_workflow_linter_job, but it's executed on the caller side and is easier
     # to debug.
     # Ensure we have at least 1 job that fails


### PR DESCRIPTION
## Changes

This PR updates some linting related integration tests that weren't testing what they expected:

 - The tests were intending to verify linting of notebooks, and set up a notebook with code to trigger a linting record.
 - The linting code was failing prematurely due to the notebook extension, not due to the problem in source.

Some usage of `greenlet` has also been replaced: it was previously unknown to the linter and various integration tests assumed this. Since #2830 these tests have no longer been working correctly.

### Related Issues

Overlaps with #2852.
Overlaps with #2867.
Overlaps with #2868.
Resolves #2843.
Resolves #2844.
Resolves #2845.
Resolves #2846.

### Tests

- [X] updated integration tests
