### PR TITLE
Pin Databricks SDK to minor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
-dependencies = ["databricks-sdk~=0.36",
+dependencies = ["databricks-sdk~=0.36.0",
                 "databricks-labs-lsql>=0.5,<0.15",
                 "databricks-labs-blueprint>=0.9.1,<0.10",
                 "PyYAML>=6.0.0,<7.0.0",


### PR DESCRIPTION
Pin Databricks SDK to minor version to circumvent the problems with the [0.37.0 release](https://github.com/databricks/databricks-sdk-py/releases/tag/v0.37.0). Will unpin later when we resolved that issues. 

Waiting on solution in:
- [ ] [lsql](https://github.com/databrickslabs/lsql/pull/320)
- [ ] [Databricks python sdk](https://github.com/databricks/databricks-sdk-py/pull/824)