### PR TITLE
Exclude TACL migration in table migration integration tests

### DIFF
--- a/tests/integration/hive_metastore/test_ext_hms.py
+++ b/tests/integration/hive_metastore/test_ext_hms.py
@@ -23,10 +23,9 @@ def sql_backend(ws, env_or_skip) -> SqlBackend:
 
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
-@pytest.mark.parametrize('prepare_tables_for_migration', ['regular'], indirect=True)
-def test_migration_job_ext_hms(ws, installation_ctx, prepare_tables_for_migration, env_or_skip):
+def test_migration_job_ext_hms(ws, installation_ctx, make_table_migration_context, env_or_skip) -> None:
+    tables, dst_schema = make_table_migration_context('regular', installation_ctx)
     ext_hms_cluster_id = env_or_skip("TEST_EXT_HMS_CLUSTER_ID")
-    tables, dst_schema = prepare_tables_for_migration
     ext_hms_ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
             wc,

--- a/tests/integration/hive_metastore/test_ext_hms.py
+++ b/tests/integration/hive_metastore/test_ext_hms.py
@@ -24,11 +24,12 @@ def sql_backend(ws, env_or_skip) -> SqlBackend:
 
 @retried(on=[NotFound, InvalidParameterValue], timeout=timedelta(minutes=5))
 def test_migration_job_ext_hms(ws, installation_ctx, make_table_migration_context, env_or_skip) -> None:
-    tables, dst_schema = make_table_migration_context('regular', installation_ctx)
+    tables, dst_schema = make_table_migration_context("regular", installation_ctx)
     ext_hms_cluster_id = env_or_skip("TEST_EXT_HMS_CLUSTER_ID")
     ext_hms_ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
             wc,
+            skip_tacl_migration=True,
             override_clusters={
                 "main": ext_hms_cluster_id,
                 "user_isolation": ext_hms_cluster_id,
@@ -44,18 +45,21 @@ def test_migration_job_ext_hms(ws, installation_ctx, make_table_migration_contex
             r"Choose a cluster policy": "0",
         },
     )
-
     ext_hms_ctx.workspace_installation.run()
-    ext_hms_ctx.deployed_workflows.run_workflow("migrate-tables")
+
+    ext_hms_ctx.deployed_workflows.run_workflow("migrate-tables", skip_job_wait=True)
+
     # assert the workflow is successful
     assert ext_hms_ctx.deployed_workflows.validate_step("migrate-tables")
 
     # assert the tables are migrated
+    missing_tables = set[str]()
     for table in tables.values():
-        try:
-            assert ws.tables.get(f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}").name
-        except NotFound:
-            assert False, f"{table.name} not found in {dst_schema.catalog_name}.{dst_schema.name}"
+        migrated_table_name = f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}"
+        if not ext_hms_ctx.workspace_client.tables.exists(migrated_table_name):
+            missing_tables.add(migrated_table_name)
+    assert not missing_tables, f"Missing migrated tables: {missing_tables}"
+
     # assert the cluster is configured correctly with ext hms
     install_state = ext_hms_ctx.installation.load(RawState)
     for job_cluster in ws.jobs.get(install_state.resources["jobs"]["migrate-tables"]).settings.job_clusters:

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -68,8 +68,7 @@ def test_table_migration_job_refreshes_migration_status(
     assert len(asserts) == 0, assert_message
 
 
-def test_table_migration_for_managed_table(installation_ctx, make_table_migration_context) -> None:
-    # This test cases test the CONVERT_TO_EXTERNAL scenario.
+def test_table_migration_convert_manged_to_external(installation_ctx, make_table_migration_context) -> None:
     tables, dst_schema = make_table_migration_context("managed", installation_ctx)
     ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(
@@ -112,10 +111,10 @@ def test_hiveserde_table_in_place_migration_job(installation_ctx, make_table_mig
         },
     )
     ctx.workspace_installation.run()
+
     ctx.deployed_workflows.run_workflow("migrate-external-hiveserde-tables-in-place-experimental")
-    # assert the workflow is successful
+
     assert ctx.deployed_workflows.validate_step("migrate-external-hiveserde-tables-in-place-experimental")
-    # assert the tables are migrated
     for table in tables.values():
         try:
             assert ctx.workspace_client.tables.get(f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}").name
@@ -135,10 +134,10 @@ def test_hiveserde_table_ctas_migration_job(installation_ctx, make_table_migrati
         },
     )
     ctx.workspace_installation.run()
+
     ctx.deployed_workflows.run_workflow("migrate-external-tables-ctas")
-    # assert the workflow is successful
+
     assert ctx.deployed_workflows.validate_step("migrate-external-tables-ctas")
-    # assert the tables are migrated
     for table in tables.values():
         try:
             assert ctx.workspace_client.tables.get(f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}").name
@@ -164,9 +163,10 @@ def test_table_migration_job_publishes_remaining_tables(installation_ctx, make_t
         table_format="UNKNOWN",
     )
     ctx.table_mapping.skip_table_or_view(dst_schema.name, second_table.name, load_table=lambda *_: table)
-    ctx.deployed_workflows.run_workflow("migrate-tables")
-    assert ctx.deployed_workflows.validate_step("migrate-tables")
 
+    ctx.deployed_workflows.run_workflow("migrate-tables")
+
+    assert ctx.deployed_workflows.validate_step("migrate-tables")
     remaining_tables = list(
         ctx.sql_backend.fetch(
             f"""

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 import pytest
 from databricks.labs.lsql.core import Row
-from databricks.sdk.errors import NotFound
 
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.hive_metastore.tables import Table
@@ -101,7 +100,9 @@ def test_table_migration_convert_manged_to_external(installation_ctx, make_table
             break
 
 
-@pytest.mark.parametrize("workflow", ["migrate-external-hiveserde-tables-in-place-experimental", "migrate-external-tables-ctas"])
+@pytest.mark.parametrize(
+    "workflow", ["migrate-external-hiveserde-tables-in-place-experimental", "migrate-external-tables-ctas"]
+)
 def test_hiveserde_table_in_place_migration_job(installation_ctx, make_table_migration_context, workflow) -> None:
     tables, dst_schema = make_table_migration_context("hiveserde", installation_ctx)
     ctx = installation_ctx.replace(
@@ -122,7 +123,7 @@ def test_hiveserde_table_in_place_migration_job(installation_ctx, make_table_mig
     for table in tables.values():
         migrated_table_name = f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}"
         if not ctx.workspace_client.tables.exists(migrated_table_name):
-           missing_tables.add(migrated_table_name)
+            missing_tables.add(migrated_table_name)
     assert not missing_tables, f"Missing migrated tables: {missing_tables}"
 
 

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -86,6 +86,8 @@ def test_table_migration_convert_manged_to_external(installation_ctx, make_table
     ctx.workspace_installation.run()
     ctx.deployed_workflows.run_workflow("migrate-tables", skip_job_wait=True)
 
+    assert ctx.deployed_workflows.validate_step("migrate-tables")
+
     missing_tables = set[str]()
     for table in tables.values():
         migrated_table_name = f"{dst_schema.catalog_name}.{dst_schema.name}.{table.name}"

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -35,7 +35,9 @@ def test_table_migration_job_refreshes_migration_status(
     )
 
     ctx.workspace_installation.run()
-    ctx.deployed_workflows.run_workflow(workflow)
+    ctx.deployed_workflows.run_workflow(workflow, skip_job_wait=True)
+
+    assert ctx.deployed_workflows.validate_step(workflow)
 
     # Avoiding MigrationStatusRefresh as it will refresh the status before fetching
     migration_status_query = f"SELECT * FROM {ctx.config.inventory_database}.migration_status"
@@ -82,7 +84,7 @@ def test_table_migration_convert_manged_to_external(installation_ctx, make_table
     )
 
     ctx.workspace_installation.run()
-    ctx.deployed_workflows.run_workflow("migrate-tables")
+    ctx.deployed_workflows.run_workflow("migrate-tables", skip_job_wait=True)
 
     missing_tables = set[str]()
     for table in tables.values():
@@ -146,7 +148,7 @@ def test_table_migration_job_publishes_remaining_tables(installation_ctx, make_t
     )
     ctx.table_mapping.skip_table_or_view(dst_schema.name, second_table.name, load_table=lambda *_: table)
 
-    ctx.deployed_workflows.run_workflow("migrate-tables")
+    ctx.deployed_workflows.run_workflow("migrate-tables", skip_job_wait=True)
 
     assert ctx.deployed_workflows.validate_step("migrate-tables")
     remaining_tables = list(

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -57,7 +57,7 @@ def test_running_real_migrate_groups_job(
 
     # TODO: Move `include_object_permissions` to context like other `include_` attributes
     # Limit the considered permissions to the following objects:
-    installation_ctx.__dict__['include_object_permissions'] = [
+    installation_ctx.config.include_object_permissions = [
         f"cluster-policies:{cluster_policy.policy_id}",
         f"TABLE:{table.full_name}",
         f"secrets:{secret_scope}",

--- a/tests/integration/workspace_access/test_workflows.py
+++ b/tests/integration/workspace_access/test_workflows.py
@@ -57,7 +57,7 @@ def test_running_real_migrate_groups_job(
 
     # TODO: Move `include_object_permissions` to context like other `include_` attributes
     # Limit the considered permissions to the following objects:
-    installation_ctx.config.include_object_permissions = [
+    installation_ctx.__dict__['include_object_permissions'] = [
         f"cluster-policies:{cluster_policy.policy_id}",
         f"TABLE:{table.full_name}",
         f"secrets:{secret_scope}",


### PR DESCRIPTION
## Changes
Exclude TACL migration in table migration integration tests because these were not asserted, and to speed up the tests and reduce flakiness

### Linked issues

Attempt to reduce flakiness blocking CI in #3239
Similar to #3437 in the sense that both PR scope integration tests to a smaller set of resources

### Tests

- [x] modified integration tests
