### PR TITLE
Ensure bugs are associated by default with the correct UCX project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,7 +4,7 @@ name: Bug Report
 description: Something is not working with UCX
 title: "[BUG]: "
 labels: ["bug", "needs-triage"]
-projects: ["databrickslabs/12"]
+projects: ["databrickslabs/13"]
 # assignees:
 #   - ucx-write
 body:


### PR DESCRIPTION
## Changes

We've switched to a new UCX project. This PR updates the template for new bugs so that they are associated with the new project that we're using instead of the old one.
