### PR TITLE
[internal] Added `debug_listing_upper_limit` to skip debug listing large workspaces

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -78,6 +78,9 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     managed_table_external_storage: str = 'CLONE'
 
+    # [INTERNAL ONLY] If specified, the large-scale scanners will only list the specified number of objects.
+    debug_listing_upper_limit: int | None = None
+
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")
 

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -505,6 +505,7 @@ class GlobalContext(abc.ABC):
             self.directfs_access_crawler_for_paths,
             self.used_tables_crawler_for_paths,
             self.config.include_job_ids,
+            self.config.debug_listing_upper_limit,
         )
 
     @cached_property
@@ -515,6 +516,7 @@ class GlobalContext(abc.ABC):
             self.directfs_access_crawler_for_queries,
             self.used_tables_crawler_for_queries,
             self.config.include_dashboard_ids,
+            self.config.debug_listing_upper_limit,
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -393,6 +393,7 @@ class WorkflowLinter:
         directfs_crawler: DirectFsAccessCrawler,
         used_tables_crawler: UsedTablesCrawler,
         include_job_ids: list[int] | None = None,
+        debug_listing_upper_limit: int | None = None,
     ):
         self._ws = ws
         self._resolver = resolver
@@ -401,12 +402,16 @@ class WorkflowLinter:
         self._directfs_crawler = directfs_crawler
         self._used_tables_crawler = used_tables_crawler
         self._include_job_ids = include_job_ids
+        self._debug_listing_upper_limit = debug_listing_upper_limit
 
     def refresh_report(self, sql_backend: SqlBackend, inventory_database: str) -> None:
         tasks = []
         all_jobs = list(self._ws.jobs.list())
         logger.info(f"Preparing {len(all_jobs)} linting tasks...")
-        for job in all_jobs:
+        for i, job in enumerate(all_jobs):
+            if self._debug_listing_upper_limit is not None and i >= self._debug_listing_upper_limit:
+                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
+                break
             if self._include_job_ids and job.job_id not in self._include_job_ids:
                 logger.info(f"Skipping job {job.job_id}...")
                 continue


### PR DESCRIPTION
This pull request introduces a new configuration option, `debug_listing_upper_limit`, to control the number of objects listed by large-scale scanners, primarily for debugging purposes. The changes span across multiple files to integrate this new option into various components.

* [WorkspaceConfig](diffhunk://#diff-e968835e310907c0bd91b566de17d346583886b114a5871e1f478fe4f8ae82dfR81-R83): Added `debug_listing_upper_limit` attribute.
* [ApplicationContext](diffhunk://#diff-f5067fb24dbf36380ff6250d2274083d96f167de7f32aed9fc993ebd4d0369a6R508): Passed `debug_listing_upper_limit` to `workflow_linter` and `query_linter` methods. [[1]](diffhunk://#diff-f5067fb24dbf36380ff6250d2274083d96f167de7f32aed9fc993ebd4d0369a6R508) [[2]](diffhunk://#diff-f5067fb24dbf36380ff6250d2274083d96f167de7f32aed9fc993ebd4d0369a6R519)
* Modified job processing to respect this limit. [[1]](diffhunk://#diff-e9b8a0fc1055c1e7d799d63ee6c440b3db47fdbcb8dccd5880f1a72db5df5837R396) [[2]](diffhunk://#diff-e9b8a0fc1055c1e7d799d63ee6c440b3db47fdbcb8dccd5880f1a72db5df5837R405-R414)
* Modified query and dashboard processing to respect this limit. [[1]](diffhunk://#diff-727142d550f18c3b04e2187c3bda1f96efdc993d18e0a1933c14fe6a23a24485R53-R60) [[2]](diffhunk://#diff-727142d550f18c3b04e2187c3bda1f96efdc993d18e0a1933c14fe6a23a24485L109-R125)