### PR TITLE
Let `WorkflowLinter.refresh_report` lint jobs from `JobsCrawler`

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -207,7 +207,7 @@ class Assessment(Workflow):  # pylint: disable=too-many-public-methods
         """
         ctx.query_linter.refresh_report()
 
-    @job_task
+    @job_task(depends_on=[assess_jobs])
     def assess_workflows(self, ctx: RuntimeContext):
         """Scans all jobs for migration issues in notebooks jobs.
 

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -584,13 +584,12 @@ class GlobalContext(abc.ABC):
     def workflow_linter(self) -> WorkflowLinter:
         return WorkflowLinter(
             self.workspace_client,
+            self.jobs_crawler,
             self.dependency_resolver,
             self.path_lookup,
             TableMigrationIndex([]),  # TODO: bring back self.tables_migrator.index()
             self.directfs_access_crawler_for_paths,
             self.used_tables_crawler_for_paths,
-            self.config.include_job_ids,
-            self.config.debug_listing_upper_limit,
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -12,6 +12,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.service import jobs
 
+from databricks.labs.ucx.assessment.jobs import JobsCrawler
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationIndex
 from databricks.labs.ucx.source_code.base import (
     DirectFsAccess,
@@ -40,37 +41,25 @@ class WorkflowLinter:
     def __init__(
         self,
         ws: WorkspaceClient,
+        jobs_crawler: JobsCrawler,
         resolver: DependencyResolver,
         path_lookup: PathLookup,
         migration_index: TableMigrationIndex,
         directfs_crawler: DirectFsAccessCrawler,
         used_tables_crawler: UsedTablesCrawler,
-        include_job_ids: list[int] | None = None,
-        debug_listing_upper_limit: int | None = None,
     ):
         self._ws = ws
+        self._jobs_crawler = jobs_crawler
         self._resolver = resolver
         self._path_lookup = path_lookup
         self._migration_index = migration_index
         self._directfs_crawler = directfs_crawler
         self._used_tables_crawler = used_tables_crawler
-        self._include_job_ids = include_job_ids
-        self._debug_listing_upper_limit = debug_listing_upper_limit
 
     def refresh_report(self, sql_backend: SqlBackend, inventory_database: str) -> None:
         tasks = []
-        items_listed = 0
-        for job in self._ws.jobs.list():
-            if self._include_job_ids is not None and job.job_id not in self._include_job_ids:
-                logger.info(f"Skipping job_id={job.job_id}")
-                continue
-            if self._debug_listing_upper_limit is not None and items_listed >= self._debug_listing_upper_limit:
-                logger.warning(f"Debug listing limit reached: {self._debug_listing_upper_limit}")
-                break
-            if job.settings is not None and job.settings.name is not None:
-                logger.info(f"Found job_id={job.job_id}: {job.settings.name}")
+        for job in self._jobs_crawler.snapshot():
             tasks.append(functools.partial(self.lint_job, job.job_id))
-            items_listed += 1
         logger.info(f"Running {len(tasks)} linting tasks in parallel...")
         job_results, errors = Threads.gather('linting workflows', tasks)
         job_problems: list[JobProblem] = []

--- a/tests/integration/assessment/test_workflows.py
+++ b/tests/integration/assessment/test_workflows.py
@@ -47,5 +47,5 @@ def test_running_real_assessment_job(
     assert actual_tables == expected_tables
 
     query = f"SELECT * FROM {installation_ctx.inventory_database}.workflow_problems"
-    for row in sql_backend.fetch(query):
-        assert row['path'] != 'UNKNOWN'
+    workflow_problems_without_path = [problem for problem in sql_backend.fetch(query) if problem["path"] == "UNKNOWN"]
+    assert not workflow_problems_without_path

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -78,8 +78,6 @@ def test_lakeview_query_dfsa_ownership(runtime_ctx) -> None:
 
 def test_path_dfsa_ownership(
     runtime_ctx,
-    make_notebook,
-    make_job,
     make_directory,
     inventory_schema,
     sql_backend,
@@ -88,18 +86,18 @@ def test_path_dfsa_ownership(
 
     # A job with a notebook task that contains direct filesystem access.
     notebook_source = b"display(spark.read.csv('/mnt/things/e/f/g'))"
-    notebook = make_notebook(path=f"{make_directory()}/notebook.py", content=notebook_source)
-    job = make_job(notebook_path=notebook)
+    notebook = runtime_ctx.make_notebook(path=f"{make_directory()}/notebook.py", content=notebook_source)
+    runtime_ctx.make_job(notebook_path=notebook)
 
     # Produce a DFSA record for the job.
     linter = WorkflowLinter(
         runtime_ctx.workspace_client,
+        runtime_ctx.jobs_crawler,
         runtime_ctx.dependency_resolver,
         runtime_ctx.path_lookup,
         TableMigrationIndex([]),
         runtime_ctx.directfs_access_crawler_for_paths,
         runtime_ctx.used_tables_crawler_for_paths,
-        include_job_ids=[job.job_id],
     )
     linter.refresh_report(sql_backend, inventory_schema)
 


### PR DESCRIPTION
## Changes

Let `WorkflowLinter.refresh_report` lint jobs from `JobsCrawler` so that we only lint what is within scope

### Linked issues

Resolves #3662
Progresses #3722

### Functionality

- [x] modified workflow linting code
- [x] modified existing workflow: `assessment`

### Tests

- [x] modified unit tests
- [x] modified integration tests
