### PR TITLE
More ownership classes

### DIFF
--- a/src/databricks/labs/ucx/assessment/clusters.py
+++ b/src/databricks/labs/ucx/assessment/clusters.py
@@ -192,6 +192,16 @@ class ClusterInfoOwnership(Ownership[ClusterInfo]):
         return record.creator
 
 
+class ClusterDetailsOwnership(Ownership[ClusterDetails]):
+    """Determine ownership of clusters in the workspace.
+
+    This is the cluster creator (if known).
+    """
+
+    def _maybe_direct_owner(self, record: ClusterDetails) -> str | None:
+        return record.creator_user_name
+
+
 @dataclass
 class PolicyInfo:
     policy_id: str

--- a/src/databricks/labs/ucx/assessment/clusters.py
+++ b/src/databricks/labs/ucx/assessment/clusters.py
@@ -182,7 +182,7 @@ class ClustersCrawler(CrawlerBase[ClusterInfo], CheckClusterMixin):
             yield ClusterInfo(*row)
 
 
-class ClusterOwnership(Ownership[ClusterInfo]):
+class ClusterInfoOwnership(Ownership[ClusterInfo]):
     """Determine ownership of clusters in the inventory.
 
     This is the cluster creator (if known).

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -20,6 +20,7 @@ from databricks.sdk.service.jobs import (
     RunType,
     SparkJarTask,
     SqlTask,
+    Job,
 )
 
 from databricks.labs.ucx.assessment.clusters import CheckClusterMixin
@@ -149,7 +150,7 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
         return task_failures
 
 
-class JobOwnership(Ownership[JobInfo]):
+class JobInfoOwnership(Ownership[JobInfo]):
     """Determine ownership of jobs (workflows) in the inventory.
 
     This is the job creator (if known).
@@ -157,6 +158,16 @@ class JobOwnership(Ownership[JobInfo]):
 
     def _maybe_direct_owner(self, record: JobInfo) -> str | None:
         return record.creator
+
+
+class JobOwnership(Ownership[Job]):
+    """Determine ownership of jobs (workflows) in the workspace.
+
+    This is the job creator (if known).
+    """
+
+    def _maybe_direct_owner(self, record: Job) -> str | None:
+        return record.creator_user_name
 
 
 @dataclass

--- a/tests/integration/assessment/test_clusters.py
+++ b/tests/integration/assessment/test_clusters.py
@@ -11,7 +11,7 @@ from databricks.labs.ucx.assessment.clusters import (
     PoliciesCrawler,
     ClusterDetailsOwnership,
     ClusterInfoOwnership,
-    ClusterPolicyOwnership, 
+    ClusterPolicyOwnership,
 )
 
 from .test_assessment import _SPARK_CONF

--- a/tests/integration/assessment/test_clusters.py
+++ b/tests/integration/assessment/test_clusters.py
@@ -9,7 +9,7 @@ from databricks.sdk.service.compute import DataSecurityMode
 from databricks.labs.ucx.assessment.clusters import (
     ClustersCrawler,
     PoliciesCrawler,
-    ClusterOwnership,
+    ClusterInfoOwnership,
     ClusterPolicyOwnership,
 )
 
@@ -53,7 +53,7 @@ def _change_cluster_owner(ws, cluster_id: str, owner_user_name: str) -> None:
     ws.api_client.do('POST', '/api/2.1/clusters/change-owner', body=body, headers=headers)
 
 
-def test_cluster_ownership(ws, runtime_ctx, make_cluster, make_user, inventory_schema, sql_backend) -> None:
+def test_clusterinfo_ownership(ws, runtime_ctx, make_cluster, make_user, inventory_schema, sql_backend) -> None:
     """Verify the ownership can be determined for crawled clusters."""
 
     # Set up two clusters: one with us as owner and one for a different user.
@@ -76,7 +76,7 @@ def test_cluster_ownership(ws, runtime_ctx, make_cluster, make_user, inventory_s
 
     # Verify ownership is as expected.
     administrator_locator = runtime_ctx.administrator_locator
-    ownership = ClusterOwnership(administrator_locator)
+    ownership = ClusterInfoOwnership(administrator_locator)
     assert ownership.owner_of(my_cluster_record) == ws.current_user.me().user_name
     assert ownership.owner_of(their_cluster_record) == another_user.user_name
 

--- a/tests/integration/assessment/test_clusters.py
+++ b/tests/integration/assessment/test_clusters.py
@@ -9,8 +9,9 @@ from databricks.sdk.service.compute import DataSecurityMode
 from databricks.labs.ucx.assessment.clusters import (
     ClustersCrawler,
     PoliciesCrawler,
+    ClusterDetailsOwnership,
     ClusterInfoOwnership,
-    ClusterPolicyOwnership,
+    ClusterPolicyOwnership, 
 )
 
 from .test_assessment import _SPARK_CONF
@@ -53,7 +54,7 @@ def _change_cluster_owner(ws, cluster_id: str, owner_user_name: str) -> None:
     ws.api_client.do('POST', '/api/2.1/clusters/change-owner', body=body, headers=headers)
 
 
-def test_clusterinfo_ownership(ws, runtime_ctx, make_cluster, make_user, inventory_schema, sql_backend) -> None:
+def test_cluster_ownership(ws, runtime_ctx, make_cluster, make_user, inventory_schema, sql_backend) -> None:
     """Verify the ownership can be determined for crawled clusters."""
 
     # Set up two clusters: one with us as owner and one for a different user.
@@ -76,9 +77,12 @@ def test_clusterinfo_ownership(ws, runtime_ctx, make_cluster, make_user, invento
 
     # Verify ownership is as expected.
     administrator_locator = runtime_ctx.administrator_locator
-    ownership = ClusterInfoOwnership(administrator_locator)
-    assert ownership.owner_of(my_cluster_record) == ws.current_user.me().user_name
-    assert ownership.owner_of(their_cluster_record) == another_user.user_name
+    info_ownership = ClusterInfoOwnership(administrator_locator)
+    assert info_ownership.owner_of(my_cluster_record) == ws.current_user.me().user_name
+    assert info_ownership.owner_of(their_cluster_record) == another_user.user_name
+    details_ownership = ClusterDetailsOwnership(administrator_locator)
+    assert details_ownership.owner_of(ws.clusters.get(my_cluster.cluster_id)) == ws.current_user.me().user_name
+    assert details_ownership.owner_of(ws.clusters.get(their_cluster.cluster_id)) == another_user.user_name
 
 
 def test_cluster_crawler_mlr_no_isolation(ws, make_cluster, inventory_schema, sql_backend):

--- a/tests/integration/assessment/test_jobs.py
+++ b/tests/integration/assessment/test_jobs.py
@@ -7,7 +7,7 @@ from databricks.sdk.retries import retried
 from databricks.sdk.service.jobs import NotebookTask, RunTask
 from databricks.sdk.service.workspace import ImportFormat
 
-from databricks.labs.ucx.assessment.jobs import JobOwnership, JobsCrawler, SubmitRunsCrawler
+from databricks.labs.ucx.assessment.jobs import JobInfoOwnership, JobsCrawler, SubmitRunsCrawler
 
 from .test_assessment import _SPARK_CONF
 
@@ -80,5 +80,5 @@ def test_job_ownership(ws, runtime_ctx, make_job, inventory_schema, sql_backend)
     job_record = next(record for record in records if record.job_id == str(job.job_id))
 
     # Verify ownership is as expected.
-    ownership = JobOwnership(runtime_ctx.administrator_locator)
+    ownership = JobInfoOwnership(runtime_ctx.administrator_locator)
     assert ownership.owner_of(job_record) == ws.current_user.me().user_name

--- a/tests/unit/assessment/test_clusters.py
+++ b/tests/unit/assessment/test_clusters.py
@@ -13,7 +13,7 @@ from databricks.labs.ucx.assessment.clusters import (
     ClusterInfoOwnership,
     ClusterInfo,
     ClusterPolicyOwnership,
-    PolicyInfo,
+    PolicyInfo, ClusterDetailsOwnership,
 )
 from databricks.labs.ucx.framework.crawlers import SqlBackend
 from databricks.labs.ucx.framework.owners import AdministratorLocator
@@ -185,7 +185,7 @@ def test_unsupported_clusters():
     assert result_set[0].failures == '["cluster type not supported : LEGACY_PASSTHROUGH"]'
 
 
-def test_clusterinfo_owner_creator() -> None:
+def test_cluster_info_owner_creator() -> None:
     admin_locator = create_autospec(AdministratorLocator)
 
     ownership = ClusterInfoOwnership(admin_locator)
@@ -195,12 +195,33 @@ def test_clusterinfo_owner_creator() -> None:
     admin_locator.get_workspace_administrator.assert_not_called()
 
 
-def test_clusterinfo_owner_creator_unknown() -> None:
+def test_cluster_info_owner_creator_unknown() -> None:
     admin_locator = create_autospec(AdministratorLocator)
     admin_locator.get_workspace_administrator.return_value = "an_admin"
 
     ownership = ClusterInfoOwnership(admin_locator)
     owner = ownership.owner_of(ClusterInfo(creator=None, cluster_id="1", success=1, failures="[]"))
+
+    assert owner == "an_admin"
+    admin_locator.get_workspace_administrator.assert_called_once()
+
+
+def test_cluster_details_owner_creator() -> None:
+    admin_locator = create_autospec(AdministratorLocator)
+
+    ownership = ClusterDetailsOwnership(admin_locator)
+    owner = ownership.owner_of(ClusterDetails(creator_user_name="bob", cluster_id="1"))
+
+    assert owner == "bob"
+    admin_locator.get_workspace_administrator.assert_not_called()
+
+
+def test_cluster_details_owner_creator_unknown() -> None:
+    admin_locator = create_autospec(AdministratorLocator)
+    admin_locator.get_workspace_administrator.return_value = "an_admin"
+
+    ownership = ClusterDetailsOwnership(admin_locator)
+    owner = ownership.owner_of(ClusterDetails(cluster_id="1"))
 
     assert owner == "an_admin"
     admin_locator.get_workspace_administrator.assert_called_once()

--- a/tests/unit/assessment/test_clusters.py
+++ b/tests/unit/assessment/test_clusters.py
@@ -10,7 +10,7 @@ from databricks.labs.ucx.assessment.azure import AzureServicePrincipalCrawler
 from databricks.labs.ucx.assessment.clusters import (
     ClustersCrawler,
     PoliciesCrawler,
-    ClusterOwnership,
+    ClusterInfoOwnership,
     ClusterInfo,
     ClusterPolicyOwnership,
     PolicyInfo,
@@ -185,21 +185,21 @@ def test_unsupported_clusters():
     assert result_set[0].failures == '["cluster type not supported : LEGACY_PASSTHROUGH"]'
 
 
-def test_cluster_owner_creator() -> None:
+def test_clusterinfo_owner_creator() -> None:
     admin_locator = create_autospec(AdministratorLocator)
 
-    ownership = ClusterOwnership(admin_locator)
+    ownership = ClusterInfoOwnership(admin_locator)
     owner = ownership.owner_of(ClusterInfo(creator="bob", cluster_id="1", success=1, failures="[]"))
 
     assert owner == "bob"
     admin_locator.get_workspace_administrator.assert_not_called()
 
 
-def test_cluster_owner_creator_unknown() -> None:
+def test_clusterinfo_owner_creator_unknown() -> None:
     admin_locator = create_autospec(AdministratorLocator)
     admin_locator.get_workspace_administrator.return_value = "an_admin"
 
-    ownership = ClusterOwnership(admin_locator)
+    ownership = ClusterInfoOwnership(admin_locator)
     owner = ownership.owner_of(ClusterInfo(creator=None, cluster_id="1", success=1, failures="[]"))
 
     assert owner == "an_admin"

--- a/tests/unit/assessment/test_clusters.py
+++ b/tests/unit/assessment/test_clusters.py
@@ -9,11 +9,12 @@ from databricks.sdk.service.compute import ClusterDetails, Policy
 from databricks.labs.ucx.assessment.azure import AzureServicePrincipalCrawler
 from databricks.labs.ucx.assessment.clusters import (
     ClustersCrawler,
-    PoliciesCrawler,
+    ClusterDetailsOwnership,
     ClusterInfoOwnership,
     ClusterInfo,
     ClusterPolicyOwnership,
-    PolicyInfo, ClusterDetailsOwnership,
+    PoliciesCrawler,
+    PolicyInfo,
 )
 from databricks.labs.ucx.framework.crawlers import SqlBackend
 from databricks.labs.ucx.framework.owners import AdministratorLocator

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -2,9 +2,9 @@ from unittest.mock import create_autospec
 
 import pytest
 from databricks.labs.lsql.backends import MockBackend
-from databricks.sdk.service.jobs import BaseJob, JobSettings
+from databricks.sdk.service.jobs import BaseJob, JobSettings, Job
 
-from databricks.labs.ucx.assessment.jobs import JobInfo, JobOwnership, JobsCrawler, SubmitRunsCrawler
+from databricks.labs.ucx.assessment.jobs import JobInfo, JobInfoOwnership, JobsCrawler, SubmitRunsCrawler, JobOwnership
 from databricks.labs.ucx.framework.owners import AdministratorLocator
 
 from .. import mock_workspace_client
@@ -135,22 +135,43 @@ def test_job_run_crawler(jobruns_ids, cluster_ids, run_ids, failures):
     assert result[0].failures == failures
 
 
-def test_pipeline_owner_creator() -> None:
+def test_jobinfo_owner_creator() -> None:
     admin_locator = create_autospec(AdministratorLocator)
 
-    ownership = JobOwnership(admin_locator)
+    ownership = JobInfoOwnership(admin_locator)
     owner = ownership.owner_of(JobInfo(creator="bob", job_id="1", success=1, failures="[]"))
 
     assert owner == "bob"
     admin_locator.get_workspace_administrator.assert_not_called()
 
 
-def test_pipeline_owner_creator_unknown() -> None:
+def test_jobinfo_owner_creator_unknown() -> None:
+    admin_locator = create_autospec(AdministratorLocator)
+    admin_locator.get_workspace_administrator.return_value = "an_admin"
+
+    ownership = JobInfoOwnership(admin_locator)
+    owner = ownership.owner_of(JobInfo(creator=None, job_id="1", success=1, failures="[]"))
+
+    assert owner == "an_admin"
+    admin_locator.get_workspace_administrator.assert_called_once()
+
+
+def test_job_owner_creator() -> None:
+    admin_locator = create_autospec(AdministratorLocator)
+
+    ownership = JobOwnership(admin_locator)
+    owner = ownership.owner_of(Job(creator_user_name="bob", job_id=1))
+
+    assert owner == "bob"
+    admin_locator.get_workspace_administrator.assert_not_called()
+
+
+def test_job_owner_creator_unknown() -> None:
     admin_locator = create_autospec(AdministratorLocator)
     admin_locator.get_workspace_administrator.return_value = "an_admin"
 
     ownership = JobOwnership(admin_locator)
-    owner = ownership.owner_of(JobInfo(creator=None, job_id="1", success=1, failures="[]"))
+    owner = ownership.owner_of(Job(job_id=1))
 
     assert owner == "an_admin"
     admin_locator.get_workspace_administrator.assert_called_once()


### PR DESCRIPTION
## Changes
Existing Ownership classes deal with inventory objects.
We sometimes also need to get ownership from workspace objects.
This PR implements these for `Job` and `ClusterDetails`

### Linked issues
Progresses #1415 

### Functionality
None

### Tests
- [x] added unit tests
- [x] added integration tests
