### PR TITLE
Exclude UCX jobs from crawling

### DIFF
--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -94,12 +94,30 @@ class JobsMixin:
 
 
 class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
+    """Crawl jobs (workflows), assess them and store the result in the inventory.
+
+    Args :
+        ws (WorkspaceClient): The workspace client to crawl the jobs with.
+        sql_backend (SqlBackend): The SQL backend to store the results with.
+        schema (str): The schema to store the results in.
+        include_job_ids (list[int] | None): If provided, only include these job ids. Otherwise, include all jobs.
+        exclude_job_ids (list[int] | None): If provided, exclude these job ids. Otherwise, include all jobs. Note: We
+            prefer `include_job_ids` for more strict scoping, but sometimes it's easier to exclude a few jobs.
+    """
+
     def __init__(
-        self, ws: WorkspaceClient, sql_backend: SqlBackend, schema, *, include_job_ids: list[int] | None = None
+        self,
+        ws: WorkspaceClient,
+        sql_backend: SqlBackend,
+        schema,
+        *,
+        include_job_ids: list[int] | None = None,
+        exclude_job_ids: list[int] | None = None,
     ):
         super().__init__(sql_backend, "hive_metastore", schema, "jobs", JobInfo)
         self._ws = ws
         self._include_job_ids = include_job_ids
+        self._exclude_job_ids = exclude_job_ids
 
     def _crawl(self) -> Iterable[JobInfo]:
         all_jobs = list(self._ws.jobs.list(expand_tasks=True))

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -123,7 +123,9 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
     def _list_jobs(self) -> Iterable[BaseJob]:
         """List the jobs.
 
-        If include job ids is defined, we get the job definition for those ids.
+        If provided, excludes jobs with id in `exclude_job_ids`.
+        If provided, exclude jobs with id not in `include_job_ids`.
+        If both provided, `exclude_job_ids` takes precedence.
         """
         try:
             jobs = self._ws.jobs.list(expand_tasks=True)

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -124,7 +124,7 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
         """List the jobs.
 
         If provided, excludes jobs with id in `exclude_job_ids`.
-        If provided, exclude jobs with id not in `include_job_ids`.
+        If provided, excludes jobs with id not in `include_job_ids`.
         If both provided, `exclude_job_ids` takes precedence.
         """
         try:

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -120,34 +120,30 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
         self._include_job_ids = include_job_ids
         self._exclude_job_ids = exclude_job_ids
 
-    def _list_jobs(self) -> Iterable[BaseJob | Job]:
+    def _list_jobs(self) -> Iterable[BaseJob]:
         """List the jobs.
 
         If include job ids is defined, we get the job definition for those ids.
         """
-        if self._include_job_ids is not None:
-            yield from self._get_jobs(*self._include_job_ids)
-            return
         try:
-            yield from self._ws.jobs.list(expand_tasks=True)
+            jobs = self._ws.jobs.list(expand_tasks=True)
         except DatabricksError as e:
             logger.error("Cannot list jobs", exc_info=e)
-            return []
-
-    def _get_jobs(self, *job_ids: int) -> Iterable[Job]:
-        """Get the job definitions for the given job ids."""
-        for job_id in job_ids:
-            job = self._get_job(job_id)
-            if job:
-                yield job
-
-    def _get_job(self, job_id: int) -> Job | None:
-        """Get a job"""
-        try:
-            return self._ws.jobs.get(job_id)
-        except DatabricksError as e:
-            logger.warning(f"Cannot get job: {job_id}", exc_info=e)
-            return None
+            return
+        while True:
+            try:
+                job = next(jobs)
+                if self._exclude_job_ids is not None and job.job_id in self._exclude_job_ids:
+                    continue
+                if self._include_job_ids is None:
+                    yield job
+                elif job.job_id in self._include_job_ids:
+                    yield job
+            except DatabricksError as e:
+                logger.error("Cannot list next jobs page", exc_info=e)
+                break
+            except StopIteration:
+                break
 
     def _crawl(self) -> Iterable[JobInfo]:
         all_jobs = list(self._list_jobs())

--- a/src/databricks/labs/ucx/assessment/jobs.py
+++ b/src/databricks/labs/ucx/assessment/jobs.py
@@ -158,9 +158,6 @@ class JobsCrawler(CrawlerBase[JobInfo], JobsMixin, CheckClusterMixin):
             job_id = job.job_id
             if not job_id:
                 continue
-            if self._include_job_ids is not None and job_id not in self._include_job_ids:
-                logger.info(f"Skipping job_id={job_id}")
-                continue
             cluster_details = ClusterDetails.from_dict(cluster_config.as_dict())
             cluster_failures = self._check_cluster_failures(cluster_details, "Job cluster")
             cluster_failures.extend(self._check_jar_task(job.settings.tasks))

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -283,6 +283,7 @@ class GlobalContext(abc.ABC):
             self.sql_backend,
             self.inventory_database,
             include_job_ids=self.config.include_job_ids,
+            exclude_job_ids=list(self.install_state.jobs.values()),
         )
 
     @cached_property

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -16,7 +16,7 @@ from databricks.labs.ucx.assessment.clusters import (
     PolicyInfo,
 )
 from databricks.labs.ucx.assessment.init_scripts import GlobalInitScriptCrawler
-from databricks.labs.ucx.assessment.jobs import JobOwnership, JobInfo, JobsCrawler, SubmitRunsCrawler
+from databricks.labs.ucx.assessment.jobs import JobOwnership, JobInfo, SubmitRunsCrawler
 from databricks.labs.ucx.assessment.pipelines import PipelinesCrawler, PipelineInfo, PipelineOwnership
 from databricks.labs.ucx.assessment.sequencing import MigrationSequencer
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -67,15 +67,6 @@ class RuntimeContext(GlobalContext):
     def installation(self) -> Installation:
         install_folder = self._config_path.parent.as_posix().removeprefix("/Workspace")
         return Installation(self.workspace_client, "ucx", install_folder=install_folder)
-
-    @cached_property
-    def jobs_crawler(self) -> JobsCrawler:
-        return JobsCrawler(
-            self.workspace_client,
-            self.sql_backend,
-            self.inventory_database,
-            include_job_ids=self.config.include_job_ids,
-        )
 
     @cached_property
     def job_ownership(self) -> JobOwnership:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -631,10 +631,9 @@ class MockRuntimeContext(
         self.make_job(content="spark.table('old.stuff')")
         self.make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
         self.make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
-        query_1 = self.make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
-        self._make_dashboard(query=query_1)
-        query_2 = self.make_query(sql_query='SELECT * from my_schema.my_table')
-        self._make_dashboard(query=query_2)
+        query_1 = self.make_query(sql_query="SELECT * from parquet.`dbfs://mnt/foo2/bar2`")
+        self.make_dashboard(query=query_1)
+        self.make_lakeview_dashboard(query="SELECT * from my_schema.my_table")
 
     def add_table(self, table: TableInfo):
         self._tables.append(table)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -193,6 +193,13 @@ def mock_workspace_client(
                 {'workspace_id': 789, 'deployment_name': 'test3'},
             ]
         ),
+        'state.json': json.dumps(
+            {
+                'resources': {
+                    'jobs': {'test': '123', 'assessment': '456'},
+                }
+            }
+        ),
     }
     ws.workspace.download.side_effect = lambda file_name, *, format=None: io.StringIO(
         download_yaml[os.path.basename(file_name)]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -165,7 +165,7 @@ def mock_workspace_client(
     ws.pipelines.get = _pipeline
     ws.workspace.get_status = lambda _: ObjectInfo(object_id=123)
     ws.get_workspace_id.return_value = 123
-    ws.jobs.list.return_value = _id_list(BaseJob, job_ids)
+    ws.jobs.list.return_value = iter(_id_list(BaseJob, job_ids))
     ws.jobs.list_runs.return_value = _id_list(BaseRun, jobruns_ids)
     ws.warehouses.get_workspace_warehouse_config().data_access_config = _load_list(EndpointConfPair, warehouse_config)
     ws.workspace.export = _workspace_export

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -99,12 +99,7 @@ def test_job_crawler_skips_all_jobs_with_empty_include_job_ids() -> None:
 def test_job_crawler_include_job_ids() -> None:
     """Only jobs with IDs in `include_job_ids` should be crawled."""
 
-    def _get_job(job_id: int) -> Job:
-        """Mock getting a job"""
-        return Job(job_id=job_id, settings=JobSettings(), creator_user_name=None)
-
     ws = mock_workspace_client()
-    ws.jobs.get.side_effect = _get_job
     ws.jobs.list.return_value = iter([
         BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
         BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -4,7 +4,7 @@ import pytest
 from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.core import Row
 from databricks.labs.ucx.progress.history import ProgressEncoder
-from databricks.sdk.service.jobs import BaseJob, JobSettings
+from databricks.sdk.service.jobs import BaseJob, Job, JobSettings
 
 from databricks.labs.ucx.__about__ import __version__ as ucx_version
 from databricks.labs.ucx.assessment.jobs import JobInfo, JobOwnership, JobsCrawler, SubmitRunsCrawler
@@ -78,6 +78,40 @@ def test_job_crawler_creator():
     crawled_creators = [record.creator for record in result]
     assert len(expected_creators) == len(crawled_creators)
     assert set(expected_creators) == set(crawled_creators)
+
+
+def test_job_crawler_skips_all_jobs_with_empty_include_job_ids() -> None:
+    """If `include_job_ids` is empty, all jobs should be skipped."""
+    ws = mock_workspace_client()
+    ws.jobs.list.return_value = (
+        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+    )
+
+    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[]).snapshot(force_refresh=True)
+
+    assert not result
+
+
+def test_job_crawler_include_job_ids() -> None:
+    """Only jobs with IDs in `include_job_ids` should be crawled."""
+
+    def _get_job(job_id: int) -> Job:
+        """Mock getting a job"""
+        return Job(job_id=job_id, settings=JobSettings(), creator_user_name=None)
+
+    ws = mock_workspace_client()
+    ws.jobs.get.side_effect = _get_job
+    ws.jobs.list.return_value = (
+        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+    )
+
+    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1]).snapshot(force_refresh=True)
+
+    assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -133,6 +133,23 @@ def test_job_crawler_exclude_job_ids() -> None:
     assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
 
 
+def test_job_crawler_exclude_job_ids_takes_preference_over_include_job_ids() -> None:
+    """The jobs with IDs in `exclude_job_ids` should be skipped, also when they are in include_job_ids."""
+
+    ws = mock_workspace_client()
+    ws.jobs.list.return_value = iter(
+        [
+            BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+            BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+            BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+        ]
+    )
+
+    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1], exclude_job_ids=[2, 3]).snapshot(force_refresh=True)
+
+    assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
+
+
 @pytest.mark.parametrize(
     "jobruns_ids,cluster_ids,run_ids,failures",
     [

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -4,7 +4,7 @@ import pytest
 from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.core import Row
 from databricks.labs.ucx.progress.history import ProgressEncoder
-from databricks.sdk.service.jobs import BaseJob, Job, JobSettings
+from databricks.sdk.service.jobs import BaseJob, JobSettings
 
 from databricks.labs.ucx.__about__ import __version__ as ucx_version
 from databricks.labs.ucx.assessment.jobs import JobInfo, JobOwnership, JobsCrawler, SubmitRunsCrawler
@@ -85,11 +85,13 @@ def test_job_crawler_creator():
 def test_job_crawler_skips_all_jobs_with_empty_include_job_ids() -> None:
     """If `include_job_ids` is empty, all jobs should be skipped."""
     ws = mock_workspace_client()
-    ws.jobs.list.return_value = iter([
-        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
-        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
-        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
-    ])
+    ws.jobs.list.return_value = iter(
+        [
+            BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+            BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+            BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+        ]
+    )
 
     result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[]).snapshot(force_refresh=True)
 
@@ -100,11 +102,13 @@ def test_job_crawler_include_job_ids() -> None:
     """Only jobs with IDs in `include_job_ids` should be crawled."""
 
     ws = mock_workspace_client()
-    ws.jobs.list.return_value = iter([
-        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
-        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
-        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
-    ])
+    ws.jobs.list.return_value = iter(
+        [
+            BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+            BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+            BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+        ]
+    )
 
     result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1]).snapshot(force_refresh=True)
 
@@ -140,7 +144,9 @@ def test_job_crawler_exclude_job_ids_takes_preference_over_include_job_ids() -> 
         ]
     )
 
-    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1, 2], exclude_job_ids=[2, 3]).snapshot(force_refresh=True)
+    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1, 2], exclude_job_ids=[2, 3]).snapshot(
+        force_refresh=True
+    )
 
     assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
 

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -67,10 +67,12 @@ def test_jobs_assessment_with_spn_cluster_no_job_tasks():
 
 def test_job_crawler_creator():
     ws = mock_workspace_client()
-    ws.jobs.list.return_value = (
-        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
-        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
-        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+    ws.jobs.list.return_value = iter(
+        [
+            BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+            BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+            BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+        ]
     )
     result = JobsCrawler(ws, MockBackend(), "ucx").snapshot(force_refresh=True)
 
@@ -83,11 +85,11 @@ def test_job_crawler_creator():
 def test_job_crawler_skips_all_jobs_with_empty_include_job_ids() -> None:
     """If `include_job_ids` is empty, all jobs should be skipped."""
     ws = mock_workspace_client()
-    ws.jobs.list.return_value = (
+    ws.jobs.list.return_value = iter([
         BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
         BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
         BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
-    )
+    ])
 
     result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[]).snapshot(force_refresh=True)
 
@@ -103,11 +105,11 @@ def test_job_crawler_include_job_ids() -> None:
 
     ws = mock_workspace_client()
     ws.jobs.get.side_effect = _get_job
-    ws.jobs.list.return_value = (
+    ws.jobs.list.return_value = iter([
         BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
         BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
         BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
-    )
+    ])
 
     result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1]).snapshot(force_refresh=True)
 
@@ -118,10 +120,12 @@ def test_job_crawler_exclude_job_ids() -> None:
     """The jobs with IDs in `exclude_job_ids` should be skipped."""
 
     ws = mock_workspace_client()
-    ws.jobs.list.return_value = (
-        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
-        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
-        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+    ws.jobs.list.return_value = iter(
+        [
+            BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+            BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+            BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+        ]
     )
 
     result = JobsCrawler(ws, MockBackend(), "ucx", exclude_job_ids=[2, 3]).snapshot(force_refresh=True)

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -114,6 +114,21 @@ def test_job_crawler_include_job_ids() -> None:
     assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
 
 
+def test_job_crawler_exclude_job_ids() -> None:
+    """The jobs with IDs in `exclude_job_ids` should be skipped."""
+
+    ws = mock_workspace_client()
+    ws.jobs.list.return_value = (
+        BaseJob(job_id=1, settings=JobSettings(), creator_user_name=None),
+        BaseJob(job_id=2, settings=JobSettings(), creator_user_name=""),
+        BaseJob(job_id=3, settings=JobSettings(), creator_user_name="bob"),
+    )
+
+    result = JobsCrawler(ws, MockBackend(), "ucx", exclude_job_ids=[2, 3]).snapshot(force_refresh=True)
+
+    assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
+
+
 @pytest.mark.parametrize(
     "jobruns_ids,cluster_ids,run_ids,failures",
     [

--- a/tests/unit/assessment/test_jobs.py
+++ b/tests/unit/assessment/test_jobs.py
@@ -140,7 +140,7 @@ def test_job_crawler_exclude_job_ids_takes_preference_over_include_job_ids() -> 
         ]
     )
 
-    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1], exclude_job_ids=[2, 3]).snapshot(force_refresh=True)
+    result = JobsCrawler(ws, MockBackend(), "ucx", include_job_ids=[1, 2], exclude_job_ids=[2, 3]).snapshot(force_refresh=True)
 
     assert result == [JobInfo(job_id="1", success=1, failures="[]", job_name="Unknown")]
 

--- a/tests/unit/hive_metastore/test_pipeline_migrate.py
+++ b/tests/unit/hive_metastore/test_pipeline_migrate.py
@@ -97,7 +97,7 @@ def test_migrate_pipelines_no_pipelines(ws) -> None:
     pipelines_crawler = PipelinesCrawler(ws, sql_backend, "inventory_database")
     jobs_crawler = JobsCrawler(ws, sql_backend, "inventory_database")
     pipelines_migrator = PipelinesMigrator(ws, pipelines_crawler, jobs_crawler, "catalog_name")
-    ws.jobs.list.return_value = [BaseJob(job_id=536591785949415), BaseJob(), BaseJob(job_id=536591785949417)]
+    ws.jobs.list.return_value = iter([BaseJob(job_id=536591785949415), BaseJob(), BaseJob(job_id=536591785949417)])
     pipelines_migrator.migrate_pipelines()
 
 


### PR DESCRIPTION
## Changes
Exclude UCX jobs from crawling to avoid confusing for users when they see UCX jobs in their assessment report.

### Linked issues

Fixes #3656
Resolves #3722
Follow up on #3732
Relates to #3731

### Functionality

- [x] modified `JobsCrawler`
- [x] modified existing workflow: `assessment`

### Tests

- [x] added unit tests
- [x] added integration tests

### PRs merged into this branch

> Merged the following PRs into this branch in an attempt to let the CI pass. Those PRs contain fixes for integration tests

From #3767:

Scope linted dashboards on mock runtime context. We should use `make_dashboard` instead of the dashboard fixture directly `_make_dashboard`. Also changed one dashboard to a `LakeviewDashboard` so that we lint that too

From #3759

Add retry mechanism to wait for the grants to exists before crawling
Resolves #3758
- [x] modified integration tests: `test_all_grant_types`

