### PR TITLE
[TECH DEBT] Use `Language` on `LocalFile`, not `CellLanguage`

### DIFF
--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -19,7 +19,6 @@ from databricks.labs.ucx.source_code.graph import (
     MaybeDependency,
 )
 from databricks.labs.ucx.source_code.known import KnownList
-from databricks.labs.ucx.source_code.notebooks.cells import CellLanguage
 from databricks.labs.ucx.source_code.path_lookup import PathLookup
 from databricks.labs.ucx.source_code.linters.python import PythonCodeAnalyzer
 

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -34,10 +34,6 @@ class LocalFile(SourceContainer):
         self._original_code = source
         self._language = language
 
-    @property
-    def path(self) -> Path:
-        return self._path
-
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
         """The dependency graph for the local file."""
         if self._language == Language.PYTHON:

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class LocalFile(SourceContainer):
+    """A container for accessing local files."""
 
     def __init__(self, path: Path, source: str, language: Language):
         self._path = path
@@ -39,6 +40,7 @@ class LocalFile(SourceContainer):
         return self._path
 
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
+        """The dependency graph for the local file."""
         if self._language == Language.PYTHON:
             context = parent.new_dependency_graph_context()
             analyzer = PythonCodeAnalyzer(context, self._original_code)
@@ -47,8 +49,7 @@ class LocalFile(SourceContainer):
                 if problem.has_missing_path():
                     problems[idx] = dataclasses.replace(problem, source_path=self._path)
             return problems
-        # supported language that does not generate dependencies
-        if self._language == Language.SQL:
+        if self._language == Language.SQL:  # SQL cannot refer other dependencies
             return []
         logger.warning(f"Unsupported language: {self._language}")
         return []

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -32,15 +32,14 @@ class LocalFile(SourceContainer):
     def __init__(self, path: Path, source: str, language: Language):
         self._path = path
         self._original_code = source
-        # using CellLanguage so we can reuse the facilities it provides
-        self._language = CellLanguage.of_language(language)
+        self._language = language
 
     @property
     def path(self) -> Path:
         return self._path
 
     def build_dependency_graph(self, parent: DependencyGraph) -> list[DependencyProblem]:
-        if self._language is CellLanguage.PYTHON:
+        if self._language == Language.PYTHON:
             context = parent.new_dependency_graph_context()
             analyzer = PythonCodeAnalyzer(context, self._original_code)
             problems = analyzer.build_graph()
@@ -49,13 +48,13 @@ class LocalFile(SourceContainer):
                     problems[idx] = dataclasses.replace(problem, source_path=self._path)
             return problems
         # supported language that does not generate dependencies
-        if self._language is CellLanguage.SQL:
+        if self._language == Language.SQL:
             return []
-        logger.warning(f"Unsupported language: {self._language.language}")
+        logger.warning(f"Unsupported language: {self._language}")
         return []
 
     def build_inherited_context(self, graph: DependencyGraph, child_path: Path) -> InheritedContext:
-        if self._language is CellLanguage.PYTHON:
+        if self._language == Language.PYTHON:
             context = graph.new_dependency_graph_context()
             analyzer = PythonCodeAnalyzer(context, self._original_code)
             inherited = analyzer.build_inherited_context(child_path)

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -1,10 +1,24 @@
 from pathlib import Path
 
+import pytest
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.files import LocalFile
+from databricks.labs.ucx.source_code.base import CurrentSessionState
+from databricks.labs.ucx.source_code.files import FileLoader, LocalFile
+from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph
 
 
 def test_local_file_path_is_accessible() -> None:
     local_file = LocalFile(Path("test.py"), "print(1)", Language.PYTHON)
     assert local_file.path == Path("test.py")
+
+
+@pytest.mark.parametrize("language", [Language.SQL, Language.SCALA, Language.R])
+def test_local_file_builds_dependency_graph_without_problems_independent_from_source(
+    simple_dependency_resolver, mock_path_lookup, language: Language
+) -> None:
+    """Unsupported language and SQL builds a dependency graph without problems"""
+    dependency = Dependency(FileLoader(), Path("test.py"))
+    graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
+    local_file = LocalFile(Path("test.py"), "does not matter", language)
+    assert not local_file.build_dependency_graph(graph)

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -48,3 +48,17 @@ def test_local_file_builds_dependency_graph_with_problems_for_python(
             Path("test.py"),
         )
     ]
+
+
+@pytest.mark.parametrize("language", [Language.SQL, Language.SCALA, Language.R])
+def test_local_file_builds_inherited_context_without_tree_found_and_problems_independent_from_source(
+    simple_dependency_resolver, mock_path_lookup, language: Language
+) -> None:
+    """Unsupported language and SQL builds an inherited context without a tree, found flag and problems"""
+    dependency = Dependency(FileLoader(), Path("test"))
+    graph = DependencyGraph(dependency, None, simple_dependency_resolver, mock_path_lookup, CurrentSessionState())
+    local_file = LocalFile(Path("test"), "does not matter", language)
+    inherited_context = local_file.build_inherited_context(graph, Path("child"))
+    assert not inherited_context.tree
+    assert not inherited_context.found
+    assert not inherited_context.problems

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -8,11 +8,6 @@ from databricks.labs.ucx.source_code.files import FileLoader, LocalFile
 from databricks.labs.ucx.source_code.graph import Dependency, DependencyGraph, DependencyProblem
 
 
-def test_local_file_path_is_accessible() -> None:
-    local_file = LocalFile(Path("test.py"), "print(1)", Language.PYTHON)
-    assert local_file.path == Path("test.py")
-
-
 @pytest.mark.parametrize("language", [Language.SQL, Language.SCALA, Language.R])
 def test_local_file_builds_dependency_graph_without_problems_independent_from_source(
     simple_dependency_resolver, mock_path_lookup, language: Language

--- a/tests/unit/source_code/test_files.py
+++ b/tests/unit/source_code/test_files.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from databricks.sdk.service.workspace import Language
+
+from databricks.labs.ucx.source_code.files import LocalFile
+
+
+def test_local_file_path_is_accessible() -> None:
+    local_file = LocalFile(Path("test.py"), "print(1)", Language.PYTHON)
+    assert local_file.path == Path("test.py")


### PR DESCRIPTION
## Changes
Use `Language` on `LocalFile`, not `CellLanguage`, as a file might consist of cells when it is a notebook, but the file language is not a cell language

### Linked issues

Breaks up #3586

### Functionality

- [x] rewrote code linting related resources

### Tests
- [x] Added tests for `LocalFile`