### PR TITLE
Tech debt: fix situations where `next()` isn't being used properly

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -139,7 +139,7 @@ class DbutilsPyLinter(PythonLinter):
     def get_dbutils_notebook_run_path_arg(node: Call):
         if len(node.args) > 0:
             return node.args[0]
-        arg = next(kw for kw in node.keywords if kw.arg == "path")
+        arg = next((kw for kw in node.keywords if kw.arg == "path"), None)
         return arg.value if arg is not None else None
 
     @staticmethod

--- a/src/databricks/labs/ucx/source_code/notebooks/cells.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/cells.py
@@ -289,9 +289,11 @@ class CellLanguage(Enum):
 
     @classmethod
     def of_language(cls, language: Language) -> CellLanguage:
-        # TODO: Should this not raise a ValueError if the language is not found?
-        #  It also  causes a GeneratorExit exception to be raised. Maybe an explicit loop is better.
-        return next((cl for cl in CellLanguage if cl.language == language))
+        for cell_language in CellLanguage:
+            if cell_language.language == language:
+                return cell_language
+        msg = f"Unsupported cell language: {language}"
+        raise ValueError(msg)
 
     @classmethod
     def of_magic_name(cls, magic_name: str) -> CellLanguage | None:

--- a/src/databricks/labs/ucx/source_code/path_lookup.py
+++ b/src/databricks/labs/ucx/source_code/path_lookup.py
@@ -87,9 +87,6 @@ class PathLookup:
             and any(subfolder.name.lower() == "egg-info" for subfolder in path.iterdir())
         )
 
-    def has_path(self, path: Path):
-        return next(p for p in self._sys_paths if path == p) is not None
-
     def prepend_path(self, path: Path):
         self._sys_paths.insert(0, path)
 

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -1028,7 +1028,7 @@ def test_migrate_views_should_be_properly_sequenced(ws):
     table_keys = [task.args[0].src.key for task in tasks]
     assert table_keys.index("hive_metastore.db1_src.v1_src") > table_keys.index("hive_metastore.db1_src.v3_src")
     assert table_keys.index("hive_metastore.db1_src.v3_src") > table_keys.index("hive_metastore.db1_src.v2_src")
-    assert next((key for key in table_keys if key == "hive_metastore.db1_src.t1_src"), None) is None
+    assert not any(key for key in table_keys if key == "hive_metastore.db1_src.t1_src")
 
 
 def test_table_in_mount_mapping_with_table_owner():


### PR DESCRIPTION
## Changes

This PR updates/fixes the way Python's builtin [`next()`](https://docs.python.org/3/library/functions.html#next) function is used. Specifically, in a few places the code assumed that `None` will be returned if there is no next value but this is incorrect.
