### PR TITLE
Fix known matches false postives for libraries starting with the same name as a library in the known.json

### DIFF
--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -91,14 +91,9 @@ class KnownList:
     def module_compatibility(self, name: str) -> Compatibility:
         if not name:
             return UNKNOWN
-        # Find exact matches.
         for module, problems in self._module_problems.items():
-            if name != module:
-                continue
-            return Compatibility(True, problems)
-        # Find parent module matches.
-        for module, problems in self._module_problems.items():
-            if not name.startswith(module + "."):
+            # Find exact matches OR parent module matches
+            if not (name == module or name.startswith(module + ".")):
                 continue
             return Compatibility(True, problems)
         return UNKNOWN

--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -91,8 +91,14 @@ class KnownList:
     def module_compatibility(self, name: str) -> Compatibility:
         if not name:
             return UNKNOWN
+        # Find exact matches.
         for module, problems in self._module_problems.items():
-            if not name.startswith(module):
+            if name != module:
+                continue
+            return Compatibility(True, problems)
+        # Find parent module matches.
+        for module, problems in self._module_problems.items():
+            if not name.startswith(module + "."):
                 continue
             return Compatibility(True, problems)
         return UNKNOWN

--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -93,6 +93,7 @@ class KnownList:
             return UNKNOWN
         for module, problems in self._module_problems.items():
             # Find exact matches OR parent module matches
+            # Note sorting when constructing module problems from known.json
             if not (name == module or name.startswith(module + ".")):
                 continue
             return Compatibility(True, problems)

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,14 +44,14 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
-@pytest.mark.parametrize("library", ["pytest", "pytest-cov", "pytest-mock"])
+@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock"])
 def test_known_compatibility(library) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)
     assert compatibility.known
 
 
-@pytest.mark.parametrize("library", ["pytest-asyncio"])
+@pytest.mark.parametrize("library", ["pytest_asyncio"])
 def test_unknown_compatibility(library: str) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,7 +44,9 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
-@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock", "_pytest", "_pytest.mark", "_pytest.mark.expression"])
+@pytest.mark.parametrize(
+    "library", ["pytest", "pytest_cov", "pytest_mock", "_pytest", "_pytest.mark", "_pytest.mark.expression"]
+)
 def test_known_compatibility(library) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,14 +44,14 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
-@pytest.mark.parametrize("library", ["pytest"])
+@pytest.mark.parametrize("library", ["pytest", "pytest-cov", "pytest-mock"])
 def test_known_compatibility(library) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)
     assert compatibility.known
 
 
-@pytest.mark.parametrize("library", ["pytest_plugin"])
+@pytest.mark.parametrize("library", ["pytest-asyncio"])
 def test_unknown_compatibility(library: str) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,7 +44,7 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
-@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock", "_pytest", "_pytest.mark"])
+@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock", "_pytest", "_pytest.mark", "_pytest.mark.expression"])
 def test_known_compatibility(library) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,6 +44,20 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
+@pytest.mark.parametrize("library", ["pytest"])
+def test_known_compatibility(library) -> None:
+    known = KnownList()
+    compatibility = known.module_compatibility(library)
+    assert compatibility.known
+
+
+@pytest.mark.parametrize("library", ["pytest_plugin"])
+def test_unknown_compatibility(library: str) -> None:
+    known = KnownList()
+    compatibility = known.module_compatibility(library)
+    assert not compatibility.known
+
+
 def test_loads_known_json():
     known_json = KnownList._get_known()  # pylint: disable=protected-access
     assert known_json is not None and len(known_json) > 0

--- a/tests/unit/source_code/test_known.py
+++ b/tests/unit/source_code/test_known.py
@@ -44,7 +44,7 @@ def test_checks_library_compatibility():
     assert not other.problems
 
 
-@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock"])
+@pytest.mark.parametrize("library", ["pytest", "pytest_cov", "pytest_mock", "_pytest", "_pytest.mark"])
 def test_known_compatibility(library) -> None:
     known = KnownList()
     compatibility = known.module_compatibility(library)


### PR DESCRIPTION
## Changes
Fix known matches false postives for libraries starting with the same name as a library in the known.json by looking for exact matches or parent module matches

### Linked issues
Resolves #2859

### Functionality

- [ ] modified linting related code

### Tests

- [ ] added unit tests
