### PR TITLE
Added DBFS Root resolution when HMS Federation is enabled

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -294,7 +294,12 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def mounts_crawler(self) -> MountsCrawler:
-        return MountsCrawler(self.sql_backend, self.workspace_client, self.inventory_database, self.config.enable_hms_federation,)
+        return MountsCrawler(
+            self.sql_backend,
+            self.workspace_client,
+            self.inventory_database,
+            self.config.enable_hms_federation,
+        )
 
     @cached_property
     def azure_service_principal_crawler(self) -> AzureServicePrincipalCrawler:

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -294,7 +294,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def mounts_crawler(self) -> MountsCrawler:
-        return MountsCrawler(self.sql_backend, self.workspace_client, self.inventory_database)
+        return MountsCrawler(self.sql_backend, self.workspace_client, self.inventory_database, self.config.enable_hms_federation,)
 
     @cached_property
     def azure_service_principal_crawler(self) -> AzureServicePrincipalCrawler:

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -346,7 +346,13 @@ class Mount:
 
 
 class MountsCrawler(CrawlerBase[Mount]):
-    def __init__(self, backend: SqlBackend, ws: WorkspaceClient, inventory_database: str, enable_hms_federation: bool = False,):
+    def __init__(
+        self,
+        backend: SqlBackend,
+        ws: WorkspaceClient,
+        inventory_database: str,
+        enable_hms_federation: bool = False,
+    ):
         super().__init__(backend, "hive_metastore", inventory_database, "mounts", Mount)
         self._dbutils = ws.dbutils
         self._enable_hms_federation = enable_hms_federation

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -25,7 +25,6 @@ def test_running_real_assessment_job(
         config_transform=lambda wc: dataclasses.replace(
             wc,
             include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
-            # enable_hms_federation=True, for debugging
         ),
     )
 

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -25,6 +25,7 @@ def test_running_real_assessment_job(
         config_transform=lambda wc: dataclasses.replace(
             wc,
             include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
+            # enable_hms_federation=True, for debugging
         ),
     )
 


### PR DESCRIPTION
This PR adds a DBFS Resolver which is used by HMS federation to resolve the DBFS root locations.

TODO:

- [x] https://github.com/databrickslabs/ucx/pull/2954
- [x] resolve special `/user/hive/metastore` as special case of DBFS mount
- [x] use `LocationTrie` to come guess locations - https://github.com/databrickslabs/ucx/pull/2965

co-authored by @vihangk-db 