### PR TITLE
Populate data for used-tables widget in assessment dashboard

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -559,12 +559,18 @@ class MockRuntimeContext(
 
     def make_linting_resources(self) -> None:
         """Make resources to lint."""
-        notebook_job = self._make_job(content="spark.read.parquet('dbfs://mnt/notebook/')")
-        file_job = self._make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
-        query = self._make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
-        dashboard = self._make_dashboard(query=query)
-        self._jobs.extend([notebook_job, file_job])
-        self._dashboards.append(dashboard)
+        notebook_job_1 = self._make_job(content="spark.read.parquet('dbfs://mnt/notebook/')")
+        notebook_job_2 = self._make_job(content="spark.table('old.stuff')")
+        file_job_1 = self._make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
+        file_job_2 = self._make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
+        query_1 = self._make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
+        dashboard_1 = self._make_dashboard(query=query_1)
+        query_2 = self._make_query(sql_query='SELECT * from my_schema.my_table')
+        dashboard_2 = self._make_dashboard(query=query_2)
+
+        self._jobs.extend([notebook_job_1, notebook_job_2, file_job_1, file_job_2])
+        self._dashboards.append(dashboard_1)
+        self._dashboards.append(dashboard_2)
 
     def add_table(self, table: TableInfo):
         self._tables.append(table)


### PR DESCRIPTION

## Changes
Our current implementation only generates DFSA records.
This PR implements samples that generate regular legacy tables that will be displayed in the used-tables wdget

### Linked issues
None

### Functionality
None

### Tests
- [x] updated integration tests
