### PR TITLE
Improve logging when skipping grant a in `create-catalogs-schemas`

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -77,7 +77,9 @@ class CatalogSchema:
         for grant in grants:
             acl_migrate_sql = grant.uc_grant_sql()
             if acl_migrate_sql is None:
-                logger.warning(f"Cannot identify UC grant for {grant.this_type_and_key()}. Skipping.")
+                logger.warning(
+                    f"Skipping legacy grant that is not supported in UC: {grant.action_type} on {grant.this_type_and_key()}"
+                )
                 continue
             logger.debug(f"Migrating acls on {grant.this_type_and_key()} using SQL query: {acl_migrate_sql}")
             self._backend.execute(acl_migrate_sql)

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -106,7 +106,7 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
         Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
         Grant('user1', 'SELECT', 'catalog2', 'schema3', 'table2'),
         Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
-        Grant('user1', 'USAGE', 'hive_metastore', 'schema2'),
+        Grant('user1', 'DENY', 'hive_metastore', 'schema2'),
     ]
     hive_grants = [
         Grant(principal="princ1", catalog="hive_metastore", action_type="USE"),
@@ -244,7 +244,7 @@ def test_no_catalog_storage():
     ws.catalogs.create.assert_has_calls(calls, any_order=True)
 
 
-def test_catalog_schema_acl():
+def test_catalog_schema_acl() -> None:
     ws = create_autospec(WorkspaceClient)
     backend = MockBackend()
     mock_prompts = MockPrompts({"Please provide storage location url for catalog: *": ""})
@@ -260,10 +260,7 @@ def test_catalog_schema_acl():
     ws.schemas.create.assert_any_call("schema2", "catalog2", comment="Created by UCX")
     queries = [
         'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `user1`',
-        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema2` TO `user1`',
-        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema3` TO `user1`',
         'GRANT USE CATALOG ON CATALOG `catalog1` TO `user1`',
-        'GRANT USE CATALOG ON CATALOG `catalog2` TO `user1`',
         'GRANT USE CATALOG ON CATALOG `catalog1` TO `princ2`',
         'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `princ2`',
         'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema2` TO `princ5`',

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -287,3 +287,4 @@ def test_create_all_catalogs_schemas_logs_untranslatable_grant(caplog) -> None:
     assert (
         "Skipping legacy grant that is not supported in UC: DENY on ('DATABASE', 'catalog2.schema3')" in caplog.messages
     )
+    ws.assert_not_called()


### PR DESCRIPTION
Improve logging when skipping grant a in `create-catalogs-schemas`