### PR TITLE
Dependency update: ensure we install with at least version 0.9.1 of `databricks-labs-blueprint`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 
 dependencies = ["databricks-sdk~=0.30",
                 "databricks-labs-lsql>=0.5,<0.13",
-                "databricks-labs-blueprint>=0.8,<0.10",
+                "databricks-labs-blueprint>=0.9.1,<0.10",
                 "PyYAML>=6.0.0,<7.0.0",
                 "sqlglot>=25.5.0,<25.25",
                 "astroid>=3.3.1"]


### PR DESCRIPTION
## Changes

In #2920 we introduced a change to ensure that notebook paths are normalised, resolving #2882. This change depended on an upstream fix (databrickslabs/blueprint#157) included in the 0.9.1 release of the dependency. This PR ensures that we run against that release or later.