### PR TITLE
Depend on a Databricks SDK release compatible with 0.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
-dependencies = ["databricks-sdk~=0.37",
+dependencies = ["databricks-sdk~=0.36",
                 "databricks-labs-lsql>=0.5,<0.14",
                 "databricks-labs-blueprint>=0.9.1,<0.10",
                 "PyYAML>=6.0.0,<7.0.0",


### PR DESCRIPTION
## Changes

It looks like in #3102 we introduced some code that imports `InvalidState`, an error class that which was introduced in SDK 0.31.0. However the project declares itself to only need 0.30.0. This was fine until DBR 16 went live: it ships with 0.30.0[^1], which means that during install we don't upgrade to latest. (Prior versions of the DBR shipped with 0.20.0 meaning that during install we upgraded to latest.)

This PR marks the project as needing at least Databricks SDK 0.31.0.

### Linked issues

Resolves #3272 

### Tests

- [x] manually running some existing integration tests

[^1]: https://docs.databricks.com/en/release-notes/runtime/16.0.html#library-upgrades