### PR TITLE
Add `QueryProblemProgressEncoder`

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -195,7 +195,7 @@ class Assessment(Workflow):
 
         Also, stores direct filesystem accesses for display in the migration dashboard.
         """
-        ctx.query_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.query_linter.refresh_report()
 
     @job_task
     def assess_workflows(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -63,7 +63,7 @@ from databricks.labs.ucx.source_code.notebooks.loaders import (
     NotebookLoader,
 )
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
-from databricks.labs.ucx.source_code.queries import QueryLinter
+from databricks.labs.ucx.source_code.queries import QueryLinter, QueryProblemOwnership
 from databricks.labs.ucx.source_code.redash import Redash
 from databricks.labs.ucx.workspace_access import generic, redash
 from databricks.labs.ucx.workspace_access.groups import GroupManager
@@ -279,6 +279,10 @@ class GlobalContext(abc.ABC):
     @cached_property
     def legacy_query_ownership(self) -> LegacyQueryOwnership:
         return LegacyQueryOwnership(self.administrator_locator, self.workspace_client)
+
+    @cached_property
+    def query_problem_ownership(self) -> QueryProblemOwnership:
+        return QueryProblemOwnership(self.administrator_locator, self.legacy_query_ownership)
 
     @cached_property
     def directfs_access_ownership(self) -> DirectFsAccessOwnership:

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -512,7 +512,9 @@ class GlobalContext(abc.ABC):
     def query_linter(self) -> QueryLinter:
         return QueryLinter(
             self.workspace_client,
-            TableMigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
+            self.sql_backend,
+            self.inventory_database,
+            TableMigrationIndex([]),
             self.directfs_access_crawler_for_queries,
             self.used_tables_crawler_for_queries,
             self.config.include_dashboard_ids,

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -30,6 +30,7 @@ from databricks.labs.ucx.progress.history import ProgressEncoder
 from databricks.labs.ucx.progress.jobs import JobsProgressEncoder
 from databricks.labs.ucx.progress.tables import TableProgressEncoder
 from databricks.labs.ucx.progress.workflow_runs import WorkflowRunRecorder
+from databricks.labs.ucx.progress.queries import QueryProblemProgressEncoder
 
 # As with GlobalContext, service factories unavoidably have a lot of public methods.
 # pylint: disable=too-many-public-methods
@@ -237,6 +238,16 @@ class RuntimeContext(GlobalContext):
             self.sql_backend,
             self.udf_ownership,
             Udf,
+            self.parent_run_id,
+            self.workspace_id,
+            self.config.ucx_catalog,
+        )
+
+    @cached_property
+    def query_problem_progress(self) -> QueryProblemProgressEncoder:
+        return QueryProblemProgressEncoder(
+            self.sql_backend,
+            self.query_problem_ownership,
             self.parent_run_id,
             self.workspace_id,
             self.config.ucx_catalog,

--- a/src/databricks/labs/ucx/progress/queries.py
+++ b/src/databricks/labs/ucx/progress/queries.py
@@ -1,0 +1,48 @@
+from dataclasses import replace
+
+from databricks.labs.lsql.backends import SqlBackend
+
+from databricks.labs.ucx.progress.history import ProgressEncoder
+from databricks.labs.ucx.progress.install import Historical
+from databricks.labs.ucx.source_code.queries import QueryProblem, QueryProblemOwnership
+
+
+class QueryProblemProgressEncoder(ProgressEncoder[QueryProblem]):
+    """Encoder class:QueryProblem to class:History.
+
+    A query problem is by definition a failure as it contains problems found while linting code compatibility with Unity
+    Catalog.
+    """
+
+    def __init__(
+        self,
+        sql_backend: SqlBackend,
+        ownership: QueryProblemOwnership,
+        run_id: int,
+        workspace_id: int,
+        catalog: str,
+        schema: str = "multiworkspace",
+        table: str = "historical",
+    ) -> None:
+        super().__init__(
+            sql_backend,
+            ownership,
+            QueryProblem,
+            run_id,
+            workspace_id,
+            catalog,
+            schema,
+            table,
+        )
+
+    def _encode_record_as_historical(self, record: QueryProblem) -> Historical:
+        """Encode record as historical.
+
+        A query problem is by definition a failure as it contains problems found while linting code compatibility with
+        Unity Catalog.
+        """
+        # For recreating the original objects, we keep the code and message on the record even though they are
+        # duplicated into the failure
+        historical = super()._encode_record_as_historical(record)
+        failure = f"[{record.code}] {record.message}"
+        return replace(historical, failures=historical.failures + [failure])

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -149,6 +149,7 @@ class MigrationProgress(Workflow):
         Also stores direct filesystem accesses for display in the migration dashboard."""
         # TODO: Ensure these are captured in the history log.
         ctx.query_linter.refresh_report()
+        ctx.query_problem_progress.append_inventory_snapshot(ctx.query_linter.snapshot())
 
     @job_task(depends_on=[verify_prerequisites])
     def assess_workflows(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -148,7 +148,7 @@ class MigrationProgress(Workflow):
         """Scans all dashboards for migration issues in SQL code of embedded widgets.
         Also stores direct filesystem accesses for display in the migration dashboard."""
         # TODO: Ensure these are captured in the history log.
-        ctx.query_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.query_linter.refresh_report()
 
     @job_task(depends_on=[verify_prerequisites])
     def assess_workflows(self, ctx: RuntimeContext):

--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -166,7 +166,7 @@ class KnownList:
             try:
                 cls._analyze_file(known_distributions, library_root, dist_info, module_path)
             except RecursionError:
-                logger.error(f"Recursion error in {module_path}")
+                logger.warning(f"Recursion error in {module_path}")
                 continue
 
     @classmethod

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -228,7 +228,7 @@ class LocalFileMigrator:
             try:
                 code = f.read()
             except UnicodeDecodeError as e:
-                logger.error(f"Could not decode file {path}: {e}")
+                logger.warning(f"Could not decode file {path}: {e}")
                 return False
             applied = False
             # Lint the code and apply fixes

--- a/src/databricks/labs/ucx/source_code/linters/from_table.py
+++ b/src/databricks/labs/ucx/source_code/linters/from_table.py
@@ -97,7 +97,7 @@ class FromTableSqlLinter(SqlLinter, Fixer, TableSqlCollector):
             for old_table in self._dependent_tables(statement):
                 src_schema = old_table.db if old_table.db else self._session_state.schema
                 if not src_schema:
-                    logger.error(f"Could not determine schema for table {old_table.name}")
+                    logger.warning(f"Could not determine schema for table {old_table.name}")
                     continue
                 dst = self._index.get(src_schema, old_table.name)
                 if not dst:

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -20,6 +21,12 @@ from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.redash import Redash
 from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,6 +44,10 @@ class QueryProblem:
     # TODO: @JCZuurmond verify these are the correct id attributes.
     # Note: Do we deduplicate the messages for a query?
     __id_attributes__: ClassVar[tuple[str, ...]] = ("query_id", "message")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> Self:
+        return cls(**data)
 
 
 @dataclass

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -48,7 +48,9 @@ class QueryProblemOwnership(Ownership[QueryProblem]):
     Defer query problem ownership to query owner.
     """
 
-    def __init__(self, administrator_locator: AdministratorLocator, legacy_query_ownership: LegacyQueryOwnership) -> None:
+    def __init__(
+        self, administrator_locator: AdministratorLocator, legacy_query_ownership: LegacyQueryOwnership
+    ) -> None:
         super().__init__(administrator_locator)
         self._legacy_query_ownership = legacy_query_ownership
 

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -56,12 +56,24 @@ class QueryLinter:
     ):
         self._ws = ws
         self._sql_backend = sql_backend
-        self._inventory_database = inventory_database
         self._migration_index = migration_index
         self._directfs_crawler = directfs_crawler
         self._used_tables_crawler = used_tables_crawler
         self._include_dashboard_ids = include_dashboard_ids
         self._debug_listing_upper_limit = debug_listing_upper_limit
+
+        self._catalog = "hive_metastore"
+        self._schema = inventory_database
+        self._table = "query_problems"
+
+    @property
+    def _full_name(self) -> str:
+        """Generates the full name of the table.
+
+        Returns:
+            str: The full table name.
+        """
+        return f"{self._catalog}.{self._schema}.{self._table}"
 
     def refresh_report(self) -> None:
         assessment_start = datetime.now(timezone.utc)
@@ -76,7 +88,7 @@ class QueryLinter:
     def _dump_problems(self, problems: Sequence[QueryProblem]) -> None:
         logger.info(f"Saving {len(problems)} linting problems...")
         self._sql_backend.save_table(
-            f'{escape_sql_identifier(self._inventory_database)}.query_problems',
+            escape_sql_identifier(self._full_name),
             problems,
             QueryProblem,
             mode='overwrite',

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import ClassVar
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.sql import Dashboard, LegacyQuery
@@ -32,6 +33,10 @@ class QueryProblem:
     query_name: str
     code: str
     message: str
+
+    # TODO: @JCZuurmond verify these are the correct id attributes.
+    # Note: Do we deduplicate the messages for a query?
+    __id_attributes__: ClassVar[tuple[str, ...]] = ("query_id", "message")
 
 
 @dataclass

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -120,6 +120,10 @@ class QueryLinter:
         self._dump_dfsas(context.all_dfsas, assessment_start, assessment_end)
         self._dump_used_tables(context.all_tables, assessment_start, assessment_end)
 
+    def snapshot(self) -> Iterable[QueryProblem]:
+        """Snapshot of the query problems."""
+        return self._try_fetch_problems()  # TODO: Should the query linter follow the crawler snapshot pattern?
+
     def _dump_problems(self, problems: Sequence[QueryProblem]) -> None:
         logger.info(f"Saving {len(problems)} linting problems...")
         self._sql_backend.save_table(
@@ -128,6 +132,11 @@ class QueryLinter:
             QueryProblem,
             mode='overwrite',
         )
+
+    def _try_fetch_problems(self) -> Iterable[QueryProblem]:
+        sql = f"SELECT * FROM {escape_sql_identifier(self._full_name)}"
+        for row in self._sql_backend.fetch(sql):
+            yield QueryProblem.from_dict(row.asDict())
 
     def _dump_dfsas(
         self,

--- a/src/databricks/labs/ucx/source_code/queries.py
+++ b/src/databricks/labs/ucx/source_code/queries.py
@@ -127,26 +127,20 @@ class QueryLinter:
         self._used_tables_crawler.dump_all(processed_tables)
 
     def _lint_dashboards(self, context: _ReportingContext) -> None:
-        dashboard_ids = self._dashboard_ids_in_scope()
-        logger.info(f"Running {len(dashboard_ids)} linting tasks...")
-        for i, dashboard_id in enumerate(dashboard_ids):
-            if self._debug_listing_upper_limit is not None and i >= self._debug_listing_upper_limit:
-                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
-                break
+        for dashboard_id in self._dashboard_ids_in_scope():
             dashboard = self._ws.dashboards.get(dashboard_id=dashboard_id)
+            logger.info(f"Linting dashboard_id={dashboard_id}: {dashboard.name}")
             problems, dfsas, tables = self._lint_and_collect_from_dashboard(dashboard, context.linted_queries)
             context.all_problems.extend(problems)
             context.all_dfsas.extend(dfsas)
             context.all_tables.extend(tables)
 
     def _lint_queries(self, context: _ReportingContext) -> None:
-        for i, query in enumerate(self._queries_in_scope()):
-            if self._debug_listing_upper_limit is not None and i >= self._debug_listing_upper_limit:
-                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
-                break
+        for query in self._queries_in_scope():
             assert query.id is not None
             if query.id in context.linted_queries:
                 continue
+            logger.info(f"Linting query_id={query.id}: {query.name}")
             context.linted_queries.add(query.id)
             problems = self.lint_query(query)
             context.all_problems.extend(problems)
@@ -158,14 +152,32 @@ class QueryLinter:
     def _dashboard_ids_in_scope(self) -> list[str]:
         if self._include_dashboard_ids is not None:  # an empty list is accepted
             return self._include_dashboard_ids
-        all_dashboards = self._ws.dashboards.list()
-        return [dashboard.id for dashboard in all_dashboards if dashboard.id]
+        items_listed = 0
+        dashboard_ids = []
+        # redash APIs are very slow to paginate, especially for large number of dashboards, so we limit the listing
+        # to a small number of items in debug mode for the assessment workflow just to complete.
+        for dashboard in self._ws.dashboards.list():
+            if self._debug_listing_upper_limit is not None and items_listed >= self._debug_listing_upper_limit:
+                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
+                break
+            if dashboard.id is None:
+                continue
+            dashboard_ids.append(dashboard.id)
+            items_listed += 1
+        return dashboard_ids
 
     def _queries_in_scope(self) -> list[LegacyQuery]:
         if self._include_dashboard_ids is not None:  # an empty list is accepted
             return []
-        all_queries = self._ws.queries_legacy.list()
-        return [query for query in all_queries if query.id]
+        items_listed = 0
+        legacy_queries = []
+        for query in self._ws.queries_legacy.list():
+            if self._debug_listing_upper_limit is not None and items_listed >= self._debug_listing_upper_limit:
+                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
+                break
+            legacy_queries.append(query)
+            items_listed += 1
+        return legacy_queries
 
     def _lint_and_collect_from_dashboard(
         self, dashboard: Dashboard, linted_queries: set[str]

--- a/src/databricks/labs/ucx/source_code/redash.py
+++ b/src/databricks/labs/ucx/source_code/redash.py
@@ -49,7 +49,7 @@ class Redash:
                 return list(self._ws.dashboards.list())
             return [self._ws.dashboards.get(dashboard_id)]
         except DatabricksError as e:
-            logger.error(f"Cannot list dashboards: {e}")
+            logger.warning(f"Cannot list dashboards: {e}")
             return []
 
     def _fix_query(self, query: LegacyQuery) -> None:

--- a/src/databricks/labs/ucx/source_code/sql/sql_parser.py
+++ b/src/databricks/labs/ucx/source_code/sql/sql_parser.py
@@ -52,7 +52,7 @@ class SqlExpression:
         # Sqlglot uses db instead of schema, watch out for that
         src_schema = table.db if table.db else session_state.schema
         if not src_schema:
-            logger.error(f"Could not determine schema for table {table.name}")
+            logger.warning(f"Could not determine schema for table {table.name}")
             return None
         return UsedTable(
             catalog_name=catalog_name,

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -18,7 +18,6 @@ from databricks.sdk.errors import (
     AlreadyExists,
     InvalidParameterValue,
     NotFound,
-    ResourceConflict,
 )
 from databricks.sdk.retries import retried
 from databricks.sdk.service import compute
@@ -91,9 +90,10 @@ def new_installation(ws, env_or_skip, make_random):
         pending.remove()
 
 
-@retried(on=[NotFound, ResourceConflict], timeout=timedelta(minutes=10))
 def test_experimental_permissions_migration_for_group_with_same_name(
-    installation_ctx, make_cluster_policy, make_cluster_policy_permissions
+    installation_ctx,
+    make_cluster_policy,
+    make_cluster_policy_permissions,
 ):
     ws_group, acc_group = installation_ctx.make_ucx_group()
     migrated_group = MigratedGroup.partial_info(ws_group, acc_group)
@@ -112,7 +112,7 @@ def test_experimental_permissions_migration_for_group_with_same_name(
 
     installation_ctx.workspace_installation.run()
 
-    installation_ctx.deployed_workflows.run_workflow("migrate-groups-experimental")
+    installation_ctx.deployed_workflows.run_workflow("migrate-groups")
 
     object_permissions = installation_ctx.generic_permissions_support.load_as_dict(
         "cluster-policies", cluster_policy.policy_id

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -13,12 +13,14 @@ def test_query_dfsa_ownership(runtime_ctx, make_query, make_dashboard, inventory
     # Produce a DFSA record for the query.
     linter = QueryLinter(
         runtime_ctx.workspace_client,
+        sql_backend,
+        inventory_schema,
         TableMigrationIndex([]),
         runtime_ctx.directfs_access_crawler_for_queries,
         runtime_ctx.used_tables_crawler_for_queries,
         include_dashboard_ids=[dashboard.id],
     )
-    linter.refresh_report(sql_backend, inventory_schema)
+    linter.refresh_report()
 
     # Find a record for the query.
     records = runtime_ctx.directfs_access_crawler_for_queries.snapshot()

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -39,7 +39,7 @@ def test_linter_from_context(simple_ctx, make_job) -> None:
     # Ensure we have at least 1 job that fails: "Deprecated file system path in call to: /mnt/things/e/f/g"
     job = make_job(content="spark.read.table('a_table').write.csv('/mnt/things/e/f/g')\n")
     simple_ctx.config.include_job_ids = [job.job_id]
-    simple_ctx.workflow_linter.refresh_report(simple_ctx.sql_backend, simple_ctx.inventory_database)
+    simple_ctx.workflow_linter.refresh_report()
 
     # Verify that the 'problems' table has content.
     cursor = simple_ctx.sql_backend.fetch(

--- a/tests/integration/source_code/test_queries.py
+++ b/tests/integration/source_code/test_queries.py
@@ -13,12 +13,14 @@ def test_query_linter_lints_queries_and_stores_dfsas_and_tables(
     dashboards.append(make_dashboard(query=queries[1]))
     linter = QueryLinter(
         ws,
+        sql_backend,
+        simple_ctx.inventory_database,
         TableMigrationIndex([]),
         simple_ctx.directfs_access_crawler_for_queries,
         simple_ctx.used_tables_crawler_for_queries,
         None,
     )
-    linter.refresh_report(sql_backend, simple_ctx.inventory_database)
+    linter.refresh_report()
     all_problems = sql_backend.fetch("SELECT * FROM query_problems", schema=simple_ctx.inventory_database)
     problems = [row for row in all_problems if row["query_name"] == queries[0].name]
     assert len(problems) == 1

--- a/tests/unit/progress/test_queries.py
+++ b/tests/unit/progress/test_queries.py
@@ -1,0 +1,46 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+from databricks.labs.ucx.framework.owners import Ownership
+from databricks.labs.ucx.framework.utils import escape_sql_identifier
+from databricks.labs.ucx.progress.queries import QueryProblemProgressEncoder
+from databricks.labs.ucx.source_code.queries import QueryProblem
+
+
+@pytest.mark.parametrize(
+    "query_problem, failure",
+    [
+        (
+            QueryProblem(
+                dashboard_id="12345",
+                dashboard_parent="dashbards/parent",
+                dashboard_name="my_dashboard",
+                query_id="23456",
+                query_parent="queries/parent",
+                query_name="my_query",
+                code="sql-parse-error",
+                message="Could not parse SQL",
+            ),
+            "[sql-parse-error] Could not parse SQL",
+        )
+    ],
+)
+def test_query_problem_progress_encoder_failures(mock_backend, query_problem: QueryProblem, failure: str) -> None:
+    """A query problem is a failure by definition as it is a result of linting code for Unity Catalog compatibility."""
+    ownership = create_autospec(Ownership)
+    ownership.owner_of.return_value = "user"
+    encoder = QueryProblemProgressEncoder(
+        mock_backend,
+        ownership,
+        run_id=1,
+        workspace_id=123456789,
+        catalog="test",
+    )
+
+    encoder.append_inventory_snapshot([query_problem])
+
+    rows = mock_backend.rows_written_for(escape_sql_identifier(encoder.full_name), "append")
+    assert len(rows) > 0, f"No rows written for: {encoder.full_name}"
+    assert rows[0].failures == [failure]
+    ownership.owner_of.assert_called_once()

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -77,7 +77,7 @@ def test_linter_runtime_refresh(run_workflow, task, linter) -> None:
     linter_class = get_type_hints(linter.func)["return"]
     mock_linter = create_autospec(linter_class)
     linter_name = linter.attrname
-    ctx = run_workflow(task, **{linter_name: mock_linter})
+    run_workflow(task, **{linter_name: mock_linter})
     mock_linter.refresh_report.assert_called_once()
 
 

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -78,7 +78,7 @@ def test_linter_runtime_refresh(run_workflow, task, linter) -> None:
     mock_linter = create_autospec(linter_class)
     linter_name = linter.attrname
     ctx = run_workflow(task, **{linter_name: mock_linter})
-    mock_linter.refresh_report.assert_called_once_with(ctx.sql_backend, ctx.inventory_database)
+    mock_linter.refresh_report.assert_called_once()
 
 
 def test_migration_progress_with_valid_prerequisites(run_workflow) -> None:

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -49,7 +49,7 @@ def test_query_linter_refresh_report_writes_query_problems(migration_index, mock
 
     linter.refresh_report()
 
-    assert mock_backend.has_rows_written_for("`test`.query_problems")
+    assert mock_backend.has_rows_written_for("`hive_metastore`.`test`.`query_problems`")
     ws.dashboards.list.assert_called_once()
     dfsa_crawler.assert_not_called()
     used_tables_crawler.assert_not_called()
@@ -65,7 +65,7 @@ def test_lints_queries(migration_index, mock_backend) -> None:
         linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, ["1"])
         linter.refresh_report()
 
-        assert mock_backend.has_rows_written_for("`test`.query_problems")
+        assert mock_backend.has_rows_written_for("`hive_metastore`.`test`.`query_problems`")
         ws.dashboards.list.assert_not_called()
         dfsa_crawler.assert_not_called()
         used_tables_crawler.assert_not_called()

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -12,6 +12,28 @@ from databricks.labs.ucx.source_code.queries import QueryLinter, QueryProblem, Q
 from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
 
 
+def test_query_problem_from_dict() -> None:
+    query_problem = QueryProblem.from_dict({
+        "dashboard_id": "dashboard_id",
+        "dashboard_parent": "dashboard_parent",
+        "dashboard_name": "dashboard_name",
+        "query_id": "query_id",
+        "query_parent": "query_parent",
+        "query_name": "query_name",
+        "code": "code",
+        "message": "message",
+    })
+
+    assert query_problem.dashboard_id == "dashboard_id"
+    assert query_problem.dashboard_parent == "dashboard_parent"
+    assert query_problem.dashboard_name == "dashboard_name"
+    assert query_problem.query_id == "query_id"
+    assert query_problem.query_parent == "query_parent"
+    assert query_problem.query_name == "query_name"
+    assert query_problem.code == "code"
+    assert query_problem.message == "message"
+
+
 def test_query_problem_ownership_defers_to_legacy_query_ownership() -> None:
     administrator_locator = create_autospec(AdministratorLocator)
     administrator_locator.get_workspace_administrator.return_value = "John Doe"

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -24,12 +24,14 @@ from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
         ),
     ],
 )
-def test_query_linter_collects_dfsas_from_queries(name, query, dfsa_paths, is_read, is_write, migration_index) -> None:
+def test_query_linter_collects_dfsas_from_queries(
+    name, query, dfsa_paths, is_read, is_write, migration_index, mock_backend
+) -> None:
     ws = create_autospec(WorkspaceClient)
     dfsa_crawler = create_autospec(DirectFsAccessCrawler)
     used_tables_crawler = create_autospec(UsedTablesCrawler)
     query = LegacyQuery.from_dict({"parent": "workspace", "name": name, "query": query})
-    linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, None)
+    linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, None)
     dfsas = linter.collect_dfsas_from_query("no-dashboard-id", query)
     ws.assert_not_called()
     dfsa_crawler.assert_not_called()
@@ -43,9 +45,9 @@ def test_query_linter_refresh_report_writes_query_problems(migration_index, mock
     ws = create_autospec(WorkspaceClient)
     dfsa_crawler = create_autospec(DirectFsAccessCrawler)
     used_tables_crawler = create_autospec(UsedTablesCrawler)
-    linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, None)
+    linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, None)
 
-    linter.refresh_report(mock_backend, inventory_database="test")
+    linter.refresh_report()
 
     assert mock_backend.has_rows_written_for("`test`.query_problems")
     ws.dashboards.list.assert_called_once()
@@ -60,8 +62,8 @@ def test_lints_queries(migration_index, mock_backend) -> None:
         ws = create_autospec(WorkspaceClient)
         dfsa_crawler = create_autospec(DirectFsAccessCrawler)
         used_tables_crawler = create_autospec(UsedTablesCrawler)
-        linter = QueryLinter(ws, migration_index, dfsa_crawler, used_tables_crawler, ["1"])
-        linter.refresh_report(mock_backend, inventory_database="test")
+        linter = QueryLinter(ws, mock_backend, "test", migration_index, dfsa_crawler, used_tables_crawler, ["1"])
+        linter.refresh_report()
 
         assert mock_backend.has_rows_written_for("`test`.query_problems")
         ws.dashboards.list.assert_not_called()

--- a/tests/unit/source_code/test_queries.py
+++ b/tests/unit/source_code/test_queries.py
@@ -151,3 +151,7 @@ def test_query_linter_snapshot(migration_index, mock_backend) -> None:
     assert query_problem.query_name == "query_name"
     assert query_problem.code == "code"
     assert query_problem.message == "message"
+
+    ws.assert_not_called()
+    dfsa_crawler.dump_all.assert_not_called()
+    used_tables_crawler.dump_all.assert_not_called()


### PR DESCRIPTION
## Changes
Add `QueryProblemProgressEncoder` to add the query problems to the history log for using it in the migration progress

### Linked issues

- [ ] Depends on #3266
- [ ] Depends on #3250

Progresses #3045
Breaks up #3112

### Functionality

- [x] modified existing workflow: `table-migration-experimental`

### Tests

- [x] modified unit tests
- [x] modified integration tests
