### PR TITLE
Improve logging when skipping legacy grant in `create-catalogs-schemas`

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -61,7 +61,7 @@ class CatalogSchema:
         self._apply_from_legacy_table_acls()
         self._update_principal_acl()
 
-    def _apply_from_legacy_table_acls(self):
+    def _apply_from_legacy_table_acls(self) -> None:
         grants = self._get_catalog_schema_hive_grants()
         for grant in grants:
             acl_migrate_sql = grant.uc_grant_sql()
@@ -73,8 +73,7 @@ class CatalogSchema:
             logger.debug(f"Migrating acls on {grant.this_type_and_key()} using SQL query: {acl_migrate_sql}")
             self._backend.execute(acl_migrate_sql)
 
-    def _update_principal_acl(self):
-
+    def _update_principal_acl(self) -> None:
         grants = self._get_catalog_schema_principal_acl_grants()
         for grant in grants:
             acl_migrate_sql = grant.uc_grant_sql()

--- a/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
+++ b/src/databricks/labs/ucx/hive_metastore/catalog_schema.py
@@ -66,7 +66,9 @@ class CatalogSchema:
         for grant in grants:
             acl_migrate_sql = grant.uc_grant_sql()
             if acl_migrate_sql is None:
-                logger.warning(f"Cannot identify UC grant for {grant.this_type_and_key()}. Skipping.")
+                logger.warning(
+                    f"Skipping legacy grant that is not supported in UC: {grant.action_type} on {grant.this_type_and_key()}"
+                )
                 continue
             logger.debug(f"Migrating acls on {grant.this_type_and_key()} using SQL query: {acl_migrate_sql}")
             self._backend.execute(acl_migrate_sql)

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -119,6 +119,7 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
             view="table_one",
             action_type="SELECT",
         ),
+        Grant(principal="user4", catalog="hive_metastore", database="schema3", action_type="DENY"),
         Grant(
             principal="user5",
             catalog="hive_metastore",
@@ -280,6 +281,9 @@ def test_create_all_catalogs_schemas_logs_untranslatable_grant(caplog) -> None:
 
     with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.hive_metastore.catalog_schema"):
         catalog_schema.create_all_catalogs_schemas(mock_prompts)
+    assert (
+        "Skipping legacy grant that is not supported in UC: DENY on ('DATABASE', 'catalog1.schema3')" in caplog.messages
+    )
     assert "Skipping legacy grant that is not supported in UC: DENY on ('CATALOG', 'catalog2')" in caplog.messages
     assert (
         "Skipping legacy grant that is not supported in UC: DENY on ('DATABASE', 'catalog2.schema2')" in caplog.messages

--- a/tests/unit/hive_metastore/test_catalog_schema.py
+++ b/tests/unit/hive_metastore/test_catalog_schema.py
@@ -100,32 +100,32 @@ def prepare_test(ws, backend: MockBackend | None = None) -> CatalogSchema:
     )
     table_mapping = TableMapping(installation, ws, backend)
     principal_acl = create_autospec(PrincipalACL)
-    hive_acl = create_autospec(GrantsCrawler)
-    grants = [
-        Grant('user1', 'SELECT', 'catalog1', 'schema3', 'table'),
-        Grant('user1', 'MODIFY', 'catalog2', 'schema2', 'table'),
-        Grant('user1', 'SELECT', 'catalog2', 'schema3', 'table2'),
-        Grant('user1', 'USAGE', 'hive_metastore', 'schema3'),
-        Grant('user1', 'DENY', 'hive_metastore', 'schema2'),
+    interactive_cluster_grants = [
+        Grant('princ1', 'SELECT', 'catalog1', 'schema3', 'table'),
+        Grant('princ1', 'MODIFY', 'catalog2', 'schema2', 'table'),
+        Grant('princ1', 'SELECT', 'catalog2', 'schema3', 'table2'),
+        Grant('princ1', 'USAGE', 'hive_metastore', 'schema3'),
+        Grant('princ1', 'DENY', 'hive_metastore', 'schema2'),
     ]
+    principal_acl.get_interactive_cluster_grants.return_value = interactive_cluster_grants
+    hive_acl = create_autospec(GrantsCrawler)
     hive_grants = [
-        Grant(principal="princ1", catalog="hive_metastore", action_type="USE"),
-        Grant(principal="princ2", catalog="hive_metastore", database="schema3", action_type="USAGE"),
+        Grant(principal="user1", catalog="hive_metastore", action_type="USE"),
+        Grant(principal="user2", catalog="hive_metastore", database="schema3", action_type="USAGE"),
         Grant(
-            principal="princ33",
+            principal="user3",
             catalog="hive_metastore",
             database="database_one",
             view="table_one",
             action_type="SELECT",
         ),
         Grant(
-            principal="princ5",
+            principal="user5",
             catalog="hive_metastore",
             database="schema2",
             action_type="USAGE",
         ),
     ]
-    principal_acl.get_interactive_cluster_grants.return_value = grants
     hive_acl.snapshot.return_value = hive_grants
 
     return CatalogSchema(ws, table_mapping, principal_acl, backend, hive_acl, "ucx")
@@ -259,13 +259,13 @@ def test_catalog_schema_acl() -> None:
     ws.catalogs.create.assert_has_calls(calls, any_order=True)
     ws.schemas.create.assert_any_call("schema2", "catalog2", comment="Created by UCX")
     queries = [
-        'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `user1`',
-        'GRANT USE CATALOG ON CATALOG `catalog1` TO `user1`',
-        'GRANT USE CATALOG ON CATALOG `catalog1` TO `princ2`',
-        'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `princ2`',
-        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema2` TO `princ5`',
-        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema3` TO `princ5`',
-        'GRANT USE CATALOG ON CATALOG `catalog2` TO `princ5`',
+        'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `princ1`',
+        'GRANT USE CATALOG ON CATALOG `catalog1` TO `princ1`',
+        'GRANT USE CATALOG ON CATALOG `catalog1` TO `user2`',
+        'GRANT USE SCHEMA ON DATABASE `catalog1`.`schema3` TO `user2`',
+        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema2` TO `user5`',
+        'GRANT USE SCHEMA ON DATABASE `catalog2`.`schema3` TO `user5`',
+        'GRANT USE CATALOG ON CATALOG `catalog2` TO `user5`',
     ]
     assert len(backend.queries) == len(queries)
     for query in queries:


### PR DESCRIPTION
Improve logging when skipping legacy grant in `create-catalogs-schemas`

Follow up on #2917
Progresses #2932