### PR TITLE
Group migration workflow improvements

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -539,10 +539,10 @@ class FasterTableScanCrawler(TablesCrawler):
         return scala_option.get() if scala_option.isDefined() else None
 
     def _all_databases(self) -> list[str]:
-        try:
-            if not self._include_database:
-                return list(self._iterator(self._external_catalog.listDatabases()))
+        if self._include_database:
             return self._include_database
+        try:
+            return list(self._iterator(self._external_catalog.listDatabases()))
         except Exception as err:  # pylint: disable=broad-exception-caught
             if "py4j.security.Py4JSecurityException" in str(err):
                 logger.error(

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -116,7 +116,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             verifier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to verify permissions. Total tasks: {len(verifier_tasks)}")
-        verifications, errors = Threads.strict("verify group permissions", verifier_tasks)
+        verifications, errors = Threads.gather("verify group permissions", verifier_tasks)
         if errors:
             logger.error(f"Detected {len(errors)} errors while verifying permissions")
             raise ManyError(errors)

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -122,7 +122,7 @@ class PermissionManager(CrawlerBase[Permissions]):
             raise ManyError(errors)
         if not all(verifications):
             unsuccessful_verifications = len(verifications) - sum(verifications)
-            logger.error(f"Detected {unsuccessful_verifications} invalidated permissions")
+            logger.warning(f"Detected {unsuccessful_verifications} invalidated permissions")
             return False
         logger.info("All permissions validated successfully. No issues found.")
         return True

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -116,9 +116,13 @@ class PermissionManager(CrawlerBase[Permissions]):
             verifier_tasks.extend(tasks_for_support)
 
         logger.info(f"Starting to verify permissions. Total tasks: {len(verifier_tasks)}")
-        Threads.strict("verify group permissions", verifier_tasks)
+        verifications, errors = Threads.strict("verify group permissions", verifier_tasks)
+        if errors:
+            raise ManyError(errors)
+        if not all(errors):
+            logger.info("Not all permissions validated successfully. No issues found.")
+            return False
         logger.info("All permissions validated successfully. No issues found.")
-
         return True
 
     def object_type_support(self) -> dict[str, AclSupport]:

--- a/src/databricks/labs/ucx/workspace_access/manager.py
+++ b/src/databricks/labs/ucx/workspace_access/manager.py
@@ -118,9 +118,11 @@ class PermissionManager(CrawlerBase[Permissions]):
         logger.info(f"Starting to verify permissions. Total tasks: {len(verifier_tasks)}")
         verifications, errors = Threads.strict("verify group permissions", verifier_tasks)
         if errors:
+            logger.error(f"Detected {len(errors)} errors while verifying permissions")
             raise ManyError(errors)
-        if not all(errors):
-            logger.info("Not all permissions validated successfully. No issues found.")
+        if not all(verifications):
+            unsuccessful_verifications = len(verifications) - sum(verifications)
+            logger.error(f"Detected {unsuccessful_verifications} invalidated permissions")
             return False
         logger.info("All permissions validated successfully. No issues found.")
         return True

--- a/src/databricks/labs/ucx/workspace_access/workflows.py
+++ b/src/databricks/labs/ucx/workspace_access/workflows.py
@@ -70,7 +70,10 @@ class LegacyGroupMigration(Workflow):
         if not ctx.config.use_legacy_permission_migration:
             logger.info("Use `migrate-groups` job, or set `use_legacy_permission_migration: true` in config.yml.")
             return
-        ctx.permission_manager.verify_group_permissions()
+        if not ctx.permission_manager.verify_group_permissions():
+            raise ValueError(
+                f"Some group permissions were not migrated successfully. Run `databricks labs ucx logs --workflow '{self._name}' --debug` for more details."
+            )
 
 
 class PermissionsMigrationAPI(Workflow):
@@ -147,7 +150,10 @@ class ValidateGroupPermissions(Workflow):
         if not ctx.config.use_legacy_permission_migration:
             logger.info("Use `migrate-groups` job, or set `use_legacy_permission_migration: true` in config.yml.")
             return
-        ctx.permission_manager.verify_group_permissions()
+        if not ctx.permission_manager.verify_group_permissions():
+            raise ValueError(
+                f"Some group permissions were not migrated successfully. Run `databricks labs ucx logs --workflow '{self._name}' --debug` for more details."
+            )
 
 
 class RemoveWorkspaceLocalGroups(Workflow):

--- a/src/databricks/labs/ucx/workspace_access/workflows.py
+++ b/src/databricks/labs/ucx/workspace_access/workflows.py
@@ -39,7 +39,12 @@ class LegacyGroupMigration(Workflow):
             return
         ctx.group_manager.reflect_account_groups_on_workspace()
 
-    @job_task(depends_on=[reflect_account_groups_on_workspace], job_cluster="tacl")
+    @job_task(job_cluster="tacl")
+    def setup_tacl(self, ctx: RuntimeContext):
+        """(Optimization) Allow the TACL job cluster to be started while we're verifying the prerequisites for
+        refreshing everything."""
+
+    @job_task(depends_on=[reflect_account_groups_on_workspace, setup_tacl], job_cluster="tacl")
     def apply_permissions_to_account_groups(self, ctx: RuntimeContext):
         """Fourth phase of the workspace-local group migration process. It does the following:
           - Assigns the full set of permissions of the original group to the account-level one

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -16,7 +16,7 @@ def test_running_real_migrate_groups_job(
     make_cluster_policy_permissions,
     make_secret_scope,
     make_secret_scope_acl,
-):
+) -> None:
     installation_ctx = installation_ctx.replace(
         config_transform=lambda wc: replace(
             wc,

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -60,24 +60,24 @@ def test_running_real_migrate_groups_job(
 
     # Wrapper functions to wait for eventual consistency of API
     @retried(on=[KeyError], timeout=dt.timedelta(minutes=1))
-    def has_workspace_group(display_name: str) -> bool:
+    def wait_for_workspace_group_to_exists(display_name: str) -> bool:
         if installation_ctx.group_manager.has_workspace_group(display_name):
             return True
         raise KeyError(f"Group not found {display_name}")
 
     @retried(on=[KeyError], timeout=dt.timedelta(minutes=1))
-    def has_account_group(display_name: str) -> bool:
+    def wait_for_account_group_to_exists(display_name: str) -> bool:
         if installation_ctx.group_manager.has_account_group(display_name):
             return True
         raise KeyError(f"Group not found {display_name}")
 
     # The account group should exist, not the original workspace group
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
-    assert has_workspace_group(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
-    assert has_account_group(acc_group_a.display_name), f"Account group not found: {acc_group_a.display_name}"
-    if not has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
+    assert wait_for_workspace_group_to_exists(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
+    assert wait_for_account_group_to_exists(acc_group_a.display_name), f"Account group not found: {acc_group_a.display_name}"
+    if not installation_ctx.group_manager.has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
         with pytest.raises(TimeoutError):
-            has_workspace_group(ws_group_a.display_name)  # Expect to NOT exists
+            wait_for_workspace_group_to_exists(ws_group_a.display_name)  # Expect to NOT exists
 
     # specific permissions api migrations are checked in different and smaller integration tests
     found = installation_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -48,7 +48,9 @@ def test_running_real_migrate_groups_job(
 
     installation_ctx.workspace_installation.run()
 
-    installation_ctx.deployed_workflows.run_workflow("migrate-groups-legacy")
+    workflow = "migrate-groups-legacy"
+    installation_ctx.deployed_workflows.run_workflow(workflow)
+    assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     @retried(on=[KeyError], timeout=dt.timedelta(minutes=1))
     def get_workspace_group(display_name: str) -> Group:

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -43,7 +43,6 @@ def test_running_real_migrate_groups_job(
     secret_scope = make_secret_scope()
     make_secret_scope_acl(scope=secret_scope, principal=ws_group.display_name, permission=AclPermission.WRITE)
 
-    installation_ctx.__dict__['include_group_names'] = [ws_group.display_name]
     # TODO: Move `include_object_permissions` to context like other `include_` attributes
     installation_ctx.__dict__['include_object_permissions'] = [
         f"cluster-policies:{cluster_policy.policy_id}",

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -68,7 +68,7 @@ def test_running_real_migrate_groups_job(
     # The original workspace group should be renamed
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
     assert wait_for_workspace_group_to_exists(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
-    if not installation_ctx.group_manager.has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
+    if installation_ctx.group_manager.has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
         with pytest.raises(TimeoutError):
             wait_for_workspace_group_to_exists(ws_group_a.display_name)  # Expect to NOT exists
 

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 import pytest
 from databricks.sdk.retries import retried
 from databricks.sdk.service import sql
-from databricks.sdk.service.iam import Group, PermissionLevel
+from databricks.sdk.service.iam import PermissionLevel
 from databricks.sdk.service.workspace import AclPermission
 
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup
@@ -67,7 +67,7 @@ def test_running_real_migrate_groups_job(
 
     # The original workspace group should be renamed
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
-    assert wait_for_workspace_group_to_exists(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
+    assert wait_for_workspace_group_to_exists(renamed_workspace_group_name), f"Workspace group not found: {renamed_workspace_group_name}"
     if installation_ctx.group_manager.has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
         with pytest.raises(TimeoutError):
             wait_for_workspace_group_to_exists(ws_group_a.display_name)  # Expect to NOT exists

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -65,16 +65,9 @@ def test_running_real_migrate_groups_job(
             return True
         raise KeyError(f"Group not found {display_name}")
 
-    @retried(on=[KeyError], timeout=dt.timedelta(minutes=1))
-    def wait_for_account_group_to_exists(display_name: str) -> bool:
-        if installation_ctx.group_manager.has_account_group(display_name):
-            return True
-        raise KeyError(f"Group not found {display_name}")
-
-    # The account group should exist, not the original workspace group
+    # The original workspace group should be renamed
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
     assert wait_for_workspace_group_to_exists(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
-    assert wait_for_account_group_to_exists(acc_group_a.display_name), f"Account group not found: {acc_group_a.display_name}"
     if not installation_ctx.group_manager.has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
         with pytest.raises(TimeoutError):
             wait_for_workspace_group_to_exists(ws_group_a.display_name)  # Expect to NOT exists

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -32,6 +32,7 @@ def test_running_real_migrate_groups_job(
         group_name=ws_group_a.display_name,
     )
 
+    # TODO: Add assert for table
     table = installation_ctx.make_table()
     installation_ctx.make_grant(ws_group_a.display_name, "SELECT", table_info=table)
 

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -72,7 +72,7 @@ def test_running_real_migrate_groups_job(
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
     assert has_workspace_group(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
     assert has_account_group(acc_group_a.display_name), f"Account group not found: {acc_group_a.display_name}"
-    if has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
+    if not has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
         with pytest.raises(TimeoutError):
             has_workspace_group(ws_group_a.display_name)  # Expect to NOT exists
 

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -49,7 +49,7 @@ def test_running_real_migrate_groups_job(
     installation_ctx.workspace_installation.run()
 
     workflow = "migrate-groups-legacy"
-    installation_ctx.deployed_workflows.run_workflow(workflow)
+    installation_ctx.deployed_workflows.run_workflow(workflow, skip_job_wait=True)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     @retried(on=[KeyError], timeout=dt.timedelta(minutes=1))

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -72,6 +72,9 @@ def test_running_real_migrate_groups_job(
     renamed_workspace_group_name = installation_ctx.renamed_group_prefix + ws_group_a.display_name
     assert has_workspace_group(renamed_workspace_group_name), f"Renamed workspace group not found: {renamed_workspace_group_name}"
     assert has_account_group(acc_group_a.display_name), f"Account group not found: {acc_group_a.display_name}"
+    if has_workspace_group(ws_group_a.display_name):  # Avoid wait on timeout
+        with pytest.raises(TimeoutError):
+            has_workspace_group(ws_group_a.display_name)  # Expect to NOT exists
 
     # specific permissions api migrations are checked in different and smaller integration tests
     found = installation_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
@@ -82,10 +85,6 @@ def test_running_real_migrate_groups_job(
         secret_scope, acc_group_a.display_name
     )
     assert scope_permission == AclPermission.WRITE
-
-    # The original workspace group should not exist, testing as last due to wait on timeout
-    with pytest.raises(TimeoutError):
-        has_workspace_group(ws_group_a.display_name)
 
 
 def test_running_legacy_validate_groups_permissions_job(

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -7,8 +7,6 @@ from databricks.sdk.service import sql
 from databricks.sdk.service.iam import PermissionLevel
 from databricks.sdk.service.workspace import AclPermission
 
-from databricks.labs.ucx.workspace_access.groups import MigratedGroup
-
 
 def test_running_real_migrate_groups_job(
     installation_ctx,

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -25,6 +25,7 @@ def test_running_real_migrate_groups_job(
     )
     ws_group_a, acc_group_a = installation_ctx.make_ucx_group(wait_for_provisioning=True)
 
+    # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
     cluster_policy = make_cluster_policy()
     make_cluster_policy_permissions(
         object_id=cluster_policy.policy_id,
@@ -36,10 +37,12 @@ def test_running_real_migrate_groups_job(
     table = installation_ctx.make_table()
     installation_ctx.make_grant(ws_group_a.display_name, "SELECT", table_info=table)
 
+    # TODO: Move `make_secret_scope` and `make_secret_scope_acl` to context like other `make_` methods
     secret_scope = make_secret_scope()
     make_secret_scope_acl(scope=secret_scope, principal=ws_group_a.display_name, permission=AclPermission.WRITE)
 
     installation_ctx.__dict__['include_group_names'] = [ws_group_a.display_name]
+    # TODO: Move `include_object_permissions` to context like other `include_` attributes
     installation_ctx.__dict__['include_object_permissions'] = [
         f"cluster-policies:{cluster_policy.policy_id}",
         f"TABLE:{table.full_name}",


### PR DESCRIPTION
## Changes
Group migration workflow improvements:
- Return early when `include_databases` is provided
- Fix unavailable external catalog on tacl cluster 
- Check outcome of verify permissions
- Setup tacl cluster
- Log what to do when group permissions did not verify successfully
- Merge duplicate tests

### Functionality

- [ ] modified existing command: `databricks labs ucx group-migration-legacy`

### Tests

- [ ] modified integration tests
