### PR TITLE
Add cli command to create directfs to table mapping

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -197,6 +197,20 @@ def create_table_mapping(
         if len(workspace_contexts) == 1:
             webbrowser.open(f"{w.config.host}/#workspace{path}")
 
+@ucx.command
+def create_directfs_mapping(
+    w: WorkspaceClient,
+    ctx: WorkspaceContext | None = None,
+    run_as_collection: bool = False,
+    a: AccountClient | None = None,
+):
+    """Create DirectFS mapping for all the direcfs references in the workspace"""
+    workspace_contexts = _get_workspace_contexts(w, a, run_as_collection)
+
+    if ctx:
+        workspace_contexts = [ctx]
+    for workspace_context in workspace_contexts:
+        workspace_context.directfs_mapping.create_directfs_mapping()
 
 @ucx.command
 def validate_external_locations(

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -457,6 +457,10 @@ class GlobalContext(abc.ABC):
         return TableMapping(self.installation, self.workspace_client, self.sql_backend)
 
     @cached_property
+    def directfs_mapping(self) -> DirectFsMapping:
+        return DirectFsMapping(self.installation, self.workspace_client, self.sql_backend)
+
+    @cached_property
     def catalog_schema(self) -> CatalogSchema:
         return CatalogSchema(self.workspace_client, self.table_mapping, self.migrate_grants, self.config.ucx_catalog)
 


### PR DESCRIPTION
## Changes
The directfs access in the code that can be replaced by table would need a mapping to be reviewed/updated by the user. Introduces a cli command that creates the mapping file from the directfs usages.

### Linked issues
Introduces #392

### Functionality

- [ ] added relevant user documentation
- [x] added new CLI command

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
