### PR TITLE
Clarify `skip` and `unskip` commands work on views

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,11 +645,14 @@ flowchart LR
 #### Step 4: Odds and Ends
 The following steps can be used to repair/amend the metastore after the upgrade process.
 
-##### Step 4.1: Skipping Table/Schema
+##### Step 4.1: Skipping schema, table or view
+
 ```bash
-databricks labs ucx skip --schema X [--table Y]
+databricks labs ucx skip --schema X [--table Y] [--view Zj]
 ```
-This command will mark the table or schema as skipped. The table will not be upgraded in the next run of the upgrade process.
+
+This command will mark the schema, table or view as to-be skipped during the migration processes,
+see [`skip` command](#skip-command).
 
 ##### Step 4.2: Moving objects
 ```bash
@@ -1477,15 +1480,15 @@ Once you're done with table migration, proceed to the [code migration](#code-mig
 ## `skip` command
 
 ```text
-databricks labs ucx skip --schema X [--table Y]
+databricks labs ucx skip --schema X [--table Y] [--view Z]
 ```
 
 Anytime after [`create-table-mapping` command](#create-table-mapping-command) is executed, you can run this command.
 
-This command allows users to skip certain schemas or tables during the [table migration](#table-migration) process.
-The command takes `--schema` and optionally `--table` flags to specify the schema and table to skip. If no `--table` flag
-is provided, all tables in the specified HMS database are skipped.
-This command is useful to temporarily disable migration of a particular schema or table.
+This command allows users to skip certain schemas, tables or views during the [table migration](#table-migration) process.
+The command takes `--schema` and, optionally, `--table` and `--view` flags to specify the schema, table or view to skip.
+If no `--table` flag is provided, all tables in the specified HMS database are skipped. The `--table` and `--view` can
+only be used exclusively. This command is useful to temporarily disable migration of a particular schema, table or view.
 
 Once you're done with table migration, proceed to the [code migration](#code-migration-commands).
 
@@ -1494,9 +1497,10 @@ Once you're done with table migration, proceed to the [code migration](#code-mig
 ## `unskip` command
 
 ```commandline
-databricks labs ucx unskip --schema X [--table Y]
+databricks labs ucx unskip --schema X [--table Y] [--view Z]
 ```
-This command removes the mark set by the [`skip` command](#skip-command) on the given schema or table.
+
+This command removes the mark set by the [`skip` command](#skip-command) on the given schema, table or view.
 
 [[back to top](#databricks-labs-ucx)]
 

--- a/labs.yml
+++ b/labs.yml
@@ -37,8 +37,9 @@ commands:
       - name: schema
         description: Schema name to skip.
       - name: table
-        description: Table Name to Skip
         description: (Optional) Table name to skip. Exclusive with `--view`.
+      - name: view
+        description: (Optional) View name to skip. Exclusive with `--table`.
 
   - name: sync-workspace-info
     is_account_level: true

--- a/labs.yml
+++ b/labs.yml
@@ -32,12 +32,13 @@ commands:
       {{end}}
 
   - name: skip
-    description: Create a skip comment on a schema or a table
+    description: Add a skip comment on a schema, table or view.
     flags:
       - name: schema
-        description: Schema Name to Skip
+        description: Schema name to skip.
       - name: table
         description: Table Name to Skip
+        description: (Optional) Table name to skip. Exclusive with `--view`.
 
   - name: sync-workspace-info
     is_account_level: true

--- a/labs.yml
+++ b/labs.yml
@@ -41,6 +41,16 @@ commands:
       - name: view
         description: (Optional) View name to skip. Exclusive with `--table`.
 
+  - name: unskip
+    description: Remove the skip comment from a schema, table or view.
+    flags:
+      - name: schema
+        description: Schema name to unskip.
+      - name: table
+        description: (Optional) Table name to unskip. Exclusive with `--view`.
+      - name: view
+        description: (Optional) View name to unskip. Exclusive with `--table`.
+
   - name: sync-workspace-info
     is_account_level: true
     description: upload workspace config to all workspaces in the account where ucx is installed

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -89,6 +89,7 @@ def installations(w: WorkspaceClient):
 @ucx.command
 def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None):
     """Create a skip comment on a schema or a table"""
+    """Create a skip comment on a schema, table or a view."""
     logger.info("Running skip command")
     if not schema:
         logger.error("--schema is a required parameter.")
@@ -102,6 +103,7 @@ def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None
 @ucx.command
 def unskip(w: WorkspaceClient, schema: str | None = None, table: str | None = None):
     """Unset the skip mark from a schema or a table"""
+    """Unset the skip mark from a schema, table or a view."""
     logger.info("Running unskip command")
     if not schema:
         logger.error("--schema is a required parameter.")

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -97,8 +97,9 @@ def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None
         logger.error("specify --table OR --view, not both")
         return None
     ctx = WorkspaceContext(w)
-    if table or view:
-        return ctx.table_mapping.skip_table_or_view(schema, table or view, ctx.tables_crawler.load_one)
+    table_or_view = table or view
+    if table_or_view:
+        return ctx.table_mapping.skip_table_or_view(schema, table_or_view, ctx.tables_crawler.load_one)
     return ctx.table_mapping.skip_schema(schema)
 
 
@@ -113,8 +114,9 @@ def unskip(w: WorkspaceClient, schema: str | None = None, table: str | None = No
         logger.error("specify --table OR --view, not both")
         return None
     ctx = WorkspaceContext(w)
-    if table or view:
-        return ctx.table_mapping.unskip_table_or_view(schema, table or view, ctx.tables_crawler.load_one)
+    table_or_view = table or view
+    if table_or_view:
+        return ctx.table_mapping.unskip_table_or_view(schema, table_or_view, ctx.tables_crawler.load_one)
     return ctx.table_mapping.unskip_schema(schema)
 
 

--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -87,30 +87,34 @@ def installations(w: WorkspaceClient):
 
 
 @ucx.command
-def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None):
-    """Create a skip comment on a schema or a table"""
+def skip(w: WorkspaceClient, schema: str | None = None, table: str | None = None, view: str | None = None) -> None:
     """Create a skip comment on a schema, table or a view."""
     logger.info("Running skip command")
     if not schema:
         logger.error("--schema is a required parameter.")
         return None
+    if table and view:
+        logger.error("specify --table OR --view, not both")
+        return None
     ctx = WorkspaceContext(w)
-    if table:
-        return ctx.table_mapping.skip_table_or_view(schema, table, ctx.tables_crawler.load_one)
+    if table or view:
+        return ctx.table_mapping.skip_table_or_view(schema, table or view, ctx.tables_crawler.load_one)
     return ctx.table_mapping.skip_schema(schema)
 
 
 @ucx.command
-def unskip(w: WorkspaceClient, schema: str | None = None, table: str | None = None):
-    """Unset the skip mark from a schema or a table"""
+def unskip(w: WorkspaceClient, schema: str | None = None, table: str | None = None, view: str | None = None) -> None:
     """Unset the skip mark from a schema, table or a view."""
     logger.info("Running unskip command")
     if not schema:
         logger.error("--schema is a required parameter.")
         return None
+    if table and view:
+        logger.error("specify --table OR --view, not both")
+        return None
     ctx = WorkspaceContext(w)
-    if table:
-        return ctx.table_mapping.unskip_table_or_view(schema, table, ctx.tables_crawler.load_one)
+    if table or view:
+        return ctx.table_mapping.unskip_table_or_view(schema, table or view, ctx.tables_crawler.load_one)
     return ctx.table_mapping.unskip_schema(schema)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -191,7 +191,22 @@ def test_installations(ws, capsys):
     assert '{"database": "ucx", "path": "/Users/foo/.ucx", "warehouse_id": "test"}' in capsys.readouterr().out
 
 
-def test_skip_with_table(ws):
+def test_skip_with_schema(ws) -> None:
+    skip(ws, "schema", None)
+
+    ws.statement_execution.execute_statement.assert_called_with(
+        warehouse_id='test',
+        statement="ALTER SCHEMA `schema` SET DBPROPERTIES('databricks.labs.ucx.skip' = true)",
+        byte_limit=None,
+        catalog=None,
+        schema=None,
+        disposition=None,
+        format=sql.Format.JSON_ARRAY,
+        wait_timeout=None,
+    )
+
+
+def test_skip_with_table(ws) -> None:
     skip(ws, "schema", "table")
 
     ws.statement_execution.execute_statement.assert_called_with(
@@ -206,12 +221,12 @@ def test_skip_with_table(ws):
     )
 
 
-def test_skip_with_schema(ws):
-    skip(ws, "schema", None)
+def test_skip_with_view(ws) -> None:
+    skip(ws, "schema", view="view")
 
     ws.statement_execution.execute_statement.assert_called_with(
         warehouse_id='test',
-        statement="ALTER SCHEMA `schema` SET DBPROPERTIES('databricks.labs.ucx.skip' = true)",
+        statement="SELECT * FROM `hive_metastore`.`ucx`.`tables` WHERE database='schema' AND name='view' LIMIT 1",
         byte_limit=None,
         catalog=None,
         schema=None,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -236,7 +236,7 @@ def test_skip_with_view(ws) -> None:
     )
 
 
-def test_skip_no_schema(ws, caplog):
+def test_skip_no_schema(ws, caplog) -> None:
     skip(ws, schema=None, table="table")
 
     assert '--schema is a required parameter.' in caplog.messages

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -242,6 +242,12 @@ def test_skip_no_schema(ws, caplog) -> None:
     assert '--schema is a required parameter.' in caplog.messages
 
 
+def test_skip_table_and_view(ws, caplog) -> None:
+    skip(ws, "schema", "table", "view")
+
+    assert "specify --table OR --view, not both" in caplog.messages
+
+
 def test_sync_workspace_info():
     a = create_autospec(AccountClient)
     sync_workspace_info(a)


### PR DESCRIPTION
## Changes
Clarify `skip` and `unskip` commands work on views. To make it even more clear: added the `--view` flag to both commands.

### Functionality

- [x] modified existing command: `databricks labs ucx skip/unskip`

### Tests

- [x] added unit tests
