### PR TITLE
Fix dynamic import issue

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -71,9 +71,18 @@ class ImportSource(NodeBase):
         problems: list[T],
     ) -> Iterable[ImportSource]:
         for node in nodes:
-            arg = node.args[0]
-            if isinstance(arg, Const):
-                yield ImportSource(node, arg.value)
+            yield from cls._make_sources_for_import_call_node(node, problem_factory, problems)
+
+    @classmethod
+    def _make_sources_for_import_call_node(
+        cls,
+        node: Call,
+        problem_factory: ProblemFactory,
+        problems: list[T],
+    ) -> Iterable[ImportSource]:
+        for inferred in InferredValue.infer_from_node(node.args[0]):
+            if inferred.is_inferred():
+                yield ImportSource(node, inferred.as_string())
                 continue
             problem = problem_factory(
                 'dependency-not-constant', "Can't check dependency not provided as a constant", node

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -79,6 +79,8 @@ class ImportSource(NodeBase):
         problem_factory: ProblemFactory,
         problems: list[T],
     ) -> Iterable[ImportSource]:
+        if not node.args:
+            return
         for inferred in InferredValue.infer_from_node(node.args[0]):
             if inferred.is_inferred():
                 yield ImportSource(node, inferred.as_string())

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -9,7 +9,6 @@ from typing import TypeVar, cast
 from astroid import (  # type: ignore
     Attribute,
     Call,
-    Const,
     InferenceError,
     Import,
     ImportFrom,

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -57,5 +57,3 @@ def test_graph_imports_dynamic_import():
     container = maybe.dependency.load(path_lookup)
     problems = container.build_dependency_graph(graph)
     assert not problems
-    all_dependencies = [dep.path for dep in graph.all_dependencies]
-    assert "astroid" in all_dependencies

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -170,6 +170,18 @@ df.write.format("delta").saveAsTable("old.things")
     assert Tree(save_call).is_from_module("spark")
 
 
+def test_locates_member_import() -> None:
+    source = """
+from importlib import import_module
+module = import_module("xyz")
+"""
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
+    import_calls = tree.locate(Call, [("import_module", Attribute), ("importlib", Name)])
+    assert import_calls
+
+
 @pytest.mark.parametrize("source, name, class_name", [("a = 123", "a", "int")])
 def test_is_instance_of(source, name, class_name) -> None:
     maybe_tree = Tree.maybe_normalized_parse(source)

--- a/tests/unit/source_code/samples/import-module.py
+++ b/tests/unit/source_code/samples/import-module.py
@@ -1,0 +1,4 @@
+import importlib
+
+module_name = "astroid"
+module = importlib.import_module(module_name)


### PR DESCRIPTION
## Changes
Our current implementation doesn't infer import names when calling `importlib.import_module(some_name)`
This PR fixes that.

### Linked issues
None

### Functionality
None

### Tests
- [x] added unit tests
