### PR TITLE
Fixed absolute path normalisation in source code analysis

### DIFF
--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -41,6 +41,7 @@ class NotebookLoader(DependencyLoader, abc.ABC):
         return None."""
         # check current working directory first
         absolute_path = path_lookup.cwd / path
+        absolute_path = absolute_path.resolve()
         if is_a_notebook(absolute_path):
             return absolute_path
         # When exported through Git, notebooks are saved with a .py extension. So check with and without extension

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -28,14 +28,18 @@ def test_malformed_pip_cell_is_supported(simple_ctx):
     assert not problems
 
 
-def test_relative_grand_parent_path_is_supported(simple_ctx, make_notebook, make_directory, make_random, watchdog_purge_suffix):
+def test_relative_grand_parent_path_is_supported(
+    simple_ctx, make_notebook, make_directory, make_random, watchdog_purge_suffix
+):
     grand_parent = make_notebook()
     top_dir = make_directory()
-    child_dir = make_directory(path = f"~/{top_dir.name}/dummy-{make_random(4)}-{watchdog_purge_suffix}")
-    source=f"""
+    child_dir = make_directory(path=f"~/{top_dir.name}/dummy-{make_random(4)}-{watchdog_purge_suffix}")
+    source = f"""
 %run ../../{grand_parent.name}
 """
-    notebook_path = make_notebook(path=f"{child_dir.as_posix()}/dummy-{make_random(4)}-{watchdog_purge_suffix}", content=source.encode("utf-8"))
+    notebook_path = make_notebook(
+        path=f"{child_dir.as_posix()}/dummy-{make_random(4)}-{watchdog_purge_suffix}", content=source.encode("utf-8")
+    )
     dependency = Dependency(NotebookLoader(), notebook_path)
     root = DependencyGraph(
         dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -36,6 +36,7 @@ def test_relative_grand_parent_path_is_supported(
     child_dir = make_directory(path=f"~/{top_dir.name}/dummy-{make_random(4)}-{watchdog_purge_suffix}")
     source = f"""
 %run ../../{grand_parent.name}
+
 """
     notebook_path = make_notebook(
         path=f"{child_dir.as_posix()}/dummy-{make_random(4)}-{watchdog_purge_suffix}", content=source.encode("utf-8")

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -5,6 +5,7 @@ from databricks.sdk.service.workspace import Language
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph
 from databricks.labs.ucx.source_code.linters.files import FileLoader
+from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader
 from databricks.labs.ucx.source_code.notebooks.sources import Notebook
 
 
@@ -24,4 +25,21 @@ def test_malformed_pip_cell_is_supported(simple_ctx):
         dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()
     )
     problems = notebook.build_dependency_graph(parent)
+    assert not problems
+
+
+def test_relative_grand_parent_path_is_supported(simple_ctx, make_notebook, make_directory, make_random, watchdog_purge_suffix):
+    grand_parent = make_notebook()
+    top_dir = make_directory()
+    child_dir = make_directory(path = f"~/{top_dir.name}/dummy-{make_random(4)}-{watchdog_purge_suffix}")
+    source=f"""
+%run ../../{grand_parent.name}
+"""
+    notebook_path = make_notebook(path=f"{child_dir.as_posix()}/dummy-{make_random(4)}-{watchdog_purge_suffix}", content=source.encode("utf-8"))
+    dependency = Dependency(NotebookLoader(), notebook_path)
+    root = DependencyGraph(
+        dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()
+    )
+    container = dependency.load(simple_ctx.path_lookup)
+    problems = container.build_dependency_graph(root)
     assert not problems


### PR DESCRIPTION
## Changes
Workspace API does not support relative subpaths such as "/a/b/../c".
This PR fixes the issue by resolving workspace paths before calling the API.

### Linked issues
Resolves #2882 
Requires #https://github.com/databrickslabs/blueprint/pull/156
Requires #https://github.com/databrickslabs/blueprint/pull/157

### Functionality
None

### Tests
- [x] added integration tests
