### PR TITLE
Make `ExternalLocations` explicitly depend on `TablesCrawler` and `MountsCrawler`

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -29,7 +29,7 @@ from databricks.labs.ucx.assessment.export import AssessmentExporter
 from databricks.labs.ucx.aws.credentials import CredentialManager
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.framework.owners import AdministratorLocator
-from databricks.labs.ucx.hive_metastore import ExternalLocations, Mounts, TablesCrawler
+from databricks.labs.ucx.hive_metastore import ExternalLocations, MountsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.catalog_schema import CatalogSchema
 from databricks.labs.ucx.hive_metastore.grants import (
     ACLMigrator,
@@ -260,6 +260,7 @@ class GlobalContext(abc.ABC):
             self.table_mapping,
             self.migration_status_refresher,
             self.migrate_grants,
+            self.external_locations,
         )
 
     @cached_property
@@ -292,8 +293,8 @@ class GlobalContext(abc.ABC):
         return TableMove(self.workspace_client, self.sql_backend)
 
     @cached_property
-    def mounts_crawler(self) -> Mounts:
-        return Mounts(self.sql_backend, self.workspace_client, self.inventory_database)
+    def mounts_crawler(self) -> MountsCrawler:
+        return MountsCrawler(self.sql_backend, self.workspace_client, self.inventory_database)
 
     @cached_property
     def azure_service_principal_crawler(self) -> AzureServicePrincipalCrawler:
@@ -301,7 +302,13 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def external_locations(self) -> ExternalLocations:
-        return ExternalLocations(self.workspace_client, self.sql_backend, self.inventory_database)
+        return ExternalLocations(
+            self.workspace_client,
+            self.sql_backend,
+            self.inventory_database,
+            self.tables_crawler,
+            self.mounts_crawler,
+        )
 
     @cached_property
     def azure_acl(self) -> AzureACL:
@@ -338,7 +345,7 @@ class GlobalContext(abc.ABC):
             self.sql_backend,
             self.installation,
             self.tables_crawler,
-            self.mounts_crawler,
+            self.external_locations,
             self.principal_locations_retriever,
         )
 

--- a/src/databricks/labs/ucx/hive_metastore/__init__.py
+++ b/src/databricks/labs/ucx/hive_metastore/__init__.py
@@ -1,8 +1,8 @@
 from databricks.labs.ucx.hive_metastore.locations import (
     ExternalLocations,
-    Mounts,
+    MountsCrawler,
     TablesInMounts,
 )
 from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
 
-__all__ = ["TablesCrawler", "Mounts", "ExternalLocations", "TablesInMounts"]
+__all__ = ["TablesCrawler", "MountsCrawler", "ExternalLocations", "TablesInMounts"]

--- a/src/databricks/labs/ucx/hive_metastore/locations.py
+++ b/src/databricks/labs/ucx/hive_metastore/locations.py
@@ -153,10 +153,11 @@ class ExternalLocations(CrawlerBase[ExternalLocation]):
         if not location:
             return None
         for mount in self._mounts_snapshot:
-            prefix = mount.as_scheme_prefix()
-            if location.startswith(prefix):
+            for prefix in (mount.as_scheme_prefix(), mount.as_fuse_prefix()):
+                if not location.startswith(prefix):
+                    continue
                 logger.debug(f"Replacing location {prefix} with {mount.source} in {location}")
-                location.replace(prefix, mount.source)
+                location = location.replace(prefix, mount.source)
                 return location
         logger.debug(f"Mount not found for location {location}. Skipping replacement.")
         return location
@@ -313,6 +314,9 @@ class Mount:
 
     def as_scheme_prefix(self) -> str:
         return f'dbfs:{self.name}'  # dbfs:/mnt/mount-name
+
+    def as_fuse_prefix(self) -> str:
+        return f'/dbfs{self.name}'  # /dbfs/mnt/mount-name
 
 
 class MountsCrawler(CrawlerBase[Mount]):

--- a/src/databricks/labs/ucx/hive_metastore/workflows.py
+++ b/src/databricks/labs/ucx/hive_metastore/workflows.py
@@ -60,7 +60,6 @@ class MigrateHiveSerdeTablesInPlace(Workflow):
         the Hive Metastore to the Unity Catalog."""
         ctx.tables_migrator.migrate_tables(
             what=What.EXTERNAL_HIVESERDE,
-            mounts_crawler=ctx.mounts_crawler,
             hiveserde_in_place_migrate=True,
         )
 
@@ -89,7 +88,6 @@ class MigrateExternalTablesCTAS(Workflow):
         """This workflow task migrates non-SYNC supported and non HiveSerde external tables using CTAS"""
         ctx.tables_migrator.migrate_tables(
             what=What.EXTERNAL_NO_SYNC,
-            mounts_crawler=ctx.mounts_crawler,
         )
 
     @job_task(job_cluster="table_migration", depends_on=[Assessment.crawl_tables])
@@ -97,7 +95,6 @@ class MigrateExternalTablesCTAS(Workflow):
         """This workflow task migrates HiveSerde tables using CTAS"""
         ctx.tables_migrator.migrate_tables(
             what=What.EXTERNAL_HIVESERDE,
-            mounts_crawler=ctx.mounts_crawler,
         )
 
     @job_task(

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -12,7 +12,6 @@ from databricks.labs.ucx.assessment.aws import AWSInstanceProfile, AWSResources,
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.aws.locations import AWSExternalLocationsMigration
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.hive_metastore import ExternalLocations
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 
 
@@ -31,12 +30,11 @@ def test_create_external_location(ws, env_or_skip, make_random, inventory_schema
     account_id = aws.validate_connection().get("Account")
     s3_prefixes = {f"s3://bucket{rand}"}
 
-    external_location = ExternalLocations(ws, sql_backend, inventory_schema)
     aws_permissions = AWSResourcePermissions(
         aws_cli_ctx.installation,
         ws,
         aws,
-        external_location,
+        aws_cli_ctx.external_locations,
         account_id,
     )
     role_candidate = AWSUCRoleCandidate(role_name, policy_name, list(s3_prefixes))
@@ -51,7 +49,7 @@ def test_create_external_location(ws, env_or_skip, make_random, inventory_schema
 
     external_location_migration = AWSExternalLocationsMigration(
         ws,
-        external_location,
+        aws_cli_ctx.external_locations,
         aws_permissions,
         aws_cli_ctx.principal_acl,
     )
@@ -109,8 +107,6 @@ def test_create_external_location_validate_acl(
     ws,
     make_user,
     make_cluster,
-    make_random,
-    sql_backend,
     aws_cli_ctx,
     env_or_skip,
     inventory_schema,
@@ -136,18 +132,17 @@ def test_create_external_location_validate_acl(
         permission_level=PermissionLevel.CAN_RESTART,
         user_name=cluster_user.user_name,
     )
-    external_location = ExternalLocations(ws, sql_backend, inventory_schema)
     account_id = aws_cli_ctx.aws.validate_connection().get("Account")
     aws_permissions = AWSResourcePermissions(
         aws_cli_ctx.installation,
         ws,
         aws_cli_ctx.aws,
-        external_location,
+        aws_cli_ctx.external_locations,
         account_id,
     )
     external_location_migration = AWSExternalLocationsMigration(
         ws,
-        external_location,
+        aws_cli_ctx.external_locations,
         aws_permissions,
         aws_cli_ctx.principal_acl,
     )

--- a/tests/integration/aws/test_credentials.py
+++ b/tests/integration/aws/test_credentials.py
@@ -29,7 +29,14 @@ def run_migration(ws, sql_backend, env_or_skip, aws_cli_ctx):
         )
 
         aws = AWSResources(env_or_skip("AWS_DEFAULT_PROFILE"))
-        location = ExternalLocations(ws, sql_backend, "inventory_schema")
+        # TODO: refactor this to a more readable code
+        location = ExternalLocations(
+            ws,
+            sql_backend,
+            "inventory_schema",
+            aws_cli_ctx.tables_crawler,
+            aws_cli_ctx.mounts_crawler,
+        )
         resource_permissions = AWSResourcePermissions(
             installation,
             ws,

--- a/tests/integration/azure/test_credentials.py
+++ b/tests/integration/azure/test_credentials.py
@@ -19,7 +19,8 @@ from databricks.labs.ucx.azure.credentials import (
     StorageCredentialValidationResult,
 )
 from databricks.labs.ucx.azure.resources import AccessConnector, AzureAPIClient, AzureResource, AzureResources
-from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, ExternalLocations
+from databricks.labs.ucx.hive_metastore import TablesCrawler
+from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, ExternalLocations, MountsCrawler
 from tests.integration.conftest import StaticServicePrincipalCrawler
 
 
@@ -79,7 +80,10 @@ def run_migration(sql_backend, inventory_schema, env_or_skip):
 
         external_location = ExternalLocation(f"{env_or_skip('TEST_MOUNT_CONTAINER')}/folder1", 1)
         sql_backend.save_table(f"{inventory_schema}.external_locations", [external_location], ExternalLocation)
-        locations = ExternalLocations(ws, sql_backend, inventory_schema)
+        # TODO: refactor this to a more readable code
+        tables_crawler = TablesCrawler(sql_backend, inventory_schema)
+        mounts_crawler = MountsCrawler(sql_backend, ws, inventory_schema)
+        locations = ExternalLocations(ws, sql_backend, inventory_schema, tables_crawler, mounts_crawler)
 
         installation = MockInstallation(
             {

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -12,7 +12,6 @@ from databricks.sdk.service.catalog import SecurableType, PermissionsChange, Pri
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AccessConnector, AzureAPIClient, AzureResource, AzureResources
-from databricks.labs.ucx.hive_metastore import ExternalLocations
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 from ..conftest import get_azure_spark_conf
 
@@ -37,7 +36,6 @@ def test_run(caplog, ws, sql_backend, inventory_schema, az_cli_ctx):
         ExternalLocation("abfss://ucx2@ziyuanqintest.dfs.core.windows.net/", 2),
     ]
     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
-    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
 
     installation = MockInstallation(
         {
@@ -66,10 +64,10 @@ def test_run(caplog, ws, sql_backend, inventory_schema, az_cli_ctx):
     )
     graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
     azurerm = AzureResources(azure_mgmt_client, graph_client)
-    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, az_cli_ctx.external_locations)
     location_migration = ExternalLocationsMigration(
         ws,
-        location_crawler,
+        az_cli_ctx.external_locations,
         azure_resource_permissions,
         azurerm,
         az_cli_ctx.principal_acl,
@@ -90,7 +88,6 @@ def test_run(caplog, ws, sql_backend, inventory_schema, az_cli_ctx):
 def test_read_only_location(caplog, ws, sql_backend, inventory_schema, az_cli_ctx):
     locations = [ExternalLocation("abfss://ucx1@ziyuanqintest.dfs.core.windows.net/", 1)]
     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
-    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
 
     installation = MockInstallation(
         {
@@ -112,11 +109,11 @@ def test_read_only_location(caplog, ws, sql_backend, inventory_schema, az_cli_ct
     )
     graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
     azurerm = AzureResources(azure_mgmt_client, graph_client)
-    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, az_cli_ctx.external_locations)
 
     location_migration = ExternalLocationsMigration(
         ws,
-        location_crawler,
+        az_cli_ctx.external_locations,
         azure_resource_permissions,
         azurerm,
         az_cli_ctx.principal_acl,
@@ -136,7 +133,6 @@ def test_missing_credential(caplog, ws, sql_backend, inventory_schema, az_cli_ct
         ExternalLocation("abfss://ucx3@ziyuanqintest.dfs.core.windows.net/two", 2),
     ]
     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
-    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
 
     installation = MockInstallation(
         {
@@ -158,10 +154,10 @@ def test_missing_credential(caplog, ws, sql_backend, inventory_schema, az_cli_ct
     )
     graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
     azurerm = AzureResources(azure_mgmt_client, graph_client)
-    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, az_cli_ctx.external_locations)
     location_migration = ExternalLocationsMigration(
         ws,
-        location_crawler,
+        az_cli_ctx.external_locations,
         azure_resource_permissions,
         azurerm,
         az_cli_ctx.principal_acl,
@@ -184,7 +180,6 @@ def test_overlapping_location(caplog, ws, sql_backend, inventory_schema, az_cli_
 
     locations = [ExternalLocation("abfss://uctest@ziyuanqintest.dfs.core.windows.net/", 1)]
     sql_backend.save_table(f"{inventory_schema}.external_locations", locations, ExternalLocation)
-    location_crawler = ExternalLocations(ws, sql_backend, inventory_schema)
 
     installation = MockInstallation(
         {
@@ -206,10 +201,10 @@ def test_overlapping_location(caplog, ws, sql_backend, inventory_schema, az_cli_
     )
     graph_client = AzureAPIClient("https://graph.microsoft.com", "https://graph.microsoft.com")
     azurerm = AzureResources(azure_mgmt_client, graph_client)
-    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, location_crawler)
+    azure_resource_permissions = AzureResourcePermissions(installation, ws, azurerm, az_cli_ctx.external_locations)
     location_migration = ExternalLocationsMigration(
         ws,
-        location_crawler,
+        az_cli_ctx.external_locations,
         azure_resource_permissions,
         azurerm,
         az_cli_ctx.principal_acl,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,7 @@ from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import Grant
-from databricks.labs.ucx.hive_metastore.locations import Mount, Mounts, ExternalLocation, ExternalLocations
+from databricks.labs.ucx.hive_metastore.locations import Mount, MountsCrawler, ExternalLocation, ExternalLocations
 from databricks.labs.ucx.hive_metastore.mapping import Rule, TableMapping
 from databricks.labs.ucx.hive_metastore.tables import Table
 from databricks.labs.ucx.install import WorkspaceInstallation, WorkspaceInstaller, AccountInstaller
@@ -357,7 +357,7 @@ class StaticServicePrincipalCrawler(AzureServicePrincipalCrawler):
         return self._spn_infos
 
 
-class StaticMountCrawler(Mounts):
+class StaticMountCrawler(MountsCrawler):
     def __init__(
         self,
         mounts: list[Mount],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -873,7 +873,11 @@ def aws_cli_ctx(installation_ctx, env_or_skip):
             installation_ctx.workspace_client,
             AWSResources(aws_profile()),
             ExternalLocations(
-                installation_ctx.workspace_client, installation_ctx.sql_backend, installation_ctx.inventory_database
+                installation_ctx.workspace_client,
+                installation_ctx.sql_backend,
+                installation_ctx.inventory_database,
+                installation_ctx.tables_crawler,
+                installation_ctx.mounts_crawler,
             ),
         )
 

--- a/tests/integration/hive_metastore/test_federation.py
+++ b/tests/integration/hive_metastore/test_federation.py
@@ -4,7 +4,7 @@ import pytest
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.account.workspaces import WorkspaceInfo
-from databricks.labs.ucx.hive_metastore import ExternalLocations
+from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler, MountsCrawler
 from databricks.labs.ucx.hive_metastore.federation import HiveMetastoreFederation
 
 
@@ -16,7 +16,9 @@ def ws():
 @pytest.mark.skip("needs to be enabled")
 def test_federation(ws, sql_backend):
     schema = 'ucx'
-    external_locations = ExternalLocations(ws, sql_backend, schema)
+    tables_crawler = TablesCrawler(sql_backend, schema)
+    mounts_crawler = MountsCrawler(sql_backend, ws, schema)
+    external_locations = ExternalLocations(ws, sql_backend, schema, tables_crawler, mounts_crawler)
     workspace_info = create_autospec(WorkspaceInfo)
     workspace_info.current.return_value = 'some_thing'
     federation = HiveMetastoreFederation(ws, external_locations, workspace_info)

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -278,7 +278,13 @@ def test_migrate_external_table_failed_sync(caplog, runtime_ctx, env_or_skip) ->
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_external_table_hiveserde_in_place(
-    ws, sql_backend, make_random, runtime_ctx, make_storage_dir, env_or_skip, make_catalog
+    ws,
+    sql_backend,
+    make_random,
+    runtime_ctx,
+    make_storage_dir,
+    env_or_skip,
+    make_catalog,
 ):
     random = make_random(4).lower()
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore", name=f"hiveserde_in_place_{random}")
@@ -296,9 +302,7 @@ def test_migrate_external_table_hiveserde_in_place(
     runtime_ctx.with_table_mapping_rules(rules)
     runtime_ctx.with_dummy_resource_permission()
 
-    runtime_ctx.tables_migrator.migrate_tables(
-        what=What.EXTERNAL_HIVESERDE, mounts_crawler=runtime_ctx.mounts_crawler, hiveserde_in_place_migrate=True
-    )
+    runtime_ctx.tables_migrator.migrate_tables(what=What.EXTERNAL_HIVESERDE, hiveserde_in_place_migrate=True)
 
     # assert results
     for src_table in src_tables.values():
@@ -315,7 +319,13 @@ def test_migrate_external_table_hiveserde_in_place(
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_migrate_external_table_hiveserde_ctas(
-    ws, sql_backend, make_random, runtime_ctx, make_storage_dir, env_or_skip, make_catalog
+    ws,
+    sql_backend,
+    make_random,
+    runtime_ctx,
+    make_storage_dir,
+    env_or_skip,
+    make_catalog,
 ):
     random = make_random(4).lower()
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore", name=f"hiveserde_ctas_{random}")
@@ -333,9 +343,7 @@ def test_migrate_external_table_hiveserde_ctas(
     runtime_ctx.with_table_mapping_rules(rules)
     runtime_ctx.with_dummy_resource_permission()
 
-    runtime_ctx.tables_migrator.migrate_tables(
-        what=What.EXTERNAL_HIVESERDE, mounts_crawler=runtime_ctx.mounts_crawler, hiveserde_in_place_migrate=False
-    )
+    runtime_ctx.tables_migrator.migrate_tables(what=What.EXTERNAL_HIVESERDE, hiveserde_in_place_migrate=False)
 
     # assert results
     for src_table in src_tables.values():

--- a/tests/unit/assessment/test_workflows.py
+++ b/tests/unit/assessment/test_workflows.py
@@ -57,7 +57,7 @@ def test_runtime_mounts(run_workflow):
 
 def test_guess_external_locations(run_workflow):
     ctx = run_workflow(Assessment.guess_external_locations)
-    assert "SELECT * FROM `hive_metastore`.`ucx`.`mounts`" in ctx.sql_backend.queries
+    assert "SELECT * FROM `hive_metastore`.`ucx`.`external_locations`" in ctx.sql_backend.queries
 
 
 def test_assess_jobs(run_workflow):

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -110,6 +110,7 @@ def backend():
 
 @pytest.fixture
 def locations(mock_ws, backend):
+    # pylint: disable=mock-no-usage
     tables_crawler = create_autospec(TablesCrawler)
     mounts_crawler = create_autospec(MountsCrawler)
     return ExternalLocations(mock_ws, backend, "ucx", tables_crawler, mounts_crawler)
@@ -217,6 +218,7 @@ def test_create_uber_principal_existing_role_in_policy(mock_ws, mock_installatio
     aws.validate_connection.return_value = {}
     aws.get_instance_profile_arn.return_value = instance_profile_arn
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"We have identified existing UCX migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
@@ -246,6 +248,7 @@ def test_create_uber_principal_existing_role(mock_ws, mock_installation, backend
     aws = create_autospec(AWSResources)
     aws.get_instance_profile_arn.return_value = instance_profile_arn
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     prompts = MockPrompts(
         {
             "There is an existing instance profile *": "yes",
@@ -286,6 +289,7 @@ def test_create_uber_principal_no_existing_role(mock_ws, mock_installation, back
     aws.create_instance_profile.return_value = instance_profile_arn
     aws.get_instance_profile_arn.return_value = instance_profile_arn
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
@@ -334,6 +338,7 @@ def test_failed_create_uber_principal(mock_ws, mock_installation, backend, locat
     aws = AWSResources("profile", command_call)
 
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
@@ -371,6 +376,7 @@ def test_create_uber_principal_set_warehouse_config_security_policy(
     aws.get_instance_profile_arn.return_value = instance_profile_arn
 
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
@@ -388,6 +394,7 @@ def test_create_uber_principal_no_storage(mock_ws, mock_installation, locations)
     )
     mock_ws.cluster_policies.get.return_value = cluster_policy
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     prompts = MockPrompts({})
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(
@@ -443,6 +450,7 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
 
 def test_create_uc_no_roles(installation_no_roles, mock_ws, caplog):
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(
         installation_no_roles,
@@ -929,6 +937,7 @@ def test_delete_role(mock_ws, installation_no_roles, backend, mocker):
 
     aws = AWSResources("profile", command_call)
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     resource_permissions = AWSResourcePermissions(installation_no_roles, mock_ws, aws, external_locations)
     resource_permissions.delete_uc_role("uc_role_1")
     assert '/path/aws iam delete-role --role-name uc_role_1 --profile profile --output json' in command_calls

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -27,9 +27,9 @@ from databricks.labs.ucx.assessment.aws import AWSPolicyAction, AWSResources, AW
 from databricks.labs.ucx.aws.access import AWSResourcePermissions
 from databricks.labs.ucx.aws.credentials import IamRoleCreation
 from databricks.labs.ucx.aws.locations import AWSExternalLocationsMigration
-from databricks.labs.ucx.hive_metastore import ExternalLocations
+from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import PrincipalACL
-from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
+from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, MountsCrawler
 from tests.unit import DEFAULT_CONFIG
 
 
@@ -110,7 +110,9 @@ def backend():
 
 @pytest.fixture
 def locations(mock_ws, backend):
-    return ExternalLocations(mock_ws, backend, "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    return ExternalLocations(mock_ws, backend, "ucx", tables_crawler, mounts_crawler)
 
 
 def test_create_external_locations(mock_ws, installation_multiple_roles, backend, locations):
@@ -214,13 +216,13 @@ def test_create_uber_principal_existing_role_in_policy(mock_ws, mock_installatio
     aws = create_autospec(AWSResources)
     aws.validate_connection.return_value = {}
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    locations = ExternalLocations(mock_ws, backend, "ucx")
+    external_locations = create_autospec(ExternalLocations)
     prompts = MockPrompts({"We have identified existing UCX migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        locations,
+        external_locations,
     )
     aws_resource_permissions.create_uber_principal(prompts)
     aws.put_role_policy.assert_called_with(
@@ -243,7 +245,7 @@ def test_create_uber_principal_existing_role(mock_ws, mock_installation, backend
     instance_profile_arn = "arn:aws:iam::12345:instance-profile/role1"
     aws = create_autospec(AWSResources)
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    locations = ExternalLocations(mock_ws, backend, "ucx")
+    external_locations = create_autospec(ExternalLocations)
     prompts = MockPrompts(
         {
             "There is an existing instance profile *": "yes",
@@ -254,7 +256,7 @@ def test_create_uber_principal_existing_role(mock_ws, mock_installation, backend
         mock_installation,
         mock_ws,
         aws,
-        locations,
+        external_locations,
     )
     aws_resource_permissions.create_uber_principal(prompts)
     definition = {"foo": "bar", "aws_attributes.instance_profile_arn": {"type": "fixed", "value": instance_profile_arn}}
@@ -283,13 +285,13 @@ def test_create_uber_principal_no_existing_role(mock_ws, mock_installation, back
     aws.create_migration_role.return_value = instance_profile_arn
     aws.create_instance_profile.return_value = instance_profile_arn
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    locations = ExternalLocations(mock_ws, backend, "ucx")
+    external_locations = create_autospec(ExternalLocations)
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        locations,
+        external_locations,
     )
 
     aws_resource_permissions.create_uber_principal(prompts)
@@ -331,13 +333,13 @@ def test_failed_create_uber_principal(mock_ws, mock_installation, backend, locat
 
     aws = AWSResources("profile", command_call)
 
-    locations = ExternalLocations(mock_ws, backend, "ucx")
+    external_locations = create_autospec(ExternalLocations)
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        locations,
+        external_locations,
     )
 
     with pytest.raises(PermissionDenied):
@@ -384,14 +386,14 @@ def test_create_uber_principal_no_storage(mock_ws, mock_installation, locations)
         policy_id="foo", name="Unity Catalog Migration (ucx) (me@example.com)", definition=json.dumps({"foo": "bar"})
     )
     mock_ws.cluster_policies.get.return_value = cluster_policy
-    locations = ExternalLocations(mock_ws, MockBackend(), "ucx")
+    external_locations = create_autospec(ExternalLocations)
     prompts = MockPrompts({})
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        locations,
+        external_locations,
     )
     assert not aws_resource_permissions.create_uber_principal(prompts)
     aws.list_attached_policies_in_role.assert_not_called()
@@ -439,8 +441,7 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
 
 
 def test_create_uc_no_roles(installation_no_roles, mock_ws, caplog):
-    sql_backend = MockBackend(rows={}, fails_on_first={})
-    external_locations = ExternalLocations(mock_ws, sql_backend, "ucx")
+    external_locations = create_autospec(ExternalLocations)
     aws = create_autospec(AWSResources)
     aws_resource_permissions = AWSResourcePermissions(
         installation_no_roles,
@@ -926,7 +927,7 @@ def test_delete_role(mock_ws, installation_no_roles, backend, mocker):
         return 0, '{"account":"1234"}', ""
 
     aws = AWSResources("profile", command_call)
-    external_locations = ExternalLocations(mock_ws, backend, 'ucx')
+    external_locations = create_autospec(ExternalLocations)
     resource_permissions = AWSResourcePermissions(installation_no_roles, mock_ws, aws, external_locations)
     resource_permissions.delete_uc_role("uc_role_1")
     assert '/path/aws iam delete-role --role-name uc_role_1 --profile profile --output json' in command_calls

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -370,11 +370,12 @@ def test_create_uber_principal_set_warehouse_config_security_policy(
     aws = create_autospec(AWSResources)
     aws.get_instance_profile_arn.return_value = instance_profile_arn
 
+    external_locations = create_autospec(ExternalLocations)
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        ExternalLocations(mock_ws, backend, "ucx"),
+        external_locations,
     )
     aws_resource_permissions.create_uber_principal(MockPrompts({".*": "yes"}))
 

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -217,14 +217,12 @@ def test_create_uber_principal_existing_role_in_policy(mock_ws, mock_installatio
     aws = create_autospec(AWSResources)
     aws.validate_connection.return_value = {}
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    external_locations = create_autospec(ExternalLocations)
-    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"We have identified existing UCX migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        external_locations,
+        locations,
     )
     aws_resource_permissions.create_uber_principal(prompts)
     aws.put_role_policy.assert_called_with(
@@ -247,8 +245,6 @@ def test_create_uber_principal_existing_role(mock_ws, mock_installation, backend
     instance_profile_arn = "arn:aws:iam::12345:instance-profile/role1"
     aws = create_autospec(AWSResources)
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    external_locations = create_autospec(ExternalLocations)
-    external_locations.snapshot.return_value = []
     prompts = MockPrompts(
         {
             "There is an existing instance profile *": "yes",
@@ -259,7 +255,7 @@ def test_create_uber_principal_existing_role(mock_ws, mock_installation, backend
         mock_installation,
         mock_ws,
         aws,
-        external_locations,
+        locations,
     )
     aws_resource_permissions.create_uber_principal(prompts)
     definition = {"foo": "bar", "aws_attributes.instance_profile_arn": {"type": "fixed", "value": instance_profile_arn}}
@@ -288,14 +284,12 @@ def test_create_uber_principal_no_existing_role(mock_ws, mock_installation, back
     aws.create_migration_role.return_value = instance_profile_arn
     aws.create_instance_profile.return_value = instance_profile_arn
     aws.get_instance_profile_arn.return_value = instance_profile_arn
-    external_locations = create_autospec(ExternalLocations)
-    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        external_locations,
+        locations,
     )
 
     aws_resource_permissions.create_uber_principal(prompts)
@@ -337,14 +331,12 @@ def test_failed_create_uber_principal(mock_ws, mock_installation, backend, locat
 
     aws = AWSResources("profile", command_call)
 
-    external_locations = create_autospec(ExternalLocations)
-    external_locations.snapshot.return_value = []
     prompts = MockPrompts({"Do you want to create new migration role *": "yes"})
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        external_locations,
+        locations,
     )
 
     with pytest.raises(PermissionDenied):
@@ -364,7 +356,12 @@ def test_failed_create_uber_principal(mock_ws, mock_installation, backend, locat
     ],
 )
 def test_create_uber_principal_set_warehouse_config_security_policy(
-    mock_ws, mock_installation, backend, get_security_policy, set_security_policy
+    mock_ws,
+    mock_installation,
+    backend,
+    get_security_policy,
+    set_security_policy,
+    locations,
 ):
     mock_ws.cluster_policies.get.return_value = Policy(definition=json.dumps({"foo": "bar"}))
     mock_ws.warehouses.get_workspace_warehouse_config.return_value = GetWorkspaceWarehouseConfigResponse(
@@ -375,13 +372,11 @@ def test_create_uber_principal_set_warehouse_config_security_policy(
     aws = create_autospec(AWSResources)
     aws.get_instance_profile_arn.return_value = instance_profile_arn
 
-    external_locations = create_autospec(ExternalLocations)
-    external_locations.snapshot.return_value = []
     aws_resource_permissions = AWSResourcePermissions(
         mock_installation,
         mock_ws,
         aws,
-        external_locations,
+        locations,
     )
     aws_resource_permissions.create_uber_principal(MockPrompts({".*": "yes"}))
 

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -933,6 +933,7 @@ def test_create_access_connectors_for_storage_accounts_logs_no_storage_accounts(
     """A warning should be logged when no storage account is present."""
     w = create_autospec(WorkspaceClient)
     external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = []
     installation = MockInstallation()
 
     azure_resources = create_autospec(AzureResources)
@@ -945,7 +946,6 @@ def test_create_access_connectors_for_storage_accounts_logs_no_storage_accounts(
     w.cluster_policies.get.assert_not_called()
     w.secrets.get_secret.assert_not_called()
     w.secrets.create_scope.assert_not_called()
-    external_locations.snapshot.assert_not_called()
     assert (
         "There are no external table present with azure storage account. Please check if assessment job is run"
         in caplog.messages

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -40,7 +40,9 @@ def test_save_spn_permissions_no_external_table(caplog):
     rows = {"SELECT \\* FROM hive_metastore.ucx.external_locations": []}
     backend = MockBackend(rows=rows)
     tables_crawler = create_autospec(TablesCrawler)
+    tables_crawler.snapshot.return_value = []
     mounts_crawler = create_autospec(MountsCrawler)
+    mounts_crawler.snapshot.return_value = []
     location = ExternalLocations(w, backend, "ucx", tables_crawler, mounts_crawler)
     installation = MockInstallation()
     azure_resources = create_autospec(AzureResources)
@@ -59,14 +61,11 @@ def test_save_spn_permissions_no_external_table(caplog):
 
 def test_save_spn_permissions_no_external_tables():
     w = create_autospec(WorkspaceClient)
-    rows = {"SELECT \\* FROM hive_metastore.ucx.external_locations": [["s3://bucket1/folder1", "0"]]}
-    backend = MockBackend(rows=rows)
-    tables_crawler = create_autospec(TablesCrawler)
-    mounts_crawler = create_autospec(MountsCrawler)
-    location = ExternalLocations(w, backend, "ucx", tables_crawler, mounts_crawler)
+    external_locations = create_autospec(ExternalLocations)
+    external_locations.snapshot.return_value = [ExternalLocation('s3://bucket1/folder1', 0)]
     installation = MockInstallation()
     azure_resources = create_autospec(AzureResources)
-    azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, location)
+    azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, external_locations)
     azure_resources.storage_accounts.return_value = []
     assert not azure_resource_permission.save_spn_permissions()
     w.cluster_policies.get.assert_not_called()

--- a/tests/unit/azure/test_access.py
+++ b/tests/unit/azure/test_access.py
@@ -28,7 +28,7 @@ from databricks.labs.ucx.azure.resources import (
     StorageAccount,
 )
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.hive_metastore import ExternalLocations
+from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler, MountsCrawler
 
 from . import azure_api_client as create_azure_api_client
 from .. import DEFAULT_CONFIG
@@ -38,7 +38,9 @@ def test_save_spn_permissions_no_external_table(caplog):
     w = create_autospec(WorkspaceClient)
     rows = {"SELECT \\* FROM hive_metastore.ucx.external_locations": []}
     backend = MockBackend(rows=rows)
-    location = ExternalLocations(w, backend, "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location = ExternalLocations(w, backend, "ucx", tables_crawler, mounts_crawler)
     installation = MockInstallation()
     azure_resources = create_autospec(AzureResources)
     azure_resources.storage_accounts.return_value = []
@@ -58,7 +60,9 @@ def test_save_spn_permissions_no_external_tables():
     w = create_autospec(WorkspaceClient)
     rows = {"SELECT \\* FROM hive_metastore.ucx.external_locations": [["s3://bucket1/folder1", "0"]]}
     backend = MockBackend(rows=rows)
-    location = ExternalLocations(w, backend, "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location = ExternalLocations(w, backend, "ucx", tables_crawler, mounts_crawler)
     installation = MockInstallation()
     azure_resources = create_autospec(AzureResources)
     azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, location)
@@ -80,7 +84,9 @@ def test_save_spn_permissions_no_azure_storage_account():
         ]
     }
     backend = MockBackend(rows=rows)
-    location = ExternalLocations(w, backend, "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location = ExternalLocations(w, backend, "ucx", tables_crawler, mounts_crawler)
     installation = MockInstallation()
     azure_resources = create_autospec(AzureResources)
     azure_resource_permission = AzureResourcePermissions(installation, w, azure_resources, location)
@@ -630,7 +636,9 @@ def test_create_uber_service_principal_when_no_storage_accounts_listed() -> None
             }
         }
     )
-    location = ExternalLocations(ws, backend, "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location = ExternalLocations(ws, backend, "ucx", tables_crawler, mounts_crawler)
     azure_resources = create_autospec(AzureResources)
     azure_resource_permission = AzureResourcePermissions(installation, ws, azure_resources, location)
     azure_resources.storage_accounts.return_value = []  # No storage accounts listed
@@ -793,7 +801,9 @@ def test_create_global_spn_set_warehouse_config_security_policy(get_security_pol
             ["abfss://container1@sto2.dfs.core.windows.net/folder1", "1"]
         ]
     }
-    location = ExternalLocations(w, MockBackend(rows=rows), "ucx")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location = ExternalLocations(w, MockBackend(rows=rows), "ucx", tables_crawler, mounts_crawler)
     installation = MockInstallation(DEFAULT_CONFIG.copy())
     api_client = create_azure_api_client()
     azure_resources = AzureResources(api_client, api_client, include_subscriptions="002")

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -26,15 +26,17 @@ EXTERNAL_LOCATIONS = MockBackend.rows("location", "table_count")
 
 def location_migration_for_test(ws, mock_backend, mock_installation, azurerm=None):
     azurerm = azurerm or AzureResources(azure_api_client(), azure_api_client())
-    tables_crawler = create_autospec(TablesCrawler)
-    mounts_crawler = create_autospec(MountsCrawler)
-    location_crawler = ExternalLocations(ws, mock_backend, "location_test", tables_crawler, mounts_crawler)
-    azure_resource_permissions = AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler)
     tables_crawler = TablesCrawler(mock_backend, 'ucx')
     mounts_crawler = MountsCrawler(mock_backend, ws, 'ucx')
-    principal_acl = PrincipalACL(ws, mock_backend, mock_installation, tables_crawler, mounts_crawler, lambda: [])
+    external_locations = ExternalLocations(ws, mock_backend, "location_test", tables_crawler, mounts_crawler)
+    azure_resource_permissions = AzureResourcePermissions(mock_installation, ws, azurerm, external_locations)
+    principal_acl = PrincipalACL(ws, mock_backend, mock_installation, tables_crawler, external_locations, lambda: [])
     external_locations_migration = ExternalLocationsMigration(
-        ws, location_crawler, azure_resource_permissions, azurerm, principal_acl
+        ws,
+        external_locations,
+        azure_resource_permissions,
+        azurerm,
+        principal_acl,
     )
     return external_locations_migration
 

--- a/tests/unit/azure/test_locations.py
+++ b/tests/unit/azure/test_locations.py
@@ -16,7 +16,7 @@ from databricks.sdk.service.catalog import (
 from databricks.labs.ucx.azure.access import AzureResourcePermissions
 from databricks.labs.ucx.azure.locations import ExternalLocationsMigration
 from databricks.labs.ucx.azure.resources import AzureResource, AzureResources, StorageAccount
-from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler, Mounts
+from databricks.labs.ucx.hive_metastore import ExternalLocations, TablesCrawler, MountsCrawler
 from databricks.labs.ucx.hive_metastore.grants import PrincipalACL
 from tests.unit.azure import azure_api_client
 
@@ -26,10 +26,12 @@ EXTERNAL_LOCATIONS = MockBackend.rows("location", "table_count")
 
 def location_migration_for_test(ws, mock_backend, mock_installation, azurerm=None):
     azurerm = azurerm or AzureResources(azure_api_client(), azure_api_client())
-    location_crawler = ExternalLocations(ws, mock_backend, "location_test")
+    tables_crawler = create_autospec(TablesCrawler)
+    mounts_crawler = create_autospec(MountsCrawler)
+    location_crawler = ExternalLocations(ws, mock_backend, "location_test", tables_crawler, mounts_crawler)
     azure_resource_permissions = AzureResourcePermissions(mock_installation, ws, azurerm, location_crawler)
     tables_crawler = TablesCrawler(mock_backend, 'ucx')
-    mounts_crawler = Mounts(mock_backend, ws, 'ucx')
+    mounts_crawler = MountsCrawler(mock_backend, ws, 'ucx')
     principal_acl = PrincipalACL(ws, mock_backend, mock_installation, tables_crawler, mounts_crawler, lambda: [])
     external_locations_migration = ExternalLocationsMigration(
         ws, location_crawler, azure_resource_permissions, azurerm, principal_acl

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -243,13 +243,12 @@ def test_save_external_location_mapping_missing_location():
         table_factory(["s3n://test_location_3/test1/table1", ""]),
     ]
     mounts_crawler = create_autospec(MountsCrawler)
+    mounts_crawler.snapshot.return_value = []
     location_crawler = ExternalLocations(ws, sql_backend, "test", tables_crawler, mounts_crawler)
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/test11")]
 
     installation = create_autospec(Installation)
     location_crawler.save_as_terraform_definitions_on_workspace(installation)
-
-    mounts_crawler.snapshot.assert_called_once()
 
     installation.upload.assert_called_with(
         "external_locations.tf",
@@ -292,6 +291,7 @@ def test_save_external_location_mapping_no_missing_location():
         table_factory(["s3://test_location/test1/table1", ""]),
     ]
     mounts_crawler = create_autospec(MountsCrawler)
+    mounts_crawler.snapshot.return_value = []
     location_crawler = ExternalLocations(ws, sql_backend, "test", tables_crawler, mounts_crawler)
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/test1")]
     location_crawler.save_as_terraform_definitions_on_workspace("~/.ucx")
@@ -311,6 +311,7 @@ def test_match_table_external_locations():
         table_factory(["abfss://cont1@storagetest1/a/table4", ""]),
     ]
     mounts_crawler = create_autospec(MountsCrawler)
+    mounts_crawler.snapshot.return_value = []
     location_crawler = ExternalLocations(ws, sql_backend, "test", tables_crawler, mounts_crawler)
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/a")]
 

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -296,7 +296,6 @@ def test_save_external_location_mapping_no_missing_location():
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/test1")]
     location_crawler.save_as_terraform_definitions_on_workspace("~/.ucx")
     ws.workspace.upload.assert_not_called()
-    mounts_crawler.snapshot.assert_called_once()
 
 
 def test_match_table_external_locations():
@@ -317,7 +316,6 @@ def test_match_table_external_locations():
 
     matching_locations, missing_locations = location_crawler.match_table_external_locations()
 
-    mounts_crawler.snapshot.assert_called_once()
     assert len(matching_locations) == 1
     assert ExternalLocation("gcs://test_location2/a/b/", 1) in missing_locations
     assert ExternalLocation("abfss://cont1@storagetest1/a/", 2) in missing_locations

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -238,7 +238,7 @@ def test_save_external_location_mapping_missing_location():
     tables_crawler.snapshot.return_value = [
         table_factory(["s3://test_location/test1/table1", ""]),
         table_factory(["gcs://test_location2/test2/table2", ""]),
-        table_factory(["abfss://cont1@storagetest1/test2/table3", ""]),
+        table_factory(["abfss://cont1@storagetest1.dfs.core.windows.net/test2/table3", ""]),
         table_factory(["s3a://test_location_2/test1/table1", ""]),
         table_factory(["s3n://test_location_3/test1/table1", ""]),
     ]

--- a/tests/unit/hive_metastore/test_locations.py
+++ b/tests/unit/hive_metastore/test_locations.py
@@ -249,6 +249,8 @@ def test_save_external_location_mapping_missing_location():
     installation = create_autospec(Installation)
     location_crawler.save_as_terraform_definitions_on_workspace(installation)
 
+    mounts_crawler.snapshot.assert_called_once()
+
     installation.upload.assert_called_with(
         "external_locations.tf",
         (
@@ -294,6 +296,7 @@ def test_save_external_location_mapping_no_missing_location():
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/test1")]
     location_crawler.save_as_terraform_definitions_on_workspace("~/.ucx")
     ws.workspace.upload.assert_not_called()
+    mounts_crawler.snapshot.assert_called_once()
 
 
 def test_match_table_external_locations():
@@ -312,6 +315,8 @@ def test_match_table_external_locations():
     ws.external_locations.list.return_value = [ExternalLocationInfo(name="loc1", url="s3://test_location/a")]
 
     matching_locations, missing_locations = location_crawler.match_table_external_locations()
+
+    mounts_crawler.snapshot.assert_called_once()
     assert len(matching_locations) == 1
     assert ExternalLocation("gcs://test_location2/a/b/", 1) in missing_locations
     assert ExternalLocation("abfss://cont1@storagetest1/a/", 2) in missing_locations

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -27,7 +27,7 @@ from databricks.labs.ucx.assessment.azure import (
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.hive_metastore import MountsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import AzureACL, Grant, PrincipalACL, ComputeLocations
-from databricks.labs.ucx.hive_metastore.locations import Mount
+from databricks.labs.ucx.hive_metastore.locations import Mount, ExternalLocations
 from databricks.labs.ucx.hive_metastore.grants import (
     AwsACL,
 )
@@ -154,6 +154,7 @@ def principal_acl(w, install, cluster_spn: list, warehouse_spn: list):
         Mount('/mnt/folder1', 'abfss://container1@storage1.dfs.core.windows.net/folder1'),
         Mount('/mnt/folder5', 's3://storage5/folder5'),
     ]
+    external_locations = ExternalLocations(ws, sql_backend, 'schema', table_crawler, mount_crawler)
 
     spn_crawler = create_autospec(AzureServicePrincipalCrawler)
     spn_crawler.get_cluster_to_storage_mapping.return_value = cluster_spn
@@ -166,7 +167,7 @@ def principal_acl(w, install, cluster_spn: list, warehouse_spn: list):
         return None
 
     locations = inner
-    return PrincipalACL(w, sql_backend, install, table_crawler, mount_crawler, locations)
+    return PrincipalACL(w, sql_backend, install, table_crawler, external_locations, locations)
 
 
 @pytest.fixture

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -154,7 +154,7 @@ def principal_acl(w, install, cluster_spn: list, warehouse_spn: list):
         Mount('/mnt/folder1', 'abfss://container1@storage1.dfs.core.windows.net/folder1'),
         Mount('/mnt/folder5', 's3://storage5/folder5'),
     ]
-    external_locations = ExternalLocations(ws, sql_backend, 'schema', table_crawler, mount_crawler)
+    external_locations = ExternalLocations(w, sql_backend, 'schema', table_crawler, mount_crawler)
 
     spn_crawler = create_autospec(AzureServicePrincipalCrawler)
     spn_crawler.get_cluster_to_storage_mapping.return_value = cluster_spn

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -25,7 +25,7 @@ from databricks.labs.ucx.assessment.azure import (
     ServicePrincipalClusterMapping,
 )
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.hive_metastore import Mounts, TablesCrawler
+from databricks.labs.ucx.hive_metastore import MountsCrawler, TablesCrawler
 from databricks.labs.ucx.hive_metastore.grants import AzureACL, Grant, PrincipalACL, ComputeLocations
 from databricks.labs.ucx.hive_metastore.locations import Mount
 from databricks.labs.ucx.hive_metastore.grants import (
@@ -149,7 +149,7 @@ def principal_acl(w, install, cluster_spn: list, warehouse_spn: list):
         ),
     ]
     table_crawler.snapshot.return_value = tables
-    mount_crawler = create_autospec(Mounts)
+    mount_crawler = create_autospec(MountsCrawler)
     mount_crawler.snapshot.return_value = [
         Mount('/mnt/folder1', 'abfss://container1@storage1.dfs.core.windows.net/folder1'),
         Mount('/mnt/folder5', 's3://storage5/folder5'),

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -389,7 +389,7 @@ def test_migrate_external_hiveserde_table_in_place(
             return location.replace("dbfs:/mnt/test", "s3://test/folder")
         return location
 
-    external_locations.resolve_mount = resolve_mount
+    external_locations.resolve_mount.side_effect = resolve_mount
 
     table_migrate = TablesMigrator(
         table_crawler,

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -477,7 +477,7 @@ def test_in_place_migrate_hiveserde_sql(table, mounts, describe, ddl, expected_h
     )
     dst_table_location = None
     if mounts and table.is_dbfs_mnt:
-        dst_table_location = ExternalLocations.resolve_mount(table.location, mounts)
+        dst_table_location = ExternalLocations.resolve_mount(table.location)
 
     hiveserde_type = table.hiveserde_type(sql_backend)
     assert hiveserde_type == expected_hiveserde_type

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -483,7 +483,7 @@ def test_in_place_migrate_hiveserde_sql(table, mounts, describe, ddl, expected_h
         mounts_crawler.snapshot.return_value = mounts
         tables_crawler = create_autospec(TablesCrawler)
         ws = create_autospec(WorkspaceClient)
-        external_locations = ExternalLocations(ws, sql_backend, '...', tables_crawler, mounts_crawler)
+        external_locations = ExternalLocations(ws, sql_backend, 'some', tables_crawler, mounts_crawler)
         dst_table_location = external_locations.resolve_mount(table.location)
 
     hiveserde_type = table.hiveserde_type(sql_backend)

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -478,6 +478,7 @@ def test_in_place_migrate_hiveserde_sql(table, mounts, describe, ddl, expected_h
     )
     dst_table_location = None
     if mounts and table.is_dbfs_mnt:
+        # pylint: disable=mock-no-usage
         mounts_crawler = create_autospec(MountsCrawler)
         mounts_crawler.snapshot.return_value = mounts
         tables_crawler = create_autospec(TablesCrawler)

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -4,9 +4,10 @@ from unittest.mock import create_autospec
 
 import pytest
 from databricks.labs.lsql.backends import MockBackend
+from databricks.sdk import WorkspaceClient
 
 from databricks.labs.ucx.framework.owners import AdministratorLocator
-from databricks.labs.ucx.hive_metastore.locations import Mount, ExternalLocations
+from databricks.labs.ucx.hive_metastore.locations import Mount, ExternalLocations, MountsCrawler
 from databricks.labs.ucx.hive_metastore.tables import (
     FasterTableScanCrawler,
     HiveSerdeType,
@@ -477,7 +478,12 @@ def test_in_place_migrate_hiveserde_sql(table, mounts, describe, ddl, expected_h
     )
     dst_table_location = None
     if mounts and table.is_dbfs_mnt:
-        dst_table_location = ExternalLocations.resolve_mount(table.location)
+        mounts_crawler = create_autospec(MountsCrawler)
+        mounts_crawler.snapshot.return_value = mounts
+        tables_crawler = create_autospec(TablesCrawler)
+        ws = create_autospec(WorkspaceClient)
+        external_locations = ExternalLocations(ws, sql_backend, '...', tables_crawler, mounts_crawler)
+        dst_table_location = external_locations.resolve_mount(table.location)
 
     hiveserde_type = table.hiveserde_type(sql_backend)
     assert hiveserde_type == expected_hiveserde_type

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -686,7 +686,7 @@ def test_create_aws_uber_principal_calls_dbutils_fs_mounts(ws) -> None:
     )
     prompts = MockPrompts({})
     create_uber_principal(ws, prompts, ctx=ctx)
-    ws.dbutils.fs.mounts.assert_called_once()
+    ws.dbutils.fs.mounts.assert_not_called()
 
 
 def test_migrate_locations_raises_value_error_for_unsupported_cloud_provider(ws) -> None:


### PR DESCRIPTION
This PR streamlines resolution of tables and mounts into external locations. previously dependencies were not direct and explicit