### PR TITLE
Rename Python AST's `Tree` methods for clarity

### DIFF
--- a/src/databricks/labs/ucx/source_code/graph.py
+++ b/src/databricks/labs/ucx/source_code/graph.py
@@ -559,7 +559,7 @@ class InheritedContext:
         if tree is None:
             return InheritedContext(self.tree, found, context.problems)
         new_tree = self.tree or Tree.new_module()
-        new_tree.append_tree(tree)
+        new_tree.attach_child_tree(tree)
         new_problems = itertools.chain(self.problems, context.problems)
         return InheritedContext(new_tree, found, new_problems)
 

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -662,7 +662,7 @@ class _CollectorWalker(DependencyGraphWalker[T], ABC):
                     logger.warning(maybe_tree.failure.message)
                     continue
                 assert maybe_tree.tree is not None
-                inherited_tree.append_tree(maybe_tree.tree)
+                inherited_tree.attach_child_tree(maybe_tree.tree)
 
     def _collect_from_source(
         self,

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -73,7 +73,7 @@ class PythonCodeAnalyzer:
             # append nodes
             node_line = base_node.node.lineno
             nodes = tree.nodes_between(last_line + 1, node_line - 1)
-            context.tree.append_nodes(nodes)
+            context.tree.attach_nodes(nodes)
             globs = tree.globals_between(last_line + 1, node_line - 1)
             context.tree.extend_globals(globs)
             last_line = node_line
@@ -86,7 +86,7 @@ class PythonCodeAnalyzer:
         assert context.tree is not None, "Tree should be initialized"
         if last_line < line_count:
             nodes = tree.nodes_between(last_line + 1, line_count)
-            context.tree.append_nodes(nodes)
+            context.tree.attach_nodes(nodes)
             globs = tree.globals_between(last_line + 1, line_count)
             context.tree.extend_globals(globs)
         return context

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -75,7 +75,7 @@ class PythonCodeAnalyzer:
             nodes = tree.nodes_between(last_line + 1, node_line - 1)
             context.tree.append_nodes(nodes)
             globs = tree.globals_between(last_line + 1, node_line - 1)
-            context.tree.append_globals(globs)
+            context.tree.extend_globals(globs)
             last_line = node_line
             # process node
             child_context = self._build_inherited_context_from_node(base_node, child_path)
@@ -88,7 +88,7 @@ class PythonCodeAnalyzer:
             nodes = tree.nodes_between(last_line + 1, line_count)
             context.tree.append_nodes(nodes)
             globs = tree.globals_between(last_line + 1, line_count)
-            context.tree.append_globals(globs)
+            context.tree.extend_globals(globs)
         return context
 
     def _parse_and_extract_nodes(self) -> tuple[Tree | None, list[NodeBase], Iterable[DependencyProblem]]:

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -211,9 +211,16 @@ class Tree:  # pylint: disable=too-many-public-methods
             code = code[0:truncate_after] + "..."
         return f"<Tree: {code}>"
 
-    def append_tree(self, tree: Tree) -> None:
+    def attach_child_tree(self, tree: Tree) -> None:
+        """Attach a child tree.
+
+        Attaching a child tree is a **stateful** operation for both the parent and child tree. After attaching a child
+        tree, a tree can be traversed starting from the parent or child tree. From both starting points all nodes in
+        both trees can be reached, though, the order of nodes will be different as that is relative to the starting
+        point.
+        """
         if not isinstance(tree.node, Module):
-            raise NotImplementedError(f"Can't append tree from {type(tree.node).__name__}")
+            raise NotImplementedError(f"Cannot attach child tree: {type(tree.node).__name__}")
         tree_module: Module = cast(Module, tree.node)
         self.append_nodes(tree_module.body)
         self.append_globals(tree_module.globals)
@@ -689,7 +696,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
         return maybe_tree
 
     def append_tree(self, tree: Tree) -> None:
-        self._make_tree().append_tree(tree)
+        self._make_tree().attach_child_tree(tree)
 
     def append_nodes(self, nodes: list[NodeNG]) -> None:
         self._make_tree().append_nodes(nodes)
@@ -705,7 +712,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
             logger.warning(maybe_tree.failure.message)
             return
         assert maybe_tree.tree is not None
-        this_tree.append_tree(maybe_tree.tree)
+        this_tree.attach_child_tree(maybe_tree.tree)
 
     def collect_dfsas(self, source_code: str) -> Iterable[DirectFsAccess]:
         maybe_tree = self._parse_and_append(source_code)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -224,6 +224,14 @@ class Tree:  # pylint: disable=too-many-public-methods
         self.append_nodes(tree_module.body)
         self.extend_globals(tree_module.globals)
 
+    def append_nodes(self, nodes: list[NodeNG]) -> None:
+        if not isinstance(self.node, Module):
+            raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
+        self_module: Module = cast(Module, self.node)
+        for node in nodes:
+            node.parent = self_module
+            self_module.body.append(node)
+
     def extend_globals(self, globs: dict[str, list[NodeNG]]) -> None:
         """Extend globals by extending the global values for each global key.
 
@@ -234,14 +242,6 @@ class Tree:  # pylint: disable=too-many-public-methods
         self_module: Module = cast(Module, self.node)
         for global_key, global_values in globs.items():
             self_module.globals[global_key] = self_module.globals.get(global_key, []) + global_values
-
-    def append_nodes(self, nodes: list[NodeNG]) -> None:
-        if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
-        self_module: Module = cast(Module, self.node)
-        for node in nodes:
-            node.parent = self_module
-            self_module.body.append(node)
 
     def is_instance_of(self, class_name: str) -> bool:
         for inferred in self.node.inferred():

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -227,7 +227,7 @@ class Tree:  # pylint: disable=too-many-public-methods
 
     def append_globals(self, globs: dict[str, list[Expr]]) -> None:
         if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Can't append globals to {type(self.node).__name__}")
+            raise NotImplementedError(f"Cannot append globals: {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)
         for name, values in globs.items():
             statements: list[Expr] = self_module.globals.get(name, None)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -225,6 +225,12 @@ class Tree:  # pylint: disable=too-many-public-methods
         self.extend_globals(tree_module.globals)
 
     def attach_nodes(self, nodes: list[NodeNG]) -> None:
+        """Attach nodes.
+
+        Attaching nodes is a **stateful** operation for both this tree's node, the parent node, and the child nodes.
+        After attaching the nodes, the parent node has the nodes in its body and the child nodes have this tree's node
+        as parent node.
+        """
         if not isinstance(self.node, Module):
             raise NotImplementedError(f"Cannot attach nodes to: {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -211,16 +211,12 @@ class Tree:  # pylint: disable=too-many-public-methods
             code = code[0:truncate_after] + "..."
         return f"<Tree: {code}>"
 
-    def append_tree(self, tree: Tree) -> Tree:
-        """returns the appended tree, not the consolidated one!"""
+    def append_tree(self, tree: Tree) -> None:
         if not isinstance(tree.node, Module):
             raise NotImplementedError(f"Can't append tree from {type(tree.node).__name__}")
         tree_module: Module = cast(Module, tree.node)
         self.append_nodes(tree_module.body)
         self.append_globals(tree_module.globals)
-        # the following may seem strange but it's actually ok to use the original module as tree root
-        # because each node points to the correct parent (practically, the tree is now only a list of statements)
-        return tree
 
     def append_globals(self, globs: dict[str, list[Expr]]) -> None:
         if not isinstance(self.node, Module):

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -221,10 +221,10 @@ class Tree:  # pylint: disable=too-many-public-methods
         if not isinstance(tree.node, Module):
             raise NotImplementedError(f"Cannot attach child tree: {type(tree.node).__name__}")
         tree_module: Module = cast(Module, tree.node)
-        self.append_nodes(tree_module.body)
+        self.attach_nodes(tree_module.body)
         self.extend_globals(tree_module.globals)
 
-    def append_nodes(self, nodes: list[NodeNG]) -> None:
+    def attach_nodes(self, nodes: list[NodeNG]) -> None:
         if not isinstance(self.node, Module):
             raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)
@@ -698,7 +698,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
         self._make_tree().attach_child_tree(tree)
 
     def append_nodes(self, nodes: list[NodeNG]) -> None:
-        self._make_tree().append_nodes(nodes)
+        self._make_tree().attach_nodes(nodes)
 
     def append_globals(self, globs: dict) -> None:
         self._make_tree().extend_globals(globs)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -226,7 +226,7 @@ class Tree:  # pylint: disable=too-many-public-methods
 
     def attach_nodes(self, nodes: list[NodeNG]) -> None:
         if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Can't append statements to {type(self.node).__name__}")
+            raise NotImplementedError(f"Cannot attach nodes to: {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)
         for node in nodes:
             node.parent = self_module
@@ -238,7 +238,7 @@ class Tree:  # pylint: disable=too-many-public-methods
         Extending globals is a stateful operation for this `Tree` (`self`), similarly to extending a list.
         """
         if not isinstance(self.node, Module):
-            raise NotImplementedError(f"Cannot extend globals: {type(self.node).__name__}")
+            raise NotImplementedError(f"Cannot extend globals to: {type(self.node).__name__}")
         self_module: Module = cast(Module, self.node)
         for global_key, global_values in globs.items():
             self_module.globals[global_key] = self_module.globals.get(global_key, []) + global_values

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -307,22 +307,22 @@ def test_is_builtin(source, name, is_builtin) -> None:
     assert False  # could not locate call
 
 
-def test_tree_append_nodes_sets_parent() -> None:
+def test_tree_attach_nodes_sets_parent() -> None:
     node = astroid.extract_node("b = a + 2")
     maybe_tree = Tree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
-    maybe_tree.tree.append_nodes([node])
+    maybe_tree.tree.attach_nodes([node])
 
     assert node.parent == maybe_tree.tree.node
 
 
-def test_tree_append_nodes_adds_node_to_body() -> None:
+def test_tree_attach_nodes_adds_node_to_body() -> None:
     node = astroid.extract_node("b = a + 2")
     maybe_tree = Tree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
-    maybe_tree.tree.append_nodes([node])
+    maybe_tree.tree.attach_nodes([node])
 
     assert maybe_tree.tree.node.body[-1] == node
 
@@ -368,9 +368,9 @@ def test_tree_attach_child_tree_raises_not_implemented_error_for_constant_node()
         Tree(Const("xyz")).attach_child_tree(Tree(Const("xyz")))
 
 
-def test_append_node_fails() -> None:
+def test_tree_attach_nodes_raises_not_implemented_error_for_constant_node() -> None:
     with pytest.raises(NotImplementedError):
-        Tree(Const("xyz")).append_nodes([])
+        Tree(Const("xyz")).attach_nodes([])
 
 
 def test_nodes_between_fails() -> None:

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -349,8 +349,8 @@ def test_has_global_fails() -> None:
     assert not Tree.new_module().has_global("xyz")
 
 
-def test_append_globals_fails() -> None:
-    with pytest.raises(NotImplementedError):
+def test_append_globals_raises_not_implemented_error_for_constant_node() -> None:
+    with pytest.raises(NotImplementedError, match="Cannot append globals: .*"):
         Tree(Const("xyz")).append_globals({})
 
 

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -369,8 +369,13 @@ def test_tree_attach_child_tree_raises_not_implemented_error_for_constant_node()
 
 
 def test_tree_attach_nodes_raises_not_implemented_error_for_constant_node() -> None:
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="Cannot attach nodes to: .*"):
         Tree(Const("xyz")).attach_nodes([])
+
+
+def test_extend_globals_raises_not_implemented_error_for_constant_node() -> None:
+    with pytest.raises(NotImplementedError, match="Cannot extend globals to: .*"):
+        Tree(Const("xyz")).extend_globals({})
 
 
 def test_nodes_between_fails() -> None:
@@ -380,11 +385,6 @@ def test_nodes_between_fails() -> None:
 
 def test_has_global_fails() -> None:
     assert not Tree.new_module().has_global("xyz")
-
-
-def test_extend_globals_raises_not_implemented_error_for_constant_node() -> None:
-    with pytest.raises(NotImplementedError, match="Cannot extend globals: .*"):
-        Tree(Const("xyz")).extend_globals({})
 
 
 def test_globals_between_fails() -> None:

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -203,12 +203,11 @@ def test_is_instance_of(source, name, class_name) -> None:
 
 def test_tree_attach_child_tree_propagates_module_reference() -> None:
     """The spark module should propagate from the parent tree."""
-    source = """
-df = spark.read.csv("hi")
-df = df.withColumn(stuff)
-df = df.withColumn(stuff2)
-""".lstrip()  # Remove first new line character
-    sources = source.split("\n")
+    sources = (
+        "df = spark.read.csv('hi')",
+        "df = df.withColumn(stuff)",
+        "df = df.withColumn(stuff2)",
+    )
     first_line_maybe_tree = Tree.maybe_normalized_parse(sources[0])
     second_line_maybe_tree = Tree.maybe_normalized_parse(sources[1])
     third_line_maybe_tree = Tree.maybe_normalized_parse(sources[2])

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -307,7 +307,7 @@ def test_is_builtin(source, name, is_builtin) -> None:
     assert False  # could not locate call
 
 
-def test_tree_append_globals_adds_assign_name_to_tree() -> None:
+def test_tree_extend_globals_adds_assign_name_to_tree() -> None:
     maybe_tree = Tree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
@@ -315,7 +315,7 @@ def test_tree_append_globals_adds_assign_name_to_tree() -> None:
     assign_name = next(node.get_children())
     assert isinstance(assign_name, AssignName)
 
-    maybe_tree.tree.append_globals({"b": [assign_name]})
+    maybe_tree.tree.extend_globals({"b": [assign_name]})
 
     assert isinstance(maybe_tree.tree.node, Module)
     assert maybe_tree.tree.node.globals.get("b") == [assign_name]
@@ -362,9 +362,9 @@ def test_has_global_fails() -> None:
     assert not Tree.new_module().has_global("xyz")
 
 
-def test_append_globals_raises_not_implemented_error_for_constant_node() -> None:
-    with pytest.raises(NotImplementedError, match="Cannot append globals: .*"):
-        Tree(Const("xyz")).append_globals({})
+def test_extend_globals_raises_not_implemented_error_for_constant_node() -> None:
+    with pytest.raises(NotImplementedError, match="Cannot extend globals: .*"):
+        Tree(Const("xyz")).extend_globals({})
 
 
 def test_globals_between_fails() -> None:

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -317,6 +317,16 @@ def test_tree_append_nodes_sets_parent() -> None:
     assert node.parent == maybe_tree.tree.node
 
 
+def test_tree_append_nodes_adds_node_to_body() -> None:
+    node = astroid.extract_node("b = a + 2")
+    maybe_tree = Tree.maybe_normalized_parse("a = 1")
+    assert maybe_tree.tree, maybe_tree.failure
+
+    maybe_tree.tree.append_nodes([node])
+
+    assert maybe_tree.tree.node.body[-1] == node
+
+
 def test_tree_extend_globals_adds_assign_name_to_tree() -> None:
     maybe_tree = Tree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -315,8 +315,8 @@ def test_repr_is_truncated() -> None:
     assert len(repr(Tree(Const("xyz")))) <= (32 + len("...") + len("<Tree: >"))
 
 
-def test_append_tree_fails() -> None:
-    with pytest.raises(NotImplementedError):
+def test_tree_attach_child_tree_raises_not_implemented_error_for_constant_node() -> None:
+    with pytest.raises(NotImplementedError, match="Cannot attach child tree: .*"):
         Tree(Const("xyz")).attach_child_tree(Tree(Const("xyz")))
 
 

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -321,6 +321,19 @@ def test_tree_append_globals_adds_assign_name_to_tree() -> None:
     assert maybe_tree.tree.node.globals.get("b") == [assign_name]
 
 
+def test_tree_attach_child_tree_appends_globals_to_parent_tree() -> None:
+    parent_tree = Tree.maybe_normalized_parse("a = 1")
+    child_tree = Tree.maybe_normalized_parse("b = a + 2")
+
+    assert parent_tree.tree, parent_tree.failure
+    assert child_tree.tree, child_tree.failure
+
+    parent_tree.tree.attach_child_tree(child_tree.tree)
+
+    assert set(parent_tree.tree.node.globals.keys()) == {"a", "b"}
+    assert set(child_tree.tree.node.globals.keys()) == {"b"}
+
+
 def test_first_statement_is_none() -> None:
     node = Const("xyz")
     assert not Tree(node).first_statement()

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -149,8 +149,15 @@ def test_appends_statements() -> None:
     assert maybe_tree_2.tree is not None, maybe_tree_2.failure
     tree_2 = maybe_tree_2.tree
     tree_1.append_tree(tree_2)
+
+    nodes = tree_1.locate(Assign, [])
+    tree = Tree(nodes[1].value)  # Starting from tree_1, we want the last assign
+    values = list(InferredValue.infer_from_node(tree.node))
+    strings = list(value.as_string() for value in values)
+    assert strings == ["Hello John!"]
+
     nodes = tree_2.locate(Assign, [])
-    tree = Tree(nodes[0].value)
+    tree = Tree(nodes[0].value)  # Starting from tree_2, we want the first assign
     values = list(InferredValue.infer_from_node(tree.node))
     strings = list(value.as_string() for value in values)
     assert strings == ["Hello John!"]

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -148,9 +148,9 @@ def test_appends_statements() -> None:
     maybe_tree_2 = Tree.maybe_normalized_parse(source_2)
     assert maybe_tree_2.tree is not None, maybe_tree_2.failure
     tree_2 = maybe_tree_2.tree
-    tree_3 = tree_1.append_tree(tree_2)
-    nodes = tree_3.locate(Assign, [])
-    tree = Tree(nodes[0].value)  # tree_3 only contains tree_2 statements
+    tree_1.append_tree(tree_2)
+    nodes = tree_2.locate(Assign, [])
+    tree = Tree(nodes[0].value)
     values = list(InferredValue.infer_from_node(tree.node))
     strings = list(value.as_string() for value in values)
     assert strings == ["Hello John!"]

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -307,6 +307,16 @@ def test_is_builtin(source, name, is_builtin) -> None:
     assert False  # could not locate call
 
 
+def test_tree_append_nodes_sets_parent() -> None:
+    node = astroid.extract_node("b = a + 2")
+    maybe_tree = Tree.maybe_normalized_parse("a = 1")
+    assert maybe_tree.tree, maybe_tree.failure
+
+    maybe_tree.tree.append_nodes([node])
+
+    assert node.parent == maybe_tree.tree.node
+
+
 def test_tree_extend_globals_adds_assign_name_to_tree() -> None:
     maybe_tree = Tree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -203,14 +203,12 @@ def test_is_instance_of(source, name, class_name) -> None:
 
 def test_tree_attach_child_tree_propagates_module_reference() -> None:
     """The spark module should propagate from the parent tree."""
-    sources = (
-        "df = spark.read.csv('hi')",
-        "df = df.withColumn(stuff)",
-        "df = df.withColumn(stuff2)",
-    )
-    first_line_maybe_tree = Tree.maybe_normalized_parse(sources[0])
-    second_line_maybe_tree = Tree.maybe_normalized_parse(sources[1])
-    third_line_maybe_tree = Tree.maybe_normalized_parse(sources[2])
+    source_1 = "df = spark.read.csv('hi')"
+    source_2 = "df = df.withColumn(stuff)"
+    source_3 = "df = df.withColumn(stuff2)"
+    first_line_maybe_tree = Tree.maybe_normalized_parse(source_1)
+    second_line_maybe_tree = Tree.maybe_normalized_parse(source_2)
+    third_line_maybe_tree = Tree.maybe_normalized_parse(source_3)
 
     assert first_line_maybe_tree.tree, first_line_maybe_tree.failure
     assert second_line_maybe_tree.tree, second_line_maybe_tree.failure

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -148,7 +148,7 @@ def test_appends_statements() -> None:
     maybe_tree_2 = Tree.maybe_normalized_parse(source_2)
     assert maybe_tree_2.tree is not None, maybe_tree_2.failure
     tree_2 = maybe_tree_2.tree
-    tree_1.append_tree(tree_2)
+    tree_1.attach_child_tree(tree_2)
 
     nodes = tree_1.locate(Assign, [])
     tree = Tree(nodes[1].value)  # Starting from tree_1, we want the last assign
@@ -217,11 +217,11 @@ def test_supports_recursive_refs_when_checking_module() -> None:
     maybe_tree_2 = Tree.maybe_normalized_parse(source_2)
     assert maybe_tree_2.tree is not None, maybe_tree_2.failure
     tree_2 = maybe_tree_2.tree
-    main_tree.append_tree(tree_2)
+    main_tree.attach_child_tree(tree_2)
     maybe_tree_3 = Tree.maybe_normalized_parse(source_3)
     assert maybe_tree_3.tree is not None, maybe_tree_3.failure
     tree_3 = maybe_tree_3.tree
-    main_tree.append_tree(tree_3)
+    main_tree.attach_child_tree(tree_3)
     assign = tree_3.locate(Assign, [])[0]
     assert Tree(assign.value).is_from_module("spark")
 
@@ -320,7 +320,7 @@ def test_repr_is_truncated() -> None:
 
 def test_append_tree_fails() -> None:
     with pytest.raises(NotImplementedError):
-        Tree(Const("xyz")).append_tree(Tree(Const("xyz")))
+        Tree(Const("xyz")).attach_child_tree(Tree(Const("xyz")))
 
 
 def test_append_node_fails() -> None:


### PR DESCRIPTION
## Changes
Rename Python AST's `Tree` methods for clarity

- Add docstrings
- Rename `append_` to `attach_` and `extend_` to more precisely describe what the methods do
- Let `attach_` and `extend_` always return `None`
- Extend unit testing

### Linked issues

Progresses #3514
Precedes #3520

### Functionality

- [x] modified code linting related
- [x] modified existing command: `databricks labs ucx lint-local-code`

### Tests

- [x] manually tested
- [x] added and modified unit tests

