### PR TITLE
Fix import member issue

### DIFF
--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -170,6 +170,18 @@ df.write.format("delta").saveAsTable("old.things")
     assert Tree(save_call).is_from_module("spark")
 
 
+def test_locates_member_import() -> None:
+    source = """
+from importlib import import_module
+module = import_module("xyz")
+"""
+    maybe_tree = Tree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None, maybe_tree.failure
+    tree = maybe_tree.tree
+    import_calls = tree.locate(Call, [("import_module", Attribute), ("importlib", Name)])
+    assert import_calls
+
+
 @pytest.mark.parametrize("source, name, class_name", [("a = 123", "a", "int")])
 def test_is_instance_of(source, name, class_name) -> None:
     maybe_tree = Tree.maybe_normalized_parse(source)


### PR DESCRIPTION
## Changes
Our current implementation does not properly collect imports when source code uses indirect import patterns such as:
```
from importlib import import_module
module = import_module("some-module")

```
This PR fixes that

### Linked issues
None

### Functionality
None

### Tests
- [x] added unit tests
