### PR TITLE
use a path instance for MISSING_SOURCE_PATH and add test

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -477,14 +477,14 @@ class DependencyResolver:
         return f"<DependencyResolver {self._notebook_resolver} {self._import_resolver} {self._file_resolver}, {self._path_lookup}>"
 
 
-MISSING_SOURCE_PATH = "<MISSING_SOURCE_PATH>"
+_MISSING_SOURCE_PATH = Path("<MISSING_SOURCE_PATH>")
 
 
 @dataclass
 class DependencyProblem:
     code: str
     message: str
-    source_path: Path = Path(MISSING_SOURCE_PATH)
+    source_path: Path = _MISSING_SOURCE_PATH
     # Lines and columns are both 0-based: the first line is line 0.
     start_line: int = -1
     start_col: int = -1
@@ -492,7 +492,7 @@ class DependencyProblem:
     end_col: int = -1
 
     def is_path_missing(self) -> bool:
-        return self.source_path == Path(MISSING_SOURCE_PATH)
+        return self.source_path == _MISSING_SOURCE_PATH
 
     def as_advisory(self) -> 'Advisory':
         return Advisory(

--- a/tests/integration/source_code/test_graph.py
+++ b/tests/integration/source_code/test_graph.py
@@ -1,8 +1,9 @@
+import dataclasses
 from pathlib import Path
 
 
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph
+from databricks.labs.ucx.source_code.graph import DependencyResolver, DependencyGraph, DependencyProblem
 from databricks.labs.ucx.source_code.known import KnownList, Compatibility, UNKNOWN
 from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver
 from databricks.labs.ucx.source_code.notebooks.loaders import NotebookLoader, NotebookResolver
@@ -57,3 +58,10 @@ def test_graph_imports_dynamic_import():
     container = maybe.dependency.load(path_lookup)
     problems = container.build_dependency_graph(graph)
     assert not problems
+
+
+def test_is_path_missing():
+    problem = DependencyProblem("some-code", "some-message")
+    assert problem.is_path_missing()
+    problem = dataclasses.replace(problem, source_path=Path("stuff"))
+    assert not problem.is_path_missing()


### PR DESCRIPTION
## Changes
improve MISSING_SOURCE_PATH handling

### Linked issues
None

### Functionality
None

### Tests
- [x] ran unit tests
