### PR TITLE
Fix issue with cleanup of failed `create-missing-principals` command

### DIFF
--- a/src/databricks/labs/ucx/aws/access.py
+++ b/src/databricks/labs/ucx/aws/access.py
@@ -100,7 +100,7 @@ class AWSResourcePermissions:
                         self._kms_key,
                     )
                     roles_created.append(role)
-            except (PermissionDenied, NotFound):
+            except (PermissionDenied, NotFound) as e:
                 logger.error(
                     "Error creating UC roles. Please review the error message and resolve the issue before "
                     "trying again. "
@@ -108,7 +108,7 @@ class AWSResourcePermissions:
                 )
                 for delete_role in roles_created:
                     self._aws_resources.delete_role(delete_role.role_name)
-                return None
+                raise e from None
 
         # We need to create a buffer between the role creation and the role update, Otherwise the update fails.
         for created_role in roles_created:

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -450,17 +450,12 @@ def test_create_uc_role_multiple_raises_error(mock_ws, installation_single_role,
     aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, aws, locations)
     role_creation = IamRoleCreation(installation_single_role, mock_ws, aws_resource_permissions)
     aws.list_all_uc_roles.return_value = []
-    role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
+    with pytest.raises(PermissionDenied):
+        role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
     assert call('UC_ROLE_BUCKET1') in aws.create_uc_role.call_args_list
     assert call('UC_ROLE_BUCKET2') in aws.create_uc_role.call_args_list
-    assert (
-        call('UC_ROLE_BUCKET1', 'UC_POLICY', {'s3://BUCKET1/*', 's3://BUCKET1'}, None, None)
-        in aws.put_role_policy.call_args_list
-    )
-    assert (
-        call('UC_ROLE_BUCKET2', 'UC_POLICY', {'s3://BUCKET2/*', 's3://BUCKET2'}, None, None)
-        in aws.put_role_policy.call_args_list
-    )
+    assert call('UC_ROLE_BUCKET1') in aws.delete_role.call_args_list
+
 
 
 def test_create_uc_no_roles(installation_no_roles, mock_ws, caplog):

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -443,6 +443,26 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
     )
 
 
+def test_create_uc_role_multiple_raises_error(mock_ws, installation_single_role, backend, locations):
+    aws = create_autospec(AWSResources)
+    aws.validate_connection.return_value = {}
+    aws.create_uc_role.side_effect = ['123', PermissionDenied()]
+    aws_resource_permissions = AWSResourcePermissions(installation_single_role, mock_ws, aws, locations)
+    role_creation = IamRoleCreation(installation_single_role, mock_ws, aws_resource_permissions)
+    aws.list_all_uc_roles.return_value = []
+    role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
+    assert call('UC_ROLE_BUCKET1') in aws.create_uc_role.call_args_list
+    assert call('UC_ROLE_BUCKET2') in aws.create_uc_role.call_args_list
+    assert (
+        call('UC_ROLE_BUCKET1', 'UC_POLICY', {'s3://BUCKET1/*', 's3://BUCKET1'}, None, None)
+        in aws.put_role_policy.call_args_list
+    )
+    assert (
+        call('UC_ROLE_BUCKET2', 'UC_POLICY', {'s3://BUCKET2/*', 's3://BUCKET2'}, None, None)
+        in aws.put_role_policy.call_args_list
+    )
+
+
 def test_create_uc_no_roles(installation_no_roles, mock_ws, caplog):
     external_locations = create_autospec(ExternalLocations)
     external_locations.snapshot.return_value = []

--- a/tests/unit/aws/test_access.py
+++ b/tests/unit/aws/test_access.py
@@ -443,7 +443,7 @@ def test_create_uc_role_multiple(mock_ws, installation_single_role, backend, loc
     )
 
 
-def test_create_uc_role_multiple_raises_error(mock_ws, installation_single_role, backend, locations):
+def test_create_uc_role_multiple_raises_error(mock_ws, installation_single_role, locations):
     aws = create_autospec(AWSResources)
     aws.validate_connection.return_value = {}
     aws.create_uc_role.side_effect = ['123', PermissionDenied()]
@@ -454,8 +454,7 @@ def test_create_uc_role_multiple_raises_error(mock_ws, installation_single_role,
         role_creation.run(MockPrompts({"Above *": "yes"}), single_role=False)
     assert call('UC_ROLE_BUCKET1') in aws.create_uc_role.call_args_list
     assert call('UC_ROLE_BUCKET2') in aws.create_uc_role.call_args_list
-    assert call('UC_ROLE_BUCKET1') in aws.delete_role.call_args_list
-
+    aws.delete_role.assert_called_once()
 
 
 def test_create_uc_no_roles(installation_no_roles, mock_ws, caplog):


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
`databricks labs ucx create-missing-principals` can sometime fail due to permission issue resulting in incomplete list of roles created. This PR handles those failure and removes the created ones to bring it back to it initial state
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->



Resolves #2358 

### Functionality

- [ ] modified existing command: `databricks labs ucx ...`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] added unit tests
- [ ] added integration tests
