### PR TITLE
Upgrade minimum required version of `pytester`: 0.2.1 → 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "pylint~=3.3.1",
     "pylint-pytest==2.0.0a0",
     "databricks-labs-pylint~=0.5",
-    "databricks-labs-pytester>=0.2.1",
+    "databricks-labs-pytester>=0.3.0",
     "pytest~=8.3.3",
     "pytest-cov~=4.1.0",
     "pytest-mock~=3.14.0",


### PR DESCRIPTION
## Changes

This PR updates the minimum required version of `pytester` from 0.2.1 to 0.3.0. As of #2852 our integration tests depends on changes introduced in databrickslabs/pytester#60 (and released with 0.3.0).