### PR TITLE
Fixed broken anchor for doc release

### DIFF
--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -1,7 +1,7 @@
 # Workflows
 
 Part of UCX is deployed as [Databricks workflows](https://docs.databricks.com/en/workflows/index.html) to orchestrate
-steps of the [migration process](/docs/reference/process). You can view the status of deployed workflows through the
+steps of the [migration process](/docs/process). You can view the status of deployed workflows through the
 [`workflows` command](/docs/reference/commands#workflows) and rerun failed workflows with the
 [`repair-run` command](/docs/reference/commands#repair-run).
 


### PR DESCRIPTION
## Changes
Fixed a broken anchor referencing process from workflows

### Tests
- [x] manually tested


<img width="1095" alt="image" src="https://github.com/user-attachments/assets/95ecf5be-e852-49dd-a95c-b3398d268dc7" />

