### PR TITLE
Add dummy id for jobs to include on `MockInstallationContext.config`

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1128,7 +1128,11 @@ class MockInstallationContext(MockRuntimeContext):
             renamed_group_prefix=self.renamed_group_prefix,
             include_group_names=self.created_groups,
             include_databases=self.created_databases,
-            include_job_ids=self.created_jobs,
+            # An empty list is not saved in the installation.save below.
+            # With a dummy id, we signal to skip all jobs.
+            # A temporary hack to speed up the WorkflowLinter, proper solution follows from issue:
+            # https://github.com/databrickslabs/blueprint/issues/179
+            include_job_ids=self.created_jobs or [1],
             include_dashboard_ids=self.created_dashboards,
             include_query_ids=self.created_queries,
             include_object_permissions=self.created_object_permissions,


### PR DESCRIPTION
## Changes
Add dummy id for jobs to include on `MockInstallationContext.config` to avoid assessing all workflows.

### Linked issues

A more proper solution would be to resolve: https://github.com/databrickslabs/blueprint/issues/179

### Tests

- [x] manually tested

