### PR TITLE
Fix `Total Tables` widget in assessment to only show table counts

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/00_3_count_total_tables.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/00_3_count_total_tables.sql
@@ -2,3 +2,5 @@
 SELECT
   COUNT(*) AS count_total_tables
 FROM inventory.tables
+WHERE
+  object_type != 'VIEW'


### PR DESCRIPTION
## Changes

Fix `Total Tables` widget in assessment dashboard by filtering out views

### Linked issues

Resolves #3252 

### Functionality

- [ ] fix dashboard widget

### Tests

- [x] manually tested
