### PR TITLE
Make `test_tacl` module more robust

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -254,7 +254,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def grants_crawler(self) -> GrantsCrawler:
-        return GrantsCrawler(self.tables_crawler, self.udfs_crawler, self.config.include_databases)
+        return GrantsCrawler(self.tables_crawler, self.udfs_crawler, include_databases=self.config.include_databases)
 
     @cached_property
     def grant_ownership(self) -> GrantOwnership:
@@ -262,7 +262,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def udfs_crawler(self) -> UdfsCrawler:
-        return UdfsCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
+        return UdfsCrawler(self.sql_backend, self.inventory_database, include_databases=self.config.include_databases)
 
     @cached_property
     def udf_ownership(self) -> UdfOwnership:
@@ -274,7 +274,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def tables_crawler(self) -> TablesCrawler:
-        return TablesCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
+        return TablesCrawler(self.sql_backend, self.inventory_database, include_databases=self.config.include_databases)
 
     @cached_property
     def jobs_crawler(self) -> JobsCrawler:

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -121,7 +121,9 @@ class RuntimeContext(GlobalContext):
     def tables_crawler(self) -> TablesCrawler:
         # Warning: Not all runtime contexts support the fast-scan implementation; it requires the JVM bridge to Spark
         # and that's not always available.
-        return FasterTableScanCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
+        return FasterTableScanCrawler(
+            self.sql_backend, self.inventory_database, include_databases=self.config.include_databases
+        )
 
     @cached_property
     def tables_in_mounts(self) -> TablesInMounts:

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -271,7 +271,7 @@ class GrantsCrawler(CrawlerBase[Grant]):
             partial(self.grants, catalog=catalog, any_file=True),
             partial(self.grants, catalog=catalog, anonymous_function=True),
         ]
-        if not self._include_databases:
+        if self._include_databases is None:
             # scan all databases, even empty ones
             for row in self._fetch(f"SHOW DATABASES FROM {escape_sql_identifier(catalog)}"):
                 tasks.append(partial(self.grants, catalog=catalog, database=row.databaseName))

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -218,7 +218,7 @@ CLUSTER_WITHOUT_ACL_FRAGMENT = "Table Access Control is not enabled on this clus
 class GrantsCrawler(CrawlerBase[Grant]):
     """Crawler that captures access controls that relate to data and other securable objects."""
 
-    def __init__(self, tables_crawler: TablesCrawler, udf: UdfsCrawler, include_databases: list[str] | None = None):
+    def __init__(self, tables_crawler: TablesCrawler, udf: UdfsCrawler, *, include_databases: list[str] | None = None):
         assert tables_crawler._sql_backend == udf._sql_backend
         assert tables_crawler._catalog == udf._catalog
         assert tables_crawler._schema == udf._schema

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -301,7 +301,12 @@ class GrantsCrawler(CrawlerBase[Grant]):
             principal_permissions[grant.principal].add(grant.action_type)
         return principal_permissions
 
-    def for_schema_info(self, schema: SchemaInfo):
+    def for_schema_info(self, schema: SchemaInfo) -> dict[str, set[str]]:
+        """Get the grants for a schema.
+
+        Returns :
+            dict[str, set[str]] : A dictionary of principal to set of action types.
+        """
         principal_permissions = defaultdict(set)
         for grant in self.grants(catalog=schema.catalog_name, database=schema.name):
             principal_permissions[grant.principal].add(grant.action_type)

--- a/src/databricks/labs/ucx/hive_metastore/table_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_migrate.py
@@ -66,7 +66,7 @@ class TablesMigrator:
             if not migration_index.is_migrated(crawled_table.database, crawled_table.name):
                 logger.warning(f"remained-hive-metastore-table: {crawled_table.key}")
 
-    def index(self, *, force_refresh: bool = False):
+    def index(self, *, force_refresh: bool = False) -> TableMigrationIndex:
         return self._migration_status_refresher.index(force_refresh=force_refresh)
 
     def convert_managed_hms_to_external(

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -422,16 +422,16 @@ class TablesCrawler(CrawlerBase[Table]):
         self._include_database = include_databases
 
     def _all_databases(self) -> list[str]:
-        if not self._include_database:
-            databases = []
-            for row in self._fetch("SHOW DATABASES"):
-                database = row[0]
-                if database == self._schema:
-                    logger.debug(f"Skipping UCX inventory schema: {database}")
-                    continue
-                databases.append(database)
-            return databases
-        return self._include_database
+        if self._include_database is not None:
+            return self._include_database
+        databases = []
+        for row in self._fetch("SHOW DATABASES"):
+            database = row[0]
+            if database == self._schema:
+                logger.debug(f"Skipping UCX inventory schema: {database}")
+                continue
+            databases.append(database)
+        return databases
 
     def load_one(self, schema_name: str, table_name: str) -> Table | None:
         query = f"SELECT * FROM {escape_sql_identifier(self.full_name)} WHERE database='{schema_name}' AND name='{table_name}' LIMIT 1"

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -586,7 +586,7 @@ class FasterTableScanCrawler(TablesCrawler):
         return scala_option.get() if scala_option.isDefined() else None
 
     def _all_databases(self) -> list[str]:
-        if self._include_databases:
+        if self._include_databases is not None:
             return self._include_databases
         try:
             return list(self._iterator(self._external_catalog.listDatabases()))

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -410,7 +410,7 @@ class MigrationCount:
 
 
 class TablesCrawler(CrawlerBase[Table]):
-    def __init__(self, sql_backend: SqlBackend, schema, include_databases: list[str] | None = None):
+    def __init__(self, sql_backend: SqlBackend, schema, *, include_databases: list[str] | None = None):
         """
         Initializes a TablesCrawler instance.
 
@@ -562,14 +562,14 @@ class FasterTableScanCrawler(TablesCrawler):
     Databricks workspace.
     """
 
-    def __init__(self, sql_backend: SqlBackend, schema, include_databases: list[str] | None = None):
+    def __init__(self, sql_backend: SqlBackend, schema, *, include_databases: list[str] | None = None):
         self._sql_backend = sql_backend
         self._include_databases = include_databases
 
         # pylint: disable-next=import-error,import-outside-toplevel
         from pyspark.sql.session import SparkSession  # type: ignore[import-not-found]
 
-        super().__init__(sql_backend, schema, include_databases)
+        super().__init__(sql_backend, schema, include_databases=include_databases)
         self._spark = SparkSession.builder.getOrCreate()
 
     @cached_property

--- a/src/databricks/labs/ucx/hive_metastore/tables.py
+++ b/src/databricks/labs/ucx/hive_metastore/tables.py
@@ -419,11 +419,11 @@ class TablesCrawler(CrawlerBase[Table]):
             schema: The schema name for the inventory persistence.
         """
         super().__init__(sql_backend, "hive_metastore", schema, "tables", Table)
-        self._include_database = include_databases
+        self._include_databases = include_databases
 
     def _all_databases(self) -> list[str]:
-        if self._include_database is not None:
-            return self._include_database
+        if self._include_databases is not None:
+            return self._include_databases
         databases = []
         for row in self._fetch("SHOW DATABASES"):
             database = row[0]
@@ -564,7 +564,7 @@ class FasterTableScanCrawler(TablesCrawler):
 
     def __init__(self, sql_backend: SqlBackend, schema, include_databases: list[str] | None = None):
         self._sql_backend = sql_backend
-        self._include_database = include_databases
+        self._include_databases = include_databases
 
         # pylint: disable-next=import-error,import-outside-toplevel
         from pyspark.sql.session import SparkSession  # type: ignore[import-not-found]
@@ -586,8 +586,8 @@ class FasterTableScanCrawler(TablesCrawler):
         return scala_option.get() if scala_option.isDefined() else None
 
     def _all_databases(self) -> list[str]:
-        if self._include_database:
-            return self._include_database
+        if self._include_databases:
+            return self._include_databases
         try:
             return list(self._iterator(self._external_catalog.listDatabases()))
         except Exception as err:  # pylint: disable=broad-exception-caught

--- a/src/databricks/labs/ucx/hive_metastore/udfs.py
+++ b/src/databricks/labs/ucx/hive_metastore/udfs.py
@@ -54,9 +54,9 @@ class UdfsCrawler(CrawlerBase[Udf]):
         self._include_database = include_databases
 
     def _all_databases(self) -> list[str]:
-        if not self._include_database:
-            return [row[0] for row in self._fetch("SHOW DATABASES")]
-        return self._include_database
+        if self._include_database is not None:
+            return self._include_database
+        return [row[0] for row in self._fetch("SHOW DATABASES")]
 
     def _try_fetch(self) -> Iterable[Udf]:
         """Tries to load udf information from the database or throws TABLE_OR_VIEW_NOT_FOUND error"""

--- a/src/databricks/labs/ucx/hive_metastore/udfs.py
+++ b/src/databricks/labs/ucx/hive_metastore/udfs.py
@@ -51,11 +51,11 @@ class UdfsCrawler(CrawlerBase[Udf]):
             schema: The schema name for the inventory persistence.
         """
         super().__init__(sql_backend, "hive_metastore", schema, "udfs", Udf)
-        self._include_database = include_databases
+        self._include_databases = include_databases
 
     def _all_databases(self) -> list[str]:
-        if self._include_database is not None:
-            return self._include_database
+        if self._include_databases is not None:
+            return self._include_databases
         return [row[0] for row in self._fetch("SHOW DATABASES")]
 
     def _try_fetch(self) -> Iterable[Udf]:

--- a/src/databricks/labs/ucx/hive_metastore/udfs.py
+++ b/src/databricks/labs/ucx/hive_metastore/udfs.py
@@ -42,7 +42,7 @@ class Udf:  # pylint: disable=too-many-instance-attributes
 
 
 class UdfsCrawler(CrawlerBase[Udf]):
-    def __init__(self, sql_backend: SqlBackend, schema: str, include_databases: list[str] | None = None):
+    def __init__(self, sql_backend: SqlBackend, schema: str, *, include_databases: list[str] | None = None):
         """
         Initializes a UdfsCrawler instance.
 

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -25,6 +25,9 @@ def test_running_real_assessment_job(
         ),
     )
 
+    installation_ctx.sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{ws_group.display_name}`")
+    installation_ctx.sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{ws_group.display_name}`")
+
     source_schema = installation_ctx.make_schema(catalog_name="hive_metastore")
     managed_table = installation_ctx.make_table(schema_name=source_schema.name)
     external_table = installation_ctx.make_table(schema_name=source_schema.name, external=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -662,7 +662,7 @@ class MockRuntimeContext(
         Overrides the FasterTableScanCrawler with TablesCrawler used as DBR is not available while running integration tests
         :return: TablesCrawler
         """
-        return TablesCrawler(self.sql_backend, self.inventory_database, self.config.include_databases)
+        return TablesCrawler(self.sql_backend, self.inventory_database, include_databases=self.config.include_databases)
 
     def save_tables(self, is_hiveserde: bool = False):
         # populate the tables crawled, as it is used by get_tables_to_migrate in the migrate-tables workflow

--- a/tests/integration/hive_metastore/test_tables.py
+++ b/tests/integration/hive_metastore/test_tables.py
@@ -34,7 +34,7 @@ def test_describe_all_tables_in_databases(ws, sql_backend, inventory_schema, mak
     schema_c = make_schema(catalog_name="hive_metastore")
     make_table(schema_name=schema_c.name)
 
-    tables = TablesCrawler(sql_backend, inventory_schema, [schema_a.name, schema_b.name])
+    tables = TablesCrawler(sql_backend, inventory_schema, include_databases=[schema_a.name, schema_b.name])
 
     all_tables = {}
     for table in tables.snapshot():
@@ -75,7 +75,7 @@ def test_partitioned_tables(ws, sql_backend, make_schema, make_table):
 
     inventory_schema = make_schema(catalog_name="hive_metastore")
 
-    tables = TablesCrawler(sql_backend, inventory_schema.name, [schema.name])
+    tables = TablesCrawler(sql_backend, inventory_schema.name, include_databases=[schema.name])
 
     all_tables = {}
     for table in tables.snapshot():

--- a/tests/integration/hive_metastore/test_udfs.py
+++ b/tests/integration/hive_metastore/test_udfs.py
@@ -18,7 +18,7 @@ def test_describe_all_udfs_in_databases(ws, sql_backend, inventory_schema, make_
     hive_udf = make_udf(schema_name=schema_a.name, hive_udf=True)
     make_udf(schema_name=schema_b.name)
 
-    udfs_crawler = UdfsCrawler(sql_backend, inventory_schema, [schema_a.name, schema_b.name])
+    udfs_crawler = UdfsCrawler(sql_backend, inventory_schema, include_databases=[schema_a.name, schema_b.name])
     udfs = udfs_crawler.snapshot()
 
     assert len(udfs) == 3

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -92,18 +92,18 @@ def test_permission_for_udfs_migration_api(ws, sql_backend, runtime_ctx, migrate
     assert {"READ_METADATA"} == actual_udf_b_grants[migrated_group.name_in_account]
 
 
-def test_permission_for_files_anonymous_func(sql_backend, runtime_ctx, make_group) -> None:
-    old = make_group()
-    new = make_group()
+def test_permission_for_files_anonymous_func(runtime_ctx) -> None:
+    old = runtime_ctx.make_group()
+    new = runtime_ctx.make_group()
     logger.debug(f"old={old.display_name}, new={new.display_name}")
 
-    sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{old.display_name}`")
-    sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{old.display_name}`")
+    runtime_ctx.sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{old.display_name}`")
+    runtime_ctx.sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{old.display_name}`")
 
     # Ignoring database, table and UDF grants by replacing the created_databases with an empty list
     grants = runtime_ctx.replace(created_databases=[]).grants_crawler
 
-    tacl_support = TableAclSupport(grants, sql_backend)
+    tacl_support = TableAclSupport(grants, runtime_ctx.sql_backend)
     apply_tasks(tacl_support, [MigratedGroup.partial_info(old, new)])
 
     any_file_actual = {grant.principal: grant.action_type for grant in grants.grants(any_file=True)}

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -92,7 +92,7 @@ def test_permission_for_udfs_migration_api(ws, sql_backend, runtime_ctx, migrate
     assert {"READ_METADATA"} == actual_udf_b_grants[migrated_group.name_in_account]
 
 
-def test_permission_for_files_anonymous_func(sql_backend, runtime_ctx, make_group):
+def test_permission_for_files_anonymous_func(sql_backend, runtime_ctx, make_group) -> None:
     old = make_group()
     new = make_group()
     logger.debug(f"old={old.display_name}, new={new.display_name}")
@@ -100,7 +100,8 @@ def test_permission_for_files_anonymous_func(sql_backend, runtime_ctx, make_grou
     sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{old.display_name}`")
     sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{old.display_name}`")
 
-    grants = runtime_ctx.grants_crawler
+    # Ignoring database, table and UDF grants by replacing the created_databases with an empty list
+    grants = runtime_ctx.replace(created_databases=[]).grants_crawler
 
     tacl_support = TableAclSupport(grants, sql_backend)
     apply_tasks(tacl_support, [MigratedGroup.partial_info(old, new)])

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -106,23 +106,18 @@ def test_permission_for_files_anonymous_func(sql_backend, runtime_ctx, make_grou
     tacl_support = TableAclSupport(grants, sql_backend)
     apply_tasks(tacl_support, [MigratedGroup.partial_info(old, new)])
 
-    any_file_actual = {}
-    for any_file_grant in grants.grants(any_file=True):
-        any_file_actual[any_file_grant.principal] = any_file_grant.action_type
+    any_file_actual = {grant.principal: grant.action_type for grant in grants.grants(any_file=True)}
+    assert old.display_name in any_file_actual, "Old group misses ANY FILE permission"
+    assert new.display_name in any_file_actual, "New group misses ANY FILE permission"
+    assert any_file_actual[old.display_name] == any_file_actual[new.display_name], "ANY FILE permissions differ"
 
-    # both old and new group have permissions
-    assert old.display_name in any_file_actual
-    assert new.display_name in any_file_actual
-    assert any_file_actual[old.display_name] == any_file_actual[new.display_name]
-
-    anonymous_function_actual = {}
-    for ano_func_grant in grants.grants(anonymous_function=True):
-        anonymous_function_actual[ano_func_grant.principal] = ano_func_grant.action_type
-
-    assert old.display_name in anonymous_function_actual
-    assert new.display_name in anonymous_function_actual
-    assert anonymous_function_actual[new.display_name] == "SELECT"
-    assert anonymous_function_actual[old.display_name] == anonymous_function_actual[new.display_name]
+    anonymous_function_actual = {grant.principal: grant.action_type for grant in grants.grants(anonymous_function=True)}
+    assert old.display_name in anonymous_function_actual, "Old group misses ANONYMOUS FUNCTION permission"
+    assert new.display_name in anonymous_function_actual, "New group misses ANONYMOUS FUNCTION permission"
+    assert anonymous_function_actual[new.display_name] == "SELECT", "New group misses SELECT permission"
+    assert (
+        anonymous_function_actual[old.display_name] == anonymous_function_actual[new.display_name]
+    ), "ANONYMOUS FUNCTION permissions differ"
 
 
 def test_hms2hms_owner_permissions(sql_backend, runtime_ctx, make_group_pair):

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -216,29 +216,28 @@ def test_hms2hms_owner_permissions(runtime_ctx, make_group_pair) -> None:
     }, second.name_in_account
 
 
-def test_permission_for_udfs(sql_backend, runtime_ctx, make_group_pair):
+def test_permission_for_udfs(runtime_ctx, make_group_pair) -> None:
+    # TODO: Move `make_group_pair` into `runtime_ctx`
+    ctx = runtime_ctx
     group = make_group_pair()
-    schema = runtime_ctx.make_schema()
-    udf_a = runtime_ctx.make_udf(schema_name=schema.name)
-    udf_b = runtime_ctx.make_udf(schema_name=schema.name)
+    schema = ctx.make_schema()
+    udf_a = ctx.make_udf(schema_name=schema.name)
+    udf_b = ctx.make_udf(schema_name=schema.name)
 
-    sql_backend.execute(f"GRANT SELECT ON FUNCTION {udf_a.full_name} TO `{group.name_in_workspace}`")
-    sql_backend.execute(f"ALTER FUNCTION {udf_a.full_name} OWNER TO `{group.name_in_workspace}`")
-    sql_backend.execute(f"GRANT READ_METADATA ON FUNCTION {udf_b.full_name} TO `{group.name_in_workspace}`")
-    sql_backend.execute(f"DENY `SELECT` ON FUNCTION {udf_b.full_name} TO `{group.name_in_workspace}`")
+    ctx.sql_backend.execute(f"GRANT SELECT ON FUNCTION {udf_a.full_name} TO `{group.name_in_workspace}`")
+    ctx.sql_backend.execute(f"ALTER FUNCTION {udf_a.full_name} OWNER TO `{group.name_in_workspace}`")
+    ctx.sql_backend.execute(f"GRANT READ_METADATA ON FUNCTION {udf_b.full_name} TO `{group.name_in_workspace}`")
+    ctx.sql_backend.execute(f"DENY `SELECT` ON FUNCTION {udf_b.full_name} TO `{group.name_in_workspace}`")
 
-    grants = runtime_ctx.grants_crawler
+    grants = ctx.grants_crawler
 
-    all_initial_grants = set()
-    for grant in grants.snapshot():
-        all_initial_grants.add(f"{grant.principal}.{grant.object_key}:{grant.action_type}")
-
+    all_initial_grants = {f"{grant.principal}.{grant.object_key}:{grant.action_type}" for grant in grants.snapshot()}
     assert f"{group.name_in_workspace}.{udf_a.full_name}:SELECT" in all_initial_grants
     assert f"{group.name_in_workspace}.{udf_a.full_name}:OWN" in all_initial_grants
     assert f"{group.name_in_workspace}.{udf_b.full_name}:READ_METADATA" in all_initial_grants
     assert f"{group.name_in_workspace}.{udf_b.full_name}:DENIED_SELECT" in all_initial_grants
 
-    tacl_support = TableAclSupport(grants, sql_backend)
+    tacl_support = TableAclSupport(grants, ctx.sql_backend)
     apply_tasks(tacl_support, [group])
 
     actual_udf_a_grants = defaultdict(set)

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -2,13 +2,28 @@ import json
 import logging
 from collections import defaultdict
 
+import pytest
+from databricks.labs.lsql.backends import CommandExecutionBackend, SqlBackend
+
 from databricks.labs.ucx.workspace_access.base import Permissions
 from databricks.labs.ucx.workspace_access.groups import MigratedGroup, MigrationState
 from databricks.labs.ucx.workspace_access.tacl import TableAclSupport
 
 from . import apply_tasks
 
+
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def sql_backend(ws, env_or_skip) -> SqlBackend:
+    """Ensure the SQL backend in this module is table access control list enabled.
+
+    We have a separate (legacy) cluster for table access control list. This
+    ensures the tests in this module to be closer to the assessment workflow.
+    """
+    cluster_id = env_or_skip("TEST_LEGACY_TABLE_ACL_CLUSTER_ID")
+    return CommandExecutionBackend(ws, cluster_id)
 
 
 def test_grants_with_permission_migration_api(runtime_ctx, migrated_group) -> None:

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -290,8 +290,8 @@ def test_verify_permission_for_udfs(
     _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     ctx = _prepare_context(runtime_ctx)
-    group = ctx.make_group()
-    schema = ctx.make_schema()
+    group, schema = ctx.make_group(), ctx.make_schema()
+    assert schema.full_name, "Schema should have a full name"
 
     ctx.sql_backend.execute(f"GRANT SELECT ON SCHEMA {schema.name} TO `{group.display_name}`")
 

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -35,19 +35,19 @@ def test_grants_with_permission_migration_api(runtime_ctx, migrated_group) -> No
     ctx.sql_backend.execute(f"ALTER SCHEMA {schema.name} OWNER TO `{migrated_group.name_in_workspace}`")
     ctx.sql_backend.execute(f"GRANT SELECT ON TABLE {table.full_name} TO `{migrated_group.name_in_workspace}`")
 
-    original_table_grants = {"a": ctx.grants_crawler.for_table_info(table)}
-    assert {"SELECT"} == original_table_grants["a"][migrated_group.name_in_workspace]
+    original_table_grants = ctx.grants_crawler.for_table_info(table)
+    assert {"SELECT"} == original_table_grants[migrated_group.name_in_workspace]
 
-    original_schema_grants = {"a": ctx.grants_crawler.for_schema_info(schema)}
-    assert {"USAGE", "OWN"} == original_schema_grants["a"][migrated_group.name_in_workspace]
+    original_schema_grants = ctx.grants_crawler.for_schema_info(schema)
+    assert {"USAGE", "OWN"} == original_schema_grants[migrated_group.name_in_workspace]
 
     MigrationState([migrated_group]).apply_to_groups_with_different_names(runtime_ctx.workspace_client)
 
-    new_table_grants = {"a": ctx.grants_crawler.for_table_info(table)}
-    assert {"SELECT"} == new_table_grants["a"][migrated_group.name_in_account]
+    new_table_grants = ctx.grants_crawler.for_table_info(table)
+    assert {"SELECT"} == new_table_grants[migrated_group.name_in_account]
 
-    new_schema_grants = {"a": ctx.grants_crawler.for_schema_info(schema)}
-    assert {"USAGE", "OWN"} == new_schema_grants["a"][migrated_group.name_in_account]
+    new_schema_grants = ctx.grants_crawler.for_schema_info(schema)
+    assert {"USAGE", "OWN"} == new_schema_grants[migrated_group.name_in_account]
 
 
 def test_permission_for_files_anonymous_func_migration_api(runtime_ctx, migrated_group) -> None:

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -252,11 +252,10 @@ def test_permission_for_udfs(runtime_ctx, make_group_pair) -> None:
 
 
 def test_verify_permission_for_udfs(runtime_ctx) -> None:
-    ctx = runtime_ctx
-    group = ctx.make_group()
-    schema = ctx.runtime_ctx.make_schema()
+    group = runtime_ctx.make_group()
+    schema = runtime_ctx.make_schema()
 
-    ctx.sql_backend.execute(f"GRANT SELECT ON SCHEMA {schema.name} TO `{group.display_name}`")
+    runtime_ctx.sql_backend.execute(f"GRANT SELECT ON SCHEMA {schema.name} TO `{group.display_name}`")
 
     item = Permissions(
         object_type="DATABASE",
@@ -271,7 +270,7 @@ def test_verify_permission_for_udfs(runtime_ctx) -> None:
         ),
     )
 
-    tacl_support = TableAclSupport(ctx.grants_crawler, ctx.sql_backend)
+    tacl_support = TableAclSupport(runtime_ctx.grants_crawler, runtime_ctx.sql_backend)
     task = tacl_support.get_verify_task(item)
     result = task()
 

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from databricks.labs.lsql.backends import CommandExecutionBackend, SqlBackend

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -51,7 +51,9 @@ def prepare_context_for_testing_grants(sql_backend_acl) -> Callable[[MockRuntime
 
 
 def test_grants_with_permission_migration_api(
-    runtime_ctx: MockRuntimeContext, migrated_group, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    migrated_group,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -77,7 +79,9 @@ def test_grants_with_permission_migration_api(
 
 
 def test_permission_for_files_anonymous_func_migration_api(
-    runtime_ctx: MockRuntimeContext, migrated_group, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    migrated_group,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -99,7 +103,9 @@ def test_permission_for_files_anonymous_func_migration_api(
 
 
 def test_permission_for_udfs_migration_api(
-    runtime_ctx: MockRuntimeContext, migrated_group, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    migrated_group,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -132,7 +138,8 @@ def test_permission_for_udfs_migration_api(
 
 
 def test_permission_for_files_anonymous_func(
-    runtime_ctx: MockRuntimeContext, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     """Test permission for any file and anonymous function to be migrated."""
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -159,7 +166,9 @@ def test_permission_for_files_anonymous_func(
 
 
 def test_hms2hms_owner_permissions(
-    runtime_ctx: MockRuntimeContext, make_group_pair, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    make_group_pair,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move `make_group_pair` into `runtime_ctx`
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -240,7 +249,9 @@ def test_hms2hms_owner_permissions(
 
 
 def test_permission_for_udfs(
-    runtime_ctx: MockRuntimeContext, make_group_pair, prepare_context_for_testing_grants
+    runtime_ctx: MockRuntimeContext,
+    make_group_pair,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move `make_group_pair` into `runtime_ctx`
     ctx = prepare_context_for_testing_grants(runtime_ctx)
@@ -274,7 +285,10 @@ def test_permission_for_udfs(
     assert {"READ_METADATA", "DENIED_SELECT"} == actual_udf_b_grants[group.name_in_account]
 
 
-def test_verify_permission_for_udfs(runtime_ctx: MockRuntimeContext, prepare_context_for_testing_grants) -> None:
+def test_verify_permission_for_udfs(
+    runtime_ctx: MockRuntimeContext,
+    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+) -> None:
     ctx = prepare_context_for_testing_grants(runtime_ctx)
     group = ctx.make_group()
     schema = ctx.make_schema()

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -251,11 +251,12 @@ def test_permission_for_udfs(runtime_ctx, make_group_pair) -> None:
     assert {"READ_METADATA", "DENIED_SELECT"} == actual_udf_b_grants[group.name_in_account]
 
 
-def test_verify_permission_for_udfs(sql_backend, runtime_ctx, make_group):
-    group = make_group()
-    schema = runtime_ctx.make_schema()
+def test_verify_permission_for_udfs(runtime_ctx) -> None:
+    ctx = runtime_ctx
+    group = ctx.make_group()
+    schema = ctx.runtime_ctx.make_schema()
 
-    sql_backend.execute(f"GRANT SELECT ON SCHEMA {schema.name} TO `{group.display_name}`")
+    ctx.sql_backend.execute(f"GRANT SELECT ON SCHEMA {schema.name} TO `{group.display_name}`")
 
     item = Permissions(
         object_type="DATABASE",
@@ -270,9 +271,7 @@ def test_verify_permission_for_udfs(sql_backend, runtime_ctx, make_group):
         ),
     )
 
-    grants = runtime_ctx.grants_crawler
-
-    tacl_support = TableAclSupport(grants, sql_backend)
+    tacl_support = TableAclSupport(ctx.grants_crawler, ctx.sql_backend)
     task = tacl_support.get_verify_task(item)
     result = task()
 

--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def sql_backend_acl(ws, env_or_skip) -> SqlBackend:
+def _sql_backend_acl(ws, env_or_skip) -> SqlBackend:
     """Ensure the SQL backend in this module is table access control list enabled.
 
     We have a separate (legacy) cluster for table access control list. This
@@ -29,7 +29,7 @@ def sql_backend_acl(ws, env_or_skip) -> SqlBackend:
 
 
 @pytest.fixture
-def prepare_context_for_testing_grants(sql_backend_acl) -> Callable[[MockRuntimeContext], MockRuntimeContext]:
+def _prepare_context(_sql_backend_acl) -> Callable[[MockRuntimeContext], MockRuntimeContext]:
     """See inner :func:`prepare` function"""
 
     def prepare(context: MockRuntimeContext):
@@ -45,7 +45,7 @@ def prepare_context_for_testing_grants(sql_backend_acl) -> Callable[[MockRuntime
         context.make_udf()
         context.tables_crawler.snapshot(force_refresh=True)
         context.udfs_crawler.snapshot(force_refresh=True)
-        return context.replace(sql_backend=sql_backend_acl)
+        return context.replace(sql_backend=_sql_backend_acl)
 
     return prepare
 
@@ -53,10 +53,10 @@ def prepare_context_for_testing_grants(sql_backend_acl) -> Callable[[MockRuntime
 def test_grants_with_permission_migration_api(
     runtime_ctx: MockRuntimeContext,
     migrated_group,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     schema = ctx.make_schema()
     table = ctx.make_table(schema_name=schema.name)
     ctx.sql_backend.execute(f"GRANT USAGE ON SCHEMA {schema.name} TO `{migrated_group.name_in_workspace}`")
@@ -81,10 +81,10 @@ def test_grants_with_permission_migration_api(
 def test_permission_for_files_anonymous_func_migration_api(
     runtime_ctx: MockRuntimeContext,
     migrated_group,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     ctx.sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{migrated_group.name_in_workspace}`")
     ctx.sql_backend.execute(f"GRANT SELECT ON ANONYMOUS FUNCTION TO `{migrated_group.name_in_workspace}`")
 
@@ -105,10 +105,10 @@ def test_permission_for_files_anonymous_func_migration_api(
 def test_permission_for_udfs_migration_api(
     runtime_ctx: MockRuntimeContext,
     migrated_group,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move migrated group into `runtime_ctx` and follow the `make_` pattern
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     schema = ctx.make_schema()
     udf_a = ctx.make_udf(schema_name=schema.name)
     udf_b = ctx.make_udf(schema_name=schema.name)
@@ -139,10 +139,10 @@ def test_permission_for_udfs_migration_api(
 
 def test_permission_for_files_anonymous_func(
     runtime_ctx: MockRuntimeContext,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     """Test permission for any file and anonymous function to be migrated."""
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
 
     old, new = ctx.make_group(), ctx.make_group()
     ctx.sql_backend.execute(f"GRANT READ_METADATA ON ANY FILE TO `{old.display_name}`")
@@ -168,10 +168,10 @@ def test_permission_for_files_anonymous_func(
 def test_hms2hms_owner_permissions(
     runtime_ctx: MockRuntimeContext,
     make_group_pair,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move `make_group_pair` into `runtime_ctx`
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     first = make_group_pair()
     second = make_group_pair()
     third = make_group_pair()
@@ -251,10 +251,10 @@ def test_hms2hms_owner_permissions(
 def test_permission_for_udfs(
     runtime_ctx: MockRuntimeContext,
     make_group_pair,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
     # TODO: Move `make_group_pair` into `runtime_ctx`
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     group = make_group_pair()
     schema = ctx.make_schema()
     udf_a = ctx.make_udf(schema_name=schema.name)
@@ -287,9 +287,9 @@ def test_permission_for_udfs(
 
 def test_verify_permission_for_udfs(
     runtime_ctx: MockRuntimeContext,
-    prepare_context_for_testing_grants: Callable[[MockRuntimeContext], MockRuntimeContext],
+    _prepare_context: Callable[[MockRuntimeContext], MockRuntimeContext],
 ) -> None:
-    ctx = prepare_context_for_testing_grants(runtime_ctx)
+    ctx = _prepare_context(runtime_ctx)
     group = ctx.make_group()
     schema = ctx.make_schema()
 

--- a/tests/unit/hive_metastore/test_tables.py
+++ b/tests/unit/hive_metastore/test_tables.py
@@ -372,7 +372,7 @@ def test_tables_crawler_should_filter_by_database():
         "SHOW TABLES FROM `hive_metastore`.`database_2`": [("", "table1", "")],
     }
     backend = MockBackend(rows=rows)
-    tables_crawler = TablesCrawler(backend, "default", ["database"])
+    tables_crawler = TablesCrawler(backend, "default", include_databases=["database"])
     results = tables_crawler.snapshot()
     assert len(results) == 2
     assert sorted(backend.queries) == sorted(

--- a/tests/unit/hive_metastore/test_udfs.py
+++ b/tests/unit/hive_metastore/test_udfs.py
@@ -47,7 +47,7 @@ def test_tables_crawler_should_filter_by_database():
         "SHOW USER FUNCTIONS FROM `hive_metastore`.`database`": SHOW_FUNCTIONS[("hive_metastore.database.function1",),],
     }
     backend = MockBackend(rows=rows)
-    udf_crawler = UdfsCrawler(backend, "default", ["database"])
+    udf_crawler = UdfsCrawler(backend, "default", include_databases=["database"])
     results = udf_crawler.snapshot()
     assert len(results) == 1
 


### PR DESCRIPTION
## Changes

Make `test_tacl` module more robust:
1. Limit the crawled grants by allowing an empty `include_databases` list.
2. Use the TACL cluster for crawling grants and the "normal" cluster for crawling tables and UDF's, just like the assessment workflow

### Linked issues

Resolves #3629
Resolves #3724
Unblocks #3680

### Tests

- [x] modified integration tests: `test_permission_for_files_anonymous_func`
