### PR TITLE
Revert workaround for #2887

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -262,14 +262,14 @@ class TableCollector(ABC):
 
 
 @dataclass
-class TableInfoNode:
+class UsedTableNode:
     table: UsedTable
     node: NodeNG
 
 
 class TablePyCollector(TableCollector, ABC):
 
-    def collect_tables(self, source_code: str):
+    def collect_tables(self, source_code: str) -> Iterable[UsedTable]:
         try:
             tree = Tree.normalize_and_parse(source_code)
             for table_node in self.collect_tables_from_tree(tree):
@@ -282,7 +282,7 @@ class TablePyCollector(TableCollector, ABC):
             logger.warning('syntax-error', exc_info=e)
 
     @abstractmethod
-    def collect_tables_from_tree(self, tree: Tree) -> Iterable[TableInfoNode]: ...
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]: ...
 
 
 class TableSqlCollector(TableCollector, ABC): ...
@@ -467,7 +467,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
         except AstroidSyntaxError as e:
             logger.warning('syntax-error', exc_info=e)
 
-    def collect_tables_from_tree(self, tree: Tree) -> Iterable[TableInfoNode]:
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]:
         for collector in self._table_collectors:
             yield from collector.collect_tables_from_tree(tree)
 

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -273,11 +273,7 @@ class TablePyCollector(TableCollector, ABC):
         try:
             tree = Tree.normalize_and_parse(source_code)
             for table_node in self.collect_tables_from_tree(tree):
-                # see https://github.com/databrickslabs/ucx/issues/2887
-                if isinstance(table_node, UsedTable):
-                    yield table_node
-                else:
-                    yield table_node.table
+                yield table_node.table
         except AstroidSyntaxError as e:
             logger.warning('syntax-error', exc_info=e)
 
@@ -458,12 +454,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
         try:
             tree = self._parse_and_append(source_code)
             for table_node in self.collect_tables_from_tree(tree):
-                # there's a bug in the code that causes this to be necessary
-                # see https://github.com/databrickslabs/ucx/issues/2887
-                if isinstance(table_node, UsedTable):
-                    yield table_node
-                else:
-                    yield table_node.table
+                yield table_node.table
         except AstroidSyntaxError as e:
             logger.warning('syntax-error', exc_info=e)
 

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -15,7 +15,7 @@ from databricks.labs.ucx.source_code.base import (
     SqlLinter,
     Fixer,
     UsedTable,
-    TableInfoNode,
+    UsedTableNode,
     TablePyCollector,
     TableSqlCollector,
     DfsaPyCollector,
@@ -388,14 +388,14 @@ class SparkTableNamePyLinter(PythonLinter, Fixer, TablePyCollector):
             return None
         return matcher if matcher.matches(node) else None
 
-    def collect_tables_from_tree(self, tree: Tree) -> Iterable[TableInfoNode]:
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]:
         for node in tree.walk():
             matcher = self._find_matcher(node)
             if matcher is None:
                 continue
             assert isinstance(node, Call)
             for used_table in matcher.collect_tables(self._from_table, self._index, self._session_state, node):
-                yield TableInfoNode(used_table, node)  # B
+                yield UsedTableNode(used_table, node)
 
 
 class _SparkSqlAnalyzer:
@@ -468,11 +468,11 @@ class SparkSqlTablePyCollector(_SparkSqlAnalyzer, TablePyCollector):
     def __init__(self, sql_collector: TableSqlCollector):
         self._sql_collector = sql_collector
 
-    def collect_tables_from_tree(self, tree: Tree) -> Iterable[TableInfoNode]:
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]:
         assert self._sql_collector
         for call_node, query in self._visit_call_nodes(tree):
             for value in InferredValue.infer_from_node(query):
                 if not value.is_inferred():
                     continue  # TODO error handling strategy
                 for table in self._sql_collector.collect_tables(value.as_string()):
-                    yield TableInfoNode(table, call_node)  # A
+                    yield UsedTableNode(table, call_node)  # A

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -475,4 +475,4 @@ class SparkSqlTablePyCollector(_SparkSqlAnalyzer, TablePyCollector):
                 if not value.is_inferred():
                     continue  # TODO error handling strategy
                 for table in self._sql_collector.collect_tables(value.as_string()):
-                    yield UsedTableNode(table, call_node)  # A
+                    yield UsedTableNode(table, call_node)

--- a/tests/unit/source_code/samples/functional/table-access.py
+++ b/tests/unit/source_code/samples/functional/table-access.py
@@ -1,0 +1,11 @@
+# Databricks notebook source
+# ucx[default-format-changed-in-dbr8:+1:0:+1:18] The default format changed in Databricks Runtime 8.0, from Parquet to Delta
+spark.table("a.b").count()
+spark.sql("SELECT * FROM b.c LEFT JOIN c.d USING (e)")
+%sql SELECT * FROM b.c LEFT JOIN c.d USING (e)
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC SELECT * FROM b.c LEFT JOIN c.d USING (e)
+

--- a/tests/unit/source_code/samples/functional/table-access.sql
+++ b/tests/unit/source_code/samples/functional/table-access.sql
@@ -1,0 +1,12 @@
+-- Databricks notebook source
+
+SELECT * FROM b.c LEFT JOIN c.d USING (e)
+
+-- COMMAND ----------
+
+-- MAGIC %python
+-- ucx[default-format-changed-in-dbr8:+1:0:+1:18] The default format changed in Databricks Runtime 8.0, from Parquet to Delta
+-- MAGIC spark.table("a.b").count()
+-- MAGIC spark.sql("SELECT * FROM b.c LEFT JOIN c.d USING (e)")
+
+


### PR DESCRIPTION
## Changes
PR #2895 introduced a workaround for #2887, although the issue was not reproduced.

Careful analysis shows that this workaround is not necessary.

Tests were added recently in `test_context.py`.

Running the above tests against v0.39 reproduces the issue:
![Screenshot 2024-10-11 at 12 51 05](https://github.com/user-attachments/assets/66bb546d-7987-41cf-bdd9-e23fc9f2c40e)

However, running the above tests against v0.40 and above does not reproduce the issue:
![Screenshot 2024-10-11 at 12 53 42](https://github.com/user-attachments/assets/72649f40-cf40-448a-87cf-d69fd765bbf5)

The issue was already fixed in `pyspark.py` by PR #2841 and it is likely that the bug reporter was running v0.39

This PR:
 - rolls back the workaround from #2895
 - renames TableInfoNode to UsedTableNode for clarity
 
### Linked issues
#2887 

### Functionality
None

### Tests
- [x] manually tested
