### PR TITLE
Rename file language helper function

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -320,7 +320,12 @@ SUPPORTED_EXTENSION_LANGUAGES = {
 }
 
 
-def file_language(path: Path) -> Language | None:
+def get_file_language_if_supported(path: Path) -> Language | None:
+    """Get the file language if it is supported by UCX.
+
+    This function returns the language of the file based on the file
+    extension. If the file extension is not supported, it returns None.
+    """
     return SUPPORTED_EXTENSION_LANGUAGES.get(path.suffix.lower())
 
 
@@ -415,7 +420,7 @@ def is_a_notebook(path: Path, content: str | None = None) -> bool:
         return path.is_notebook()
     if not path.is_file():
         return False
-    language = file_language(path)
+    language = get_file_language_if_supported(path)
     if not language:
         return False
     magic_header = f"{LANGUAGE_COMMENT_PREFIXES.get(language)} {NOTEBOOK_HEADER}"

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -320,8 +320,8 @@ SUPPORTED_EXTENSION_LANGUAGES = {
 }
 
 
-def get_file_language_if_supported(path: Path) -> Language | None:
-    """Get the file language if it is supported by UCX's linter module.
+def infer_file_language_if_supported(path: Path) -> Language | None:
+    """Infer the file language if it is supported by UCX's linter module.
 
     This function returns the language of the file based on the file
     extension. If the file extension is not supported, it returns None.
@@ -422,7 +422,7 @@ def is_a_notebook(path: Path, content: str | None = None) -> bool:
         return path.is_notebook()
     if not path.is_file():
         return False
-    language = get_file_language_if_supported(path)
+    language = infer_file_language_if_supported(path)
     if not language:
         return False
     magic_header = f"{LANGUAGE_COMMENT_PREFIXES.get(language)} {NOTEBOOK_HEADER}"

--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -321,10 +321,12 @@ SUPPORTED_EXTENSION_LANGUAGES = {
 
 
 def get_file_language_if_supported(path: Path) -> Language | None:
-    """Get the file language if it is supported by UCX.
+    """Get the file language if it is supported by UCX's linter module.
 
     This function returns the language of the file based on the file
     extension. If the file extension is not supported, it returns None.
+
+    Use this function to filter paths before passing it to the linters.
     """
     return SUPPORTED_EXTENSION_LANGUAGES.get(path.suffix.lower())
 

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.base import get_file_language_if_supported, safe_read_text
+from databricks.labs.ucx.source_code.base import infer_file_language_if_supported, safe_read_text
 from databricks.labs.ucx.source_code.graph import (
     SourceContainer,
     DependencyGraph,
@@ -95,7 +95,7 @@ class FileLoader(DependencyLoader):
             # Paths are excluded from further processing by loading them as stub container.
             # Note we don't return `None`, as the path is found.
             return StubContainer(resolved_path)
-        language = get_file_language_if_supported(resolved_path)
+        language = infer_file_language_if_supported(resolved_path)
         if not language:
             return StubContainer(resolved_path)
         content = safe_read_text(resolved_path)

--- a/src/databricks/labs/ucx/source_code/files.py
+++ b/src/databricks/labs/ucx/source_code/files.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.base import file_language, safe_read_text
+from databricks.labs.ucx.source_code.base import get_file_language_if_supported, safe_read_text
 from databricks.labs.ucx.source_code.graph import (
     SourceContainer,
     DependencyGraph,
@@ -95,7 +95,7 @@ class FileLoader(DependencyLoader):
             # Paths are excluded from further processing by loading them as stub container.
             # Note we don't return `None`, as the path is found.
             return StubContainer(resolved_path)
-        language = file_language(resolved_path)
+        language = get_file_language_if_supported(resolved_path)
         if not language:
             return StubContainer(resolved_path)
         content = safe_read_text(resolved_path)

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -203,7 +203,7 @@ class NotebookLinter:
         # TODO deal with workspace notebooks
         language = get_file_language_if_supported(resolved)
         # we only support Python notebooks for now
-        if language is not Language.PYTHON:
+        if language != Language.PYTHON:
             logger.warning(f"Unsupported notebook language: {language}")
             return None
         source = safe_read_text(resolved)

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -9,7 +9,7 @@ from typing import cast
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import (
-    get_file_language_if_supported,
+    infer_file_language_if_supported,
     Advice,
     Failure,
     safe_read_text,
@@ -201,7 +201,7 @@ class NotebookLinter:
         if resolved is None:
             return None  # already reported during dependency building
         # TODO deal with workspace notebooks
-        language = get_file_language_if_supported(resolved)
+        language = infer_file_language_if_supported(resolved)
         # we only support Python notebooks for now
         if language != Language.PYTHON:
             logger.warning(f"Unsupported notebook language: {language}")

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -9,7 +9,7 @@ from typing import cast
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import (
-    file_language,
+    get_file_language_if_supported,
     Advice,
     Failure,
     safe_read_text,
@@ -201,7 +201,7 @@ class NotebookLinter:
         if resolved is None:
             return None  # already reported during dependency building
         # TODO deal with workspace notebooks
-        language = file_language(resolved)
+        language = get_file_language_if_supported(resolved)
         # we only support Python notebooks for now
         if language is not Language.PYTHON:
             logger.warning(f"Unsupported notebook language: {language}")

--- a/src/databricks/labs/ucx/source_code/linters/files.py
+++ b/src/databricks/labs/ucx/source_code/linters/files.py
@@ -9,9 +9,9 @@ from typing import cast
 from databricks.sdk.service.workspace import Language
 
 from databricks.labs.ucx.source_code.base import (
-    infer_file_language_if_supported,
     Advice,
     Failure,
+    infer_file_language_if_supported,
     safe_read_text,
 )
 from databricks.labs.ucx.source_code.files import LocalFile

--- a/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
+++ b/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
@@ -18,7 +18,7 @@ from databricks.labs.ucx.source_code.base import (
     LocatedAdvice,
     UsedTable,
     SourceInfo,
-    get_file_language_if_supported,
+    infer_file_language_if_supported,
     is_a_notebook,
     safe_read_text,
 )
@@ -149,7 +149,7 @@ class _CollectorWalker(DependencyGraphWalker[S], abc.ABC):
         path_lookup: PathLookup,
         inherited_tree: Tree | None,
     ) -> Iterable[S]:
-        language = get_file_language_if_supported(dependency.path)
+        language = infer_file_language_if_supported(dependency.path)
         if not language:
             logger.warning(f"Unsupported language for {dependency.path}")
             return

--- a/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
+++ b/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
@@ -151,7 +151,7 @@ class _CollectorWalker(DependencyGraphWalker[S], abc.ABC):
     ) -> Iterable[S]:
         language = get_file_language_if_supported(dependency.path)
         if not language:
-            logger.warning(f"Unknown language for {dependency.path}")
+            logger.warning(f"Unsupported language for {dependency.path}")
             return
         cell_language = CellLanguage.of_language(language)
         source = safe_read_text(dependency.path)

--- a/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
+++ b/src/databricks/labs/ucx/source_code/linters/graph_walkers.py
@@ -18,7 +18,7 @@ from databricks.labs.ucx.source_code.base import (
     LocatedAdvice,
     UsedTable,
     SourceInfo,
-    file_language,
+    get_file_language_if_supported,
     is_a_notebook,
     safe_read_text,
 )
@@ -149,7 +149,7 @@ class _CollectorWalker(DependencyGraphWalker[S], abc.ABC):
         path_lookup: PathLookup,
         inherited_tree: Tree | None,
     ) -> Iterable[S]:
-        language = file_language(dependency.path)
+        language = get_file_language_if_supported(dependency.path)
         if not language:
             logger.warning(f"Unknown language for {dependency.path}")
             return

--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.base import is_a_notebook, file_language, safe_read_text
+from databricks.labs.ucx.source_code.base import is_a_notebook, get_file_language_if_supported, safe_read_text
 from databricks.labs.ucx.source_code.graph import (
     BaseNotebookResolver,
     Dependency,
@@ -102,7 +102,7 @@ class NotebookLoader(DependencyLoader):
 
     @staticmethod
     def _detect_language(path: Path, content: str) -> Language | None:
-        language = file_language(path)
+        language = get_file_language_if_supported(path)
         if language:
             return language
         for cell_language in CellLanguage:

--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.base import is_a_notebook, infer_file_language_if_supported, safe_read_text
+from databricks.labs.ucx.source_code.base import infer_file_language_if_supported, is_a_notebook, safe_read_text
 from databricks.labs.ucx.source_code.graph import (
     BaseNotebookResolver,
     Dependency,

--- a/src/databricks/labs/ucx/source_code/notebooks/loaders.py
+++ b/src/databricks/labs/ucx/source_code/notebooks/loaders.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.ucx.source_code.base import is_a_notebook, get_file_language_if_supported, safe_read_text
+from databricks.labs.ucx.source_code.base import is_a_notebook, infer_file_language_if_supported, safe_read_text
 from databricks.labs.ucx.source_code.graph import (
     BaseNotebookResolver,
     Dependency,
@@ -102,7 +102,7 @@ class NotebookLoader(DependencyLoader):
 
     @staticmethod
     def _detect_language(path: Path, content: str) -> Language | None:
-        language = get_file_language_if_supported(path)
+        language = infer_file_language_if_supported(path)
         if language:
             return language
         for cell_language in CellLanguage:


### PR DESCRIPTION
## Changes
Rename and document getting supported file language helper function to make more clear what it does.

IMO it was not clear that this function contains essential decision power as it is the filter for passing files to the linter only if they are supported (in contrast with inferring any language - also the non-supported ones). 

For example, before #3655, the `FileLinter` contains filters for extensions, however this redundant as that is already handled by this helper function.

The rename makes it more explicit what this function does. The documentation makes it more clear how to use the function

### Functionality

- [x] modified linter related code.
