### PR TITLE
[TECH DEBT] Make session state public on `LinterContext` and access it from the context

### DIFF
--- a/src/databricks/labs/ucx/source_code/known.py
+++ b/src/databricks/labs/ucx/source_code/known.py
@@ -189,7 +189,7 @@ class KnownList:
         logger.info(f"Processing module: {module_ref}")
         session_state = CurrentSessionState()
         ctx = LinterContext(empty_index, session_state)
-        linter = FileLinter(ctx, PathLookup.from_sys_path(module_path.parent), session_state, module_path)
+        linter = FileLinter(ctx, PathLookup.from_sys_path(module_path.parent), module_path)
         known_problems = set()
         for problem in linter.lint():
             known_problems.add(KnownProblem(problem.code, problem.message))

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -55,8 +55,8 @@ class LinterContext:
         sql_dfsa_collectors: list[DfsaSqlCollector] = []
         sql_table_collectors: list[TableSqlCollector] = []
 
-        if index is not None:
-            from_table = FromTableSqlLinter(index, session_state=self.session_state)
+        if self._index is not None:
+            from_table = FromTableSqlLinter(self._index, session_state=self.session_state)
             sql_linters.append(from_table)
             sql_fixers.append(from_table)
             sql_table_collectors.append(from_table)
@@ -64,7 +64,7 @@ class LinterContext:
             python_linters.append(spark_sql)
             python_fixers.append(spark_sql)
             python_table_collectors.append(SparkSqlTablePyCollector(from_table))
-            spark_table = SparkTableNamePyLinter(from_table, index, self.session_state)
+            spark_table = SparkTableNamePyLinter(from_table, self._index, self.session_state)
             python_linters.append(spark_table)
             python_fixers.append(spark_table)
             python_table_collectors.append(spark_table)

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -43,7 +43,7 @@ class LinterContext:
         session_state: CurrentSessionState | None = None,
     ):
         self._index = index
-        session_state = CurrentSessionState() if not session_state else session_state
+        self.session_state = CurrentSessionState() if not session_state else session_state
 
         python_linters: list[PythonLinter] = []
         python_fixers: list[Fixer] = []
@@ -56,7 +56,7 @@ class LinterContext:
         sql_table_collectors: list[TableSqlCollector] = []
 
         if index is not None:
-            from_table = FromTableSqlLinter(index, session_state=session_state)
+            from_table = FromTableSqlLinter(index, session_state=self.session_state)
             sql_linters.append(from_table)
             sql_fixers.append(from_table)
             sql_table_collectors.append(from_table)
@@ -64,7 +64,7 @@ class LinterContext:
             python_linters.append(spark_sql)
             python_fixers.append(spark_sql)
             python_table_collectors.append(SparkSqlTablePyCollector(from_table))
-            spark_table = SparkTableNamePyLinter(from_table, index, session_state)
+            spark_table = SparkTableNamePyLinter(from_table, index, self.session_state)
             python_linters.append(spark_table)
             python_fixers.append(spark_table)
             python_table_collectors.append(spark_table)
@@ -74,14 +74,14 @@ class LinterContext:
         sql_dfsa_collectors.append(sql_direct_fs)
 
         python_linters += [
-            DirectFsAccessPyLinter(session_state),
-            DBRv8d0PyLinter(dbr_version=session_state.dbr_version),
-            SparkConnectPyLinter(session_state),
-            DbutilsPyLinter(session_state),
+            DirectFsAccessPyLinter(self.session_state),
+            DBRv8d0PyLinter(dbr_version=self.session_state.dbr_version),
+            SparkConnectPyLinter(self.session_state),
+            DbutilsPyLinter(self.session_state),
             DirectFsAccessSqlPylinter(sql_direct_fs),
         ]
 
-        python_dfsa_collectors += [DirectFsAccessPyLinter(session_state, prevent_spark_duplicates=False)]
+        python_dfsa_collectors += [DirectFsAccessPyLinter(self.session_state, prevent_spark_duplicates=False)]
 
         self._linters: dict[Language, list[SqlLinter] | list[PythonLinter]] = {
             Language.PYTHON: python_linters,

--- a/src/databricks/labs/ucx/source_code/linters/context.py
+++ b/src/databricks/labs/ucx/source_code/linters/context.py
@@ -37,6 +37,12 @@ from databricks.labs.ucx.source_code.linters.from_table import FromTableSqlLinte
 
 
 class LinterContext:
+    """The context with UCX's linters.
+
+    Use this context outside the `linters` module as an entrypoint to the
+    linters in the `linters' module.
+    """
+
     def __init__(
         self,
         index: TableMigrationIndex | None = None,

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -10,7 +10,6 @@ from typing import cast
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import (
-    CurrentSessionState,
     file_language,
     is_a_notebook,
     Advice,
@@ -44,16 +43,10 @@ class NotebookLinter:
     """
 
     def __init__(
-        self,
-        context: LinterContext,
-        path_lookup: PathLookup,
-        session_state: CurrentSessionState,
-        notebook: Notebook,
-        parent_tree: Tree | None = None,
+        self, context: LinterContext, path_lookup: PathLookup, notebook: Notebook, parent_tree: Tree | None = None
     ):
         self._context: LinterContext = context
         self._path_lookup = path_lookup
-        self._session_state = session_state
         self._notebook: Notebook = notebook
         self._parent_tree = parent_tree or Tree.new_module()
 
@@ -144,7 +137,7 @@ class NotebookLinter:
     def _parse_tree(self, tree: Tree) -> Failure | None:
         """Parse tree by looking for referred notebooks and path changes that might affect loading notebooks."""
         code_path_nodes = self._list_magic_lines_with_run_command(tree) + SysPathChange.extract_from_tree(
-            self._session_state, tree
+            self._context.session_state, tree
         )
         # Sys path changes require to load children in order of reading
         for base_node in sorted(code_path_nodes, key=lambda node: (node.node.lineno, node.node.col_offset)):
@@ -269,14 +262,12 @@ class FileLinter:
         self,
         context: LinterContext,
         path_lookup: PathLookup,
-        session_state: CurrentSessionState,
         path: Path,
         inherited_tree: Tree | None = None,
         content: str | None = None,
     ):
         self._context = context
         self._path_lookup = path_lookup
-        self._session_state = session_state
         self._path = path
         self._inherited_tree = inherited_tree
         self._content = content
@@ -338,9 +329,7 @@ class FileLinter:
             yield Failure("unknown-language", f"Cannot detect language for {self._path}", 0, 0, 1, 1)
             return
         notebook = Notebook.parse(self._path, self._content, language)
-        notebook_linter = NotebookLinter(
-            self._context, self._path_lookup, self._session_state, notebook, self._inherited_tree
-        )
+        notebook_linter = NotebookLinter(self._context, self._path_lookup, notebook, self._inherited_tree)
         yield from notebook_linter.lint()
 
 

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -267,14 +267,14 @@ class FileLinter:
 
     def __init__(
         self,
-        ctx: LinterContext,
+        context: LinterContext,
         path_lookup: PathLookup,
         session_state: CurrentSessionState,
         path: Path,
         inherited_tree: Tree | None = None,
         content: str | None = None,
     ):
-        self._ctx: LinterContext = ctx
+        self._context = context
         self._path_lookup = path_lookup
         self._session_state = session_state
         self._path = path
@@ -325,7 +325,7 @@ class FileLinter:
                 yield Failure("unknown-language", f"Cannot detect language for {self._path}", 0, 0, 1, 1)
         else:
             try:
-                linter = self._ctx.linter(language)
+                linter = self._context.linter(language)
                 yield from linter.lint(self._content)
             except ValueError as err:
                 failure_message = f"Error while parsing content of {self._path.as_posix()}: {err}"
@@ -339,7 +339,7 @@ class FileLinter:
             return
         notebook = Notebook.parse(self._path, self._content, language)
         notebook_linter = NotebookLinter(
-            self._ctx, self._path_lookup, self._session_state, notebook, self._inherited_tree
+            self._context, self._path_lookup, self._session_state, notebook, self._inherited_tree
         )
         yield from notebook_linter.lint()
 

--- a/src/databricks/labs/ucx/source_code/linters/folders.py
+++ b/src/databricks/labs/ucx/source_code/linters/folders.py
@@ -81,9 +81,7 @@ class LocalCodeLinter:
             yield problem.as_located_advice()
         if linted_paths is None:
             linted_paths = set()
-        walker = LintingWalker(
-            graph, linted_paths, self._path_lookup, path.name, self._session_state, self._context_factory
-        )
+        walker = LintingWalker(graph, linted_paths, self._path_lookup, path.name, self._context_factory)
         yield from walker
 
 

--- a/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
+++ b/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
@@ -111,7 +111,7 @@ class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
         inherited_tree: Tree | None,
     ) -> Iterable[LocatedAdvice]:
         # FileLinter determines which file/notebook linter to use
-        linter = FileLinter(self._context_factory(), path_lookup, self._session_state, dependency.path, inherited_tree)
+        linter = FileLinter(self._context_factory(), path_lookup, dependency.path, inherited_tree)
         for advice in linter.lint():
             yield LocatedAdvice(advice, dependency.path)
 

--- a/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
+++ b/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
@@ -93,12 +93,10 @@ class LintingWalker(DependencyGraphWalker[LocatedAdvice]):
         walked_paths: set[Path],
         path_lookup: PathLookup,
         key: str,
-        session_state: CurrentSessionState,
         context_factory: Callable[[], LinterContext],
     ):
         super().__init__(graph, walked_paths, path_lookup)
         self._key = key
-        self._session_state = session_state
         self._context_factory = context_factory
 
     def _log_walk_one(self, dependency: Dependency) -> None:
@@ -130,7 +128,6 @@ class _CollectorWalker(DependencyGraphWalker[S], abc.ABC):
         migration_index: TableMigrationIndex,
     ):
         super().__init__(graph, walked_paths, path_lookup)
-        self._session_state = session_state
         self._linter_context = LinterContext(migration_index, session_state)
 
     def _process_dependency(

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -185,7 +185,6 @@ class WorkflowLinter:
             linted_paths,
             self._path_lookup,
             task.task_key,
-            session_state,
             lambda: LinterContext(self._migration_index, session_state),
         )
         yield from walker

--- a/tests/unit/source_code/linters/test_graph_walkers.py
+++ b/tests/unit/source_code/linters/test_graph_walkers.py
@@ -49,7 +49,7 @@ def test_linting_walker_populates_paths(simple_dependency_resolver, mock_path_lo
     xgraph = DependencyGraph(root, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
     current_session = CurrentSessionState()
     walker = LintingWalker(
-        xgraph, set(), mock_path_lookup, "key", current_session, lambda: LinterContext(migration_index, current_session)
+        xgraph, set(), mock_path_lookup, "key", lambda: LinterContext(migration_index, current_session)
     )
     advices = 0
     for advice in walker:

--- a/tests/unit/source_code/test_functional.py
+++ b/tests/unit/source_code/test_functional.py
@@ -147,7 +147,7 @@ class Functional:
         session_state.named_parameters = {"my-widget": "my-path.py"}
         ctx = LinterContext(migration_index, session_state)
         if self.parent is None:
-            linter = FileLinter(ctx, path_lookup, session_state, self.path)
+            linter = FileLinter(ctx, path_lookup, self.path)
             return linter.lint()
         # use dependency graph built from parent
         is_notebook = is_a_notebook(self.parent)
@@ -158,7 +158,7 @@ class Functional:
         assert container is not None
         container.build_dependency_graph(root_graph)
         inherited_tree = root_graph.build_inherited_tree(self.parent, self.path)
-        linter = FileLinter(ctx, path_lookup, session_state, self.path, inherited_tree)
+        linter = FileLinter(ctx, path_lookup, self.path, inherited_tree)
         return linter.lint()
 
     def _regex_match(self, regex: re.Pattern[str]) -> Generator[tuple[Comment, dict[str, Any]], None, None]:


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
Make session state public on `LinterContext` and access it from the context instead of passing it along.

### Linked issues

Breaks up #3586

### Functionality

- [x] rewrote code linting related resources

### Tests
- [x] Reusing existing tests