### PR TITLE
Implement disposition field in SQL backend

### DIFF
--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from databricks.sdk.core import Config
+from databricks.sdk.service.sql import Disposition
 
 __all__ = ["WorkspaceConfig"]
 
@@ -91,6 +92,8 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
 
     # Skip TACL migration during table migration
     skip_tacl_migration: bool = False
+
+    query_statement_disposition: Disposition | None = None
 
     def replace_inventory_variable(self, text: str) -> str:
         return text.replace("$inventory", f"hive_metastore.{self.inventory_database}")

--- a/src/databricks/labs/ucx/contexts/workspace_cli.py
+++ b/src/databricks/labs/ucx/contexts/workspace_cli.py
@@ -43,7 +43,9 @@ class WorkspaceContext(CliContext):
 
     @cached_property
     def sql_backend(self) -> SqlBackend:
-        return StatementExecutionBackend(self.workspace_client, self.config.warehouse_id)
+        return StatementExecutionBackend(
+            self.workspace_client, self.config.warehouse_id, disposition=self.config.query_statement_disposition
+        )
 
     @cached_property
     def cluster_access(self) -> ClusterAccess:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -45,6 +45,7 @@ from databricks.sdk.service.sql import (
     CreateWarehouseRequestWarehouseType,
     EndpointInfoWarehouseType,
     SpotInstancePolicy,
+    Disposition,
 )
 from databricks.sdk.useragent import with_extra
 
@@ -259,6 +260,12 @@ class WorkspaceInstaller(WorkspaceContext):
         recon_tolerance_percent = int(
             self.prompts.question("Reconciliation threshold, in percentage", default="5", valid_number=True)
         )
+
+        query_statement_disposition = self.prompts.confirm(
+            "Do you want to use the EXTERNAL_LINKS disposition value for query statements? (Only needed with large workspaces)"
+        )
+        query_statement_disposition = Disposition.EXTERNAL_LINKS if query_statement_disposition else None
+
         return WorkspaceConfig(
             inventory_database=inventory_database,
             ucx_catalog=ucx_catalog,
@@ -276,6 +283,7 @@ class WorkspaceInstaller(WorkspaceContext):
             recon_tolerance_percent=recon_tolerance_percent,
             upload_dependencies=upload_dependencies,
             default_owner_group=default_owner_group,
+            query_statement_disposition=query_statement_disposition,
         )
 
     def _compare_remote_local_versions(self):

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -262,7 +262,7 @@ class WorkspaceInstaller(WorkspaceContext):
         )
 
         query_statement_disposition = self.prompts.confirm(
-            "Do you want to use the EXTERNAL_LINKS disposition value for query statements? (Only needed with large workspaces)"
+            "Do you want to use the `EXTERNAL_LINKS` disposition for query statements? (Only needed when exporting more than 25 MiB of data from workspaces with many resources)"
         )
         query_statement_disposition = Disposition.EXTERNAL_LINKS if query_statement_disposition else None
 

--- a/src/databricks/labs/ucx/source_code/known.json
+++ b/src/databricks/labs/ucx/source_code/known.json
@@ -253,14 +253,6 @@
     "audioread.rawread": [],
     "audioread.version": []
   },
-  "autocommand": {
-    "autocommand": [],
-    "autocommand.autoasync": [],
-    "autocommand.autocommand": [],
-    "autocommand.automain": [],
-    "autocommand.autoparse": [],
-    "autocommand.errors": []
-  },
   "azure": {
     "azure.digitaltwins": [],
     "azure.digitaltwins.core": []
@@ -998,12 +990,6 @@
     "backcall": [],
     "backcall._signatures": [],
     "backcall.backcall": []
-  },
-  "backports.tarfile": {
-    "backports": [],
-    "backports.tarfile": [],
-    "backports.tarfile.compat": [],
-    "backports.tarfile.compat.py38": []
   },
   "bcrypt": {
     "bcrypt": []
@@ -6639,11 +6625,6 @@
     "importlib_resources.readers": [],
     "importlib_resources.simple": []
   },
-  "inflect": {
-    "inflect": [],
-    "inflect.compat": [],
-    "inflect.compat.py38": []
-  },
   "iniconfig": {
     "iniconfig": []
   },
@@ -6838,22 +6819,11 @@
     "jaraco.classes.meta": [],
     "jaraco.classes.properties": []
   },
-  "jaraco.collections": {
-    "jaraco.collections": []
-  },
   "jaraco.context": {
     "jaraco.context": []
   },
   "jaraco.functools": {
     "jaraco.functools": []
-  },
-  "jaraco.text": {
-    "jaraco.text": [],
-    "jaraco.text.layouts": [],
-    "jaraco.text.show-newlines": [],
-    "jaraco.text.strip-prefix": [],
-    "jaraco.text.to-dvorak": [],
-    "jaraco.text.to-qwerty": []
   },
   "jax-jumpy": {
     "jumpy": [],
@@ -32844,21 +32814,6 @@
     "trl.trainer.sft_config": [],
     "trl.trainer.sft_trainer": [],
     "trl.trainer.utils": []
-  },
-  "typeguard": {
-    "typeguard": [],
-    "typeguard._checkers": [],
-    "typeguard._config": [],
-    "typeguard._decorators": [],
-    "typeguard._exceptions": [],
-    "typeguard._functions": [],
-    "typeguard._importhook": [],
-    "typeguard._memo": [],
-    "typeguard._pytest_plugin": [],
-    "typeguard._suppression": [],
-    "typeguard._transformer": [],
-    "typeguard._union_transformer": [],
-    "typeguard._utils": []
   },
   "types-python-dateutil": {},
   "types-pyyaml": {},

--- a/src/databricks/labs/ucx/source_code/known.json
+++ b/src/databricks/labs/ucx/source_code/known.json
@@ -253,6 +253,14 @@
     "audioread.rawread": [],
     "audioread.version": []
   },
+  "autocommand": {
+    "autocommand": [],
+    "autocommand.autoasync": [],
+    "autocommand.autocommand": [],
+    "autocommand.automain": [],
+    "autocommand.autoparse": [],
+    "autocommand.errors": []
+  },
   "azure": {
     "azure.digitaltwins": [],
     "azure.digitaltwins.core": []
@@ -990,6 +998,12 @@
     "backcall": [],
     "backcall._signatures": [],
     "backcall.backcall": []
+  },
+  "backports.tarfile": {
+    "backports": [],
+    "backports.tarfile": [],
+    "backports.tarfile.compat": [],
+    "backports.tarfile.compat.py38": []
   },
   "bcrypt": {
     "bcrypt": []
@@ -6625,6 +6639,11 @@
     "importlib_resources.readers": [],
     "importlib_resources.simple": []
   },
+  "inflect": {
+    "inflect": [],
+    "inflect.compat": [],
+    "inflect.compat.py38": []
+  },
   "iniconfig": {
     "iniconfig": []
   },
@@ -6819,11 +6838,22 @@
     "jaraco.classes.meta": [],
     "jaraco.classes.properties": []
   },
+  "jaraco.collections": {
+    "jaraco.collections": []
+  },
   "jaraco.context": {
     "jaraco.context": []
   },
   "jaraco.functools": {
     "jaraco.functools": []
+  },
+  "jaraco.text": {
+    "jaraco.text": [],
+    "jaraco.text.layouts": [],
+    "jaraco.text.show-newlines": [],
+    "jaraco.text.strip-prefix": [],
+    "jaraco.text.to-dvorak": [],
+    "jaraco.text.to-qwerty": []
   },
   "jax-jumpy": {
     "jumpy": [],
@@ -32814,6 +32844,21 @@
     "trl.trainer.sft_config": [],
     "trl.trainer.sft_trainer": [],
     "trl.trainer.utils": []
+  },
+  "typeguard": {
+    "typeguard": [],
+    "typeguard._checkers": [],
+    "typeguard._config": [],
+    "typeguard._decorators": [],
+    "typeguard._exceptions": [],
+    "typeguard._functions": [],
+    "typeguard._importhook": [],
+    "typeguard._memo": [],
+    "typeguard._pytest_plugin": [],
+    "typeguard._suppression": [],
+    "typeguard._transformer": [],
+    "typeguard._union_transformer": [],
+    "typeguard._utils": []
   },
   "types-python-dateutil": {},
   "types-pyyaml": {},


### PR DESCRIPTION
### Description

This feature aims to the chance of running SQL statement for assessment results export in case of large workspaces with a large amount of findings.  
Introducing the `query_statement_disposition` value during the UCX installation can allow users to select the proper disposition method to use when running large queries. This parameter is added in the `config.yml` file and used for the SqlBackend definition. Using this approach, large queries will not fail.

### Changes
Added SQL query statement disposition choice during the UCX installation
Added `query_statement_disposition` value in the config file

### Linked issues

Resolves #3447

### Functionality

- [X] modified existing commands: `databricks labs install ucx`, `databricks labs ucx export-assessment`

### Tests

- [X] manually tested
