### PR TITLE
Skip applying permissions for workspace system groups to Unity Catalog resources

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -592,7 +592,7 @@ class AzureACL:
 
 
 class PrincipalACL:
-    _system_groups = {"admins", "users"}
+    _workspace_system_groups = {"admins", "users"}
 
     def __init__(
         self,
@@ -694,7 +694,7 @@ class PrincipalACL:
             if acl.user_name is not None:
                 principal_list.append(acl.user_name)
             if acl.group_name is not None:
-                if acl.group_name in self._system_groups:
+                if acl.group_name in self._workspace_system_groups:  # Do not exists on account level
                     continue
                 principal_list.append(acl.group_name)
             if acl.service_principal_name is not None:

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -592,6 +592,8 @@ class AzureACL:
 
 
 class PrincipalACL:
+    _system_groups = {"admins", "users"}
+
     def __init__(
         self,
         ws: WorkspaceClient,
@@ -692,7 +694,7 @@ class PrincipalACL:
             if acl.user_name is not None:
                 principal_list.append(acl.user_name)
             if acl.group_name is not None:
-                if acl.group_name == "admins":
+                if acl.group_name in self._system_groups:
                     continue
                 principal_list.append(acl.group_name)
             if acl.service_principal_name is not None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1228,7 +1228,7 @@ def prepare_tables_for_migration(
 
 
 @pytest.fixture
-def prepared_principal_acl(runtime_ctx, env_or_skip, make_mounted_location, make_catalog, make_schema):
+def prepared_principal_acl(runtime_ctx, make_mounted_location, make_catalog, make_schema):
     src_schema = make_schema(catalog_name="hive_metastore")
     src_external_table = runtime_ctx.make_table(
         catalog_name=src_schema.catalog_name,

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -200,6 +200,6 @@ def test_create_catalog_schema_when_users_group_in_warehouse_acl(
         runtime_ctx.catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
     failed_to_migrate_message = (
-        f"failed-to-migrate: Failed to migrate ACL for {src_table.full_name} to {dst_catalog_name}"
+        f"failed-to-migrate: Failed to migrate ACL for {src_schema.full_name} to {dst_catalog_name}"
     )
     assert failed_to_migrate_message not in caplog.messages

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -137,7 +137,7 @@ def test_create_catalog_schema_with_principal_acl_aws(
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
-def test_create_catalog_schema_with_legacy_hive_metastore_privileges(  # TODO: Issue about ACL vs grants vs privileges
+def test_create_catalog_schema_with_legacy_hive_metastore_privileges(
     ws: WorkspaceClient,
     runtime_ctx,
     make_random,
@@ -191,6 +191,7 @@ def test_create_catalog_schema_when_users_group_in_warehouse_acl(
     rule = Rule("workspace", dst_catalog_name, src_schema.name, dst_schema_name, src_table.name, src_table.name)
     runtime_ctx.with_table_mapping_rules([rule])
     runtime_ctx.with_dummy_resource_permission()
+    runtime_ctx.make_group()
     warehouse = make_warehouse()
     make_warehouse_permissions(object_id=warehouse.id, permission_level=PermissionLevel.CAN_USE, group_name="users")
     mock_prompts = MockPrompts({"Please provide storage location url for catalog: *": ""})

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -174,3 +174,32 @@ def test_create_catalog_schema_with_legacy_hive_metastore_privileges(  # TODO: I
     schema_grants = get_schema_permissions_list(f"{dst_catalog_name}.{dst_schema_name}")
     assert schema_grants.privilege_assignments is not None
     assert PrivilegeAssignment(table_owner.user_name, [Privilege.USE_SCHEMA]) in schema_grants.privilege_assignments
+
+
+@retried(on=[NotFound], timeout=timedelta(minutes=2))
+def test_create_catalog_schema_when_users_group_in_warehouse_acl(
+    caplog,
+    runtime_ctx,
+    make_random,
+    make_warehouse,
+    make_warehouse_permissions,
+) -> None:
+    """Privileges inferred from being part of the 'users' group are ignored."""
+    src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
+    src_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)
+    dst_catalog_name = f"ucx_{make_random()}"
+    dst_schema_name = "test"
+    rule = Rule("workspace", dst_catalog_name, src_schema.name, dst_schema_name, src_table.name, src_table.name)
+    runtime_ctx.with_table_mapping_rules([rule])
+    runtime_ctx.with_dummy_resource_permission()
+    warehouse = make_warehouse()
+    make_warehouse_permissions(object_id=warehouse.id, permission_level=PermissionLevel.CAN_USE, group_name="users")
+    mock_prompts = MockPrompts({"Please provide storage location url for catalog: *": ""})
+
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.ucx.account.aggregate"):
+        runtime_ctx.catalog_schema.create_all_catalogs_schemas(mock_prompts)
+
+    failed_to_migrate_message = (
+        f"failed-to-migrate: Failed to migrate ACL for {src_table.full_name} to {dst_catalog_name}"
+    )
+    assert failed_to_migrate_message not in caplog.messages

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -146,7 +146,7 @@ def test_create_catalog_schema_with_legacy_hive_metastore_privileges(  # TODO: I
 ) -> None:
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)
-    dst_catalog_name = f"ucx-{make_random()}"
+    dst_catalog_name = f"ucx_{make_random()}"
     dst_schema_name = "test"
     rules = [Rule("workspace", dst_catalog_name, src_schema.name, dst_schema_name, src_table.name, src_table.name)]
     runtime_ctx.with_table_mapping_rules(rules)

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -176,7 +176,6 @@ def test_create_catalog_schema_with_legacy_hive_metastore_privileges(  # TODO: I
     assert PrivilegeAssignment(table_owner.user_name, [Privilege.USE_SCHEMA]) in schema_grants.privilege_assignments
 
 
-@retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_create_catalog_schema_when_users_group_in_warehouse_acl(
     caplog,
     runtime_ctx,
@@ -184,7 +183,7 @@ def test_create_catalog_schema_when_users_group_in_warehouse_acl(
     make_warehouse,
     make_warehouse_permissions,
 ) -> None:
-    """Privileges inferred from being part of the 'users' group are ignored."""
+    """Privileges inferred from being a member of the 'users' group are ignored."""
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)
     dst_catalog_name = f"ucx_{make_random()}"

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -137,7 +137,7 @@ def test_create_catalog_schema_with_principal_acl_aws(
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
-def test_create_catalog_schema_with_legacy_acls(
+def test_create_catalog_schema_with_legacy_hive_metastore_privileges(  # TODO: Issue about ACL vs grants vs privileges
     ws: WorkspaceClient,
     runtime_ctx,
     make_random,

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -77,6 +77,10 @@ def ws():
                     service_principal_name='spn1',
                     all_permissions=[iam.Permission(permission_level=iam.PermissionLevel.CAN_USE)],
                 ),
+                iam.AccessControlResponse(
+                    group_name='admins',
+                    all_permissions=[iam.Permission(permission_level=iam.PermissionLevel.CAN_USE)],
+                ),
             ],
         ),
         'warehouse1': iam.ObjectPermissions(
@@ -84,6 +88,7 @@ def ws():
             object_type="warehouses",
             access_control_list=[
                 iam.AccessControlResponse(group_name='group2', all_permissions=[iam.Permission(inherited=False)]),
+                iam.AccessControlResponse(group_name='users', all_permissions=[iam.Permission(inherited=False)]),
             ],
         ),
     }


### PR DESCRIPTION
## Changes
Skip applying permissions for workspace system groups because they do not exist on the account level.

### Linked issues

Resolves #2986

### Functionality

ACL related code
- [x] modified existing command: `databricks labs ucx create-catalog-schemas`
- [x] modified existing workflow: `migrate-table-*`

### Tests

- [x] added unit tests
- [x] added integration tests
