### PR TITLE
Document to run `validate-groups-membership` before groups migration, not after

### DIFF
--- a/docs/ucx/docs/reference/commands/index.mdx
+++ b/docs/ucx/docs/reference/commands/index.mdx
@@ -159,8 +159,9 @@ Workspace Group Name  Members Count  Account Group Name  Members Count  Differen
 
 This command validates the groups to see if the groups at the account level and workspace level have different membership.
 This command is useful for administrators who want to ensure that the groups have the correct membership. It can also be
-used to debug issues related to group membership. See [group migration](docs/reference/local-group-migration.md) and
-[group migration](/docs/reference/workflows#group-migration-workflow) for more details.
+used to debug issues related to group membership. See
+[group migration](/docs/reference/workflows#group-migration-workflow) and
+[group migration](docs/reference/local-group-migration.md) for more details.
 
 Valid group membership is important to ensure users has correct access after legacy table ACL is migrated in [table migration process](/docs/process/#table-migration-process)
 
@@ -282,7 +283,7 @@ are eligible to be run as a collection. User can run the below commands as colle
 - `migrate-tables`
 - `migrate-acls`
 - `migrate-dbsql-dashboards`
-- `validate-group-membership`
+- `validate-groups-membership`
 Ex: `databricks labs ucx ensure-assessment-run --run-as-collection=True`
 
 ## Metastore related commands

--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -107,7 +107,8 @@ A Databricks admin [assigns account groups to workspaces](https://docs.databrick
 using [identity federation](https://docs.databricks.com/en/admin/users-groups/index.html#enable-identity-federation)
 to manage groups from a single place: your Databricks account. We expect UCX users to create account groups
 centrally while most other Databricks resources that UCX touches are scoped to a single workspace.
-If you do not have account groups matching the workspace in which UCX is installed, please
+For extra confidence, run [`validate-groups-membership` command](#validate-groups-membership-command) before running the
+group migration. If you do not have account groups matching groups in the workspace in which UCX is installed, you can
 run [`create-account-groups` command](/docs/reference/commands#create-account-groups) before running the group migration workflow.
 
 The group migration workflow is designed to migrate workspace-local groups to account-level groups. It verifies if
@@ -148,13 +149,11 @@ executed after a successful run of the assessment workflow. The group migration 
    destination groups.
 
 After successfully running the group migration workflow:
-1. Use [`validate-groups-membership` command](/docs/reference/commands#validate-groups-membership) for extra confidence the newly created
-   account level groups are considered to be valid.
-2. Run the [`remove-workspace-local-backup-grups`](/docs/reference/commands#validate-groups-membership) to remove workspace-level backup
+1. Run the [`remove-workspace-local-backup-grups`](/docs/reference/commands#validate-groups-membership) to remove workspace-level backup
    groups, along with their permissions. This should only be executed after confirming that the workspace-local
    migration worked successfully for all the groups involved. This step is necessary to clean up the workspace and
    remove any unnecessary groups and permissions.
-3. Proceed to the [table migration process](/docs/process#table-migration-process).
+2. Proceed to the [table migration process](/docs/process#table-migration-process).
 
 For additional information see:
 - The [detailed design](/docs/reference/local-group-migration) of thie group migration workflow.

--- a/src/databricks/labs/ucx/queries/assessment/estimates/01_0_group_migration.md
+++ b/src/databricks/labs/ucx/queries/assessment/estimates/01_0_group_migration.md
@@ -12,13 +12,13 @@ Follow those steps in order to successfully migrate your groups to the account:
 
 If you're not using an Identity Provider (Okta, Azure Entra etc...):
 1. Create the groups at the account level, consider using the [create-account-groups](https://github.com/databrickslabs/ucx/blob/main/README.md#create-account-groups-command) command.
-   1. For extra safety, consider running [validate-group-membership](https://github.com/databrickslabs/ucx/blob/main/README.md#validate-groups-membership-command) command to validate that you have the same amount of groups/users in the workspace and the account
+   1. For extra safety, consider running [validate-groups-membership](https://github.com/databrickslabs/ucx/blob/main/README.md#validate-groups-membership-command) command to validate that you have the same amount of groups/users in the workspace and the account
    2. Enable SCIM at the Account level.
 
 If you're using an Identity Provider:
 1. Enable SCIM at the account level
 2. Disable SCIM at the workspace level if not done already.
 3. Trigger a sync from your IdP to the account
-   1. To validate that all groups are properly setup for the group migration, run [validate-group-membership](https://github.com/databrickslabs/ucx/blob/main/README.md#validate-groups-membership-command)
+   1. To validate that all groups are properly setup for the group migration, run [validate-groups-membership](https://github.com/databrickslabs/ucx/blob/main/README.md#validate-groups-membership-command)
 
 Once the account groups are setup, perform the group migration by using the Group migration workflow, more information in the [docs](https://github.com/databrickslabs/ucx/blob/main/README.md#group-migration-workflow)


### PR DESCRIPTION
## Changes
Document to run `validate-groups-membership` before groups migration, not after, as this is the correct order.

### Linked issues

Resolves #3506