### PR TITLE
Update migration progress workflow to also re-lint dashboards and jobs

### DIFF
--- a/docs/table_persistence.md
+++ b/docs/table_persistence.md
@@ -14,8 +14,8 @@ Table Utilization:
 | permissions              | RW                  |                           | RW             | RO                      |              | RO             |                             |                 |
 | jobs                     | RW                  | RW                        |                |                         | RO           |                |                             |                 |
 | clusters                 | RW                  | RW                        |                |                         |              |                |                             |                 |
-| directfs_in_paths        | RW                  |                           |                |                         |              |                |                             | RW              |
-| directfs_in_queries      | RW                  |                           |                |                         |              |                |                             | RW              |
+| directfs_in_paths        | RW                  | RW                        |                |                         |              |                |                             | RW              |
+| directfs_in_queries      | RW                  | RW                        |                |                         |              |                |                             | RW              |
 | external_locations       | RW                  |                           |                | RO                      |              |                |                             |                 |
 | workspace                | RW                  |                           | RO             |                         | RO           |                |                             |                 |
 | workspace_objects        | RW                  |                           |                |                         |              |                |                             |                 |
@@ -27,8 +27,8 @@ Table Utilization:
 | submit_runs              | RW                  |                           |                |                         |              |                |                             |                 |
 | policies                 | RW                  | RW                        |                |                         |              |                |                             |                 |
 | migration_status         |                     | RW                        |                | RW                      |              | RW             |                             |                 |
-| query_problems           | RW                  |                           |                |                         |              |                |                             | RW              |
-| workflow_problems        | RW                  |                           |                |                         |              |                |                             | RW              |
+| query_problems           | RW                  | RW                        |                |                         |              |                |                             | RW              |
+| workflow_problems        | RW                  | RW                        |                |                         |              |                |                             | RW              |
 | udfs                     | RW                  | RW                        | RO             |                         |              |                |                             |                 |
 | logs                     | RW                  |                           | RW             | RW                      |              | RW             | RW                          |                 |
 | recon_results            |                     |                           |                |                         |              |                | RW                          |                 |

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -12,7 +12,7 @@ from databricks.labs.ucx.assessment.jobs import JobsCrawler, SubmitRunsCrawler
 from databricks.labs.ucx.assessment.pipelines import PipelinesCrawler
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.application import GlobalContext
-from databricks.labs.ucx.hive_metastore import TablesInMounts
+from databricks.labs.ucx.hive_metastore import TablesInMounts, TablesCrawler
 from databricks.labs.ucx.hive_metastore.table_size import TableSizeCrawler
 from databricks.labs.ucx.hive_metastore.tables import FasterTableScanCrawler
 from databricks.labs.ucx.installer.logs import TaskRunWarningRecorder
@@ -84,7 +84,7 @@ class RuntimeContext(GlobalContext):
         return GlobalInitScriptCrawler(self.workspace_client, self.sql_backend, self.inventory_database)
 
     @cached_property
-    def tables_crawler(self) -> FasterTableScanCrawler:
+    def tables_crawler(self) -> TablesCrawler:
         return FasterTableScanCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
 
     @cached_property

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -1,3 +1,4 @@
+from typing import get_type_hints
 from unittest.mock import create_autospec
 
 import pytest
@@ -5,35 +6,25 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import CatalogInfo, MetastoreAssignment
 from databricks.sdk.service.jobs import BaseRun, RunResultState, RunState
 
-from databricks.labs.ucx.assessment.clusters import ClustersCrawler, PoliciesCrawler
-from databricks.labs.ucx.assessment.jobs import JobsCrawler
-from databricks.labs.ucx.assessment.pipelines import PipelinesCrawler
 from databricks.labs.ucx.progress.workflows import MigrationProgress
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
-from databricks.labs.ucx.hive_metastore import TablesCrawler
-from databricks.labs.ucx.hive_metastore.grants import GrantsCrawler
-from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
-from databricks.labs.ucx.hive_metastore.udfs import UdfsCrawler
 
 
 @pytest.mark.parametrize(
-    "task, crawler, crawler_class",
-    [
-        (MigrationProgress.crawl_tables, RuntimeContext.tables_crawler, TablesCrawler),
-        (MigrationProgress.crawl_udfs, RuntimeContext.udfs_crawler, UdfsCrawler),
-        (MigrationProgress.crawl_grants, RuntimeContext.grants_crawler, GrantsCrawler),
-        (MigrationProgress.assess_jobs, RuntimeContext.jobs_crawler, JobsCrawler),
-        (MigrationProgress.assess_clusters, RuntimeContext.clusters_crawler, ClustersCrawler),
-        (MigrationProgress.assess_pipelines, RuntimeContext.pipelines_crawler, PipelinesCrawler),
-        (MigrationProgress.crawl_cluster_policies, RuntimeContext.policies_crawler, PoliciesCrawler),
-        (
-            MigrationProgress.refresh_table_migration_status,
-            RuntimeContext.migration_status_refresher,
-            TableMigrationStatusRefresher,
-        ),
-    ],
+    "task, crawler",
+    (
+        (MigrationProgress.crawl_tables, RuntimeContext.tables_crawler),
+        (MigrationProgress.crawl_udfs, RuntimeContext.udfs_crawler),
+        (MigrationProgress.crawl_grants, RuntimeContext.grants_crawler),
+        (MigrationProgress.assess_jobs, RuntimeContext.jobs_crawler),
+        (MigrationProgress.assess_clusters, RuntimeContext.clusters_crawler),
+        (MigrationProgress.assess_pipelines, RuntimeContext.pipelines_crawler),
+        (MigrationProgress.crawl_cluster_policies, RuntimeContext.policies_crawler),
+        (MigrationProgress.refresh_table_migration_status, RuntimeContext.migration_status_refresher),
+    ),
 )
-def test_migration_progress_runtime_refresh(run_workflow, task, crawler, crawler_class) -> None:
+def test_migration_progress_runtime_refresh(run_workflow, task, crawler) -> None:
+    crawler_class = get_type_hints(crawler.func)["return"]
     mock_crawler = create_autospec(crawler_class)
     crawler_name = crawler.attrname
     run_workflow(task, **{crawler_name: mock_crawler})


### PR DESCRIPTION
## Changes

This PR updates the `experimental-migration-progress` workflow so that it also re-runs the linting tasks for dashboard queries and notebooks that are associated with jobs. (It was always the intention that this happen once linting was part of the `assessment` workflow.)

### Linked issues

Relates #2678.

### Functionality

- modified existing workflow: `migration-progress-experimental`

### Tests

- added unit tests
- existing integration tests
