### PR TITLE
Remove a dead (ownership-related) class

### DIFF
--- a/src/databricks/labs/ucx/framework/owners.py
+++ b/src/databricks/labs/ucx/framework/owners.py
@@ -2,17 +2,13 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import cached_property
-from typing import ClassVar, Generic, Protocol, TypeVar, final
+from typing import Generic, TypeVar, final
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.service.iam import User
 
 logger = logging.getLogger(__name__)
-
-
-class DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict]
 
 
 Record = TypeVar("Record")


### PR DESCRIPTION
## Changes

This PR trivially removes a dead class; this was detritus left over from an intermediate version of the ownership mechanism that limited `Record` to `dataclass` classes. However this limitation was removed prior to the original code being merged (and the mechanism can be used with any class).