### PR TITLE
Handle Databricks errors during workspace listings in the table migration status refresher

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -167,3 +167,6 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
             except NotFound:
                 logger.warning(f"Catalog {catalog.name} no longer exists. Skipping checking its migration status.")
                 continue
+            except DatabricksError as e:
+                logger.warning(f"Received error while listing schemas in catalog: {catalog.name}", exc_info=e)
+                continue

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -98,6 +98,9 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
                     f"Schema {schema.catalog_name}.{schema.name} no longer exists. Skipping checking its migration status."
                 )
                 continue
+            except DatabricksError as e:
+                logger.warning(f"Received error while listing tables in schema: {schema.full_name}", exc_info=e)
+                continue
             for table in tables:
                 if not table.properties:
                     continue

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -97,7 +97,7 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
                 logger.warning(f"Schema {schema.full_name} no longer exists. Skipping checking its migration status.")
                 continue
             except DatabricksError as e:
-                logger.warning(f"Received error while listing tables in schema: {schema.full_name}", exc_info=e)
+                logger.warning(f"Error while listing tables in schema: {schema.full_name}", exc_info=e)
                 continue
             for table in tables:
                 if not table.properties:
@@ -159,7 +159,7 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
         try:
             yield from self._ws.catalogs.list()
         except DatabricksError as e:
-            logger.warning("Cannot list catalogs", exc_info=e)
+            logger.error("Cannot list catalogs", exc_info=e)
 
     def _iter_schemas(self):
         for catalog in self._iter_catalogs():
@@ -169,5 +169,5 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
                 logger.warning(f"Catalog {catalog.name} no longer exists. Skipping checking its migration status.")
                 continue
             except DatabricksError as e:
-                logger.warning(f"Received error while listing schemas in catalog: {catalog.name}", exc_info=e)
+                logger.warning(f"Error while listing schemas in catalog: {catalog.name}", exc_info=e)
                 continue

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -94,9 +94,7 @@ class TableMigrationStatusRefresher(CrawlerBase[TableMigrationStatus]):
                 # ws.tables.list returns Iterator[TableInfo], so we need to convert it to a list in order to catch the exception
                 tables = list(self._ws.tables.list(catalog_name=schema.catalog_name, schema_name=schema.name))
             except NotFound:
-                logger.warning(
-                    f"Schema {schema.catalog_name}.{schema.name} no longer exists. Skipping checking its migration status."
-                )
+                logger.warning(f"Schema {schema.full_name} no longer exists. Skipping checking its migration status.")
                 continue
             except DatabricksError as e:
                 logger.warning(f"Received error while listing tables in schema: {schema.full_name}", exc_info=e)

--- a/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migration_status.py
@@ -10,7 +10,7 @@ from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.framework.crawlers import CrawlerBase
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
-from databricks.labs.ucx.hive_metastore import TablesCrawler
+from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -1044,7 +1044,10 @@ def test_table_status_seen_tables(caplog):
     client = create_autospec(WorkspaceClient)
     client.catalogs.list.return_value = [CatalogInfo(name="cat1"), CatalogInfo(name="deleted_cat")]
     client.schemas.list.side_effect = [
-        [SchemaInfo(catalog_name="cat1", name="schema1", full_name="cat1.schema1"), SchemaInfo(catalog_name="cat1", name="deleted_schema", full_name="cat1.deleted_schema")],
+        [
+            SchemaInfo(catalog_name="cat1", name="schema1", full_name="cat1.schema1"),
+            SchemaInfo(catalog_name="cat1", name="deleted_schema", full_name="cat1.deleted_schema"),
+        ],
         NotFound(),
     ]
     client.tables.list.side_effect = [

--- a/tests/unit/hive_metastore/test_table_migrate.py
+++ b/tests/unit/hive_metastore/test_table_migrate.py
@@ -1044,7 +1044,7 @@ def test_table_status_seen_tables(caplog):
     client = create_autospec(WorkspaceClient)
     client.catalogs.list.return_value = [CatalogInfo(name="cat1"), CatalogInfo(name="deleted_cat")]
     client.schemas.list.side_effect = [
-        [SchemaInfo(catalog_name="cat1", name="schema1"), SchemaInfo(catalog_name="cat1", name="deleted_schema")],
+        [SchemaInfo(catalog_name="cat1", name="schema1", full_name="cat1.schema1"), SchemaInfo(catalog_name="cat1", name="deleted_schema", full_name="cat1.deleted_schema")],
         NotFound(),
     ]
     client.tables.list.side_effect = [

--- a/tests/unit/hive_metastore/test_table_migration_status.py
+++ b/tests/unit/hive_metastore/test_table_migration_status.py
@@ -1,0 +1,62 @@
+from unittest.mock import create_autospec
+
+import pytest
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import BadRequest, DatabricksError, NotFound
+from databricks.sdk.service.catalog import CatalogInfo, SchemaInfo
+
+from databricks.labs.ucx.hive_metastore.tables import TablesCrawler
+from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
+
+
+def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_catalogs_list(mock_backend) -> None:
+    ws = create_autospec(WorkspaceClient)
+    ws.catalogs.list.side_effect = BadRequest()
+    tables_crawler = create_autospec(TablesCrawler)
+
+    refresher = TableMigrationStatusRefresher(ws, mock_backend, "test", tables_crawler)
+
+    seen_tables = refresher.get_seen_tables()
+
+    assert not seen_tables
+    ws.catalogs.list.assert_called_once()
+    ws.schemas.list.assert_not_called()
+    ws.tables.list.assert_not_called()
+    tables_crawler.snapshot.assert_not_called()
+
+
+@pytest.mark.parametrize("error", [BadRequest(), NotFound()])
+def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_schemas_list(mock_backend, error: DatabricksError) -> None:
+    ws = create_autospec(WorkspaceClient)
+    ws.catalogs.list.return_value = [CatalogInfo(name="test")]
+    ws.schemas.list.side_effect = error
+    tables_crawler = create_autospec(TablesCrawler)
+
+    refresher = TableMigrationStatusRefresher(ws, mock_backend, "test", tables_crawler)
+
+    seen_tables = refresher.get_seen_tables()
+
+    assert not seen_tables
+    ws.catalogs.list.assert_called_once()
+    ws.schemas.list.assert_called_once()
+    ws.tables.list.assert_not_called()
+    tables_crawler.snapshot.assert_not_called()
+
+
+@pytest.mark.parametrize("error", [BadRequest(), NotFound()])
+def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_tables_list(mock_backend, error: DatabricksError) -> None:
+    ws = create_autospec(WorkspaceClient)
+    ws.catalogs.list.return_value = [CatalogInfo(name="test")]
+    ws.schemas.list.return_value = [SchemaInfo(catalog_name="test", name="test")]
+    ws.tables.list.side_effect = error
+    tables_crawler = create_autospec(TablesCrawler)
+
+    refresher = TableMigrationStatusRefresher(ws, mock_backend, "test", tables_crawler)
+
+    seen_tables = refresher.get_seen_tables()
+
+    assert not seen_tables
+    ws.catalogs.list.assert_called_once()
+    ws.schemas.list.assert_called_once()
+    ws.tables.list.assert_called_once()
+    tables_crawler.snapshot.assert_not_called()

--- a/tests/unit/hive_metastore/test_table_migration_status.py
+++ b/tests/unit/hive_metastore/test_table_migration_status.py
@@ -26,7 +26,9 @@ def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_cata
 
 
 @pytest.mark.parametrize("error", [BadRequest(), NotFound()])
-def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_schemas_list(mock_backend, error: DatabricksError) -> None:
+def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_schemas_list(
+    mock_backend, error: DatabricksError
+) -> None:
     ws = create_autospec(WorkspaceClient)
     ws.catalogs.list.return_value = [CatalogInfo(name="test")]
     ws.schemas.list.side_effect = error
@@ -44,7 +46,9 @@ def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_sche
 
 
 @pytest.mark.parametrize("error", [BadRequest(), NotFound()])
-def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_tables_list(mock_backend, error: DatabricksError) -> None:
+def test_table_migration_status_refresher_get_seen_tables_handles_errors_on_tables_list(
+    mock_backend, error: DatabricksError
+) -> None:
     ws = create_autospec(WorkspaceClient)
     ws.catalogs.list.return_value = [CatalogInfo(name="test")]
     ws.schemas.list.return_value = [SchemaInfo(catalog_name="test", name="test")]


### PR DESCRIPTION
## Changes
Handle Databricks errors during workspace listings in the table migration status refresher

### Linked issues

Resolves #3262

### Functionality

- [x] modified existing workflow: `assessment`

### Tests

- [x] added unit tests