### PR TITLE
Fixed `SystemError: AST constructor recursion depth mismatch` failing the entire job

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -34,7 +34,6 @@ from databricks.labs.ucx.source_code.base import (
     SourceInfo,
     UsedTable,
     LineageAtom,
-    PythonSequentialLinter,
     read_text,
 )
 from databricks.labs.ucx.source_code.directfs_access import (
@@ -52,7 +51,7 @@ from databricks.labs.ucx.source_code.graph import (
 )
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import Tree, PythonSequentialLinter
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter, Notebook
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
@@ -638,8 +637,12 @@ class _CollectorWalker(DependencyGraphWalker[T], ABC):
             if cell.language is CellLanguage.PYTHON:
                 if inherited_tree is None:
                     inherited_tree = Tree.new_module()
-                tree = Tree.normalize_and_parse(cell.original_code)
-                inherited_tree.append_tree(tree)
+                maybe_tree = Tree.maybe_normalized_parse(cell.original_code)
+                if maybe_tree.failure:
+                    logger.warning(maybe_tree.failure.message)
+                    continue
+                assert maybe_tree.tree is not None
+                inherited_tree.append_tree(maybe_tree.tree)
 
     def _collect_from_source(
         self,

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -8,15 +8,17 @@ from databricks.labs.ucx.source_code.base import (
     Linter,
     SqlSequentialLinter,
     CurrentSessionState,
-    PythonSequentialLinter,
-    PythonLinter,
     SqlLinter,
-    TablePyCollector,
     TableSqlCollector,
     TableCollector,
     DfsaCollector,
-    DfsaPyCollector,
     DfsaSqlCollector,
+)
+from databricks.labs.ucx.source_code.python.python_ast import (
+    PythonLinter,
+    TablePyCollector,
+    DfsaPyCollector,
+    PythonSequentialLinter,
 )
 from databricks.labs.ucx.source_code.linters.directfs import DirectFsAccessPyLinter, DirectFsAccessSqlLinter
 from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter

--- a/src/databricks/labs/ucx/source_code/linters/directfs.py
+++ b/src/databricks/labs/ucx/source_code/linters/directfs.py
@@ -9,14 +9,18 @@ from databricks.labs.ucx.source_code.base import (
     Advice,
     Deprecation,
     CurrentSessionState,
-    PythonLinter,
     SqlLinter,
-    DfsaPyCollector,
     DirectFsAccessNode,
     DfsaSqlCollector,
     DirectFsAccess,
 )
-from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeVisitor, TreeHelper
+from databricks.labs.ucx.source_code.python.python_ast import (
+    Tree,
+    TreeVisitor,
+    TreeHelper,
+    PythonLinter,
+    DfsaPyCollector,
+)
 from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 from databricks.labs.ucx.source_code.sql.sql_parser import SqlParser, SqlExpression
 

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -17,8 +17,8 @@ from astroid import (  # type: ignore
     NodeNG,
 )
 
-from databricks.labs.ucx.source_code.base import Advice, Advisory, CurrentSessionState, PythonLinter
-from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase, TreeVisitor
+from databricks.labs.ucx.source_code.base import Advice, Advisory, CurrentSessionState
+from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase, TreeVisitor, PythonLinter
 from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 

--- a/src/databricks/labs/ucx/source_code/linters/spark_connect.py
+++ b/src/databricks/labs/ucx/source_code/linters/spark_connect.py
@@ -6,12 +6,11 @@ from astroid import Attribute, Call, Const, Name, NodeNG  # type: ignore
 from databricks.labs.ucx.source_code.base import (
     Advice,
     Failure,
-    PythonLinter,
     CurrentSessionState,
 )
 from databricks.sdk.service.compute import DataSecurityMode
 
-from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper
+from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper, PythonLinter
 
 
 @dataclass

--- a/src/databricks/labs/ucx/source_code/linters/table_creation.py
+++ b/src/databricks/labs/ucx/source_code/linters/table_creation.py
@@ -7,9 +7,8 @@ from astroid import Attribute, Call, NodeNG  # type: ignore
 
 from databricks.labs.ucx.source_code.base import (
     Advice,
-    PythonLinter,
 )
-from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper
+from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper, PythonLinter
 
 
 @dataclass

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import cast
 
-from astroid import AstroidSyntaxError, Module, NodeNG  # type: ignore
+from astroid import Module, NodeNG  # type: ignore
 
 from databricks.sdk.service.workspace import Language
 
@@ -17,7 +17,6 @@ from databricks.labs.ucx.source_code.base import (
     Advice,
     Failure,
     Linter,
-    PythonSequentialLinter,
     CurrentSessionState,
     Advisory,
     file_language,
@@ -37,7 +36,7 @@ from databricks.labs.ucx.source_code.linters.imports import (
     UnresolvedPath,
 )
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
-from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase
+from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase, PythonSequentialLinter
 from databricks.labs.ucx.source_code.notebooks.cells import (
     CellLanguage,
     Cell,
@@ -196,13 +195,14 @@ class NotebookLinter:
                 continue
 
     def _load_tree_from_python_cell(self, python_cell: PythonCell, register_trees: bool) -> Iterable[Advice]:
-        try:
-            tree = Tree.normalize_and_parse(python_cell.original_code)
-            if register_trees:
-                self._python_trees[python_cell] = tree
-            yield from self._load_children_from_tree(tree)
-        except AstroidSyntaxError as e:
-            yield Failure('syntax-error', str(e), 0, 0, 0, 0)
+        maybe_tree = Tree.maybe_normalized_parse(python_cell.original_code)
+        if maybe_tree.failure:
+            yield maybe_tree.failure
+        assert maybe_tree.tree is not None
+        tree = maybe_tree.tree
+        if register_trees:
+            self._python_trees[python_cell] = tree
+        yield from self._load_children_from_tree(tree)
 
     def _load_children_from_tree(self, tree: Tree) -> Iterable[Advice]:
         assert isinstance(tree.node, Module)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import builtins
 import sys
-from abc import ABC
+from abc import ABC, abstractmethod
 import logging
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TypeVar, cast
 
 from astroid import (  # type: ignore
@@ -24,6 +25,19 @@ from astroid import (  # type: ignore
     NodeNG,
     parse,
     Uninferable,
+    AstroidSyntaxError,
+)
+
+from databricks.labs.ucx.source_code.base import (
+    Failure,
+    Linter,
+    Advice,
+    TableCollector,
+    UsedTable,
+    UsedTableNode,
+    DfsaCollector,
+    DirectFsAccess,
+    DirectFsAccessNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,18 +47,67 @@ missing_handlers: set[str] = set()
 T = TypeVar("T", bound=NodeNG)
 
 
+@dataclass(frozen=True)
+class MaybeTree:
+    tree: Tree | None
+    failure: Failure | None
+
+    def walk(self) -> Iterable[NodeNG]:
+        if self.tree is None:
+            assert self.failure is not None
+            logger.warning(self.failure.message)
+            return []
+        return self.tree.walk()
+
+    def first_statement(self) -> NodeNG | None:
+        if self.tree is None:
+            assert self.failure is not None
+            logger.warning(self.failure.message)
+            return None
+        return self.tree.first_statement()
+
+    def locate(self, node_type: type[T], match_nodes: list[tuple[str, type]]) -> list[T]:
+        # TODO: remove
+        if self.tree is None:
+            assert self.failure is not None
+            logger.warning(self.failure.message)
+            return []
+        return self.tree.locate(node_type, match_nodes)
+
+
 class Tree:
 
+    @classmethod
+    def maybe_parse(cls, code: str) -> MaybeTree:
+        try:
+            root = parse(code)
+            tree = Tree(root)
+            return MaybeTree(tree, None)
+        except AstroidSyntaxError as e:
+            return cls._definitely_failure('syntax-error', code, e)
+        except SystemError as e:
+            # see https://github.com/databrickslabs/ucx/issues/2976
+            return cls._definitely_failure('system-error', code, e)
+
     @staticmethod
-    def parse(code: str) -> Tree:
-        root = parse(code)
-        return Tree(root)
+    def _definitely_failure(message_code: str, source_code: str, e: Exception) -> MaybeTree:
+        return MaybeTree(
+            None,
+            Failure(
+                code=message_code,
+                message=f"Failed to parse code `{source_code}`: {e}. Report this as an issue on UCX GitHub.",
+                # Lines and columns are both 0-based: the first line is line 0.
+                start_line=0,
+                start_col=0,
+                end_line=1,
+                end_col=1,
+            ),
+        )
 
     @classmethod
-    def normalize_and_parse(cls, code: str) -> Tree:
+    def maybe_normalized_parse(cls, code: str) -> MaybeTree:
         code = cls.normalize(code)
-        root = parse(code)
-        return Tree(root)
+        return cls.maybe_parse(code)
 
     @classmethod
     def normalize(cls, code: str) -> str:
@@ -496,3 +559,131 @@ class NodeBase(ABC):
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: {repr(self._node)}>"
+
+
+class PythonLinter(Linter):
+
+    def lint(self, code: str) -> Iterable[Advice]:
+        maybe_tree = Tree.maybe_normalized_parse(code)
+        if maybe_tree.failure:
+            yield maybe_tree.failure
+            return
+        assert maybe_tree.tree is not None
+        yield from self.lint_tree(maybe_tree.tree)
+
+    @abstractmethod
+    def lint_tree(self, tree: Tree) -> Iterable[Advice]: ...
+
+
+class TablePyCollector(TableCollector, ABC):
+
+    def collect_tables(self, source_code: str) -> Iterable[UsedTable]:
+        maybe_tree = Tree.maybe_normalized_parse(source_code)
+        if maybe_tree.failure:
+            logger.warning(maybe_tree.failure.message)
+            return
+        assert maybe_tree.tree is not None
+        for table_node in self.collect_tables_from_tree(maybe_tree.tree):
+            yield table_node.table
+
+    @abstractmethod
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]: ...
+
+
+class DfsaPyCollector(DfsaCollector, ABC):
+
+    def collect_dfsas(self, source_code: str) -> Iterable[DirectFsAccess]:
+        maybe_tree = Tree.maybe_normalized_parse(source_code)
+        if maybe_tree.failure:
+            logger.warning(maybe_tree.failure.message)
+            return
+        assert maybe_tree.tree is not None
+        for dfsa_node in self.collect_dfsas_from_tree(maybe_tree.tree):
+            yield dfsa_node.dfsa
+
+    @abstractmethod
+    def collect_dfsas_from_tree(self, tree: Tree) -> Iterable[DirectFsAccessNode]: ...
+
+
+class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
+
+    def __init__(
+        self,
+        linters: list[PythonLinter],
+        dfsa_collectors: list[DfsaPyCollector],
+        table_collectors: list[TablePyCollector],
+    ):
+        self._linters = linters
+        self._dfsa_collectors = dfsa_collectors
+        self._table_collectors = table_collectors
+        self._tree: Tree | None = None
+
+    def lint(self, code: str) -> Iterable[Advice]:
+        maybe_tree = self._parse_and_append(code)
+        if maybe_tree.failure:
+            yield maybe_tree.failure
+            return
+        assert maybe_tree.tree is not None
+        yield from self.lint_tree(maybe_tree.tree)
+
+    def lint_tree(self, tree: Tree) -> Iterable[Advice]:
+        for linter in self._linters:
+            yield from linter.lint_tree(tree)
+
+    def _parse_and_append(self, code: str) -> MaybeTree:
+        maybe_tree = Tree.maybe_normalized_parse(code)
+        if maybe_tree.failure:
+            return maybe_tree
+        assert maybe_tree.tree is not None
+        self.append_tree(maybe_tree.tree)
+        return maybe_tree
+
+    def append_tree(self, tree: Tree) -> None:
+        self._make_tree().append_tree(tree)
+
+    def append_nodes(self, nodes: list[NodeNG]) -> None:
+        self._make_tree().append_nodes(nodes)
+
+    def append_globals(self, globs: dict) -> None:
+        self._make_tree().append_globals(globs)
+
+    def process_child_cell(self, code: str) -> None:
+        this_tree = self._make_tree()
+        maybe_tree = Tree.maybe_normalized_parse(code)
+        if maybe_tree.failure:
+            # TODO: bubble up this error
+            logger.warning(maybe_tree.failure.message)
+            return
+        assert maybe_tree.tree is not None
+        this_tree.append_tree(maybe_tree.tree)
+
+    def collect_dfsas(self, source_code: str) -> Iterable[DirectFsAccess]:
+        maybe_tree = self._parse_and_append(source_code)
+        if maybe_tree.failure:
+            logger.warning(maybe_tree.failure.message)
+            return
+        assert maybe_tree.tree is not None
+        for dfsa_node in self.collect_dfsas_from_tree(maybe_tree.tree):
+            yield dfsa_node.dfsa
+
+    def collect_dfsas_from_tree(self, tree: Tree) -> Iterable[DirectFsAccessNode]:
+        for collector in self._dfsa_collectors:
+            yield from collector.collect_dfsas_from_tree(tree)
+
+    def collect_tables(self, source_code: str) -> Iterable[UsedTable]:
+        maybe_tree = self._parse_and_append(source_code)
+        if maybe_tree.failure:
+            logger.warning(maybe_tree.failure.message)
+            return
+        assert maybe_tree.tree is not None
+        for table_node in self.collect_tables_from_tree(maybe_tree.tree):
+            yield table_node.table
+
+    def collect_tables_from_tree(self, tree: Tree) -> Iterable[UsedTableNode]:
+        for collector in self._table_collectors:
+            yield from collector.collect_tables_from_tree(tree)
+
+    def _make_tree(self) -> Tree:
+        if self._tree is None:
+            self._tree = Tree.new_module()
+        return self._tree

--- a/tests/integration/source_code/message_codes.py
+++ b/tests/integration/source_code/message_codes.py
@@ -11,7 +11,10 @@ def main():
     product_info = ProductInfo.from_class(Advice)
     source_code = product_info.version_file().parent
     for file in source_code.glob("**/*.py"):
-        tree = Tree.parse(file.read_text())
+        maybe_tree = Tree.maybe_parse(file.read_text())
+        if not maybe_tree.tree:
+            continue
+        tree = maybe_tree.tree
         # recursively detect values of "code" kwarg in calls
         for node in tree.walk():
             if not isinstance(node, astroid.Call):

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -576,40 +576,45 @@ def test_direct_cloud_access_to_volumes_reports_nothing(empty_index, fs_function
 
 
 def test_get_full_function_name_for_member_function() -> None:
-    tree = Tree.parse("value.attr()")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("value.attr()")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value.attr'
 
 
 def test_get_full_function_name_for_member_member_function() -> None:
-    tree = Tree.parse("value1.value2.attr()")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("value1.value2.attr()")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value1.value2.attr'
 
 
 def test_get_full_function_name_for_chained_function() -> None:
-    tree = Tree.parse("value.attr1().attr2()")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("value.attr1().attr2()")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value.attr1.attr2'
 
 
 def test_get_full_function_name_for_global_function() -> None:
-    tree = Tree.parse("name()")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("name()")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'name'
 
 
 def test_get_full_function_name_for_non_method() -> None:
-    tree = Tree.parse("not_a_function")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("not_a_function")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert TreeHelper.get_full_function_name(node.value) is None
 
@@ -617,8 +622,9 @@ def test_get_full_function_name_for_non_method() -> None:
 def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.parse("call('some.things')")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("call('some.things')")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     matcher.apply(from_table, migration_index, node.value)
@@ -630,8 +636,9 @@ def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None
 def test_apply_table_name_matcher_with_existing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.parse("call('old.things')")
-    node = tree.first_statement()
+    tree = Tree.maybe_parse("call('old.things')")
+    assert tree.tree is not None
+    node = tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     matcher.apply(from_table, migration_index, node.value)

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -14,8 +14,9 @@ from databricks.labs.ucx.source_code.python.python_ast import Tree
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls() -> None:
-    tree = Tree.parse('')
-    assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
+    tree = Tree.maybe_parse('')
+    assert tree.tree is not None
+    assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
 
 
 def test_linter_returns_list_of_dbutils_notebook_run_calls() -> None:
@@ -24,34 +25,40 @@ dbutils.notebook.run("stuff")
 for i in z:
     ww =   dbutils.notebook.run("toto")
 """
-    tree = Tree.parse(code)
-    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
     assert {"toto", "stuff"} == {str(call.node.args[0].value) for call in calls}
 
 
 def test_linter_returns_empty_list_of_imports() -> None:
-    tree = Tree.parse('')
-    assert not ImportSource.extract_from_tree(tree, DependencyProblem.from_node)[0]
+    tree = Tree.maybe_parse('')
+    assert tree.tree is not None
+    assert not ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]
 
 
 def test_linter_returns_import() -> None:
-    tree = Tree.parse('import x')
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree, DependencyProblem.from_node)[0]]
+    tree = Tree.maybe_parse('import x')
+    assert tree.tree is not None
+    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns_import_from() -> None:
-    tree = Tree.parse('from x import z')
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree, DependencyProblem.from_node)[0]]
+    tree = Tree.maybe_parse('from x import z')
+    assert tree.tree is not None
+    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns_import_module() -> None:
-    tree = Tree.parse('importlib.import_module("x")')
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree, DependencyProblem.from_node)[0]]
+    tree = Tree.maybe_parse('importlib.import_module("x")')
+    assert tree.tree is not None
+    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns__import__() -> None:
-    tree = Tree.parse('importlib.__import__("x")')
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree, DependencyProblem.from_node)[0]]
+    tree = Tree.maybe_parse('importlib.__import__("x")')
+    assert tree.tree is not None
+    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns_appended_absolute_paths() -> None:
@@ -60,8 +67,9 @@ import sys
 sys.path.append("absolute_path_1")
 sys.path.append("absolute_path_2")
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
 
 
@@ -71,8 +79,9 @@ import sys as stuff
 stuff.path.append("absolute_path_1")
 stuff.path.append("absolute_path_2")
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
 
 
@@ -81,8 +90,9 @@ def test_linter_returns_appended_absolute_paths_with_sys_path_alias() -> None:
 from sys import path as stuff
 stuff.append("absolute_path")
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "absolute_path" in [p.path for p in appended]
 
 
@@ -92,8 +102,9 @@ import sys
 import os
 sys.path.append(os.path.abspath("relative_path"))
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -103,8 +114,9 @@ import sys
 import os as stuff
 sys.path.append(stuff.path.abspath("relative_path"))
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -114,8 +126,9 @@ import sys
 from os import path as stuff
 sys.path.append(stuff.abspath("relative_path"))
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -125,8 +138,9 @@ import sys
 from os.path import abspath
 sys.path.append(abspath("relative_path"))
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -136,8 +150,9 @@ import sys
 from os.path import abspath as stuff
 sys.path.append(stuff("relative_path"))
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -147,8 +162,9 @@ import sys
 path = "absolute_path_1"
 sys.path.append(path)
 """
-    tree = Tree.parse(code)
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1"] == [p.path for p in appended]
 
 
@@ -188,8 +204,9 @@ dbutils.notebook.run(name)
     ],
 )
 def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
-    tree = Tree.parse(code)
-    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
+    tree = Tree.maybe_parse(code)
+    assert tree.tree is not None
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
     all_paths: list[str] = []
     for call in calls:
         _, paths = call.get_notebook_paths(CurrentSessionState())

--- a/tests/unit/source_code/linters/test_spark_connect.py
+++ b/tests/unit/source_code/linters/test_spark_connect.py
@@ -236,7 +236,7 @@ sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
             end_line=6,
             end_col=24,
         ),
-    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.parse(code).walk()]))
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.maybe_parse(code).walk()]))
 
 
 def test_logging_serverless(session_state) -> None:
@@ -248,6 +248,9 @@ log4jLogger = sc._jvm.org.apache.log4j
 
     """
 
+    maybe_tree = Tree.maybe_parse(code)
+    assert maybe_tree.tree is not None
+    tree = maybe_tree.tree
     assert [
         Failure(
             code='spark-logging-in-shared-clusters',
@@ -266,7 +269,7 @@ log4jLogger = sc._jvm.org.apache.log4j
             end_line=2,
             end_col=38,
         ),
-    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.parse(code).walk()]))
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in tree.walk()]))
 
 
 def test_valid_code() -> None:

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -272,7 +272,9 @@ def test_unsupported_magic_raises_problem(simple_dependency_resolver, mock_path_
     source = """
 %unsupported stuff '"%#@!
 """
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree, maybe_tree.failure
+    tree = maybe_tree.tree
     commands, _ = MagicLine.extract_from_tree(tree, DependencyProblem.from_node)
     dependency = Dependency(FileLoader(), Path(""))
     graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -6,7 +6,9 @@ from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_extracts_root() -> None:
-    tree = Tree.parse("o.m1().m2().m3()")
+    maybe_tree = Tree.maybe_parse("o.m1().m2().m3()")
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     stmt = tree.first_statement()
     root = Tree(stmt).root
     assert root == tree.node
@@ -14,12 +16,12 @@ def test_extracts_root() -> None:
 
 
 def test_no_first_statement() -> None:
-    tree = Tree.parse("")
-    assert not tree.first_statement()
+    maybe_tree = Tree.maybe_parse("")
+    assert maybe_tree.tree is None
 
 
 def test_extract_call_by_name() -> None:
-    tree = Tree.parse("o.m1().m2().m3()")
+    tree = Tree.maybe_parse("o.m1().m2().m3()")
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
@@ -30,7 +32,7 @@ def test_extract_call_by_name() -> None:
 
 
 def test_extract_call_by_name_none() -> None:
-    tree = Tree.parse("o.m1().m2().m3()")
+    tree = Tree.maybe_parse("o.m1().m2().m3()")
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
@@ -56,7 +58,7 @@ def test_extract_call_by_name_none() -> None:
     ],
 )
 def test_linter_gets_arg(code, arg_index, arg_name, expected) -> None:
-    tree = Tree.parse(code)
+    tree = Tree.maybe_parse(code)
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
@@ -81,7 +83,7 @@ def test_linter_gets_arg(code, arg_index, arg_name, expected) -> None:
     ],
 )
 def test_args_count(code, expected) -> None:
-    tree = Tree.parse(code)
+    tree = Tree.maybe_parse(code)
     stmt = tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
@@ -92,7 +94,7 @@ def test_args_count(code, expected) -> None:
 def test_tree_walks_nodes_once() -> None:
     nodes = set()
     count = 0
-    tree = Tree.parse("o.m1().m2().m3()")
+    tree = Tree.maybe_parse("o.m1().m2().m3()")
     for node in tree.walk():
         nodes.add(node)
         count += 1
@@ -120,8 +122,8 @@ def test_parses_incorrectly_indented_code() -> None:
 """
     # ensure it would fail if not normalized
     with pytest.raises(AstroidSyntaxError):
-        Tree.parse(source)
-    Tree.normalize_and_parse(source)
+        Tree.maybe_parse(source)
+    Tree.maybe_normalized_parse(source)
     assert True
 
 
@@ -132,15 +134,19 @@ name="name"
 version="version"
 formatted=message_unformatted % (name, version)
 """
-    Tree.normalize_and_parse(source)
+    Tree.maybe_normalized_parse(source)
     assert True
 
 
 def test_appends_statements() -> None:
     source_1 = "a = 'John'"
-    tree_1 = Tree.normalize_and_parse(source_1)
+    maybe_tree_1 = Tree.maybe_normalized_parse(source_1)
+    assert maybe_tree_1.tree is not None, maybe_tree_1.failure
+    tree_1 = maybe_tree_1.tree
     source_2 = 'b = f"Hello {a}!"'
-    tree_2 = Tree.normalize_and_parse(source_2)
+    maybe_tree_2 = Tree.maybe_normalized_parse(source_2)
+    assert maybe_tree_2.tree is not None, maybe_tree_2.failure
+    tree_2 = maybe_tree_2.tree
     tree_3 = tree_1.append_tree(tree_2)
     nodes = tree_3.locate(Assign, [])
     tree = Tree(nodes[0].value)  # tree_3 only contains tree_2 statements
@@ -154,7 +160,9 @@ def test_is_from_module() -> None:
 df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     save_call = tree.locate(
         Call, [("saveAsTable", Attribute), ("format", Attribute), ("write", Attribute), ("df", Name)]
     )[0]
@@ -163,7 +171,9 @@ df.write.format("delta").saveAsTable("old.things")
 
 @pytest.mark.parametrize("source, name, class_name", [("a = 123", "a", "int")])
 def test_is_instance_of(source, name, class_name) -> None:
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     assert isinstance(tree.node, Module)
     module = tree.node
     var = module.globals.get(name, None)
@@ -181,11 +191,18 @@ def test_supports_recursive_refs_when_checking_module() -> None:
     source_3 = """
     df = df.withColumn(stuff2)
     """
-    main_tree = Tree.normalize_and_parse(source_1)
-    main_tree.append_tree(Tree.normalize_and_parse(source_2))
-    tree = Tree.normalize_and_parse(source_3)
-    main_tree.append_tree(tree)
-    assign = tree.locate(Assign, [])[0]
+    maybe_tree = Tree.maybe_normalized_parse(source_1)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    main_tree = maybe_tree.tree
+    maybe_tree_2 = Tree.maybe_normalized_parse(source_2)
+    assert maybe_tree_2.tree is not None, maybe_tree_2.failure
+    tree_2 = maybe_tree_2.tree
+    main_tree.append_tree(tree_2)
+    maybe_tree_3 = Tree.maybe_normalized_parse(source_3)
+    assert maybe_tree_3.tree is not None, maybe_tree_3.failure
+    tree_3 = maybe_tree_3.tree
+    main_tree.append_tree(tree_3)
+    assign = tree_3.locate(Assign, [])[0]
     assert Tree(assign.value).is_from_module("spark")
 
 
@@ -193,7 +210,9 @@ def test_renumbers_positively() -> None:
     source = """df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
     assert len(nodes) == 2
     assert nodes[0].lineno == 1
@@ -209,7 +228,9 @@ def test_renumbers_negatively() -> None:
     source = """df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
     assert len(nodes) == 2
     assert nodes[0].lineno == 1
@@ -231,7 +252,9 @@ df.write.format("delta").saveAsTable("old.things")
     ],
 )
 def test_counts_lines(source: str, line_count: int) -> None:
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     assert tree.line_count() == line_count
 
 
@@ -251,7 +274,9 @@ x = stuff()""",
     ],
 )
 def test_is_builtin(source, name, is_builtin) -> None:
-    tree = Tree.normalize_and_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
     for node in nodes:
         if isinstance(node, Assign):

--- a/tests/unit/source_code/python/test_python_infer.py
+++ b/tests/unit/source_code/python/test_python_infer.py
@@ -6,7 +6,9 @@ from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_infers_empty_list() -> None:
-    tree = Tree.parse("a=[]")
+    maybe_tree = Tree.maybe_parse("a=[]")
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[0].value)
     values = list(InferredValue.infer_from_node(tree.node))
@@ -14,7 +16,9 @@ def test_infers_empty_list() -> None:
 
 
 def test_infers_empty_tuple() -> None:
-    tree = Tree.parse("a=tuple()")
+    maybe_tree = Tree.maybe_parse("a=tuple()")
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[0].value)
     values = list(InferredValue.infer_from_node(tree.node))
@@ -22,7 +26,9 @@ def test_infers_empty_tuple() -> None:
 
 
 def test_infers_empty_set() -> None:
-    tree = Tree.parse("a={}")
+    maybe_tree = Tree.maybe_parse("a={}")
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[0].value)
     values = list(InferredValue.infer_from_node(tree.node))
@@ -34,7 +40,9 @@ def test_infers_fstring_value() -> None:
 value = "abc"
 fstring = f"Hello {value}!"
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of fstring = ...
     values = list(InferredValue.infer_from_node(tree.node))
@@ -48,7 +56,9 @@ def test_infers_fstring_dict_value() -> None:
 value = { "abc": 123 }
 fstring = f"Hello {value['abc']}!"
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of fstring = ...
     values = list(InferredValue.infer_from_node(tree.node))
@@ -62,7 +72,9 @@ def test_infers_string_format_value() -> None:
 value = "abc"
 fstring = "Hello {0}!".format(value)
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of fstring = ...
     values = list(InferredValue.infer_from_node(tree.node))
@@ -79,7 +91,9 @@ for value1 in values_1:
     for value2 in values_2:
         fstring = f"Hello {value1}, {value2}!"
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[2].value)  # value of fstring = ...
     values = list(InferredValue.infer_from_node(tree.node))
@@ -95,7 +109,9 @@ def test_infers_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of value = ...
     values = list(InferredValue.infer_from_node(tree.node, state))
@@ -110,7 +126,9 @@ def test_infers_externally_defined_values() -> None:
 for name in ["my-widget-1", "my-widget-2"]:
     value = dbutils.widgets.get(name)
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[0].value)  # value of value = ...
     values = list(InferredValue.infer_from_node(tree.node, state))
@@ -125,7 +143,9 @@ def test_fails_to_infer_missing_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of value = ...
     values = InferredValue.infer_from_node(tree.node, state)
@@ -137,7 +157,9 @@ def test_survives_absence_of_externally_defined_values() -> None:
     name = "my-widget"
     value = dbutils.widgets.get(name)
     """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[1].value)  # value of value = ...
     values = InferredValue.infer_from_node(tree.node, CurrentSessionState())
@@ -152,7 +174,9 @@ values = dbutils.widgets.getAll()
 name = "my-widget"
 value = values[name]
 """
-    tree = Tree.parse(source)
+    maybe_tree = Tree.maybe_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
     tree = Tree(nodes[2].value)  # value of value = ...
     values = list(InferredValue.infer_from_node(tree.node, state))

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -262,8 +262,9 @@ stuff2 = dbutils.notebook.run("where is notebook 1?")
 stuff3 = dbutils.notebook.run("where is notebook 2?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.parse(source)
-    nodes = linter.list_dbutils_notebook_run_calls(tree)
+    tree = Tree.maybe_parse(source)
+    assert tree.tree is not None
+    nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
     assert len(nodes) == 2
 
 
@@ -274,8 +275,9 @@ do_something_with_stuff(stuff)
 stuff2 = notebook.run("where is notebook 1?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.parse(source)
-    nodes = linter.list_dbutils_notebook_run_calls(tree)
+    tree = Tree.maybe_parse(source)
+    assert tree.tree is not None
+    nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
     assert len(nodes) == 0
 
 


### PR DESCRIPTION
This PR adds more deterministic, Go-style, error handling for parsing Python code

Fix #2976
