### PR TITLE
Schedule the migration progress workflow to run daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,11 +919,11 @@ The output is processed and displayed in the migration dashboard using the in `r
 
 ## [EXPERIMENTAL] Migration Progress Workflow
 
-The manually triggered `migration-progress-experimental` workflow populates the tables visualized in the
+The `migration-progress-experimental` workflow populates the tables visualized in the
 [migration progress dashboard](#dashboards) by updating a **subset** of the [inventory tables](#assessment-workflow)
-to [track Unity Catalog compatability](docs/migration-progress.md) of Hive and workspace objects that need to be migrated.
+to [track Unity Catalog compatability](docs/migration-progress.md) of Hive and workspace objects that need to be migrated. It runs automatically once a day, but can also be triggered manually.
 
-The following pre-requisites need to be fulfilled before running the workflow:
+The following pre-requisites need to be fulfilled before the workflow will run successfully:
 - [UC metastore attached to workspace](../README.md#assign-metastore-command)
 - [UCX catalog exists](../README.md#create-ucx-catalog-command)
 - [Assessment job ran successfully](../README.md#ensure-assessment-run-command)

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -6,6 +6,7 @@ from databricks.labs.blueprint.installation import Installation
 from databricks.labs.lsql.backends import SqlBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.core import Config
+from databricks.sdk.service.jobs import CronSchedule
 
 from databricks.labs.ucx.config import WorkspaceConfig
 
@@ -70,6 +71,11 @@ class Workflow:
     @property
     def name(self):
         return self._name
+
+    @property
+    def schedule(self) -> CronSchedule | None:
+        """The default (cron) schedule for this workflow, or None if it is not scheduled."""
+        return None
 
     def tasks(self) -> Iterable[Task]:
         # return __task__ from every method in this class that has this attribute

--- a/src/databricks/labs/ucx/framework/tasks.py
+++ b/src/databricks/labs/ucx/framework/tasks.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
@@ -77,7 +78,10 @@ class Workflow:
                 continue
             fn = getattr(self, attr)
             if hasattr(fn, "__task__"):
-                yield fn.__task__
+                task_definition = fn.__task__
+                # Substitute placeholder for workflow name (unavailable at time of declaration).
+                with_workflow = dataclasses.replace(task_definition, workflow=self.name)
+                yield with_workflow
 
 
 def job_task(

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -160,7 +160,7 @@ class WorkspaceInstaller(WorkspaceContext):
             raise SystemExit(msg)
 
         self._is_account_install = self._force_install == "account"
-        self._tasks = Workflows.all().tasks()
+        self._workflows = Workflows.all()
 
     @cached_property
     def upgrades(self) -> Upgrades:
@@ -197,7 +197,7 @@ class WorkspaceInstaller(WorkspaceContext):
                 self.workspace_client,
                 self.wheels,
                 self.product_info,
-                self._tasks,
+                self._workflows,
             )
             workspace_installation = WorkspaceInstallation(
                 config,
@@ -500,8 +500,16 @@ class WorkspaceInstallation(InstallationMixin):
         sql_backend = StatementExecutionBackend(ws, config.warehouse_id)
         wheels = product_info.wheels(ws)
         prompts = Prompts()
-        tasks = Workflows.all().tasks()
-        workflows_installer = WorkflowsDeployment(config, installation, install_state, ws, wheels, product_info, tasks)
+        workflows = Workflows.all()
+        workflows_installer = WorkflowsDeployment(
+            config,
+            installation,
+            install_state,
+            ws,
+            wheels,
+            product_info,
+            workflows,
+        )
 
         return cls(
             config,

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -58,7 +58,6 @@ from databricks.labs.ucx.assessment.pipelines import PipelineInfo
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.account_cli import AccountContext
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
-from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation, Mount
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatus
@@ -151,7 +150,6 @@ class WorkspaceInstaller(WorkspaceContext):
         self,
         ws: WorkspaceClient,
         environ: dict[str, str] | None = None,
-        tasks: list[Task] | None = None,
     ):
         super().__init__(ws)
         if not environ:
@@ -162,7 +160,7 @@ class WorkspaceInstaller(WorkspaceContext):
             raise SystemExit(msg)
 
         self._is_account_install = self._force_install == "account"
-        self._tasks = tasks if tasks else Workflows.all().tasks()
+        self._tasks = Workflows.all().tasks()
 
     @cached_property
     def upgrades(self) -> Upgrades:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -831,7 +831,8 @@ class WorkflowsDeployment(InstallationMixin):
 
         job_tasks = []
         job_clusters: set[str] = {Task.job_cluster}
-        for task in self._workflows[workflow_name].tasks():
+        workflow = self._workflows[workflow_name]
+        for task in workflow.tasks():
             job_clusters.add(task.job_cluster)
             job_tasks.append(self._job_task(task, remote_wheels))
         job_tasks.append(self._job_parse_logs_task(job_tasks, workflow_name, remote_wheels))
@@ -847,6 +848,7 @@ class WorkflowsDeployment(InstallationMixin):
             "tags": tags,
             "job_clusters": self._job_clusters(job_clusters),
             "email_notifications": email_notifications,
+            "schedule": workflow.schedule,
             "tasks": job_tasks,
         }
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -600,7 +600,7 @@ class WorkflowsDeployment(InstallationMixin):
         self._install_state = install_state
         self._wheels = wheels
         self._product_info = product_info
-        self._workflows = workflows.workflows()
+        self._workflows = workflows.workflows
         self._this_file = Path(__file__)
         super().__init__(config, installation, ws)
 

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -728,10 +728,13 @@ class WorkflowsDeployment(InstallationMixin):
         return dashboard_link
 
     def _workflow_names(self) -> list[str]:
-        # Workflows are excluded if they _is_testing() and all tests are testing.
-        return [workflow_name
-                for workflow_name, tasks in self._workflows.items()
-                if not self._is_testing() or any(not t.is_testing() for t in tasks.tasks())]
+        names = []
+        # Workflows are excluded if _is_testing() and all tasks are testing.
+        for workflow_name, tasks in self._workflows.items():
+            if self._is_testing() and all(t.is_testing() for t in tasks.tasks()):
+                continue
+            names.append(workflow_name)
+        return names
 
     def _job_cluster_spark_conf(self, cluster_key: str):
         conf_from_installation = self._config.spark_conf if self._config.spark_conf else {}

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -606,8 +606,11 @@ class WorkflowsDeployment(InstallationMixin):
 
     def create_jobs(self) -> None:
         remote_wheels = self._upload_wheel()
-        desired_workflows = {workflow for workflow, tasks in self._workflows.items()
-                             if any(task.cloud_compatible(self._ws.config) for task in tasks.tasks())}
+        desired_workflows = {
+            workflow
+            for workflow, tasks in self._workflows.items()
+            if any(task.cloud_compatible(self._ws.config) for task in tasks.tasks())
+        }
 
         wheel_runner = ""
         if self._config.override_clusters:

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -812,7 +812,7 @@ class WorkflowsDeployment(InstallationMixin):
                 job_task.notebook_task = jobs.NotebookTask(notebook_path=wheel_runner, base_parameters=widget_values)
         return settings
 
-    def _job_settings(self, step_name: str, remote_wheels: list[str]) -> dict[str, Any]:
+    def _job_settings(self, workflow_name: str, remote_wheels: list[str]) -> dict[str, Any]:
         email_notifications = None
         if not self._config.override_clusters and "@" in self._my_username:
             # set email notifications only if we're running the real
@@ -824,11 +824,11 @@ class WorkflowsDeployment(InstallationMixin):
         job_tasks = []
         job_clusters: set[str] = {Task.job_cluster}
         for task in self._tasks:
-            if task.workflow != step_name:
+            if task.workflow != workflow_name:
                 continue
             job_clusters.add(task.job_cluster)
             job_tasks.append(self._job_task(task, remote_wheels))
-        job_tasks.append(self._job_parse_logs_task(job_tasks, step_name, remote_wheels))
+        job_tasks.append(self._job_parse_logs_task(job_tasks, workflow_name, remote_wheels))
         version = self._product_info.version()
         version = version if not self._ws.config.is_gcp else version.replace("+", "-")
         tags = {"version": f"v{version}"}
@@ -837,7 +837,7 @@ class WorkflowsDeployment(InstallationMixin):
             date_to_remove = self._get_test_purge_time()
             tags.update({"RemoveAfter": date_to_remove})
         return {
-            "name": self._name(step_name),
+            "name": self._name(workflow_name),
             "tags": tags,
             "job_clusters": self._job_clusters(job_clusters),
             "email_notifications": email_notifications,

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -29,7 +29,7 @@ class MigrationProgress(Workflow):
     def schedule(self) -> CronSchedule:
         """Schedule the migration progress workflow to run by default daily at 5:00 a.m. (UTC)."""
         return CronSchedule(
-            quartz_cron_expression="0 5 * * *", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
+            quartz_cron_expression="0 0 5 * * *", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
         )
 
     @job_task(job_cluster="user_isolation")

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+from databricks.sdk.service.jobs import CronSchedule, PauseStatus
+
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 from databricks.labs.ucx.framework.tasks import Workflow, job_task
 
@@ -22,6 +24,13 @@ class MigrationProgress(Workflow):
 
     def __init__(self) -> None:
         super().__init__('migration-progress-experimental')
+
+    @property
+    def schedule(self) -> CronSchedule:
+        """Schedule the migration progress workflow to run by default daily at 5:00 a.m. (UTC)."""
+        return CronSchedule(
+            quartz_cron_expression="0 5 * * *", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
+        )
 
     @job_task(job_cluster="user_isolation")
     def verify_prerequisites(self, ctx: RuntimeContext) -> None:

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -29,7 +29,7 @@ class MigrationProgress(Workflow):
     def schedule(self) -> CronSchedule:
         """Schedule the migration progress workflow to run by default daily at 5:00 a.m. (UTC)."""
         return CronSchedule(
-            quartz_cron_expression="0 0 5 * * *", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
+            quartz_cron_expression="0 0 5 * * ?", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
         )
 
     @job_task(job_cluster="user_isolation")

--- a/src/databricks/labs/ucx/queries/progress/main/00_0_migration_progress.md
+++ b/src/databricks/labs/ucx/queries/progress/main/00_0_migration_progress.md
@@ -8,7 +8,7 @@ height: 4
 > the [UCX catalog exists](https://github.com/databrickslabs/ucx?tab=readme-ov-file#create-ucx-catalog-command).
 
 This dashboard displays the migration progress, with data visualized from the `migration-progress-experimental`
-workflow. This workflow is designed to run regularly — either daily or weekly — to provide an up-to-date overview of the
+workflow. This workflow is designed runs daily (by default) to provide an up-to-date overview of the
 migration progress.
 
 In addition to offering real-time insights into migration progress, the dashboard also facilitates planning and task

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -8,7 +8,7 @@ from databricks.sdk.config import with_user_agent_extra
 from databricks.labs.ucx.__about__ import __version__
 from databricks.labs.ucx.assessment.workflows import Assessment, Failing
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
-from databricks.labs.ucx.framework.tasks import Task, Workflow, parse_args
+from databricks.labs.ucx.framework.tasks import Workflow, parse_args
 from databricks.labs.ucx.installer.logs import TaskLogger
 from databricks.labs.ucx.hive_metastore.workflows import (
     ScanTablesInMounts,
@@ -31,11 +31,7 @@ logger = logging.getLogger(__name__)
 
 class Workflows:
     def __init__(self, workflows: list[Workflow]):
-        self._tasks: list[Task] = []
-        self._workflows: dict[str, Workflow] = {}
-        for workflow in workflows:
-            self._workflows[workflow.name] = workflow
-            self._tasks.extend(workflow.tasks())
+        self._workflows: dict[str, Workflow] = {workflow.name: workflow for workflow in workflows}
 
     @classmethod
     def all(cls):
@@ -56,9 +52,6 @@ class Workflows:
                 Failing(),
             ]
         )
-
-    def tasks(self) -> list[Task]:
-        return self._tasks
 
     def workflows(self) -> dict[str, Workflow]:
         return self._workflows

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import os
 import sys
@@ -36,11 +35,7 @@ class Workflows:
         self._workflows: dict[str, Workflow] = {}
         for workflow in workflows:
             self._workflows[workflow.name] = workflow
-            for task_definition in workflow.tasks():
-                # Add the workflow name to the task definition, because we cannot access
-                # the workflow name from the method decorator
-                with_workflow = dataclasses.replace(task_definition, workflow=workflow.name)
-                self._tasks.append(with_workflow)
+            self._tasks.extend(workflow.tasks())
 
     @classmethod
     def all(cls):

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 class Workflows:
     def __init__(self, workflows: list[Workflow]):
-        self._workflows: dict[str, Workflow] = {workflow.name: workflow for workflow in workflows}
+        self.workflows: dict[str, Workflow] = {workflow.name: workflow for workflow in workflows}
 
     @classmethod
     def all(cls):
@@ -53,9 +53,6 @@ class Workflows:
             ]
         )
 
-    def workflows(self) -> dict[str, Workflow]:
-        return self._workflows
-
     def trigger(self, *argv):
         named_parameters = parse_args(*argv)
         config_path = Path(named_parameters["config"])
@@ -64,11 +61,11 @@ class Workflows:
         task_name = named_parameters.get("task", "not specified")
         workflow_name = named_parameters.get("workflow", "not specified")
         attempt = named_parameters.get("attempt", "0")
-        if workflow_name not in self._workflows:
-            msg = f'workflow "{workflow_name}" not found. Valid workflows are: {", ".join(self._workflows.keys())}'
+        if workflow_name not in self.workflows:
+            msg = f'workflow "{workflow_name}" not found. Valid workflows are: {", ".join(self.workflows.keys())}'
             raise KeyError(msg)
         print(f"UCX v{__version__}")
-        workflow = self._workflows[workflow_name]
+        workflow = self.workflows[workflow_name]
         if task_name == "parse_logs":
             return ctx.task_run_warning_recorder.snapshot()
         # both CLI commands and workflow names appear in telemetry under `cmd`

--- a/src/databricks/labs/ucx/runtime.py
+++ b/src/databricks/labs/ucx/runtime.py
@@ -60,6 +60,9 @@ class Workflows:
     def tasks(self) -> list[Task]:
         return self._tasks
 
+    def workflows(self) -> dict[str, Workflow]:
+        return self._workflows
+
     def trigger(self, *argv):
         named_parameters = parse_args(*argv)
         config_path = Path(named_parameters["config"])

--- a/tests/integration/cmds.py
+++ b/tests/integration/cmds.py
@@ -7,10 +7,10 @@ import yaml
 from databricks.labs.ucx.runtime import Workflows
 
 if __name__ == '__main__':
-    workflows = Workflows.all()
+    all_workflows = Workflows.all()
     root = Path(__file__).parent / '../..'
     metadata = yaml.safe_load((root / 'labs.yml').read_text())
-    keys = workflows._workflows.keys()  # pylint: disable=protected-access
+    keys = all_workflows.workflows.keys()
     cmd_names = sorted(set([x["name"] for x in metadata["commands"]] + list(keys)))
     (root / '.venv/cmds.json').write_text(json.dumps(cmd_names, indent=2))
     sys.stderr.write(f'Wrote {len(cmd_names)} command names to {root}/.venv/cmds.json\n')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,6 @@ from databricks.labs.ucx.azure.access import AzureResourcePermissions, StoragePe
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
-from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.catalog_schema import Catalog
 from databricks.labs.ucx.hive_metastore.grants import Grant
@@ -1144,10 +1143,6 @@ class MockInstallationContext(MockRuntimeContext):
         return ProductInfo.for_testing(WorkspaceConfig)
 
     @cached_property
-    def tasks(self) -> list[Task]:
-        return Workflows.all().tasks()
-
-    @cached_property
     def workflows_deployment(self) -> WorkflowsDeployment:
         return WorkflowsDeployment(
             self.config,
@@ -1156,7 +1151,7 @@ class MockInstallationContext(MockRuntimeContext):
             self.workspace_client,
             self.product_info.wheels(self.workspace_client),
             self.product_info,
-            self.tasks,
+            Workflows.all(),
         )
 
     @cached_property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,7 @@ from databricks.labs.ucx.contexts.workspace_cli import WorkspaceContext
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 from databricks.labs.ucx.framework.tasks import Task
 from databricks.labs.ucx.hive_metastore import TablesCrawler
+from databricks.labs.ucx.hive_metastore.catalog_schema import Catalog
 from databricks.labs.ucx.hive_metastore.grants import Grant
 from databricks.labs.ucx.hive_metastore.locations import Mount, MountsCrawler, ExternalLocation, ExternalLocations
 from databricks.labs.ucx.hive_metastore.mapping import Rule, TableMapping
@@ -471,6 +472,8 @@ class MockRuntimeContext(
         make_lakeview_dashboard_fixture,
         make_cluster_policy_fixture,
         make_cluster_policy_permissions_fixture,
+        make_secret_scope_fixture,
+        make_secret_scope_acl_fixture,
         env_or_skip_fixture,
         ws_fixture,
         make_random_fixture,
@@ -494,9 +497,12 @@ class MockRuntimeContext(
         self._make_lakeview_dashboard = make_lakeview_dashboard_fixture
         self._make_cluster_policy = make_cluster_policy_fixture
         self._make_cluster_policy_permissions = make_cluster_policy_permissions_fixture
+        self._make_secret_scope = make_secret_scope_fixture
+        self._make_secret_scope_acl = make_secret_scope_acl_fixture
         self._env_or_skip = env_or_skip_fixture
         self._tables: list[TableInfo] = []
         self._schemas: list[SchemaInfo] = []
+        self._catalogs: list[Catalog] = []
         self._groups: list[Group] = []
         self._udfs: list[FunctionInfo] = []
         self._grants: list[Grant] = []
@@ -504,6 +510,9 @@ class MockRuntimeContext(
         self._queries: list[LegacyQuery] = []
         self._lakeview_query_id: str | None = None
         self._dashboards: list[SdkRedashDashboard | SdkLakeviewDashboard] = []
+        self._cluster_policies: list[CreatePolicyResponse] = []
+        self._secret_scopes: list[str] = []
+
         # TODO: add methods to pre-populate the following:
         self._spn_infos: list[AzureServicePrincipalInfo] = []
 
@@ -571,10 +580,20 @@ class MockRuntimeContext(
         return grant
 
     def make_cluster_policy(self, **kwargs) -> CreatePolicyResponse:
-        return self._make_cluster_policy(**kwargs)
+        cluster_policy = self._make_cluster_policy(**kwargs)
+        self._cluster_policies.append(cluster_policy)
+        return cluster_policy
 
     def make_cluster_policy_permissions(self, **kwargs):
         return self._make_cluster_policy_permissions(**kwargs)
+
+    def make_secret_scope(self, **kwargs):
+        secret_scope = self._make_secret_scope(**kwargs)
+        self._secret_scopes.append(secret_scope)
+        return secret_scope
+
+    def make_secret_scope_acl(self, **kwargs):
+        return self._make_secret_scope_acl(**kwargs)
 
     def make_job(self, **kwargs) -> Job:
         job = self._make_job(**kwargs)
@@ -603,7 +622,9 @@ class MockRuntimeContext(
         return self._make_notebook(**kwargs)
 
     def make_catalog(self, **kwargs):
-        return self._make_catalog(**kwargs)
+        catalog = self._make_catalog(**kwargs)
+        self._catalogs.append(catalog)
+        return catalog
 
     def make_linting_resources(self) -> None:
         """Make resources to lint."""
@@ -632,6 +653,7 @@ class MockRuntimeContext(
             include_job_ids=self.created_jobs,
             include_dashboard_ids=self.created_dashboards,
             include_query_ids=self.created_queries,
+            include_object_permissions=self.created_object_permissions,
         )
 
     @cached_property
@@ -758,6 +780,35 @@ class MockRuntimeContext(
                 raise ValueError(f"Unsupported dashboard: {dashboard}")
         return dashboard_ids
 
+    @property
+    def created_object_permissions(self) -> list[str]:
+        # Initialize include_object_permissions for the created fixtures
+        # Currently only supports the object types for which the fixtures exist
+        created_object_permissions = set()
+
+        # GenericPermissionsSupport
+        for cluster_policy in self._cluster_policies:
+            created_object_permissions.add(f"cluster_policies:{cluster_policy.policy_id}")
+        for job in self._jobs:
+            created_object_permissions.add(f"jobs:{job.job_id}")
+
+        # TableAclSupport
+        for table in self._tables:
+            created_object_permissions.add(f"TABLE:{table.full_name}")
+        for schema in self._schemas:
+            created_object_permissions.add(f"DATABASE:{schema.full_name}")
+        for catalog in self._catalogs:
+            created_object_permissions.add(f"CATALOG:{catalog.name}")
+        for udf in self._udfs:
+            created_object_permissions.add(f"FUNCTION:{udf.name}")
+
+        for secret_scope in self._secret_scopes:
+            created_object_permissions.add(f"secrets:{secret_scope}")
+        for query in self._queries:
+            created_object_permissions.add(f"queries:{query.id}")
+
+        return list(created_object_permissions)
+
     @cached_property
     def azure_service_principal_crawler(self) -> StaticServicePrincipalCrawler:
         return StaticServicePrincipalCrawler(
@@ -810,6 +861,8 @@ def runtime_ctx(  # pylint: disable=too-many-arguments
     make_lakeview_dashboard,
     make_cluster_policy,
     make_cluster_policy_permissions,
+    make_secret_scope,
+    make_secret_scope_acl,
     env_or_skip,
     make_random,
 ) -> MockRuntimeContext:
@@ -826,6 +879,8 @@ def runtime_ctx(  # pylint: disable=too-many-arguments
         make_lakeview_dashboard,
         make_cluster_policy,
         make_cluster_policy_permissions,
+        make_secret_scope,
+        make_secret_scope_acl,
         env_or_skip,
         ws,
         make_random,
@@ -949,7 +1004,7 @@ def aws_cli_ctx(installation_ctx, env_or_skip):
 class MockInstallationContext(MockRuntimeContext):
     __test__ = False
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments, too-many-locals
         self,
         make_catalog_fixture,
         make_schema_fixture,
@@ -967,6 +1022,8 @@ class MockInstallationContext(MockRuntimeContext):
         make_lakeview_dashboard_fixture,
         make_cluster_policy,
         make_cluster_policy_permissions,
+        make_secret_scope_fixture,
+        make_secret_scope_acl_fixture,
         ws_fixture,
         watchdog_purge_suffix,
     ):
@@ -983,6 +1040,8 @@ class MockInstallationContext(MockRuntimeContext):
             make_lakeview_dashboard_fixture,
             make_cluster_policy,
             make_cluster_policy_permissions,
+            make_secret_scope_fixture,
+            make_secret_scope_acl_fixture,
             env_or_skip_fixture,
             ws_fixture,
             make_random_fixture,
@@ -1055,10 +1114,6 @@ class MockInstallationContext(MockRuntimeContext):
         return lambda wc: wc
 
     @cached_property
-    def include_object_permissions(self) -> None:
-        return None
-
-    @cached_property
     def config(self) -> WorkspaceConfig:
         workspace_config = self.workspace_installer.configure()
         default_cluster_id, tacl_cluster_id, table_migration_cluster_id = self.running_clusters
@@ -1076,7 +1131,7 @@ class MockInstallationContext(MockRuntimeContext):
             include_job_ids=self.created_jobs,
             include_dashboard_ids=self.created_dashboards,
             include_query_ids=self.created_queries,
-            include_object_permissions=self.include_object_permissions,
+            include_object_permissions=self.created_object_permissions,
             warehouse_id=self._env_or_skip("TEST_DEFAULT_WAREHOUSE_ID"),
             ucx_catalog=self.ucx_catalog,
         )
@@ -1167,6 +1222,8 @@ def installation_ctx(  # pylint: disable=too-many-arguments,too-many-locals
     make_lakeview_dashboard,
     make_cluster_policy,
     make_cluster_policy_permissions,
+    make_secret_scope,
+    make_secret_scope_acl,
     watchdog_purge_suffix,
 ) -> Generator[MockInstallationContext, None, None]:
     ctx = MockInstallationContext(
@@ -1186,6 +1243,8 @@ def installation_ctx(  # pylint: disable=too-many-arguments,too-many-locals
         make_lakeview_dashboard,
         make_cluster_policy,
         make_cluster_policy_permissions,
+        make_secret_scope,
+        make_secret_scope_acl,
         ws,
         watchdog_purge_suffix,
     )

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -22,7 +22,7 @@ def test_running_real_migration_progress_job(installation_ctx: MockInstallationC
     # The assessment workflow is a prerequisite for migration-progress: it needs to successfully complete before we can
     # test the migration-progress workflow.
     workflow = "assessment"
-    installation_ctx.deployed_workflows.run_workflow(workflow)
+    installation_ctx.deployed_workflows.run_workflow(workflow, skip_job_wait=True)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     # After the assessment, a user (maybe) installs the progress tracking
@@ -30,7 +30,7 @@ def test_running_real_migration_progress_job(installation_ctx: MockInstallationC
 
     # Run the migration-progress workflow until completion.
     workflow = "migration-progress-experimental"
-    installation_ctx.deployed_workflows.run_workflow(workflow)
+    installation_ctx.deployed_workflows.run_workflow(workflow, skip_job_wait=True)
     assert installation_ctx.deployed_workflows.validate_step(workflow), f"Workflow failed: {workflow}"
 
     # Ensure that the migration-progress workflow populated the `workflow_runs` table.

--- a/tests/integration/progress/test_workflows.py
+++ b/tests/integration/progress/test_workflows.py
@@ -48,7 +48,9 @@ def test_migration_progress_job_has_schedule(ws: WorkspaceClient, installation_c
 
     workflow_id = installation_ctx.install_state.jobs["migration-progress-experimental"]
     workflow = ws.jobs.get(workflow_id)
+    assert workflow.settings
     schedule = workflow.settings.schedule
+    assert schedule is not None, "No schedule found for the migration-progress workflow."
     assert schedule.quartz_cron_expression, "No cron expression found for the migration-progress workflow."
     assert schedule.timezone_id, "No time-zone specified for scheduling the migration-progress workflow."
     assert schedule.pause_status == PauseStatus.UNPAUSED, "Workflow schedule should not be paused."

--- a/tests/integration/recon/test_migrate_recon.py
+++ b/tests/integration/recon/test_migrate_recon.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.hive_metastore.tables import What
 
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
-def test_migrate_managed_tables_and_recon(ws, sql_backend, runtime_ctx, make_catalog):
+def test_migrate_managed_tables_and_recon(runtime_ctx, make_catalog) -> None:
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)
 

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -101,7 +101,7 @@ def not_found(_):
     raise NotFound(msg)
 
 
-def test_create_database(ws, caplog, mock_installation, any_prompt):
+def test_create_database(ws, caplog, mock_installation, any_prompt) -> None:
     sql_backend = MockBackend(
         fails_on_first={'CREATE TABLE': '[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable is incorrect'}
     )
@@ -139,7 +139,7 @@ def test_create_database(ws, caplog, mock_installation, any_prompt):
     wheels.upload_to_wsfs.assert_called()
 
 
-def test_install_cluster_override_jobs(ws, mock_installation):
+def test_install_cluster_override_jobs(ws, mock_installation) -> None:
     wheels = create_autospec(WheelsV2)
     workflows_installation = WorkflowsDeployment(
         WorkspaceConfig(inventory_database='ucx', override_clusters={"main": 'one', "tacl": 'two'}, policy_id='123'),
@@ -160,7 +160,7 @@ def test_install_cluster_override_jobs(ws, mock_installation):
     wheels.upload_to_dbfs.assert_not_called()
 
 
-def test_writeable_dbfs(ws, tmp_path, mock_installation):
+def test_writeable_dbfs(ws, tmp_path, mock_installation) -> None:
     """Ensure configure does not add cluster override for happy path of writable DBFS"""
     wheels = create_autospec(WheelsV2)
     workflows_installation = WorkflowsDeployment(
@@ -512,7 +512,7 @@ def test_create_cluster_policy(ws, mock_installation) -> None:
     )
 
 
-def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_installation):
+def test_main_with_existing_conf_does_not_recreate_config(ws, mocker, mock_installation) -> None:
     webbrowser_open = mocker.patch("webbrowser.open")
     sql_backend = MockBackend()
     prompts = MockPrompts(
@@ -582,7 +582,7 @@ def test_remove_database(ws):
     workflow_installer.create_jobs.assert_not_called()
 
 
-def test_remove_jobs_no_state(ws):
+def test_remove_jobs_no_state(ws) -> None:
     sql_backend = MockBackend()
     ws = create_autospec(WorkspaceClient)
     prompts = MockPrompts(
@@ -615,7 +615,7 @@ def test_remove_jobs_no_state(ws):
     wheels.upload_to_wsfs.assert_not_called()
 
 
-def test_remove_jobs_with_state_missing_job(ws, caplog, mock_installation_with_jobs):
+def test_remove_jobs_with_state_missing_job(ws, caplog, mock_installation_with_jobs) -> None:
     ws.jobs.delete.side_effect = InvalidParameterValue("job id 123 not found")
 
     sql_backend = MockBackend()
@@ -1110,7 +1110,7 @@ def test_open_config(ws, mocker, mock_installation):
     webbrowser_open.assert_called_with('https://localhost/#workspace~/mock/config.yml')
 
 
-def test_triggering_assessment_wf(ws, mocker, mock_installation):
+def test_triggering_assessment_wf(ws, mocker, mock_installation) -> None:
     ws.jobs.run_now = mocker.Mock()
     mocker.patch("webbrowser.open")
     sql_backend = MockBackend()
@@ -1142,7 +1142,7 @@ def test_triggering_assessment_wf(ws, mocker, mock_installation):
     ws.jobs.run_now.assert_not_called()
 
 
-def test_triggering_assessment_wf_w_job(ws, mocker, mock_installation):
+def test_triggering_assessment_wf_w_job(ws, mocker, mock_installation) -> None:
     ws.jobs.run_now = mocker.Mock()
     mocker.patch("webbrowser.open")
     sql_backend = MockBackend()
@@ -1225,7 +1225,7 @@ def test_runs_upgrades_on_more_recent_version(ws, any_prompt):
     wheels.upload_to_wsfs.assert_called()
 
 
-def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt):
+def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt) -> None:
     sql_backend = MockBackend()
     install_state = InstallState.from_installation(mock_installation_extra_jobs)
     wheels = create_autospec(WheelsV2)
@@ -1283,7 +1283,7 @@ def test_remove_jobs(ws, caplog, mock_installation_extra_jobs, any_prompt):
     assert 'Corrupt installation state. Skipping job_id=125 as it is not managed by UCX' in caplog.messages
 
 
-def test_remove_jobs_already_deleted(ws, caplog, mock_installation_extra_jobs, any_prompt):
+def test_remove_jobs_already_deleted(ws, caplog, mock_installation_extra_jobs, any_prompt) -> None:
     sql_backend = MockBackend()
     ws.jobs.delete.side_effect = InvalidParameterValue()
     install_state = InstallState.from_installation(mock_installation_extra_jobs)
@@ -1498,7 +1498,7 @@ def test_check_inventory_database_exists(ws, mock_installation):
         install.configure()
 
 
-def test_user_not_admin(ws, mock_installation):
+def test_user_not_admin(ws, mock_installation) -> None:
     ws.current_user.me = lambda: iam.User(user_name="me@example.com", groups=[iam.ComplexValue(display="group1")])
     wheels = create_autospec(WheelsV2)
     workspace_installation = WorkflowsDeployment(

--- a/tests/unit/install/test_install_dashboards.py
+++ b/tests/unit/install/test_install_dashboards.py
@@ -14,6 +14,7 @@ from databricks.sdk.errors import NotFound, InvalidParameterValue
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.install import WorkspaceInstallation
 from databricks.labs.ucx.installer.workflows import WorkflowsDeployment
+from databricks.labs.ucx.runtime import Workflows
 
 
 PRODUCT_INFO = ProductInfo.from_class(WorkspaceConfig)
@@ -31,7 +32,7 @@ def workspace_installation(request, ws, any_prompt) -> WorkspaceInstallation:
         ws,
         wheels,
         PRODUCT_INFO,
-        [],
+        Workflows([]),
     )
     return WorkspaceInstallation(
         WorkspaceConfig(inventory_database='ucx'),

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -39,7 +39,7 @@ def side_effect_remove_after_in_tags_settings(**settings) -> CreateResponse:
     return CreateResponse(job_id=1)
 
 
-def test_workflows_deployment_creates_jobs_with_remove_after_tag(mock_installation):
+def test_workflows_deployment_creates_jobs_with_remove_after_tag(mock_installation) -> None:
     ws = create_autospec(WorkspaceClient)
     ws.current_user.me.return_value = User(user_name="user", groups=[ComplexValue(display="admins")])
     ws.jobs.create.side_effect = side_effect_remove_after_in_tags_settings

--- a/tests/unit/installer/test_workflows.py
+++ b/tests/unit/installer/test_workflows.py
@@ -10,8 +10,9 @@ from databricks.sdk.service.iam import ComplexValue, User
 from databricks.sdk.service.jobs import BaseRun, CreateResponse, Run, RunOutput, RunResultState, RunState, RunTask
 
 from databricks.labs.ucx.config import WorkspaceConfig
-from databricks.labs.ucx.framework.tasks import Task
+from databricks.labs.ucx.framework.tasks import Workflow, job_task
 from databricks.labs.ucx.installer.workflows import DeployedWorkflows, WorkflowsDeployment
+from databricks.labs.ucx.runtime import Workflows
 
 
 class ResourceDoesNotExistIter:
@@ -47,7 +48,15 @@ def test_workflows_deployment_creates_jobs_with_remove_after_tag(mock_installati
     install_state = InstallState.from_installation(mock_installation)
     wheels = create_autospec(WheelsV2)
     product_info = ProductInfo.for_testing(WorkspaceConfig)
-    tasks = [Task("workflow", "task", "docs", lambda *_: None)]
+
+    class Dummy(Workflow):
+        def __init__(self):
+            super().__init__('dummy')
+
+        @job_task
+        def task(self, ctx):
+            """docs"""
+
     workflows_deployment = WorkflowsDeployment(
         config,
         mock_installation,
@@ -55,7 +64,7 @@ def test_workflows_deployment_creates_jobs_with_remove_after_tag(mock_installati
         ws,
         wheels,
         product_info,
-        tasks=tasks,
+        workflows=Workflows([Dummy()]),
     )
     try:
         workflows_deployment.create_jobs()

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigra
 from databricks.labs.ucx.progress.history import ProgressEncoder
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import CatalogInfo, MetastoreAssignment
-from databricks.sdk.service.jobs import BaseRun, RunResultState, RunState
+from databricks.sdk.service.jobs import BaseRun, RunResultState, RunState, PauseStatus
 
 from databricks.labs.ucx.progress.workflows import MigrationProgress
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
@@ -169,3 +169,9 @@ def test_migration_progress_record_workflow_run(run_workflow, mock_backend) -> N
     ]
     # Finish-time must be indistinguishable from or later than the start time.
     assert all(row["started_at"] <= row["finished_at"] for row in rows)
+
+
+def test_migration_progress_has_schedule() -> None:
+    workflow = MigrationProgress()
+    schedule = workflow.schedule
+    assert schedule is not None and schedule.pause_status == PauseStatus.UNPAUSED

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -2,14 +2,14 @@ from databricks.labs.ucx.runtime import Workflows
 
 
 def test_workflows_detected() -> None:
-    workflows = Workflows.all()
+    all_workflows = Workflows.all()
 
-    assert len(workflows.workflows()) > 0, "No workflows detected"
+    assert len(all_workflows.workflows) > 0, "No workflows detected"
 
 
 def test_tasks_detected() -> None:
-    workflows = Workflows.all()
+    all_workflows = Workflows.all()
 
-    for name, workflow in workflows.workflows().items():
+    for name, workflow in all_workflows.workflows.items():
         tasks = list(workflow.tasks())
         assert len(tasks) > 0, f"No tasks detected for workflow: {name}"

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,9 +1,15 @@
 from databricks.labs.ucx.runtime import Workflows
 
 
+def test_workflows_detected() -> None:
+    workflows = Workflows.all()
+
+    assert len(workflows.workflows()) > 0, "No workflows detected"
+
+
 def test_tasks_detected() -> None:
     workflows = Workflows.all()
 
-    tasks = workflows.tasks()
-
-    assert len(tasks) > 1
+    for name, workflow in workflows.workflows().items():
+        tasks = list(workflow.tasks())
+        assert len(tasks) > 0, f"No tasks detected for workflow: {name}"

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -1,7 +1,7 @@
 from databricks.labs.ucx.runtime import Workflows
 
 
-def test_tasks_detected():
+def test_tasks_detected() -> None:
     workflows = Workflows.all()
 
     tasks = workflows.tasks()


### PR DESCRIPTION
## Changes

This PR updates the UCX installation so that the migration progress workflow runs automatically once per day.

Changes include:

 - Refactoring some of the plumbing that we use for managing/installing workflows.
 - Allowing workflows to have a (Cron-based) schedule attached to them.
 - ~Allowing the default schedule to be overridden via configuration during installation.~ (Will be addressed in a new PR.)
 - Configuring the migration progress workflow to run daily, by default at 5 a.m. (UTC).

### Functionality

- updated relevant user documentation
- modified existing workflow: `migration-progress-experimental`

### Tests

- added and existing unit tests
- added and existing integration tests
