### PR TITLE
Unit test updates: workspace client fixture (`ws`)

### DIFF
--- a/tests/integration/workspace_access/test_permissions_manager.py
+++ b/tests/integration/workspace_access/test_permissions_manager.py
@@ -5,7 +5,7 @@ from databricks.labs.ucx.workspace_access.groups import MigrationState
 from databricks.labs.ucx.workspace_access.manager import PermissionManager
 
 
-def test_permissions_snapshot(ws, sql_backend, inventory_schema):
+def test_permissions_snapshot(sql_backend, inventory_schema):
     class StubbedCrawler(AclSupport):
         def get_crawler_tasks(self) -> Iterable[Callable[..., Permissions | None]]:
             yield lambda: Permissions(object_id="abc", object_type="bcd", raw="def")

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -165,6 +165,8 @@ def mock_workspace_client(
     ws.current_user.me.side_effect = lambda: iam.User(
         user_name="me@example.com", groups=[iam.ComplexValue(display="admins")]
     )
+    ws.api_client.do.return_value = {}
+    ws.permissions.get.return_value = {}
     ws.clusters.list.return_value = _id_list(ClusterDetails, cluster_ids)
     ws.cluster_policies.list.return_value = _id_list(Policy, policy_ids)
     ws.cluster_policies.get = _cluster_policy

--- a/tests/unit/account/test_aggregate.py
+++ b/tests/unit/account/test_aggregate.py
@@ -1,9 +1,7 @@
 import logging
-from unittest.mock import create_autospec
 
 import pytest
-from databricks.sdk import AccountClient, Workspace, WorkspaceClient
-from databricks.sdk.service import iam
+from databricks.sdk import AccountClient, Workspace
 from databricks.labs.lsql.backends import MockBackend
 
 from databricks.labs.ucx.account.aggregate import AccountAggregate
@@ -17,19 +15,8 @@ UCX_TABLES = MockBackend.rows("catalog", "database", "table", "object_type", "ta
 
 
 @pytest.fixture
-def ws() -> WorkspaceClient:
-    workspace_client = create_autospec(WorkspaceClient)
-    workspace_client.current_user.me.return_value = iam.User(
-        user_name="user",
-        groups=[iam.ComplexValue(display="admins")],
-    )
-    workspace_client.get_workspace_id.return_value = 123
-    return workspace_client
-
-
-@pytest.fixture
 def account_client(ws, acc_client) -> AccountClient:
-    workspace = Workspace(workspace_name="test", workspace_id=123)
+    workspace = Workspace(workspace_name="test", workspace_id=ws.get_workspace_id())
     acc_client.workspaces.list.return_value = [workspace]
     acc_client.get_workspace_client.return_value = ws
     return acc_client

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,11 +12,13 @@ from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.tables import FasterTableScanCrawler
 from databricks.labs.ucx.source_code.graph import BaseNotebookResolver
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
-from databricks.sdk import WorkspaceClient, AccountClient
+from databricks.sdk import AccountClient
 from databricks.sdk.config import Config
 
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
+
+from . import mock_workspace_client
 
 pytest.register_assert_rewrite('databricks.labs.blueprint.installation')
 
@@ -120,7 +122,7 @@ def spark_table_crawl_mocker(mocker):
 
 
 @pytest.fixture
-def run_workflow(mocker, mock_installation, spark_table_crawl_mocker):
+def run_workflow(mocker, mock_installation, ws, spark_table_crawl_mocker):
     def inner(cb, **replace) -> RuntimeContext:
         with _lock, patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.0"}):
             pyspark_sql_session = mocker.Mock()
@@ -128,9 +130,6 @@ def run_workflow(mocker, mock_installation, spark_table_crawl_mocker):
             if 'installation' not in replace:
                 replace['installation'] = mock_installation
             if 'workspace_client' not in replace:
-                ws = create_autospec(WorkspaceClient)
-                ws.api_client.do.return_value = {}
-                ws.permissions.get.return_value = {}
                 replace['workspace_client'] = ws
             if 'sql_backend' not in replace:
                 replace['sql_backend'] = MockBackend()
@@ -197,3 +196,8 @@ def mock_notebook_resolver():
 @pytest.fixture
 def mock_backend() -> MockBackend:
     return MockBackend()
+
+
+@pytest.fixture
+def ws():
+    return mock_workspace_client()

--- a/tests/unit/hive_metastore/test_migrate_acls.py
+++ b/tests/unit/hive_metastore/test_migrate_acls.py
@@ -2,7 +2,6 @@ import logging
 from unittest.mock import create_autospec
 import pytest
 from databricks.labs.lsql.backends import SqlBackend
-from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.account.workspaces import WorkspaceInfo
 from databricks.labs.ucx.hive_metastore.grants import MigrateGrants, ACLMigrator, Grant
@@ -14,13 +13,6 @@ from databricks.labs.ucx.hive_metastore.tables import TablesCrawler, Table
 from databricks.labs.ucx.workspace_access.groups import GroupManager, MigratedGroup
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def ws():
-    client = create_autospec(WorkspaceClient)
-    client.get_workspace_id.return_value = "12345"
-    return client
 
 
 @pytest.fixture

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -38,13 +38,6 @@ from .. import mock_table_mapping, mock_workspace_client
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def ws():
-    client = create_autospec(WorkspaceClient)
-    client.get_workspace_id.return_value = "12345"
-    return client
-
-
 def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     errors = {}
     rows = {r"SYNC .*": MockBackend.rows("status_code", "description")[("SUCCESS", "test")]}
@@ -79,7 +72,7 @@ def test_migrate_dbfs_root_tables_should_produce_proper_queries(ws):
     assert (
         f"ALTER TABLE `ucx_default`.`db1_dst`.`managed_dbfs` "
         f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '123');"
     ) in backend.queries
     assert (
         "SYNC TABLE `ucx_default`.`db1_dst`.`managed_other` FROM `hive_metastore`.`db1_src`.`managed_other`;"
@@ -127,7 +120,7 @@ def test_dbfs_non_delta_tables_should_produce_proper_queries(ws):
     assert (
         f"ALTER TABLE `ucx_default`.`db1_dst`.`managed_dbfs` "
         f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , "
-        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+        f"'{Table.UPGRADED_FROM_WS_PARAM}' = '123');"
     ) in backend.queries
 
 
@@ -179,7 +172,7 @@ def test_migrate_external_tables_should_produce_proper_queries(ws):
         (
             f"ALTER TABLE `ucx_default`.`db1_dst`.`external_dst` "
             f"SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.external_src' , "
-            f"'{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+            f"'{Table.UPGRADED_FROM_WS_PARAM}' = '123');"
         ),
     ]
 
@@ -467,7 +460,7 @@ def test_migrate_view_should_produce_proper_queries(ws):
     assert create in backend.queries
     src = "ALTER VIEW `hive_metastore`.`db1_src`.`view_src` SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.view_dst');"
     assert src in backend.queries
-    dst = f"ALTER VIEW `ucx_default`.`db1_dst`.`view_dst` SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.view_src' , '{Table.UPGRADED_FROM_WS_PARAM}' = '12345');"
+    dst = f"ALTER VIEW `ucx_default`.`db1_dst`.`view_dst` SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.view_src' , '{Table.UPGRADED_FROM_WS_PARAM}' = '123');"
     assert dst in backend.queries
     migrate_grants.apply.assert_called()
 
@@ -960,7 +953,7 @@ def test_migrate_acls_should_produce_proper_queries(ws, caplog):
         'CREATE TABLE IF NOT EXISTS `ucx_default`.`db1_dst`.`managed_dbfs` DEEP CLONE `hive_metastore`.`db1_src`.`managed_dbfs`;',
         "ALTER TABLE `hive_metastore`.`db1_src`.`managed_dbfs` SET TBLPROPERTIES ('upgraded_to' = 'ucx_default.db1_dst.managed_dbfs');",
         "COMMENT ON TABLE `hive_metastore`.`db1_src`.`managed_dbfs` IS 'This table is deprecated. Please use `ucx_default.db1_dst.managed_dbfs` instead of `hive_metastore.db1_src.managed_dbfs`.';",
-        "ALTER TABLE `ucx_default`.`db1_dst`.`managed_dbfs` SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , 'upgraded_from_workspace_id' = '12345');",
+        "ALTER TABLE `ucx_default`.`db1_dst`.`managed_dbfs` SET TBLPROPERTIES ('upgraded_from' = 'hive_metastore.db1_src.managed_dbfs' , 'upgraded_from_workspace_id' = '123');",
     ]
 
 

--- a/tests/unit/recon/test_migration_recon.py
+++ b/tests/unit/recon/test_migration_recon.py
@@ -1,8 +1,4 @@
-from unittest.mock import create_autospec
-
-import pytest
 from databricks.labs.lsql.backends import MockBackend
-from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
@@ -13,13 +9,6 @@ from databricks.labs.ucx.recon.metadata_retriever import DatabricksTableMetadata
 from databricks.labs.ucx.recon.migration_recon import MigrationRecon
 from databricks.labs.ucx.recon.schema_comparator import StandardSchemaComparator
 from tests.unit import mock_table_mapping
-
-
-@pytest.fixture
-def ws():
-    client = create_autospec(WorkspaceClient)
-    client.get_workspace_id.return_value = "12345"
-    return client
 
 
 MIGRATION_STATUS = MockBackend.rows(

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -65,7 +65,6 @@ def test_join_collection_join_collection_account_admin():
 
 def test_join_collection_join_collection_account_admin_workspace_id_not_collection_workspace_admin():
     ws = mock_workspace_client()
-    ws.current_user.me = lambda: iam.User(user_name="me@example.com")
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_client.workspaces.list.side_effect = [
@@ -139,7 +138,7 @@ def test_join_collection_join_existing_collection():
 
 def test_get_workspaces_context_not_collection_admin(caplog):
     ws = mock_workspace_client()
-    ws.current_user.me = lambda: iam.User(user_name="me@example.com")
+    ws.current_user.me.side_effect = lambda: iam.User(user_name="not-admin@example.com")
     account_client = create_autospec(AccountClient)
     account_client.get_workspace_client.return_value = ws
     account_installer = AccountInstaller(account_client)


### PR DESCRIPTION
## Changes

This PR introduces a `ws` fixture for the unit tests, and refactors some of the existing unit tests that were using their own custom fixtures.

We now have an upstream dependency (`pytester`) that provides a fixture of the same name, but it is intended for use with integration tests. Without `ws` as part of the local `conftest.py` for unit tests it is easy to inadvertently inject the upstream fixture (which doesn't work as intended.)

### Tests

- updated unit tests
