### PR TITLE
Catch `AttributeError` in `InfferedValue._safe_infer_internal`

### DIFF
--- a/src/databricks/labs/ucx/source_code/python/python_infer.py
+++ b/src/databricks/labs/ucx/source_code/python/python_infer.py
@@ -69,7 +69,7 @@ class InferredValue:
     def _safe_infer_internal(cls, node: NodeNG) -> Iterator[Iterable[NodeNG]]:
         try:
             yield from cls._unsafe_infer_internal(node)
-        except (InferenceError, KeyError) as e:
+        except (InferenceError, KeyError, AttributeError) as e:
             logger.debug(f"When inferring: {node}", exc_info=e)
             yield [Uninferable]
 


### PR DESCRIPTION
## Changes

Catch `AttributeError` in `InfferedValue._safe_infer_internal` to make the inference safer. 

It is a bug in Astroid https://github.com/pylint-dev/astroid/issues/2683

### Linked issues

Resolves #3659

### Functionality

- [x] strengthen source code linting code, specifically value inference