### PR TITLE
Broaden safe read text caught exception scope

### DIFF
--- a/src/databricks/labs/ucx/source_code/base.py
+++ b/src/databricks/labs/ucx/source_code/base.py
@@ -408,7 +408,7 @@ def safe_read_text(path: Path, size: int = -1) -> str | None:
     """
     try:
         return read_text(path, size=size)
-    except (FileNotFoundError, UnicodeDecodeError, PermissionError) as e:
+    except (OSError, UnicodeError) as e:
         logger.warning(f"Could not read file: {path}", exc_info=e)
         return None
 


### PR DESCRIPTION
## Changes
Broaden safe read text exception scope to be more safe when reading a text file. Also the tests are extended.

### Linked issues

Relates to #3703
Relates to #3704

### Functionality

- [x] Changes in the code linting parts

### Tests

- [x] added unit tests
