### PR TITLE
Exclude ucx dashboards from Lakeview dashboard crawler

### DIFF
--- a/src/databricks/labs/ucx/assessment/dashboards.py
+++ b/src/databricks/labs/ucx/assessment/dashboards.py
@@ -310,11 +310,13 @@ class LakeviewDashboardCrawler(CrawlerBase[Dashboard]):
         schema: str,
         *,
         include_dashboard_ids: list[str] | None = None,
+        exclude_dashboard_ids: list[str] | None = None,
         include_query_ids: list[str] | None = None,
     ):
         super().__init__(sql_backend, "hive_metastore", schema, "lakeview_dashboards", Dashboard)
         self._ws = ws
         self._include_dashboard_ids = include_dashboard_ids
+        self._exclude_dashboard_ids = exclude_dashboard_ids
         self._include_query_ids = include_query_ids
 
     def _crawl(self) -> Iterable[Dashboard]:

--- a/src/databricks/labs/ucx/assessment/dashboards.py
+++ b/src/databricks/labs/ucx/assessment/dashboards.py
@@ -324,6 +324,8 @@ class LakeviewDashboardCrawler(CrawlerBase[Dashboard]):
         for sdk_dashboard in self._list_dashboards():
             if sdk_dashboard.dashboard_id is None:
                 continue
+            if sdk_dashboard.dashboard_id in (self._exclude_dashboard_ids or []):
+                continue
             dashboard = Dashboard.from_sdk_lakeview_dashboard(sdk_dashboard)
             dashboards.append(dashboard)
         return dashboards

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -303,6 +303,7 @@ class GlobalContext(abc.ABC):
             self.sql_backend,
             self.inventory_database,
             include_dashboard_ids=self.config.include_dashboard_ids,
+            exclude_dashboard_ids=list(self.install_state.dashboards.values()),
             include_query_ids=self.config.include_query_ids,
         )
 

--- a/tests/unit/assessment/test_dashboards.py
+++ b/tests/unit/assessment/test_dashboards.py
@@ -471,6 +471,23 @@ def test_lakeview_dashboard_crawler_skips_exclude_dashboard_ids(caplog, mock_bac
     ws.lakeview.list.assert_called_once()
 
 
+def test_lakeview_dashboard_crawler_skips_exclude_dashboard_ids_takes_priority_over_include_dashboard_ids(
+    caplog, mock_backend
+) -> None:
+    ws = create_autospec(WorkspaceClient)
+    ws.lakeview.get.side_effect = lambda dashboard_id: SdkLakeviewDashboard(dashboard_id=dashboard_id)
+    crawler = LakeviewDashboardCrawler(
+        ws, mock_backend, "test", include_dashboard_ids=["did1", "did2"], exclude_dashboard_ids=["did2"]
+    )
+
+    crawler.snapshot()
+
+    rows = mock_backend.rows_written_for("hive_metastore.test.lakeview_dashboards", "overwrite")
+    assert rows == [Row(id="did1", name=None, parent=None, query_ids=[], tags=[], creator_id=None)]
+    ws.lakeview.list.assert_not_called()
+    ws.lakeview.get.assert_has_calls([call("did1"), call("did2")])
+
+
 def test_lakeview_dashboard_crawler_list_queries_includes_query_ids(mock_backend) -> None:
     ws = create_autospec(WorkspaceClient)
     datasets = [

--- a/tests/unit/assessment/test_dashboards.py
+++ b/tests/unit/assessment/test_dashboards.py
@@ -458,6 +458,19 @@ def test_lakeview_dashboard_crawler_skips_not_found_dashboard_ids(caplog, mock_b
     ws.lakeview.list.assert_not_called()
 
 
+def test_lakeview_dashboard_crawler_skips_exclude_dashboard_ids(caplog, mock_backend) -> None:
+    ws = create_autospec(WorkspaceClient)
+    dashboards = [SdkLakeviewDashboard(dashboard_id="did1"), SdkLakeviewDashboard(dashboard_id="did2")]
+    ws.lakeview.list.side_effect = lambda: (dashboard for dashboard in dashboards)  # Expects an iterator
+    crawler = LakeviewDashboardCrawler(ws, mock_backend, "test", exclude_dashboard_ids=["did2"])
+
+    crawler.snapshot()
+
+    rows = mock_backend.rows_written_for("hive_metastore.test.lakeview_dashboards", "overwrite")
+    assert rows == [Row(id="did1", name=None, parent=None, query_ids=[], tags=[], creator_id=None)]
+    ws.lakeview.list.assert_called_once()
+
+
 def test_lakeview_dashboard_crawler_list_queries_includes_query_ids(mock_backend) -> None:
     ws = create_autospec(WorkspaceClient)
     datasets = [


### PR DESCRIPTION
## Changes
Exclude ucx dashboards from Lakeview dashboard crawler as this would be a false positive dashboard

### Linked issues
Resolves #3441

### Functionality

- [x] modified existing workflow: `assessment`

### Tests

- [x] manually tested
- [x] added unit tests
- [x] verified on staging environment (screenshot attached)
