### PR TITLE
Fix typo in workflow name (in error message)

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/workflows.py
+++ b/src/databricks/labs/ucx/workspace_access/workflows.py
@@ -73,7 +73,7 @@ class LegacyGroupMigration(Workflow):
         if not ctx.permission_manager.verify_group_permissions():
             raise ValueError(
                 "Some group permissions were not migrated successfully. Wait for an hour then use the "
-                "`validate-group-permissions` workflow to validate the permissions after the API caught up. "
+                "`validate-groups-permissions` workflow to validate the permissions after the API caught up. "
                 f"Run `databricks labs ucx logs --workflow '{self._name}' --debug` for more details."
             )
 


### PR DESCRIPTION
## Changes

This PR fixes a trivial typo in an error message where the wrong workflow name is given.
