### PR TITLE
Dbr16 support

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -295,11 +295,7 @@ class TablesMigrator:
         return self._spark._jvm.org.apache.spark.sql.catalyst.catalog.CatalogTable  # pylint: disable=protected-access
 
     def _convert_hms_table_to_external(self, src_table: Table) -> bool:
-        """Converts a Hive metastore table to external using Spark JVM methods.
-
-        TODO:
-            This method fails for Databricks runtime 16.0, probably due to the JDK update (https://docs.databricks.com/en/release-notes/runtime/16.0.html#breaking-change-jdk-17-is-now-the-default).
-        """
+        """Converts a Hive metastore table to external using Spark JVM methods."""
         logger.info(f"Changing HMS managed table {src_table.name} to External Table type.")
         inventory_table = self._tables_crawler.full_name
         try:
@@ -327,6 +323,8 @@ class TablesMigrator:
                 old_table.schemaPreservesCase(),
                 old_table.ignoredProperties(),
                 old_table.viewOriginalText(),
+                # From DBR 16, there's a new table property: entityStorageLocations (Seq[EntityStorageLocation])
+                *([old_table.entityStorageLocations()] if hasattr(old_table, 'entityStorageLocations') else []),
             )
             self._catalog.alterTable(new_table)
             self._update_table_status(src_table, inventory_table)

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -121,11 +121,11 @@ def test_table_migration_convert_manged_to_external(installation_ctx, make_table
 
     # The assessment workflow is a prerequisite, and now verified by the workflow: it needs to successfully complete
     # before we can test the migration workflow.
-    ctx.deployed_workflows.run_workflow("assessment")
+    ctx.deployed_workflows.run_workflow("assessment", skip_job_wait=True)
     assert ctx.deployed_workflows.validate_step("assessment"), "Workflow failed: assessment"
 
     # The workflow under test.
-    ctx.deployed_workflows.run_workflow("migrate-tables")
+    ctx.deployed_workflows.run_workflow("migrate-tables", skip_job_wait=True)
     assert ctx.deployed_workflows.validate_step("migrate-tables")
 
     missing_tables = set[str]()
@@ -163,7 +163,7 @@ def test_hiveserde_table_in_place_migration_job(installation_ctx, make_table_mig
 
     # The assessment workflow is a prerequisite, and now verified by the workflow: it needs to successfully complete
     # before we can test the migration workflow.
-    ctx.deployed_workflows.run_workflow("assessment")
+    ctx.deployed_workflows.run_workflow("assessment", skip_job_wait=True)
     assert ctx.deployed_workflows.validate_step("assessment"), "Workflow failed: assessment"
 
     # The workflow under test.
@@ -191,12 +191,11 @@ def test_hiveserde_table_ctas_migration_job(ws, installation_ctx, make_table_mig
 
     # The assessment workflow is a prerequisite, and now verified by the workflow: it needs to successfully complete
     # before we can test the migration workflow.
-    ctx.deployed_workflows.run_workflow("assessment")
+    ctx.deployed_workflows.run_workflow("assessment", skip_job_wait=True)
     assert ctx.deployed_workflows.validate_step("assessment"), "Workflow failed: assessment"
 
     # The workflow under test.
-    ctx.deployed_workflows.run_workflow("migrate-external-tables-ctas")
-    # assert the workflow is successful
+    ctx.deployed_workflows.run_workflow("migrate-external-tables-ctas", skip_job_wait=True)
     assert ctx.deployed_workflows.validate_step("migrate-external-tables-ctas")
     # assert the tables are migrated
     missing_tables = set[str]()

--- a/tests/integration/hive_metastore/test_workflows.py
+++ b/tests/integration/hive_metastore/test_workflows.py
@@ -99,12 +99,7 @@ def test_table_migration_job_refreshes_migration_status(
 
 
 def test_table_migration_convert_manged_to_external(installation_ctx, make_table_migration_context) -> None:
-    """Convert managed tables to external before migrating.
-
-    Note:
-        This test fails from Databricks runtime 16.0 (https://docs.databricks.com/en/release-notes/runtime/16.0.html),
-        probably due to the JDK update (https://docs.databricks.com/en/release-notes/runtime/16.0.html#breaking-change-jdk-17-is-now-the-default).
-    """
+    """Convert managed tables to external before migrating."""
     tables, dst_schema = make_table_migration_context("managed", installation_ctx)
     ctx = installation_ctx.replace(
         config_transform=lambda wc: dataclasses.replace(


### PR DESCRIPTION
## Changes

This PR adds DBR16 compatibility for the code that (optionally) converts HMS tables to external tables within the `migrate-tables` workflow.

### Linked issues

Follows #3459.

### Functionality

- modified existing workflow: `migrate-tables`

### Tests

- manually tested (for DBR16)
- existing integration tests (for DBR15)
- verified on staging environment (see screenshot below)

![image](https://github.com/user-attachments/assets/ae75c4fb-2d6e-4bad-907c-2f9b8b3abff0)