### PR TITLE
Fix Integration test failure of migration_tables

### DIFF
--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -175,7 +175,6 @@ def test_migrate_external_table(
     assert migration_status[0].dst_table == src_external_table.name
 
 
-@pytest.mark.skip("https://github.com/databrickslabs/ucx/issues/3054")
 def test_migrate_managed_table_to_external_table_without_conversion(
     ws,
     sql_backend,
@@ -219,7 +218,6 @@ def test_migrate_managed_table_to_external_table_without_conversion(
     assert migration_status[0].dst_table == src_external_table.name
 
 
-@pytest.mark.skip("https://github.com/databrickslabs/ucx/issues/3055")
 def test_migrate_managed_table_to_external_table_with_clone(
     ws,
     sql_backend,

--- a/tests/unit/source_code/test_directfs_access.py
+++ b/tests/unit/source_code/test_directfs_access.py
@@ -11,7 +11,6 @@ from databricks.labs.ucx.source_code.directfs_access import (
     DirectFsAccess,
     DirectFsAccessOwnership,
 )
-from databricks.labs.ucx.source_code.python.python_ast import DfsaPyCollector
 
 
 def test_crawler_appends_dfsas() -> None:


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This change unskips the two integration test which are failing.
The underlying issue is fixed as part of https://github.com/databrickslabs/ucx/pull/3020


Resolves #3054 
Resolves #3055 

### Functionality


### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
