### PR TITLE
Cater for empty python cells

### DIFF
--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -198,10 +198,12 @@ class NotebookLinter:
         maybe_tree = Tree.maybe_normalized_parse(python_cell.original_code)
         if maybe_tree.failure:
             yield maybe_tree.failure
-        assert maybe_tree.tree is not None
         tree = maybe_tree.tree
+        # a cell with only comments will not produce a tree
         if register_trees:
-            self._python_trees[python_cell] = tree
+            self._python_trees[python_cell] = tree or Tree.new_module()
+        if not tree:
+            return
         yield from self._load_children_from_tree(tree)
 
     def _load_children_from_tree(self, tree: Tree) -> Iterable[Advice]:


### PR DESCRIPTION
## Changes
Notebok cells such as the following will crash the dependency builder.
This PR fixes the issue.
```
# COMMAND ----------

#only run this step if you are running below Databricks runtime 13.2 GPU; if using 13.2 and above this is not needed.
%sh
wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
sudo add-apt-repository -y "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
sudo apt-get update

```

### Linked issues
None

### Functionality
None

### Tests
- [x] ran solacc on failed repo

