### PR TITLE
[DOCS] Explain when to run `remove-workspace-local-backup-groups` workflow

### DIFF
--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -1,8 +1,9 @@
 # Workflows
 
-Part of this application is deployed as [Databricks Workflows](https://docs.databricks.com/en/workflows/index.html).
-You can view the status of deployed workflows via the [`workflows` command](/docs/reference/commands#workflows).
-Failed workflows can be fixed with the [`repair-run` command](/docs/reference/commands#repair-run).
+Part of UCX is deployed as [Databricks workflows](https://docs.databricks.com/en/workflows/index.html) to orchestrate
+steps of the [migration process](/docs/reference/process). You can view the status of deployed workflows through the
+[`workflows` command](/docs/reference/commands#workflows) and rerun failed workflows with the
+[`repair-run` command](/docs/reference/commands#repair-run).
 
 ## Assessment workflow
 

--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -146,10 +146,8 @@ executed after a successful run of the assessment workflow. The group migration 
    destination groups.
 
 After successfully running the group migration workflow:
-1. Run the [`remove-workspace-local-backup-grups`](/docs/reference/commands#validate-groups-membership) to remove workspace-level backup
-   groups, along with their permissions. This should only be executed after confirming that the workspace-local
-   migration worked successfully for all the groups involved. This step is necessary to clean up the workspace and
-   remove any unnecessary groups and permissions.
+1. [Remove workspace-level backup groups](#remove-workspace-local-backup-groups) along with their
+   permissions.
 2. Proceed to the [table migration process](/docs/process#table-migration-process).
 
 For additional information see:
@@ -157,7 +155,13 @@ For additional information see:
 - The [migration process diagram](/docs/process) showing the group migration workflow in context of the whole
   migration process.
 
+### Remove workspace local backup groups
 
+> Run this workflow only **after** the [group migration workflow](#group-migration-workflow)
+
+The `remove-workspace-local-backup-groups` removes the now renamed and redundant workspace-local groups along with their
+permissions. Run this workflow after confirming that the group migration is successful for all the groups involved.
+Running this workflow is optional but recommended to keep the workspace clean.
 
 ## Table migration workflows
 

--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -4,8 +4,6 @@ Part of this application is deployed as [Databricks Workflows](https://docs.data
 You can view the status of deployed workflows via the [`workflows` command](/docs/reference/commands#workflows).
 Failed workflows can be fixed with the [`repair-run` command](/docs/reference/commands#repair-run).
 
-
-
 ## Assessment workflow
 
 ![ucx_assessment_workflow](/img/ucx_assessment_workflow.png)
@@ -93,8 +91,6 @@ Proceed to the [group migration workflow](/docs/reference/workflows#group-migrat
 The UCX assessment workflow is designed to only run once, re-running will **not** update the existing results. If the
 inventory and findings for a workspace need to be updated then first reinstall UCX by [uninstalling](/docs/installation#uninstall-ucx)
 and [installing](/docs/installation) it again.
-
-
 
 ## Group migration workflow
 
@@ -238,9 +234,6 @@ The output is processed and displayed in the migration dashboard using the in `r
   - run the scan tables in mounts [workflow](/docs/reference/workflows/#experimental-migration-progress-workflow)
   - run the [`create-table-mapping` command](/docs/reference/commands#create-table-mapping)
     - or manually create a `mapping.csv` file in Workspace -> Applications -> ucx
-
-
-
 
 ## [EXPERIMENTAL] Migration Progress Workflow
 


### PR DESCRIPTION
## Changes
 Explain when to run `remove-workspace-local-backup-groups` workflow as the documentation was not clear about this.

### Functionality

- [x] added relevant user documentation
