### PR TITLE
Implementation an Ownership factory

### DIFF
--- a/src/databricks/labs/ucx/assessment/clusters.py
+++ b/src/databricks/labs/ucx/assessment/clusters.py
@@ -30,7 +30,7 @@ from databricks.labs.ucx.assessment.crawlers import (
 )
 from databricks.labs.ucx.assessment.init_scripts import CheckInitScriptMixin
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 logger = logging.getLogger(__name__)
@@ -191,6 +191,9 @@ class ClusterOwnership(Ownership[ClusterInfo]):
     This is the cluster creator (if known).
     """
 
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, ClusterInfo)
+
     def _maybe_direct_owner(self, record: ClusterInfo) -> str | None:
         return record.creator
 
@@ -255,6 +258,9 @@ class ClusterPolicyOwnership(Ownership[PolicyInfo]):
 
     This is the creator of the cluster policy (if known).
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, PolicyInfo)
 
     def _maybe_direct_owner(self, record: PolicyInfo) -> str | None:
         return record.creator

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -26,7 +26,7 @@ from databricks.sdk.service.jobs import (
 from databricks.labs.ucx.assessment.clusters import CheckClusterMixin
 from databricks.labs.ucx.assessment.crawlers import spark_version_compatibility
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 logger = logging.getLogger(__name__)
@@ -157,6 +157,9 @@ class JobOwnership(Ownership[JobInfo]):
 
     This is the job creator (if known).
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, JobInfo)
 
     def _maybe_direct_owner(self, record: JobInfo) -> str | None:
         return record.creator

--- a/src/databricks/labs/ucx/assessment/pipelines.py
+++ b/src/databricks/labs/ucx/assessment/pipelines.py
@@ -10,7 +10,7 @@ from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.assessment.clusters import CheckClusterMixin
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 logger = logging.getLogger(__name__)
@@ -85,6 +85,9 @@ class PipelineOwnership(Ownership[PipelineInfo]):
 
     This is the pipeline creator (if known).
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, PipelineInfo)
 
     def _maybe_direct_owner(self, record: PipelineInfo) -> str | None:
         return record.creator_name

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -32,7 +32,7 @@ from databricks.labs.ucx.azure.access import (
     StoragePermissionMapping,
 )
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.locations import (
@@ -403,6 +403,9 @@ class GrantOwnership(Ownership[Grant]):
 
     At the present we can't determine a specific owner for grants.
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, Grant)
 
     def _maybe_direct_owner(self, record: Grant) -> None:
         return None

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -171,7 +171,7 @@ class TableMigrationOwnership(Ownership[TableMigrationStatus]):
     """
 
     def __init__(self, tables_crawler: TablesCrawler, table_ownership: TableOwnership) -> None:
-        super().__init__(table_ownership._administrator_locator)
+        super().__init__(table_ownership._administrator_locator, TableMigrationStatus)
         self._tables_crawler = tables_crawler
         self._table_ownership = table_ownership
         self._indexed_tables: dict[tuple[str, str], Table] | None = None

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -16,7 +16,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 logger = logging.getLogger(__name__)
@@ -667,6 +667,9 @@ class TableOwnership(Ownership[Table]):
 
     At the present we don't determine a specific owner for tables.
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, Table)
 
     def _maybe_direct_owner(self, record: Table) -> None:
         return None

--- a/src/databricks/labs/ucx/hive_metastore/udfs.py
+++ b/src/databricks/labs/ucx/hive_metastore/udfs.py
@@ -9,7 +9,7 @@ from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk.errors import Unknown, NotFound
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
-from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.owners import Ownership, AdministratorLocator
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 
 logger = logging.getLogger(__name__)
@@ -150,6 +150,9 @@ class UdfOwnership(Ownership[Udf]):
 
     At the present we don't determine a specific owner for UDFs.
     """
+
+    def __init__(self, administrator_locator: AdministratorLocator):
+        super().__init__(administrator_locator, Udf)
 
     def _maybe_direct_owner(self, record: Udf) -> None:
         return None

--- a/src/databricks/labs/ucx/source_code/directfs_access.py
+++ b/src/databricks/labs/ucx/source_code/directfs_access.py
@@ -73,7 +73,7 @@ class DirectFsAccessOwnership(Ownership[DirectFsAccess]):
         workspace_path_ownership: WorkspacePathOwnership,
         workspace_client: WorkspaceClient,
     ) -> None:
-        super().__init__(administrator_locator)
+        super().__init__(administrator_locator, DirectFsAccess)
         self._workspace_path_ownership = workspace_path_ownership
         self._workspace_client = workspace_client
 

--- a/tests/unit/framework/test_owners.py
+++ b/tests/unit/framework/test_owners.py
@@ -23,7 +23,7 @@ class _OwnershipFixture(Ownership[Record]):
         owner_fn: Callable[[Record], str | None] = lambda _: None,
     ):
         mock_admin_locator = create_autospec(AdministratorLocator)  # pylint: disable=mock-no-usage
-        super().__init__(mock_admin_locator)
+        super().__init__(mock_admin_locator, object)
         self._owner_fn = owner_fn
         self.mock_admin_locator = mock_admin_locator
 


### PR DESCRIPTION
## Changes
Every asset has an owner and our implementation requires that the owner be retrieved using a specialized `Ownership` instance. 
There is also a requirement that such `Ownership` be retrieved from the `GlobalContext`, which in complex scenarios may result in a proliferation of constructor parameters.
This PR implements an `Ownership` factory that makes it easy to retrieve the appropriate `xxxOwnership` from the `GlobalContext`, simply using the `Record` type being considered.

### Linked issues
Progresses #1415

### Functionality
None

### Tests
- [x] added unit tests
