### PR TITLE
Create specific failure for Python syntax error while parsing with Astroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,13 @@ dbutils.notebook.run(a)
 
 [[back to top](#databricks-labs-ucx)]
 
+## `python-parse-error`
+
+This is a generic message indicating that the Python code could not be parsed. The user must manually check the Python
+code.
+
+[[back to top](#databricks-labs-ucx)]
+
 ## `python-udf-in-shared-clusters`
 
 `applyInPandas` requires DBR 14.3 LTS or above on Unity Catalog clusters in Shared access mode. Example:

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -26,7 +26,7 @@ from astroid import (  # type: ignore
     parse,
     Uninferable,
 )
-from astroid.exceptions import AstroidSyntaxError
+from astroid.exceptions import AstroidSyntaxError  # type: ignore
 
 from databricks.labs.ucx.source_code.base import (
     Failure,

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -100,7 +100,10 @@ class Tree:  # pylint: disable=too-many-public-methods
             None,
             Failure(
                 code="python-parse-error",
-                message=f"Failed to parse code `{source_code}`: {type(e)}: {e}. Report this as an issue on UCX GitHub.",
+                message=(
+                    "Please report the following error as an issue on UCX GitHub. "
+                    f"Caught error `{type(e)} : {e}` while parsing code: {source_code}"
+                ),
                 # Lines and columns are both 0-based: the first line is line 0.
                 start_line=0,
                 start_col=0,

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -96,12 +96,18 @@ class Tree:  # pylint: disable=too-many-public-methods
                     end_col=(e.error.end_offset or 2) - 1,
                 ),
             )
+        new_issue_url = (
+            "https://github.com/databrickslabs/ucx/issues/new?title=[BUG]:+Python+parse+error"
+            "&labels=migrate/code,needs-triage,bug"
+            "&body=%23+Current+behaviour%0A%0ACannot+parse+the+following+Python+code"
+            f"%0A%0A%60%60%60+python%0A{source_code}%0A%60%60%60"
+        )
         return MaybeTree(
             None,
             Failure(
                 code="python-parse-error",
                 message=(
-                    "Please report the following error as an issue on UCX GitHub. "
+                    f"Please report the following error as an issue on UCX GitHub: {new_issue_url}\n"
                     f"Caught error `{type(e)} : {e}` while parsing code: {source_code}"
                 ),
                 # Lines and columns are both 0-based: the first line is line 0.

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -195,7 +195,7 @@ def test_graph_builder_parse_error(
     problems = analyser.build_graph()
     codes = {_.code for _ in problems}
 
-    assert codes == {'system-error'}
+    assert codes == {"python-parse-error"}
 
 
 def test_parses_python_cell_with_magic_commands(simple_dependency_resolver, mock_path_lookup) -> None:

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -4,7 +4,7 @@ import re
 import pytest
 from databricks.sdk.service.workspace import Language, ObjectType, ObjectInfo
 
-from databricks.labs.ucx.source_code.base import CurrentSessionState
+from databricks.labs.ucx.source_code.base import CurrentSessionState, Failure
 from databricks.labs.ucx.source_code.graph import DependencyGraph, DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader
@@ -290,3 +290,16 @@ dbutils.notebook.run(f"Hey {name2}")
     linter = DbutilsPyLinter(CurrentSessionState())
     advices = list(linter.lint(source))
     assert not advices
+
+
+def test_tree_maybe_parse_fails_on_jupyter_magic() -> None:
+    source = "%tb"
+    tree = Tree.maybe_parse(source)
+    assert tree.failure == Failure(
+        "python-parse-error",
+        f"Failed to parse code due to invalid syntax: {source}",
+        start_line=0,
+        start_col=0,
+        end_line=0,
+        end_col=1,
+    )


### PR DESCRIPTION
## Changes
Create specific failure for Python syntax error while parsing with Astroid.

If we parse Python code with a syntax error, the user needs to manually check the code:
1. Create a specific failure for this case.
2. Rename `system-error` to `python-parse-error` to match `sql-parse-error` and explain in the README so user knows what to do.
3. Keep generic failure with direction to create Github issues to surface other issues.

### Linked issues

Closes #3457

### Functionality

- [x] modified Python linting related code

### Tests

- [x] added unit tests
