### PR TITLE
[CHORE] Moving `QueryLinter` input objects to signature

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -195,7 +195,7 @@ class Assessment(Workflow):
 
         Also, stores direct filesystem accesses for display in the migration dashboard.
         """
-        ctx.query_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.query_linter.refresh_report()
 
     @job_task
     def assess_workflows(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -535,7 +535,9 @@ class GlobalContext(abc.ABC):
     def query_linter(self) -> QueryLinter:
         return QueryLinter(
             self.workspace_client,
-            TableMigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
+            self.sql_backend,
+            self.inventory_database,
+            TableMigrationIndex([]),
             self.directfs_access_crawler_for_queries,
             self.used_tables_crawler_for_queries,
             self.config.include_dashboard_ids,

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -145,7 +145,7 @@ class MigrationProgress(Workflow):
         """Scans all dashboards for migration issues in SQL code of embedded widgets.
         Also stores direct filesystem accesses for display in the migration dashboard."""
         # TODO: Ensure these are captured in the history log.
-        ctx.query_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.query_linter.refresh_report()
 
     @job_task(depends_on=[verify_prerequisites])
     def assess_workflows(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -56,12 +56,24 @@ class QueryLinter:
     ):
         self._ws = ws
         self._sql_backend = sql_backend
-        self._inventory_database = inventory_database
         self._migration_index = migration_index
         self._directfs_crawler = directfs_crawler
         self._used_tables_crawler = used_tables_crawler
         self._include_dashboard_ids = include_dashboard_ids
         self._debug_listing_upper_limit = debug_listing_upper_limit
+
+        self._catalog = "hive_metastore"
+        self._schema = inventory_database
+        self._table = "query_problems"
+
+    @property
+    def _full_name(self) -> str:
+        """Generates the full name of the table.
+
+        Returns:
+            str: The full table name.
+        """
+        return f"{self._catalog}.{self._schema}.{self._table}"
 
     def refresh_report(self) -> None:
         assessment_start = datetime.now(timezone.utc)
@@ -76,7 +88,7 @@ class QueryLinter:
     def _dump_problems(self, problems: Sequence[QueryProblem]) -> None:
         logger.info(f"Saving {len(problems)} linting problems...")
         self._sql_backend.save_table(
-            f'{escape_sql_identifier(self._inventory_database)}.query_problems',
+            escape_sql_identifier(self._full_name),
             problems,
             QueryProblem,
             mode='overwrite',

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -13,12 +13,14 @@ def test_query_dfsa_ownership(runtime_ctx, make_query, make_dashboard, inventory
     # Produce a DFSA record for the query.
     linter = QueryLinter(
         runtime_ctx.workspace_client,
+        sql_backend,
+        inventory_schema,
         TableMigrationIndex([]),
         runtime_ctx.directfs_access_crawler_for_queries,
         runtime_ctx.used_tables_crawler_for_queries,
         include_dashboard_ids=[dashboard.id],
     )
-    linter.refresh_report(sql_backend, inventory_schema)
+    linter.refresh_report()
 
     # Find a record for the query.
     records = runtime_ctx.directfs_access_crawler_for_queries.snapshot()

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -39,7 +39,7 @@ def test_linter_from_context(simple_ctx, make_job) -> None:
     # Ensure we have at least 1 job that fails: "Deprecated file system path in call to: /mnt/things/e/f/g"
     job = make_job(content="spark.read.table('a_table').write.csv('/mnt/things/e/f/g')\n")
     simple_ctx.config.include_job_ids = [job.job_id]
-    simple_ctx.workflow_linter.refresh_report(simple_ctx.sql_backend, simple_ctx.inventory_database)
+    simple_ctx.workflow_linter.refresh_report()
 
     # Verify that the 'problems' table has content.
     cursor = simple_ctx.sql_backend.fetch(

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -39,7 +39,7 @@ def test_linter_from_context(simple_ctx, make_job) -> None:
     # Ensure we have at least 1 job that fails: "Deprecated file system path in call to: /mnt/things/e/f/g"
     job = make_job(content="spark.read.table('a_table').write.csv('/mnt/things/e/f/g')\n")
     simple_ctx.config.include_job_ids = [job.job_id]
-    simple_ctx.workflow_linter.refresh_report()
+    simple_ctx.workflow_linter.refresh_report(simple_ctx.sql_backend, simple_ctx.inventory_database)
 
     # Verify that the 'problems' table has content.
     cursor = simple_ctx.sql_backend.fetch(

--- a/tests/integration/source_code/test_queries.py
+++ b/tests/integration/source_code/test_queries.py
@@ -13,12 +13,14 @@ def test_query_linter_lints_queries_and_stores_dfsas_and_tables(
     dashboards.append(make_dashboard(query=queries[1]))
     linter = QueryLinter(
         ws,
+        sql_backend,
+        simple_ctx.inventory_database,
         TableMigrationIndex([]),
         simple_ctx.directfs_access_crawler_for_queries,
         simple_ctx.used_tables_crawler_for_queries,
         None,
     )
-    linter.refresh_report(sql_backend, simple_ctx.inventory_database)
+    linter.refresh_report()
     all_problems = sql_backend.fetch("SELECT * FROM query_problems", schema=simple_ctx.inventory_database)
     problems = [row for row in all_problems if row["query_name"] == queries[0].name]
     assert len(problems) == 1

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -77,7 +77,7 @@ def test_linter_runtime_refresh(run_workflow, task, linter) -> None:
     linter_class = get_type_hints(linter.func)["return"]
     mock_linter = create_autospec(linter_class)
     linter_name = linter.attrname
-    ctx = run_workflow(task, **{linter_name: mock_linter})
+    run_workflow(task, **{linter_name: mock_linter})
     mock_linter.refresh_report.assert_called_once()
 
 

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -78,7 +78,7 @@ def test_linter_runtime_refresh(run_workflow, task, linter) -> None:
     mock_linter = create_autospec(linter_class)
     linter_name = linter.attrname
     ctx = run_workflow(task, **{linter_name: mock_linter})
-    mock_linter.refresh_report.assert_called_once_with(ctx.sql_backend, ctx.inventory_database)
+    mock_linter.refresh_report.assert_called_once()
 
 
 def test_migration_progress_with_valid_prerequisites(run_workflow) -> None:

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -49,7 +49,7 @@ def test_query_linter_refresh_report_writes_query_problems(migration_index, mock
 
     linter.refresh_report()
 
-    assert mock_backend.has_rows_written_for("`test`.query_problems")
+    assert mock_backend.has_rows_written_for("`hive_metastore`.`test`.`query_problems`")
     ws.dashboards.list.assert_called_once()
     dfsa_crawler.assert_not_called()
     used_tables_crawler.assert_not_called()
@@ -65,7 +65,7 @@ def test_lints_queries(migration_index, mock_backend) -> None:
         linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, ["1"])
         linter.refresh_report()
 
-        assert mock_backend.has_rows_written_for("`test`.query_problems")
+        assert mock_backend.has_rows_written_for("`hive_metastore`.`test`.`query_problems`")
         ws.dashboards.list.assert_not_called()
         dfsa_crawler.assert_not_called()
         used_tables_crawler.assert_not_called()

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -24,12 +24,14 @@ from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
         ),
     ],
 )
-def test_query_linter_collects_dfsas_from_queries(name, query, dfsa_paths, is_read, is_write, migration_index) -> None:
+def test_query_linter_collects_dfsas_from_queries(
+    name, query, dfsa_paths, is_read, is_write, migration_index, mock_backend
+) -> None:
     ws = create_autospec(WorkspaceClient)
     dfsa_crawler = create_autospec(DirectFsAccessCrawler)
     used_tables_crawler = create_autospec(UsedTablesCrawler)
     query = LegacyQuery.from_dict({"parent": "workspace", "name": name, "query": query})
-    linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, None)
+    linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, None)
     dfsas = linter.collect_dfsas_from_query("no-dashboard-id", query)
     ws.assert_not_called()
     dfsa_crawler.assert_not_called()
@@ -43,9 +45,9 @@ def test_query_linter_refresh_report_writes_query_problems(migration_index, mock
     ws = create_autospec(WorkspaceClient)
     dfsa_crawler = create_autospec(DirectFsAccessCrawler)
     used_tables_crawler = create_autospec(UsedTablesCrawler)
-    linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, None)
+    linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, None)
 
-    linter.refresh_report(mock_backend, inventory_database="test")
+    linter.refresh_report()
 
     assert mock_backend.has_rows_written_for("`test`.query_problems")
     ws.dashboards.list.assert_called_once()
@@ -60,8 +62,8 @@ def test_lints_queries(migration_index, mock_backend) -> None:
         ws = create_autospec(WorkspaceClient)
         dfsa_crawler = create_autospec(DirectFsAccessCrawler)
         used_tables_crawler = create_autospec(UsedTablesCrawler)
-        linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, ["1"])
-        linter.refresh_report(mock_backend, inventory_database="test")
+        linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, ["1"])
+        linter.refresh_report()
 
         assert mock_backend.has_rows_written_for("`test`.query_problems")
         ws.dashboards.list.assert_not_called()


### PR DESCRIPTION
## Changes
Follow the more common pattern of expect objects in a class signature. Those objects are passed on from the context. Makes testing more straightforward

Breaking down the linked PR below.

### Linked issues
Progresses #3045
Breaks up #3112

### Tests

- [x] modified unit tests
- [x] modified integration tests
