### PR TITLE
Set UsedTable.is_read/is_write for spark calls

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -236,7 +236,7 @@ class SourceInfo:
 class UsedTable(SourceInfo):
 
     @classmethod
-    def parse(cls, value: str, default_schema: str) -> UsedTable:
+    def parse(cls, value: str, default_schema: str, is_read=True, is_write=False) -> UsedTable:
         parts = value.split(".")
         if len(parts) >= 3:
             catalog_name = parts.pop(0)
@@ -246,7 +246,9 @@ class UsedTable(SourceInfo):
             schema_name = parts.pop(0)
         else:
             schema_name = default_schema
-        return UsedTable(catalog_name=catalog_name, schema_name=schema_name, table_name=parts[0])
+        return UsedTable(
+            catalog_name=catalog_name, schema_name=schema_name, table_name=parts[0], is_read=is_read, is_write=is_write
+        )
 
     catalog_name: str = SourceInfo.UNKNOWN
     schema_name: str = SourceInfo.UNKNOWN

--- a/tests/unit/source_code/test_context.py
+++ b/tests/unit/source_code/test_context.py
@@ -10,7 +10,7 @@ from databricks.labs.ucx.source_code.linters.context import LinterContext
         ('spark.table("a.b").count()', {'r:a.b'}),
         ('spark.getTable("a.b")', {'r:a.b'}),
         ('spark.cacheTable("a.b")', {'r:a.b'}),
-        ('spark.range(10).saveAsTable("a.b")', {'r:a.b'}),  # TODO: bug: has to be w:a.b
+        ('spark.range(10).saveAsTable("a.b")', {'w:a.b'}),
         ('spark.sql("SELECT * FROM b.c LEFT JOIN c.d USING (e)")', {'r:b.c', 'r:c.d'}),
         ('spark.sql("SELECT * FROM delta.`/foo/bar`")', set()),
     ],


### PR DESCRIPTION
## Changes
Current code does not populate `is_read` or `is_write` for spark calls.
This PR fixes the issue.

### Linked issues
Resolves #2893 

### Functionality
None

### Tests
- [x] updated unit tests
