### PR TITLE
Handle `PermissionDenied` when retrieving `WorkspaceClient`s from account

### DIFF
--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -51,8 +51,12 @@ class AccountWorkspaces:
             workspaces = self.get_accessible_workspaces()
         clients = []
         for workspace in workspaces:
-            ws = self.client_for(workspace)
-            clients.append(ws)
+            try:
+                ws = self.client_for(workspace)
+            except PermissionDenied as e:
+                logger.warning(f"Cannot get a workspace client for: {workspace.deployment_name}", exc_info=e)
+            else:
+                clients.append(ws)
         return clients
 
     def sync_workspace_info(self, workspaces: list[Workspace] | None = None):

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -549,3 +549,17 @@ def test_account_workspaces_can_administer_handles_permission_denied_error_for_c
         can_administer = account_workspaces.can_administer(workspace)
     assert not can_administer
     assert "User cannot access workspace: test" in caplog.messages
+
+
+def test_account_workspaces_workspace_clients_handles_permission_denied() -> None:
+    acc = create_autospec(AccountClient)
+    acc.get_workspace_client.side_effect = PermissionDenied
+    account_workspaces = AccountWorkspaces(acc)
+
+    try:
+        clients = account_workspaces.workspace_clients([Workspace()])
+    except PermissionDenied:
+        assert False, "Workspace clients does not handle `PermissionDenied`"
+    else:
+        assert len(clients) == 0
+

--- a/tests/unit/account/test_workspaces.py
+++ b/tests/unit/account/test_workspaces.py
@@ -551,15 +551,16 @@ def test_account_workspaces_can_administer_handles_permission_denied_error_for_c
     assert "User cannot access workspace: test" in caplog.messages
 
 
-def test_account_workspaces_workspace_clients_handles_permission_denied() -> None:
+def test_account_workspaces_workspace_clients_handles_permission_denied(caplog) -> None:
     acc = create_autospec(AccountClient)
     acc.get_workspace_client.side_effect = PermissionDenied
     account_workspaces = AccountWorkspaces(acc)
 
     try:
-        clients = account_workspaces.workspace_clients([Workspace()])
+        with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.account.workspaces"):
+            clients = account_workspaces.workspace_clients([Workspace(deployment_name="test")])
     except PermissionDenied:
         assert False, "Workspace clients does not handle `PermissionDenied`"
     else:
         assert len(clients) == 0
-
+        assert "Cannot get a workspace client for: test" in caplog.messages


### PR DESCRIPTION
## Changes
Handle `PermissionDenied` when retrieving `WorkspaceClient`s from account

### Linked issues
Resolves #2874

### Functionality

- [x] modified existing command: `databricks labs ucx sync-workspace-info`

### Tests

- [x] added unit tests
