### PR TITLE
Make `MaybeTree` the main Python AST entrypoint for constructing the syntax tree

### DIFF
--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -51,7 +51,7 @@ from databricks.labs.ucx.source_code.graph import (
 )
 from databricks.labs.ucx.source_code.linters.context import LinterContext
 from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage
-from databricks.labs.ucx.source_code.python.python_ast import Tree, PythonSequentialLinter
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree, PythonSequentialLinter
 from databricks.labs.ucx.source_code.notebooks.sources import FileLinter, Notebook
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.used_table import UsedTablesCrawler
@@ -657,7 +657,7 @@ class _CollectorWalker(DependencyGraphWalker[T], ABC):
             if cell.language is CellLanguage.PYTHON:
                 if inherited_tree is None:
                     inherited_tree = Tree.new_module()
-                maybe_tree = Tree.maybe_normalized_parse(cell.original_code)
+                maybe_tree = MaybeTree.maybe_normalized_parse(cell.original_code)
                 if maybe_tree.failure:
                     logger.warning(maybe_tree.failure.message)
                     continue

--- a/src/databricks/labs/ucx/source_code/jobs.py
+++ b/src/databricks/labs/ucx/source_code/jobs.py
@@ -657,7 +657,7 @@ class _CollectorWalker(DependencyGraphWalker[T], ABC):
             if cell.language is CellLanguage.PYTHON:
                 if inherited_tree is None:
                     inherited_tree = Tree.new_module()
-                maybe_tree = MaybeTree.maybe_normalized_parse(cell.original_code)
+                maybe_tree = MaybeTree.from_source_code(cell.original_code)
                 if maybe_tree.failure:
                     logger.warning(maybe_tree.failure.message)
                     continue

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -22,12 +22,13 @@ from databricks.labs.ucx.source_code.linters.directfs import DIRECT_FS_ACCESS_PA
 from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter
 from databricks.labs.ucx.source_code.python.python_ast import (
-    Tree,
-    TreeHelper,
+    DfsaPyCollector,
     MatchingVisitor,
+    MaybeTree,
     PythonLinter,
     TablePyCollector,
-    DfsaPyCollector,
+    Tree,
+    TreeHelper,
 )
 
 logger = logging.getLogger(__name__)
@@ -412,7 +413,7 @@ class SparkTableNamePyLinter(PythonLinter, Fixer, TablePyCollector):
             yield from matcher.lint(self._from_table, self._index, self._session_state, node)
 
     def apply(self, code: str) -> str:
-        maybe_tree = Tree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(code)
         if not maybe_tree.tree:
             assert maybe_tree.failure is not None
             logger.warning(maybe_tree.failure.message)
@@ -486,7 +487,7 @@ class SparkSqlPyLinter(_SparkSqlAnalyzer, PythonLinter, Fixer):
     def apply(self, code: str) -> str:
         if not self._sql_fixer:
             return code
-        maybe_tree = Tree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return code

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -412,7 +412,7 @@ class SparkTableNamePyLinter(PythonLinter, Fixer, TablePyCollector):
             yield from matcher.lint(self._from_table, self._index, self._session_state, node)
 
     def apply(self, code: str) -> str:
-        maybe_tree = Tree.maybe_parse(code)
+        maybe_tree = Tree.maybe_normalized_parse(code)
         if not maybe_tree.tree:
             assert maybe_tree.failure is not None
             logger.warning(maybe_tree.failure.message)

--- a/src/databricks/labs/ucx/source_code/linters/pyspark.py
+++ b/src/databricks/labs/ucx/source_code/linters/pyspark.py
@@ -413,7 +413,7 @@ class SparkTableNamePyLinter(PythonLinter, Fixer, TablePyCollector):
             yield from matcher.lint(self._from_table, self._index, self._session_state, node)
 
     def apply(self, code: str) -> str:
-        maybe_tree = MaybeTree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.from_source_code(code)
         if not maybe_tree.tree:
             assert maybe_tree.failure is not None
             logger.warning(maybe_tree.failure.message)
@@ -487,7 +487,7 @@ class SparkSqlPyLinter(_SparkSqlAnalyzer, PythonLinter, Fixer):
     def apply(self, code: str) -> str:
         if not self._sql_fixer:
             return code
-        maybe_tree = MaybeTree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.from_source_code(code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return code

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -196,7 +196,7 @@ class NotebookLinter:
                 continue
 
     def _load_tree_from_python_cell(self, python_cell: PythonCell, register_trees: bool) -> Iterable[Advice]:
-        maybe_tree = MaybeTree.maybe_normalized_parse(python_cell.original_code)
+        maybe_tree = MaybeTree.from_source_code(python_cell.original_code)
         if maybe_tree.failure:
             yield maybe_tree.failure
         tree = maybe_tree.tree

--- a/src/databricks/labs/ucx/source_code/notebooks/sources.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/sources.py
@@ -36,7 +36,7 @@ from databricks.labs.ucx.source_code.linters.imports import (
     UnresolvedPath,
 )
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
-from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase, PythonSequentialLinter
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, NodeBase, PythonSequentialLinter, Tree
 from databricks.labs.ucx.source_code.notebooks.cells import (
     CellLanguage,
     Cell,
@@ -196,7 +196,7 @@ class NotebookLinter:
                 continue
 
     def _load_tree_from_python_cell(self, python_cell: PythonCell, register_trees: bool) -> Iterable[Advice]:
-        maybe_tree = Tree.maybe_normalized_parse(python_cell.original_code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(python_cell.original_code)
         if maybe_tree.failure:
             yield maybe_tree.failure
         tree = maybe_tree.tree

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -93,7 +93,7 @@ class PythonCodeAnalyzer:
 
     def _parse_and_extract_nodes(self) -> tuple[Tree | None, list[NodeBase], Iterable[DependencyProblem]]:
         problems: list[DependencyProblem] = []
-        maybe_tree = MaybeTree.maybe_normalized_parse(self._python_code)
+        maybe_tree = MaybeTree.from_source_code(self._python_code)
         if maybe_tree.failure:
             return None, [], [DependencyProblem(maybe_tree.failure.code, maybe_tree.failure.message)]
         assert maybe_tree.tree is not None

--- a/src/databricks/labs/ucx/source_code/python/python_analyzer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_analyzer.py
@@ -21,7 +21,7 @@ from databricks.labs.ucx.source_code.linters.imports import (
     UnresolvedPath,
 )
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
-from databricks.labs.ucx.source_code.python.python_ast import Tree, NodeBase
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree, NodeBase
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class PythonCodeAnalyzer:
 
     def _parse_and_extract_nodes(self) -> tuple[Tree | None, list[NodeBase], Iterable[DependencyProblem]]:
         problems: list[DependencyProblem] = []
-        maybe_tree = Tree.maybe_normalized_parse(self._python_code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(self._python_code)
         if maybe_tree.failure:
             return None, [], [DependencyProblem(maybe_tree.failure.code, maybe_tree.failure.message)]
         assert maybe_tree.tree is not None

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -51,25 +51,6 @@ class MaybeTree:
     tree: Tree | None
     failure: Failure | None
 
-    def walk(self) -> Iterable[NodeNG]:
-        # mainly a helper method for unit testing
-        if self.tree is None:  # no cov
-            assert self.failure is not None
-            logger.warning(self.failure.message)
-            return []
-        return self.tree.walk()
-
-    def first_statement(self) -> NodeNG | None:
-        # mainly a helper method for unit testing
-        if self.tree is None:  # no cov
-            assert self.failure is not None
-            logger.warning(self.failure.message)
-            return None
-        return self.tree.first_statement()
-
-
-class Tree:
-
     @classmethod
     def maybe_normalized_parse(cls, code: str) -> MaybeTree:
         code = cls._normalize(code)
@@ -158,6 +139,25 @@ class Tree:
             if len(matches) & 1:
                 in_multi_line_comment = not in_multi_line_comment
         return "\n".join(lines)
+
+    def walk(self) -> Iterable[NodeNG]:
+        # mainly a helper method for unit testing
+        if self.tree is None:  # no cov
+            assert self.failure is not None
+            logger.warning(self.failure.message)
+            return []
+        return self.tree.walk()
+
+    def first_statement(self) -> NodeNG | None:
+        # mainly a helper method for unit testing
+        if self.tree is None:  # no cov
+            assert self.failure is not None
+            logger.warning(self.failure.message)
+            return None
+        return self.tree.first_statement()
+
+
+class Tree:
 
     @classmethod
     def new_module(cls) -> Tree:
@@ -621,7 +621,7 @@ class NodeBase(ABC):
 class PythonLinter(Linter):
 
     def lint(self, code: str) -> Iterable[Advice]:
-        maybe_tree = Tree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(code)
         if maybe_tree.failure:
             yield maybe_tree.failure
             return
@@ -635,7 +635,7 @@ class PythonLinter(Linter):
 class TablePyCollector(TableCollector, ABC):
 
     def collect_tables(self, source_code: str) -> Iterable[UsedTable]:
-        maybe_tree = Tree.maybe_normalized_parse(source_code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(source_code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return
@@ -650,7 +650,7 @@ class TablePyCollector(TableCollector, ABC):
 class DfsaPyCollector(DfsaCollector, ABC):
 
     def collect_dfsas(self, source_code: str) -> Iterable[DirectFsAccess]:
-        maybe_tree = Tree.maybe_normalized_parse(source_code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(source_code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return
@@ -688,7 +688,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
             yield from linter.lint_tree(tree)
 
     def _parse_and_append(self, code: str) -> MaybeTree:
-        maybe_tree = Tree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(code)
         if maybe_tree.failure:
             return maybe_tree
         assert maybe_tree.tree is not None
@@ -706,7 +706,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
 
     def process_child_cell(self, code: str) -> None:
         this_tree = self._make_tree()
-        maybe_tree = Tree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.maybe_normalized_parse(code)
         if maybe_tree.failure:
             # TODO: bubble up this error
             logger.warning(maybe_tree.failure.message)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -48,6 +48,23 @@ T = TypeVar("T", bound=NodeNG)
 
 @dataclass(frozen=True)
 class MaybeTree:
+    """A :class:`Tree` or a :class:`Failure`.
+
+    The `MaybeTree` is designed to either contain a `Tree` OR a `Failure`,
+    never both or neither. Typically, a `Tree` is constructed using the
+    `MaybeTree` class method(s) that yields a `Failure` if the `Tree` could
+    NOT be constructed, otherwise it yields the `Tree`, resulting in code that
+    looks like:
+
+    ``` python
+    maybe_tree = Tree.from_<class method>(<arguments>)
+    if maybe_tree.failure:
+        # Handle failure and return early
+    assert maybe_tree.tree, "Tree should be not-None when Failure is None."
+    # Use tree
+    ```
+    """
+
     tree: Tree | None
     failure: Failure | None
 

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -71,6 +71,11 @@ class MaybeTree:
 class Tree:
 
     @classmethod
+    def maybe_normalized_parse(cls, code: str) -> MaybeTree:
+        code = cls._normalize(code)
+        return cls._maybe_parse(code)
+
+    @classmethod
     def _maybe_parse(cls, code: str) -> MaybeTree:
         try:
             root = parse(code)
@@ -116,11 +121,6 @@ class Tree:
                 end_col=1,
             ),
         )
-
-    @classmethod
-    def maybe_normalized_parse(cls, code: str) -> MaybeTree:
-        code = cls._normalize(code)
-        return cls._maybe_parse(code)
 
     @classmethod
     def _normalize(cls, code: str) -> str:

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -119,11 +119,11 @@ class Tree:
 
     @classmethod
     def maybe_normalized_parse(cls, code: str) -> MaybeTree:
-        code = cls.normalize(code)
+        code = cls._normalize(code)
         return cls._maybe_parse(code)
 
     @classmethod
-    def normalize(cls, code: str) -> str:
+    def _normalize(cls, code: str) -> str:
         code = cls._normalize_indents(code)
         code = cls._convert_magic_lines_to_magic_commands(code)
         return code

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -66,7 +66,10 @@ class MaybeTree:
     """
 
     tree: Tree | None
+    """The UCX Python abstract syntax tree object"""
+
     failure: Failure | None
+    """The failure during constructing the tree"""
 
     @classmethod
     def from_source_code(cls, code: str) -> MaybeTree:

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -68,10 +68,10 @@ class MaybeTree:
         return self.tree.first_statement()
 
 
-class Tree:  # pylint: disable=too-many-public-methods
+class Tree:
 
     @classmethod
-    def maybe_parse(cls, code: str) -> MaybeTree:
+    def _maybe_parse(cls, code: str) -> MaybeTree:
         try:
             root = parse(code)
             tree = Tree(root)
@@ -120,7 +120,7 @@ class Tree:  # pylint: disable=too-many-public-methods
     @classmethod
     def maybe_normalized_parse(cls, code: str) -> MaybeTree:
         code = cls.normalize(code)
-        return cls.maybe_parse(code)
+        return cls._maybe_parse(code)
 
     @classmethod
     def normalize(cls, code: str) -> str:

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -128,8 +128,8 @@ class Tree:
         code = cls._convert_magic_lines_to_magic_commands(code)
         return code
 
-    @classmethod
-    def _normalize_indents(cls, python_code: str) -> str:
+    @staticmethod
+    def _normalize_indents(python_code: str) -> str:
         lines = python_code.split("\n")
         for line in lines:
             # skip leading ws and comments
@@ -147,8 +147,8 @@ class Tree:
             return "\n".join(lines)
         return python_code
 
-    @classmethod
-    def _convert_magic_lines_to_magic_commands(cls, python_code: str) -> str:
+    @staticmethod
+    def _convert_magic_lines_to_magic_commands(python_code: str) -> str:
         lines = python_code.split("\n")
         magic_markers = {"%", "!"}
         in_multi_line_comment = False

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -61,11 +61,11 @@ class MaybeTree:
         try:
             root = parse(code)
             tree = Tree(root)
-            return MaybeTree(tree, None)
+            return cls(tree, None)
         except Exception as e:  # pylint: disable=broad-exception-caught
             # see https://github.com/databrickslabs/ucx/issues/2976
             failure = cls._failure_from_exception(code, e)
-            return MaybeTree(None, failure)
+            return cls(None, failure)
 
     @staticmethod
     def _failure_from_exception(source_code: str, e: Exception) -> Failure:
@@ -162,7 +162,7 @@ class Tree:
     @classmethod
     def new_module(cls) -> Tree:
         node = Module("root")
-        return Tree(node)
+        return cls(node)
 
     def __init__(self, node: NodeNG):
         self._node: NodeNG = node
@@ -181,11 +181,10 @@ class Tree:
     def walk(self) -> Iterable[NodeNG]:
         yield from self._walk(self._node)
 
-    @classmethod
-    def _walk(cls, node: NodeNG) -> Iterable[NodeNG]:
+    def _walk(self, node: NodeNG) -> Iterable[NodeNG]:
         yield node
         for child in node.get_children():
-            yield from cls._walk(child)
+            yield from self._walk(child)
 
     def locate(self, node_type: type[T], match_nodes: list[tuple[str, type]]) -> list[T]:
         visitor = MatchingVisitor(node_type, match_nodes)

--- a/src/databricks/labs/ucx/source_code/python/python_ast.py
+++ b/src/databricks/labs/ucx/source_code/python/python_ast.py
@@ -52,7 +52,8 @@ class MaybeTree:
     failure: Failure | None
 
     @classmethod
-    def maybe_normalized_parse(cls, code: str) -> MaybeTree:
+    def from_source_code(cls, code: str) -> MaybeTree:
+        """Normalize and parse the source code to get a `Tree` or parse `Failure`."""
         code = cls._normalize(code)
         return cls._maybe_parse(code)
 
@@ -620,7 +621,7 @@ class NodeBase(ABC):
 class PythonLinter(Linter):
 
     def lint(self, code: str) -> Iterable[Advice]:
-        maybe_tree = MaybeTree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.from_source_code(code)
         if maybe_tree.failure:
             yield maybe_tree.failure
             return
@@ -634,7 +635,7 @@ class PythonLinter(Linter):
 class TablePyCollector(TableCollector, ABC):
 
     def collect_tables(self, source_code: str) -> Iterable[UsedTable]:
-        maybe_tree = MaybeTree.maybe_normalized_parse(source_code)
+        maybe_tree = MaybeTree.from_source_code(source_code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return
@@ -649,7 +650,7 @@ class TablePyCollector(TableCollector, ABC):
 class DfsaPyCollector(DfsaCollector, ABC):
 
     def collect_dfsas(self, source_code: str) -> Iterable[DirectFsAccess]:
-        maybe_tree = MaybeTree.maybe_normalized_parse(source_code)
+        maybe_tree = MaybeTree.from_source_code(source_code)
         if maybe_tree.failure:
             logger.warning(maybe_tree.failure.message)
             return
@@ -687,7 +688,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
             yield from linter.lint_tree(tree)
 
     def _parse_and_append(self, code: str) -> MaybeTree:
-        maybe_tree = MaybeTree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.from_source_code(code)
         if maybe_tree.failure:
             return maybe_tree
         assert maybe_tree.tree is not None
@@ -705,7 +706,7 @@ class PythonSequentialLinter(Linter, DfsaCollector, TableCollector):
 
     def process_child_cell(self, code: str) -> None:
         this_tree = self._make_tree()
-        maybe_tree = MaybeTree.maybe_normalized_parse(code)
+        maybe_tree = MaybeTree.from_source_code(code)
         if maybe_tree.failure:
             # TODO: bubble up this error
             logger.warning(maybe_tree.failure.message)

--- a/tests/integration/source_code/message_codes.py
+++ b/tests/integration/source_code/message_codes.py
@@ -11,7 +11,7 @@ def main():
     product_info = ProductInfo.from_class(Advice)
     source_code = product_info.version_file().parent
     for file in source_code.glob("**/*.py"):
-        maybe_tree = MaybeTree.maybe_normalized_parse(file.read_text())
+        maybe_tree = MaybeTree.from_source_code(file.read_text())
         if not maybe_tree.tree:
             continue
         tree = maybe_tree.tree

--- a/tests/integration/source_code/message_codes.py
+++ b/tests/integration/source_code/message_codes.py
@@ -2,7 +2,7 @@ import astroid  # type: ignore[import-untyped]
 from databricks.labs.blueprint.wheels import ProductInfo
 
 from databricks.labs.ucx.source_code.base import Advice
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 
 
 def main():
@@ -11,7 +11,7 @@ def main():
     product_info = ProductInfo.from_class(Advice)
     source_code = product_info.version_file().parent
     for file in source_code.glob("**/*.py"):
-        maybe_tree = Tree._maybe_parse(file.read_text())
+        maybe_tree = MaybeTree.maybe_normalized_parse(file.read_text())
         if not maybe_tree.tree:
             continue
         tree = maybe_tree.tree

--- a/tests/integration/source_code/message_codes.py
+++ b/tests/integration/source_code/message_codes.py
@@ -11,7 +11,7 @@ def main():
     product_info = ProductInfo.from_class(Advice)
     source_code = product_info.version_file().parent
     for file in source_code.glob("**/*.py"):
-        maybe_tree = Tree.maybe_parse(file.read_text())
+        maybe_tree = Tree._maybe_parse(file.read_text())
         if not maybe_tree.tree:
             continue
         tree = maybe_tree.tree

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -576,7 +576,7 @@ def test_direct_cloud_access_to_volumes_reports_nothing(empty_index, fs_function
 
 
 def test_get_full_function_name_for_member_function() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("value.attr()")
+    maybe_tree = MaybeTree.from_source_code("value.attr()")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -585,7 +585,7 @@ def test_get_full_function_name_for_member_function() -> None:
 
 
 def test_get_full_function_name_for_member_member_function() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("value1.value2.attr()")
+    maybe_tree = MaybeTree.from_source_code("value1.value2.attr()")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -594,7 +594,7 @@ def test_get_full_function_name_for_member_member_function() -> None:
 
 
 def test_get_full_function_name_for_chained_function() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("value.attr1().attr2()")
+    maybe_tree = MaybeTree.from_source_code("value.attr1().attr2()")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -603,7 +603,7 @@ def test_get_full_function_name_for_chained_function() -> None:
 
 
 def test_get_full_function_name_for_global_function() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("name()")
+    maybe_tree = MaybeTree.from_source_code("name()")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -612,7 +612,7 @@ def test_get_full_function_name_for_global_function() -> None:
 
 
 def test_get_full_function_name_for_non_method() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("not_a_function")
+    maybe_tree = MaybeTree.from_source_code("not_a_function")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -622,7 +622,7 @@ def test_get_full_function_name_for_non_method() -> None:
 def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    maybe_tree = MaybeTree.maybe_normalized_parse("call('some.things')")
+    maybe_tree = MaybeTree.from_source_code("call('some.things')")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -636,7 +636,7 @@ def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None
 def test_apply_table_name_matcher_with_existing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    maybe_tree = MaybeTree.maybe_normalized_parse("call('old.things')")
+    maybe_tree = MaybeTree.from_source_code("call('old.things')")
     assert maybe_tree.tree is not None
     node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -8,7 +8,7 @@ from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import Deprecation, CurrentSessionState, SqlLinter
 from databricks.labs.ucx.source_code.linters.context import LinterContext
-from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, TreeHelper
 from databricks.labs.ucx.source_code.linters.pyspark import SparkSqlPyLinter
 from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinter
 from databricks.labs.ucx.source_code.linters.pyspark import SparkCallMatcher, SparkTableNamePyLinter
@@ -576,45 +576,45 @@ def test_direct_cloud_access_to_volumes_reports_nothing(empty_index, fs_function
 
 
 def test_get_full_function_name_for_member_function() -> None:
-    tree = Tree.maybe_normalized_parse("value.attr()")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("value.attr()")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value.attr'
 
 
 def test_get_full_function_name_for_member_member_function() -> None:
-    tree = Tree.maybe_normalized_parse("value1.value2.attr()")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("value1.value2.attr()")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value1.value2.attr'
 
 
 def test_get_full_function_name_for_chained_function() -> None:
-    tree = Tree.maybe_normalized_parse("value.attr1().attr2()")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("value.attr1().attr2()")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'value.attr1.attr2'
 
 
 def test_get_full_function_name_for_global_function() -> None:
-    tree = Tree.maybe_normalized_parse("name()")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("name()")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     assert TreeHelper.get_full_function_name(node.value) == 'name'
 
 
 def test_get_full_function_name_for_non_method() -> None:
-    tree = Tree.maybe_normalized_parse("not_a_function")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("not_a_function")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert TreeHelper.get_full_function_name(node.value) is None
 
@@ -622,9 +622,9 @@ def test_get_full_function_name_for_non_method() -> None:
 def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.maybe_normalized_parse("call('some.things')")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("call('some.things')")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     matcher.apply(from_table, migration_index, node.value)
@@ -636,9 +636,9 @@ def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None
 def test_apply_table_name_matcher_with_existing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.maybe_normalized_parse("call('old.things')")
-    assert tree.tree is not None
-    node = tree.tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("call('old.things')")
+    assert maybe_tree.tree is not None
+    node = maybe_tree.tree.first_statement()
     assert isinstance(node, Expr)
     assert isinstance(node.value, Call)
     matcher.apply(from_table, migration_index, node.value)

--- a/tests/unit/source_code/linters/test_pyspark.py
+++ b/tests/unit/source_code/linters/test_pyspark.py
@@ -576,7 +576,7 @@ def test_direct_cloud_access_to_volumes_reports_nothing(empty_index, fs_function
 
 
 def test_get_full_function_name_for_member_function() -> None:
-    tree = Tree.maybe_parse("value.attr()")
+    tree = Tree.maybe_normalized_parse("value.attr()")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -585,7 +585,7 @@ def test_get_full_function_name_for_member_function() -> None:
 
 
 def test_get_full_function_name_for_member_member_function() -> None:
-    tree = Tree.maybe_parse("value1.value2.attr()")
+    tree = Tree.maybe_normalized_parse("value1.value2.attr()")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -594,7 +594,7 @@ def test_get_full_function_name_for_member_member_function() -> None:
 
 
 def test_get_full_function_name_for_chained_function() -> None:
-    tree = Tree.maybe_parse("value.attr1().attr2()")
+    tree = Tree.maybe_normalized_parse("value.attr1().attr2()")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -603,7 +603,7 @@ def test_get_full_function_name_for_chained_function() -> None:
 
 
 def test_get_full_function_name_for_global_function() -> None:
-    tree = Tree.maybe_parse("name()")
+    tree = Tree.maybe_normalized_parse("name()")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -612,7 +612,7 @@ def test_get_full_function_name_for_global_function() -> None:
 
 
 def test_get_full_function_name_for_non_method() -> None:
-    tree = Tree.maybe_parse("not_a_function")
+    tree = Tree.maybe_normalized_parse("not_a_function")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -622,7 +622,7 @@ def test_get_full_function_name_for_non_method() -> None:
 def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.maybe_parse("call('some.things')")
+    tree = Tree.maybe_normalized_parse("call('some.things')")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)
@@ -636,7 +636,7 @@ def test_apply_table_name_matcher_with_missing_constant(migration_index) -> None
 def test_apply_table_name_matcher_with_existing_constant(migration_index) -> None:
     from_table = FromTableSqlLinter(migration_index, CurrentSessionState('old'))
     matcher = SparkCallMatcher('things', 1, 1, 0)
-    tree = Tree.maybe_parse("call('old.things')")
+    tree = Tree.maybe_normalized_parse("call('old.things')")
     assert tree.tree is not None
     node = tree.tree.first_statement()
     assert isinstance(node, Expr)

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -10,13 +10,13 @@ from databricks.labs.ucx.source_code.linters.files import FileLoader
 
 from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter, ImportSource, SysPathChange
 from databricks.labs.ucx.source_code.python.python_analyzer import PythonCodeAnalyzer
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls() -> None:
-    tree = Tree.maybe_normalized_parse('')
-    assert tree.tree is not None
-    assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse('')
+    assert maybe_tree.tree is not None
+    assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
 
 
 def test_linter_returns_list_of_dbutils_notebook_run_calls() -> None:
@@ -25,40 +25,44 @@ dbutils.notebook.run("stuff")
 for i in z:
     ww =   dbutils.notebook.run("toto")
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert {"toto", "stuff"} == {str(call.node.args[0].value) for call in calls}
 
 
 def test_linter_returns_empty_list_of_imports() -> None:
-    tree = Tree.maybe_normalized_parse('')
-    assert tree.tree is not None
-    assert not ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]
+    maybe_tree = MaybeTree.maybe_normalized_parse('')
+    assert maybe_tree.tree is not None
+    assert not ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
 
 
 def test_linter_returns_import() -> None:
-    tree = Tree.maybe_normalized_parse('import x')
-    assert tree.tree is not None
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
+    maybe_tree = MaybeTree.maybe_normalized_parse('import x')
+    assert maybe_tree.tree is not None
+    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
+    assert ["x"] == [node.name for node in import_nodes]
 
 
 def test_linter_returns_import_from() -> None:
-    tree = Tree.maybe_normalized_parse('from x import z')
-    assert tree.tree is not None
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
+    maybe_tree = MaybeTree.maybe_normalized_parse('from x import z')
+    assert maybe_tree.tree is not None
+    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
+    assert ["x"] == [node.name for node in import_nodes]
 
 
 def test_linter_returns_import_module() -> None:
-    tree = Tree.maybe_normalized_parse('importlib.import_module("x")')
-    assert tree.tree is not None
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
+    maybe_tree = MaybeTree.maybe_normalized_parse('importlib.import_module("x")')
+    assert maybe_tree.tree is not None
+    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
+    assert ["x"] == [node.name for node in import_nodes]
 
 
 def test_linter_returns__import__() -> None:
-    tree = Tree.maybe_normalized_parse('importlib.__import__("x")')
-    assert tree.tree is not None
-    assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
+    maybe_tree = MaybeTree.maybe_normalized_parse('importlib.__import__("x")')
+    assert maybe_tree.tree is not None
+    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
+    assert ["x"] == [node.name for node in import_nodes]
 
 
 def test_linter_returns_appended_absolute_paths() -> None:
@@ -67,9 +71,9 @@ import sys
 sys.path.append("absolute_path_1")
 sys.path.append("absolute_path_2")
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
 
 
@@ -79,9 +83,9 @@ import sys as stuff
 stuff.path.append("absolute_path_1")
 stuff.path.append("absolute_path_2")
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
 
 
@@ -90,9 +94,9 @@ def test_linter_returns_appended_absolute_paths_with_sys_path_alias() -> None:
 from sys import path as stuff
 stuff.append("absolute_path")
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "absolute_path" in [p.path for p in appended]
 
 
@@ -102,9 +106,9 @@ import sys
 import os
 sys.path.append(os.path.abspath("relative_path"))
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -114,9 +118,9 @@ import sys
 import os as stuff
 sys.path.append(stuff.path.abspath("relative_path"))
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -126,9 +130,9 @@ import sys
 from os import path as stuff
 sys.path.append(stuff.abspath("relative_path"))
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -138,9 +142,9 @@ import sys
 from os.path import abspath
 sys.path.append(abspath("relative_path"))
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -150,9 +154,9 @@ import sys
 from os.path import abspath as stuff
 sys.path.append(stuff("relative_path"))
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
 
 
@@ -162,9 +166,9 @@ import sys
 path = "absolute_path_1"
 sys.path.append(path)
 """
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1"] == [p.path for p in appended]
 
 
@@ -204,9 +208,9 @@ dbutils.notebook.run(name)
     ],
 )
 def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
-    tree = Tree.maybe_normalized_parse(code)
-    assert tree.tree is not None
-    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    assert maybe_tree.tree is not None
+    calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     all_paths: list[str] = []
     for call in calls:
         _, paths = call.get_notebook_paths(CurrentSessionState())

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -37,29 +37,17 @@ def test_linter_returns_empty_list_of_imports() -> None:
     assert not ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
 
 
-def test_linter_returns_import() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('import x')
-    assert maybe_tree.tree is not None
-    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
-    assert ["x"] == [node.name for node in import_nodes]
-
-
-def test_linter_returns_import_from() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('from x import z')
-    assert maybe_tree.tree is not None
-    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
-    assert ["x"] == [node.name for node in import_nodes]
-
-
-def test_linter_returns_import_module() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('importlib.import_module("x")')
-    assert maybe_tree.tree is not None
-    import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
-    assert ["x"] == [node.name for node in import_nodes]
-
-
-def test_linter_returns__import__() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('importlib.__import__("x")')
+@pytest.mark.parametrize(
+    "import_statement",
+    [
+        "import x",
+        "from x import z",
+        "importlib.import_module('x')",
+        "importlib.__import__('x')",
+    ]
+)
+def test_import_source_extract_from_tree(import_statement: str) -> None:
+    maybe_tree = MaybeTree.maybe_normalized_parse(import_statement)
     assert maybe_tree.tree is not None
     import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
     assert ["x"] == [node.name for node in import_nodes]

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -14,7 +14,7 @@ from databricks.labs.ucx.source_code.python.python_ast import Tree
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls() -> None:
-    tree = Tree.maybe_parse('')
+    tree = Tree.maybe_normalized_parse('')
     assert tree.tree is not None
     assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
 
@@ -25,38 +25,38 @@ dbutils.notebook.run("stuff")
 for i in z:
     ww =   dbutils.notebook.run("toto")
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
     assert {"toto", "stuff"} == {str(call.node.args[0].value) for call in calls}
 
 
 def test_linter_returns_empty_list_of_imports() -> None:
-    tree = Tree.maybe_parse('')
+    tree = Tree.maybe_normalized_parse('')
     assert tree.tree is not None
     assert not ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]
 
 
 def test_linter_returns_import() -> None:
-    tree = Tree.maybe_parse('import x')
+    tree = Tree.maybe_normalized_parse('import x')
     assert tree.tree is not None
     assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns_import_from() -> None:
-    tree = Tree.maybe_parse('from x import z')
+    tree = Tree.maybe_normalized_parse('from x import z')
     assert tree.tree is not None
     assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns_import_module() -> None:
-    tree = Tree.maybe_parse('importlib.import_module("x")')
+    tree = Tree.maybe_normalized_parse('importlib.import_module("x")')
     assert tree.tree is not None
     assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
 
 def test_linter_returns__import__() -> None:
-    tree = Tree.maybe_parse('importlib.__import__("x")')
+    tree = Tree.maybe_normalized_parse('importlib.__import__("x")')
     assert tree.tree is not None
     assert ["x"] == [node.name for node in ImportSource.extract_from_tree(tree.tree, DependencyProblem.from_node)[0]]
 
@@ -67,7 +67,7 @@ import sys
 sys.path.append("absolute_path_1")
 sys.path.append("absolute_path_2")
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
@@ -79,7 +79,7 @@ import sys as stuff
 stuff.path.append("absolute_path_1")
 stuff.path.append("absolute_path_2")
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
@@ -90,7 +90,7 @@ def test_linter_returns_appended_absolute_paths_with_sys_path_alias() -> None:
 from sys import path as stuff
 stuff.append("absolute_path")
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "absolute_path" in [p.path for p in appended]
@@ -102,7 +102,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("relative_path"))
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -114,7 +114,7 @@ import sys
 import os as stuff
 sys.path.append(stuff.path.abspath("relative_path"))
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -126,7 +126,7 @@ import sys
 from os import path as stuff
 sys.path.append(stuff.abspath("relative_path"))
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -138,7 +138,7 @@ import sys
 from os.path import abspath
 sys.path.append(abspath("relative_path"))
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -150,7 +150,7 @@ import sys
 from os.path import abspath as stuff
 sys.path.append(stuff("relative_path"))
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -162,7 +162,7 @@ import sys
 path = "absolute_path_1"
 sys.path.append(path)
 """
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), tree.tree)
     assert ["absolute_path_1"] == [p.path for p in appended]
@@ -204,7 +204,7 @@ dbutils.notebook.run(name)
     ],
 )
 def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
-    tree = Tree.maybe_parse(code)
+    tree = Tree.maybe_normalized_parse(code)
     assert tree.tree is not None
     calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree.tree)
     all_paths: list[str] = []

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -14,7 +14,7 @@ from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 
 
 def test_linter_returns_empty_list_of_dbutils_notebook_run_calls() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('')
+    maybe_tree = MaybeTree.from_source_code('')
     assert maybe_tree.tree is not None
     assert not DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
 
@@ -25,14 +25,14 @@ dbutils.notebook.run("stuff")
 for i in z:
     ww =   dbutils.notebook.run("toto")
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert {"toto", "stuff"} == {str(call.node.args[0].value) for call in calls}
 
 
 def test_linter_returns_empty_list_of_imports() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse('')
+    maybe_tree = MaybeTree.from_source_code('')
     assert maybe_tree.tree is not None
     assert not ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
 
@@ -47,7 +47,7 @@ def test_linter_returns_empty_list_of_imports() -> None:
     ]
 )
 def test_import_source_extract_from_tree(import_statement: str) -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse(import_statement)
+    maybe_tree = MaybeTree.from_source_code(import_statement)
     assert maybe_tree.tree is not None
     import_nodes = ImportSource.extract_from_tree(maybe_tree.tree, DependencyProblem.from_node)[0]
     assert ["x"] == [node.name for node in import_nodes]
@@ -59,7 +59,7 @@ import sys
 sys.path.append("absolute_path_1")
 sys.path.append("absolute_path_2")
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
@@ -71,7 +71,7 @@ import sys as stuff
 stuff.path.append("absolute_path_1")
 stuff.path.append("absolute_path_2")
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1", "absolute_path_2"] == [p.path for p in appended]
@@ -82,7 +82,7 @@ def test_linter_returns_appended_absolute_paths_with_sys_path_alias() -> None:
 from sys import path as stuff
 stuff.append("absolute_path")
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "absolute_path" in [p.path for p in appended]
@@ -94,7 +94,7 @@ import sys
 import os
 sys.path.append(os.path.abspath("relative_path"))
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -106,7 +106,7 @@ import sys
 import os as stuff
 sys.path.append(stuff.path.abspath("relative_path"))
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -118,7 +118,7 @@ import sys
 from os import path as stuff
 sys.path.append(stuff.abspath("relative_path"))
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -130,7 +130,7 @@ import sys
 from os.path import abspath
 sys.path.append(abspath("relative_path"))
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -142,7 +142,7 @@ import sys
 from os.path import abspath as stuff
 sys.path.append(stuff("relative_path"))
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert "relative_path" in [p.path for p in appended]
@@ -154,7 +154,7 @@ import sys
 path = "absolute_path_1"
 sys.path.append(path)
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     appended = SysPathChange.extract_from_tree(CurrentSessionState(), maybe_tree.tree)
     assert ["absolute_path_1"] == [p.path for p in appended]
@@ -196,7 +196,7 @@ dbutils.notebook.run(name)
     ],
 )
 def test_infers_dbutils_notebook_run_dynamic_value(code, expected) -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     all_paths: list[str] = []

--- a/tests/unit/source_code/linters/test_python_imports.py
+++ b/tests/unit/source_code/linters/test_python_imports.py
@@ -44,7 +44,7 @@ def test_linter_returns_empty_list_of_imports() -> None:
         "from x import z",
         "importlib.import_module('x')",
         "importlib.__import__('x')",
-    ]
+    ],
 )
 def test_import_source_extract_from_tree(import_statement: str) -> None:
     maybe_tree = MaybeTree.from_source_code(import_statement)

--- a/tests/unit/source_code/linters/test_spark_connect.py
+++ b/tests/unit/source_code/linters/test_spark_connect.py
@@ -4,7 +4,7 @@ import pytest
 
 
 from databricks.labs.ucx.source_code.base import Failure, CurrentSessionState
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 from databricks.labs.ucx.source_code.linters.spark_connect import LoggingMatcher, SparkConnectPyLinter
 from databricks.sdk.service.compute import DataSecurityMode
 
@@ -208,6 +208,7 @@ sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
 
     """
 
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
     assert [
         Failure(
             code='spark-logging-in-shared-clusters',
@@ -236,7 +237,7 @@ sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
             end_line=6,
             end_col=24,
         ),
-    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.maybe_normalized_parse(code).walk()]))
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in maybe_tree.walk()]))
 
 
 def test_logging_serverless(session_state) -> None:
@@ -248,7 +249,7 @@ log4jLogger = sc._jvm.org.apache.log4j
 
     """
 
-    maybe_tree = Tree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
     assert maybe_tree.tree is not None
     tree = maybe_tree.tree
     assert [

--- a/tests/unit/source_code/linters/test_spark_connect.py
+++ b/tests/unit/source_code/linters/test_spark_connect.py
@@ -208,7 +208,7 @@ sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
 
     """
 
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert [
         Failure(
             code='spark-logging-in-shared-clusters',
@@ -249,7 +249,7 @@ log4jLogger = sc._jvm.org.apache.log4j
 
     """
 
-    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    maybe_tree = MaybeTree.from_source_code(code)
     assert maybe_tree.tree is not None
     tree = maybe_tree.tree
     assert [

--- a/tests/unit/source_code/linters/test_spark_connect.py
+++ b/tests/unit/source_code/linters/test_spark_connect.py
@@ -236,7 +236,7 @@ sc._jvm.org.apache.log4j.LogManager.getLogger(__name__).info("test")
             end_line=6,
             end_col=24,
         ),
-    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.maybe_parse(code).walk()]))
+    ] == list(chain.from_iterable([logging_matcher.lint(node) for node in Tree.maybe_normalized_parse(code).walk()]))
 
 
 def test_logging_serverless(session_state) -> None:
@@ -248,7 +248,7 @@ log4jLogger = sc._jvm.org.apache.log4j
 
     """
 
-    maybe_tree = Tree.maybe_parse(code)
+    maybe_tree = Tree.maybe_normalized_parse(code)
     assert maybe_tree.tree is not None
     tree = maybe_tree.tree
     assert [

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -268,7 +268,7 @@ def test_unsupported_magic_raises_problem(simple_dependency_resolver, mock_path_
     source = """
 %unsupported stuff '"%#@!
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree, maybe_tree.failure
     tree = maybe_tree.tree
     commands, _ = MagicLine.extract_from_tree(tree, DependencyProblem.from_node)

--- a/tests/unit/source_code/notebooks/test_cells.py
+++ b/tests/unit/source_code/notebooks/test_cells.py
@@ -9,7 +9,7 @@ from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyResolver, DependencyProblem
 from databricks.labs.ucx.source_code.linters.files import FileLoader, ImportFileResolver
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 from databricks.labs.ucx.source_code.notebooks.cells import (
     CellLanguage,
     PipCell,
@@ -268,7 +268,7 @@ def test_unsupported_magic_raises_problem(simple_dependency_resolver, mock_path_
     source = """
 %unsupported stuff '"%#@!
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree, maybe_tree.failure
     tree = maybe_tree.tree
     commands, _ = MagicLine.extract_from_tree(tree, DependencyProblem.from_node)

--- a/tests/unit/source_code/python/test_python_ast.py
+++ b/tests/unit/source_code/python/test_python_ast.py
@@ -2,12 +2,12 @@ import pytest
 import astroid  # type: ignore
 from astroid import Assign, AssignName, Attribute, Call, Const, Expr, Module, Name  # type: ignore
 
-from databricks.labs.ucx.source_code.python.python_ast import Tree, TreeHelper
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree, TreeHelper
 from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_extracts_root() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("o.m1().m2().m3()")
+    maybe_tree = MaybeTree.maybe_normalized_parse("o.m1().m2().m3()")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     stmt = tree.first_statement()
@@ -17,14 +17,14 @@ def test_extracts_root() -> None:
 
 
 def test_no_first_statement() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("")
+    maybe_tree = MaybeTree.maybe_normalized_parse("")
     assert maybe_tree.tree is not None
     assert maybe_tree.tree.first_statement() is None
 
 
 def test_extract_call_by_name() -> None:
-    tree = Tree.maybe_normalized_parse("o.m1().m2().m3()")
-    stmt = tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("o.m1().m2().m3()")
+    stmt = maybe_tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
     act = TreeHelper.extract_call_by_name(stmt.value, "m2")
@@ -34,8 +34,8 @@ def test_extract_call_by_name() -> None:
 
 
 def test_extract_call_by_name_none() -> None:
-    tree = Tree.maybe_normalized_parse("o.m1().m2().m3()")
-    stmt = tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse("o.m1().m2().m3()")
+    stmt = maybe_tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
     act = TreeHelper.extract_call_by_name(stmt.value, "m5000")
@@ -60,8 +60,8 @@ def test_extract_call_by_name_none() -> None:
     ],
 )
 def test_linter_gets_arg(code, arg_index, arg_name, expected) -> None:
-    tree = Tree.maybe_normalized_parse(code)
-    stmt = tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    stmt = maybe_tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
     act = TreeHelper.get_arg(stmt.value, arg_index, arg_name)
@@ -85,19 +85,19 @@ def test_linter_gets_arg(code, arg_index, arg_name, expected) -> None:
     ],
 )
 def test_args_count(code, expected) -> None:
-    tree = Tree.maybe_normalized_parse(code)
-    stmt = tree.first_statement()
+    maybe_tree = MaybeTree.maybe_normalized_parse(code)
+    stmt = maybe_tree.first_statement()
     assert isinstance(stmt, Expr)
     assert isinstance(stmt.value, Call)
     act = TreeHelper.args_count(stmt.value)
     assert act == expected
 
 
-def test_tree_walks_nodes_once() -> None:
+def test_maybe_tree_walks_nodes_once() -> None:
     nodes = set()
     count = 0
-    tree = Tree.maybe_normalized_parse("o.m1().m2().m3()")
-    for node in tree.walk():
+    maybe_tree = MaybeTree.maybe_normalized_parse("o.m1().m2().m3()")
+    for node in maybe_tree.walk():
         nodes.add(node)
         count += 1
     assert len(nodes) == count
@@ -110,7 +110,7 @@ name="name"
 version="version"
 formatted=message_unformatted % (name, version)
 """
-    Tree.maybe_normalized_parse(source)
+    MaybeTree.maybe_normalized_parse(source)
     assert True
 
 
@@ -118,8 +118,8 @@ def test_tree_attach_child_tree_infers_value() -> None:
     """Attaching trees allows traversing from both parent and child."""
     inferred_string = "Hello John!"
     parent_source, child_source = "a = 'John'", 'b = f"Hello {a}!"'
-    parent_maybe_tree = Tree.maybe_normalized_parse(parent_source)
-    child_maybe_tree = Tree.maybe_normalized_parse(child_source)
+    parent_maybe_tree = MaybeTree.maybe_normalized_parse(parent_source)
+    child_maybe_tree = MaybeTree.maybe_normalized_parse(child_source)
 
     assert parent_maybe_tree.tree is not None, parent_maybe_tree.failure
     assert child_maybe_tree.tree is not None, child_maybe_tree.failure
@@ -142,7 +142,7 @@ def test_is_from_module() -> None:
 df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     save_call = tree.locate(
@@ -156,7 +156,7 @@ def test_locates_member_import() -> None:
 from importlib import import_module
 module = import_module("xyz")
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     import_calls = tree.locate(Call, [("import_module", Attribute), ("importlib", Name)])
@@ -165,7 +165,7 @@ module = import_module("xyz")
 
 @pytest.mark.parametrize("source, name, class_name", [("a = 123", "a", "int")])
 def test_is_instance_of(source, name, class_name) -> None:
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     assert isinstance(tree.node, Module)
@@ -180,9 +180,9 @@ def test_tree_attach_child_tree_propagates_module_reference() -> None:
     source_1 = "df = spark.read.csv('hi')"
     source_2 = "df = df.withColumn(stuff)"
     source_3 = "df = df.withColumn(stuff2)"
-    first_line_maybe_tree = Tree.maybe_normalized_parse(source_1)
-    second_line_maybe_tree = Tree.maybe_normalized_parse(source_2)
-    third_line_maybe_tree = Tree.maybe_normalized_parse(source_3)
+    first_line_maybe_tree = MaybeTree.maybe_normalized_parse(source_1)
+    second_line_maybe_tree = MaybeTree.maybe_normalized_parse(source_2)
+    third_line_maybe_tree = MaybeTree.maybe_normalized_parse(source_3)
 
     assert first_line_maybe_tree.tree, first_line_maybe_tree.failure
     assert second_line_maybe_tree.tree, second_line_maybe_tree.failure
@@ -199,7 +199,7 @@ def test_renumbers_positively() -> None:
     source = """df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
@@ -217,7 +217,7 @@ def test_renumbers_negatively() -> None:
     source = """df = spark.read.csv("hi")
 df.write.format("delta").saveAsTable("old.things")
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
@@ -241,7 +241,7 @@ df.write.format("delta").saveAsTable("old.things")
     ],
 )
 def test_counts_lines(source: str, line_count: int) -> None:
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     assert tree.line_count() == line_count
@@ -263,7 +263,7 @@ x = stuff()""",
     ],
 )
 def test_is_builtin(source, name, is_builtin) -> None:
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = list(tree.node.get_children())
@@ -280,7 +280,7 @@ def test_is_builtin(source, name, is_builtin) -> None:
 
 def test_tree_attach_nodes_sets_parent() -> None:
     node = astroid.extract_node("b = a + 2")
-    maybe_tree = Tree.maybe_normalized_parse("a = 1")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
     maybe_tree.tree.attach_nodes([node])
@@ -290,7 +290,7 @@ def test_tree_attach_nodes_sets_parent() -> None:
 
 def test_tree_attach_nodes_adds_node_to_body() -> None:
     node = astroid.extract_node("b = a + 2")
-    maybe_tree = Tree.maybe_normalized_parse("a = 1")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
     maybe_tree.tree.attach_nodes([node])
@@ -299,7 +299,7 @@ def test_tree_attach_nodes_adds_node_to_body() -> None:
 
 
 def test_tree_extend_globals_adds_assign_name_to_tree() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("a = 1")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a = 1")
     assert maybe_tree.tree, maybe_tree.failure
 
     node = astroid.extract_node("b = a + 2")
@@ -313,16 +313,16 @@ def test_tree_extend_globals_adds_assign_name_to_tree() -> None:
 
 
 def test_tree_attach_child_tree_appends_globals_to_parent_tree() -> None:
-    parent_tree = Tree.maybe_normalized_parse("a = 1")
-    child_tree = Tree.maybe_normalized_parse("b = a + 2")
+    parent_maybe_tree = MaybeTree.maybe_normalized_parse("a = 1")
+    child_maybe_tree = MaybeTree.maybe_normalized_parse("b = a + 2")
 
-    assert parent_tree.tree, parent_tree.failure
-    assert child_tree.tree, child_tree.failure
+    assert parent_maybe_tree.tree, parent_maybe_tree.failure
+    assert child_maybe_tree.tree, child_maybe_tree.failure
 
-    parent_tree.tree.attach_child_tree(child_tree.tree)
+    parent_maybe_tree.tree.attach_child_tree(child_maybe_tree.tree)
 
-    assert set(parent_tree.tree.node.globals.keys()) == {"a", "b"}
-    assert set(child_tree.tree.node.globals.keys()) == {"b"}
+    assert set(parent_maybe_tree.tree.node.globals.keys()) == {"a", "b"}
+    assert set(child_maybe_tree.tree.node.globals.keys()) == {"b"}
 
 
 def test_first_statement_is_none() -> None:

--- a/tests/unit/source_code/python/test_python_infer.py
+++ b/tests/unit/source_code/python/test_python_infer.py
@@ -6,7 +6,7 @@ from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_infers_empty_list() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("a=[]")
+    maybe_tree = MaybeTree.from_source_code("a=[]")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -16,7 +16,7 @@ def test_infers_empty_list() -> None:
 
 
 def test_infers_empty_tuple() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("a=tuple()")
+    maybe_tree = MaybeTree.from_source_code("a=tuple()")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -26,7 +26,7 @@ def test_infers_empty_tuple() -> None:
 
 
 def test_infers_empty_set() -> None:
-    maybe_tree = MaybeTree.maybe_normalized_parse("a={}")
+    maybe_tree = MaybeTree.from_source_code("a={}")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -40,7 +40,7 @@ def test_infers_fstring_value() -> None:
 value = "abc"
 fstring = f"Hello {value}!"
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -56,7 +56,7 @@ def test_infers_fstring_dict_value() -> None:
 value = { "abc": 123 }
 fstring = f"Hello {value['abc']}!"
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -72,7 +72,7 @@ def test_infers_string_format_value() -> None:
 value = "abc"
 fstring = "Hello {0}!".format(value)
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -91,7 +91,7 @@ for value1 in values_1:
     for value2 in values_2:
         fstring = f"Hello {value1}, {value2}!"
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -109,7 +109,7 @@ def test_infers_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -126,7 +126,7 @@ def test_infers_externally_defined_values() -> None:
 for name in ["my-widget-1", "my-widget-2"]:
     value = dbutils.widgets.get(name)
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -143,7 +143,7 @@ def test_fails_to_infer_missing_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -157,7 +157,7 @@ def test_survives_absence_of_externally_defined_values() -> None:
     name = "my-widget"
     value = dbutils.widgets.get(name)
     """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -174,7 +174,7 @@ values = dbutils.widgets.getAll()
 name = "my-widget"
 value = values[name]
 """
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])

--- a/tests/unit/source_code/python/test_python_infer.py
+++ b/tests/unit/source_code/python/test_python_infer.py
@@ -1,12 +1,12 @@
 from astroid import Assign  # type: ignore
 
 from databricks.labs.ucx.source_code.base import CurrentSessionState
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree
 from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_infers_empty_list() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("a=[]")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a=[]")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -16,7 +16,7 @@ def test_infers_empty_list() -> None:
 
 
 def test_infers_empty_tuple() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("a=tuple()")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a=tuple()")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -26,7 +26,7 @@ def test_infers_empty_tuple() -> None:
 
 
 def test_infers_empty_set() -> None:
-    maybe_tree = Tree.maybe_normalized_parse("a={}")
+    maybe_tree = MaybeTree.maybe_normalized_parse("a={}")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -40,7 +40,7 @@ def test_infers_fstring_value() -> None:
 value = "abc"
 fstring = f"Hello {value}!"
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -56,7 +56,7 @@ def test_infers_fstring_dict_value() -> None:
 value = { "abc": 123 }
 fstring = f"Hello {value['abc']}!"
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -72,7 +72,7 @@ def test_infers_string_format_value() -> None:
 value = "abc"
 fstring = "Hello {0}!".format(value)
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -91,7 +91,7 @@ for value1 in values_1:
     for value2 in values_2:
         fstring = f"Hello {value1}, {value2}!"
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -109,7 +109,7 @@ def test_infers_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -126,7 +126,7 @@ def test_infers_externally_defined_values() -> None:
 for name in ["my-widget-1", "my-widget-2"]:
     value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -143,7 +143,7 @@ def test_fails_to_infer_missing_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -157,7 +157,7 @@ def test_survives_absence_of_externally_defined_values() -> None:
     name = "my-widget"
     value = dbutils.widgets.get(name)
     """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -174,7 +174,7 @@ values = dbutils.widgets.getAll()
 name = "my-widget"
 value = values[name]
 """
-    maybe_tree = Tree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])

--- a/tests/unit/source_code/python/test_python_infer.py
+++ b/tests/unit/source_code/python/test_python_infer.py
@@ -6,7 +6,7 @@ from databricks.labs.ucx.source_code.python.python_infer import InferredValue
 
 
 def test_infers_empty_list() -> None:
-    maybe_tree = Tree.maybe_parse("a=[]")
+    maybe_tree = Tree.maybe_normalized_parse("a=[]")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -16,7 +16,7 @@ def test_infers_empty_list() -> None:
 
 
 def test_infers_empty_tuple() -> None:
-    maybe_tree = Tree.maybe_parse("a=tuple()")
+    maybe_tree = Tree.maybe_normalized_parse("a=tuple()")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -26,7 +26,7 @@ def test_infers_empty_tuple() -> None:
 
 
 def test_infers_empty_set() -> None:
-    maybe_tree = Tree.maybe_parse("a={}")
+    maybe_tree = Tree.maybe_normalized_parse("a={}")
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -40,7 +40,7 @@ def test_infers_fstring_value() -> None:
 value = "abc"
 fstring = f"Hello {value}!"
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -56,7 +56,7 @@ def test_infers_fstring_dict_value() -> None:
 value = { "abc": 123 }
 fstring = f"Hello {value['abc']}!"
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -72,7 +72,7 @@ def test_infers_string_format_value() -> None:
 value = "abc"
 fstring = "Hello {0}!".format(value)
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -91,7 +91,7 @@ for value1 in values_1:
     for value2 in values_2:
         fstring = f"Hello {value1}, {value2}!"
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -109,7 +109,7 @@ def test_infers_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -126,7 +126,7 @@ def test_infers_externally_defined_values() -> None:
 for name in ["my-widget-1", "my-widget-2"]:
     value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -143,7 +143,7 @@ def test_fails_to_infer_missing_externally_defined_value() -> None:
 name = "my-widget"
 value = dbutils.widgets.get(name)
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -157,7 +157,7 @@ def test_survives_absence_of_externally_defined_values() -> None:
     name = "my-widget"
     value = dbutils.widgets.get(name)
     """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])
@@ -174,7 +174,7 @@ values = dbutils.widgets.getAll()
 name = "my-widget"
 value = values[name]
 """
-    maybe_tree = Tree.maybe_parse(source)
+    maybe_tree = Tree.maybe_normalized_parse(source)
     assert maybe_tree.tree is not None, maybe_tree.failure
     tree = maybe_tree.tree
     nodes = tree.locate(Assign, [])

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -4,7 +4,7 @@ import re
 import pytest
 from databricks.sdk.service.workspace import Language, ObjectType, ObjectInfo
 
-from databricks.labs.ucx.source_code.base import CurrentSessionState, Failure
+from databricks.labs.ucx.source_code.base import CurrentSessionState
 from databricks.labs.ucx.source_code.graph import DependencyGraph, DependencyResolver
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -9,7 +9,7 @@ from databricks.labs.ucx.source_code.graph import DependencyGraph, DependencyRes
 from databricks.labs.ucx.source_code.known import KnownList
 from databricks.labs.ucx.source_code.linters.files import ImportFileResolver, FileLoader
 from databricks.labs.ucx.source_code.linters.imports import DbutilsPyLinter
-from databricks.labs.ucx.source_code.python.python_ast import Tree
+from databricks.labs.ucx.source_code.python.python_ast import MaybeTree
 from databricks.labs.ucx.source_code.notebooks.sources import Notebook
 from databricks.labs.ucx.source_code.notebooks.loaders import (
     NotebookResolver,
@@ -262,9 +262,9 @@ stuff2 = dbutils.notebook.run("where is notebook 1?")
 stuff3 = dbutils.notebook.run("where is notebook 2?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.maybe_normalized_parse(source)
-    assert tree.tree is not None
-    nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None
+    nodes = linter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert len(nodes) == 2
 
 
@@ -275,9 +275,9 @@ do_something_with_stuff(stuff)
 stuff2 = notebook.run("where is notebook 1?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.maybe_normalized_parse(source)
-    assert tree.tree is not None
-    nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
+    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    assert maybe_tree.tree is not None
+    nodes = linter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert len(nodes) == 0
 
 

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -262,7 +262,7 @@ stuff2 = dbutils.notebook.run("where is notebook 1?")
 stuff3 = dbutils.notebook.run("where is notebook 2?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None
     nodes = linter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert len(nodes) == 2
@@ -275,7 +275,7 @@ do_something_with_stuff(stuff)
 stuff2 = notebook.run("where is notebook 1?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    maybe_tree = MaybeTree.maybe_normalized_parse(source)
+    maybe_tree = MaybeTree.from_source_code(source)
     assert maybe_tree.tree is not None
     nodes = linter.list_dbutils_notebook_run_calls(maybe_tree.tree)
     assert len(nodes) == 0

--- a/tests/unit/source_code/test_notebook.py
+++ b/tests/unit/source_code/test_notebook.py
@@ -262,7 +262,7 @@ stuff2 = dbutils.notebook.run("where is notebook 1?")
 stuff3 = dbutils.notebook.run("where is notebook 2?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.maybe_parse(source)
+    tree = Tree.maybe_normalized_parse(source)
     assert tree.tree is not None
     nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
     assert len(nodes) == 2
@@ -275,7 +275,7 @@ do_something_with_stuff(stuff)
 stuff2 = notebook.run("where is notebook 1?")
 """
     linter = DbutilsPyLinter(CurrentSessionState())
-    tree = Tree.maybe_parse(source)
+    tree = Tree.maybe_normalized_parse(source)
     assert tree.tree is not None
     nodes = linter.list_dbutils_notebook_run_calls(tree.tree)
     assert len(nodes) == 0
@@ -290,16 +290,3 @@ dbutils.notebook.run(f"Hey {name2}")
     linter = DbutilsPyLinter(CurrentSessionState())
     advices = list(linter.lint(source))
     assert not advices
-
-
-def test_tree_maybe_parse_fails_on_jupyter_magic() -> None:
-    source = "%tb"
-    tree = Tree.maybe_parse(source)
-    assert tree.failure == Failure(
-        "python-parse-error",
-        f"Failed to parse code due to invalid syntax: {source}",
-        start_line=0,
-        start_col=0,
-        end_line=0,
-        end_col=1,
-    )


### PR DESCRIPTION
## Changes
Make `MaybeTree` the main Python AST entrypoint for constructing the syntax tree:
- Move the `@classmethod`s and `@staticmethod`s that construct a `MaybeTree` from the `Tree` to the `MaybeTree` class as this uses the `@classmethod` properly by returning the initialization of the for `cls` argument
- Make the `@classmethod` that normalizes the source code before parsing the only entrypoint by removing the other `@classmethod` that does not normalize the source code before parsing to enforce normalization (and resolve the linked issues below)
- Rename `normalized_parse` to `from_source_code` to match the commonly used naming for `classmethod`s within UCX

### Linked issues

Resolves #3457
Resolves #3213

### Functionality

- [ ] modified Python linting related code

### Tests

- [ ] added unit tests
