### PR TITLE
Allowing skipping TACLs migration during table migration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,7 @@ access the configuration file from the command line. Here's the description of c
   * `num_threads`: An optional integer representing the number of threads to use for migration.
   * `database_to_catalog_mapping`: An optional dictionary mapping source database names to target catalog names.
   * `default_catalog`: An optional string representing the default catalog name.
+  * `skip_tacl_migration`: Optional flag, allow skipping TACL migration when migrating tables or creating catalogs and schemas.
   * `default_owner_group`: Assigns this group to all migrated objects (catalogs, databases, tables, views, etc.). The group has to be an account group and the user running the migration has to be a member of this group.
   * `log_level`: An optional string representing the log level.
   * `workspace_start_path`: A string representing the starting path for notebooks and directories crawler in the workspace.

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -86,6 +86,9 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     # Default table owner, assigned to a group
     default_owner_group: str | None = None
 
+    # Skip TACL migration during table migration
+    skip_tacl_migration: bool = False
+
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")
 

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -349,6 +349,7 @@ class GlobalContext(abc.ABC):
             self.sql_backend,
             self.group_manager,
             grant_loaders,
+            skip_tacl_migration=self.config.skip_tacl_migration,
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -777,13 +777,20 @@ class MigrateGrants:
         sql_backend: SqlBackend,
         group_manager: GroupManager,
         grant_loaders: list[Callable[[], Iterable[Grant]]],
+        *,
+        skip_tacl_migration: bool = False,
     ):
         self._sql_backend = sql_backend
         self._group_manager = group_manager
         # List of grant loaders, the assumption that the first one is a loader for ownership grants
         self._grant_loaders = grant_loaders
+        if skip_tacl_migration:
+            logger.warning("Skipping TACL migration")
+        self._skip_tacl_migration = skip_tacl_migration
 
     def apply(self, src: SecurableObject, dst: SecurableObject) -> bool:
+        if self._skip_tacl_migration:
+            return True
         grants = self._match_grants(src)
         for grant in grants:
             acl_migrate_sql = grant.uc_grant_sql(dst.kind, dst.full_name)

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -241,6 +241,8 @@ class WorkspaceInstaller(WorkspaceContext):
         configure_groups.run()
         include_databases = self._select_databases()
 
+        skip_tacl_migration = self.prompts.confirm("Do you want to skip TACL migration when migrating tables?")
+
         # Checking if the user wants to define a default owner group.
         default_owner_group = None
         if self.prompts.confirm("Do you want to define a default owner group for all tables and schemas? "):
@@ -262,6 +264,7 @@ class WorkspaceInstaller(WorkspaceContext):
             group_match_by_external_id=configure_groups.group_match_by_external_id,  # type: ignore[arg-type]
             include_group_names=configure_groups.include_group_names,
             renamed_group_prefix=configure_groups.renamed_group_prefix,
+            skip_tacl_migration=skip_tacl_migration,
             log_level=log_level,
             num_threads=num_threads,
             include_databases=include_databases,

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -352,6 +352,7 @@ def test_run_workflow_creates_failure_many_error(ws, mocker, mock_installation_w
         ),
         (r"Min workers for auto-scale.*", "2", {"min_workers": 2}),
         (r"Max workers for auto-scale.*", "20", {"max_workers": 20}),
+        (r"Do you want to skip TACL.*", "yes", {"skip_tacl_migration": True}),
     ],
 )
 def test_configure_sets_expected_workspace_configuration_values(


### PR DESCRIPTION
closes #3042 
