### PR TITLE
Fix integration test: `test_running_real_assessment_job_ext_hms`

### DIFF
--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -1,7 +1,15 @@
 import dataclasses
 
-from databricks.labs.lsql.backends import CommandExecutionBackend
+import pytest
+
+from databricks.labs.lsql.backends import CommandExecutionBackend, SqlBackend
 from databricks.sdk.service.iam import PermissionLevel
+
+
+@pytest.fixture
+def sql_backend(ws, env_or_skip) -> SqlBackend:
+    cluster_id = env_or_skip("TEST_EXT_HMS_CLUSTER_ID")
+    return CommandExecutionBackend(ws, cluster_id)
 
 
 def test_running_real_assessment_job_ext_hms(
@@ -21,7 +29,6 @@ def test_running_real_assessment_job_ext_hms(
         group_name=ws_group.display_name,
     )
     ext_hms_ctx = installation_ctx.replace(
-        sql_backend=CommandExecutionBackend(ws, cluster_id),
         config_transform=lambda wc: dataclasses.replace(
             wc,
             override_clusters={

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -8,6 +8,11 @@ from databricks.sdk.service.iam import PermissionLevel
 
 @pytest.fixture
 def sql_backend(ws, env_or_skip) -> SqlBackend:
+    """Ensure the SQL backend using during fixture setup is attached to the external HMS.
+
+    Various resources are created during setup of the installation context: this ensures that
+    they are created in the external HMS where the assessment workflow will be run. (Otherwise they will not be found.)
+    """
     cluster_id = env_or_skip("TEST_EXT_HMS_CLUSTER_ID")
     return CommandExecutionBackend(ws, cluster_id)
 

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -11,7 +11,7 @@ def test_running_real_assessment_job_ext_hms(
     make_cluster_policy,
     make_cluster_policy_permissions,
 ) -> None:
-    cluster_id = env_or_skip('TEST_EXT_HMS_CLUSTER_ID')
+    main_cluster_id = env_or_skip("TEST_EXT_HMS_NOUC_CLUSTER_ID")
     ws_group, _ = installation_ctx.make_ucx_group(wait_for_provisioning=True)
     # TODO: Move `make_cluster_policy` and `make_cluster_policy_permissions` to context like other `make_` methods
     cluster_policy = make_cluster_policy()
@@ -24,7 +24,9 @@ def test_running_real_assessment_job_ext_hms(
         sql_backend=CommandExecutionBackend(ws, cluster_id),
         config_transform=lambda wc: dataclasses.replace(
             wc,
-            override_clusters=None,
+            override_clusters={
+                "main": main_cluster_id,
+            },
             include_object_permissions=[f"cluster-policies:{cluster_policy.policy_id}"],
         ),
         extend_prompts={

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -3,6 +3,7 @@ import dataclasses
 import pytest
 
 from databricks.labs.lsql.backends import CommandExecutionBackend, SqlBackend
+from databricks.sdk.service.compute import CreatePolicyResponse
 from databricks.sdk.service.iam import PermissionLevel
 
 
@@ -36,7 +37,7 @@ def test_running_real_assessment_job_ext_hms(installation_ctx, env_or_skip) -> N
     )
     del installation_ctx  # Use ext_hms_ctx from now on instead of installation_ctx to ensure the external HMS is used.
     ws_group, _ = ext_hms_ctx.make_ucx_group(wait_for_provisioning=True)
-    cluster_policy = ext_hms_ctx.make_cluster_policy()
+    cluster_policy: CreatePolicyResponse = ext_hms_ctx.make_cluster_policy()
     ext_hms_ctx.make_cluster_policy_permissions(
         object_id=cluster_policy.policy_id,
         permission_level=PermissionLevel.CAN_USE,

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -9,7 +9,7 @@ from databricks.sdk.service.iam import PermissionLevel
 
 @pytest.fixture
 def sql_backend(ws, env_or_skip) -> SqlBackend:
-    """Ensure the SQL backend using during fixture setup is attached to the external HMS.
+    """Ensure the SQL backend used during fixture setup is attached to the external HMS.
 
     Various resources are created during setup of the installation context: this ensures that
     they are created in the external HMS where the assessment workflow will be run. (Otherwise they will not be found.)

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -13,7 +13,6 @@ def sql_backend(ws, env_or_skip) -> SqlBackend:
 
 
 def test_running_real_assessment_job_ext_hms(
-    ws,
     installation_ctx,
     env_or_skip,
     make_cluster_policy,

--- a/tests/integration/assessment/test_ext_hms.py
+++ b/tests/integration/assessment/test_ext_hms.py
@@ -48,8 +48,9 @@ def test_running_real_assessment_job_ext_hms(
     ext_hms_ctx.workspace_installation.run()
 
     workflow = "assessment"
-    ext_hms_ctx.deployed_workflows.run_workflow(workflow)
-    assert ext_hms_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
+    ext_hms_ctx.deployed_workflows.run_workflow(workflow, skip_job_wait=True)
+    workflow_completed_successfully = ext_hms_ctx.deployed_workflows.validate_step(workflow)
+    assert workflow_completed_successfully, f"Workflow failed: {workflow}"
 
     after = ext_hms_ctx.generic_permissions_support.load_as_dict("cluster-policies", cluster_policy.policy_id)
     assert ws_group.display_name in after, f"Group {ws_group.display_name} not found in cluster policy"

--- a/tests/integration/hive_metastore/test_ext_hms.py
+++ b/tests/integration/hive_metastore/test_ext_hms.py
@@ -13,6 +13,11 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def sql_backend(ws, env_or_skip) -> SqlBackend:
+    """Ensure the SQL backend used during fixture setup is attached to the external HMS.
+
+    Various resources are created during setup of the installation context: this ensures that
+    they are created in the external HMS where the assessment workflow will be run. (Otherwise they will not be found.)
+    """
     cluster_id = env_or_skip("TEST_EXT_HMS_CLUSTER_ID")
     return CommandExecutionBackend(ws, cluster_id)
 


### PR DESCRIPTION
## Changes

This PR updates the `test_running_real_assessment_job_ext_hms` integration test:

 - It ensures that the workflow runs on a cluster with an external HMS, instead of faking it. (The previous method was insufficient once we switched to the fast table crawler and the Python4J bridge became needed.)
 - Update the test fixture so that the resources it creates to be crawled are created in the external HMS, not the main one. Without this the assessment crawlers partially fail because the resources they are configured to crawl do not exist on the external HMS.

### Linked issues

Resolves #3134.
Resolves #3246.

### Tests

- updated integration test
