### PR TITLE
Update permissions crawling so that it doesn't fail if a secret scope disappears during crawling

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -31,6 +31,7 @@ class PermissionManager(CrawlerBase[Permissions]):
         logger.debug("Crawling permissions")
         crawler_tasks = list(self._get_crawler_tasks())
         logger.info(f"Starting to crawl permissions. Total tasks: {len(crawler_tasks)}")
+        # Note: tasks can return Permissions | None, but threads.gather() filters out None results.
         items, errors = Threads.gather("crawl permissions", crawler_tasks)
         acute_errors = []
         for error in errors:


### PR DESCRIPTION
## Changes

This PR updates the secret scope support so that permissions crawling doesn't fail when a secret scope is listed but disappears before the ACLs can be retrieved. Instead of failing the task we now log a warning and complete normally.

### Functionality

- modified existing workflow: `assessment`

### Tests

- added unit tests
- existing integration tests
