### PR TITLE
Fixed errors related to unsupported cell languages

### DIFF
--- a/tests/unit/source_code/linters/test_directfs.py
+++ b/tests/unit/source_code/linters/test_directfs.py
@@ -1,11 +1,18 @@
+from collections.abc import Iterable
+from pathlib import Path
+from unittest.mock import create_autospec
+
 import pytest
 
-from databricks.labs.ucx.source_code.base import Deprecation, Advice, CurrentSessionState, Failure
+from databricks.labs.ucx.source_code.base import Deprecation, Advice, CurrentSessionState, Failure, DirectFsAccess
+from databricks.labs.ucx.source_code.graph import DependencyGraph
+from databricks.labs.ucx.source_code.jobs import DfsaCollectorWalker
 from databricks.labs.ucx.source_code.linters.directfs import (
     DIRECT_FS_ACCESS_PATTERNS,
     DirectFsAccessPyLinter,
     DirectFsAccessSqlLinter,
 )
+from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage
 
 
 @pytest.mark.parametrize(
@@ -145,3 +152,18 @@ def test_dfsa_queries_failure(query: str) -> None:
             end_col=1024,
         ),
     ]
+
+
+class _TestCollectorWalker(DfsaCollectorWalker):
+    # inherit from DfsaCollectorWalker because it's public
+
+    def collect_from_source(self, language: CellLanguage) -> Iterable[DirectFsAccess]:
+        return self._collect_from_source("empty", language, Path(""), None)
+
+
+@pytest.mark.parametrize("language", list(iter(CellLanguage)))
+def test_collector_supports_all_cell_languages(language, mock_path_lookup, migration_index):
+    graph = create_autospec(DependencyGraph)
+    graph.assert_not_called()
+    collector = _TestCollectorWalker(graph, set(), mock_path_lookup, CurrentSessionState(), migration_index)
+    list(collector.collect_from_source(language))


### PR DESCRIPTION
## Changes
Our current implementation logs warnings when encountering notebook cells that are not Python or SQL
This PR fixes that

### Linked issues
Resolves #2977 

### Functionality
None

### Tests
- [x] manually tested
- [x] added unit tests
