### PR TITLE
Persist workflow problems in UCX multiworkspace catalog

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -213,7 +213,7 @@ class Assessment(Workflow):  # pylint: disable=too-many-public-methods
 
         Also, stores direct filesystem accesses for display in the migration dashboard.
         """
-        ctx.workflow_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.workflow_linter.snapshot()
 
 
 class Failing(Workflow):

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -589,6 +589,8 @@ class GlobalContext(abc.ABC):
     def workflow_linter(self) -> WorkflowLinter:
         return WorkflowLinter(
             self.workspace_client,
+            self.sql_backend,
+            self.inventory_database,
             self.jobs_crawler,
             self.dependency_resolver,
             self.path_lookup,

--- a/src/databricks/labs/ucx/contexts/workflow_task.py
+++ b/src/databricks/labs/ucx/contexts/workflow_task.py
@@ -32,6 +32,7 @@ from databricks.labs.ucx.progress.history import ProgressEncoder
 from databricks.labs.ucx.progress.jobs import JobsProgressEncoder
 from databricks.labs.ucx.progress.tables import TableProgressEncoder
 from databricks.labs.ucx.progress.workflow_runs import WorkflowRunRecorder
+from databricks.labs.ucx.source_code.jobs import JobProblem, JobProblemOwnership
 
 # As with GlobalContext, service factories unavoidably have a lot of public methods.
 # pylint: disable=too-many-public-methods
@@ -80,6 +81,15 @@ class RuntimeContext(GlobalContext):
     @cached_property
     def job_ownership(self) -> JobOwnership:
         return JobOwnership(self.administrator_locator)
+
+    @cached_property
+    def workflow_problem_ownership(self) -> JobProblemOwnership:
+        return JobProblemOwnership(
+            self.administrator_locator,
+            self.workspace_client,
+            self.workspace_path_ownership,
+            self.job_ownership,
+        )
 
     @cached_property
     def submit_runs_crawler(self) -> SubmitRunsCrawler:
@@ -212,6 +222,17 @@ class RuntimeContext(GlobalContext):
             self.job_ownership,
             [self.directfs_access_crawler_for_paths, self.directfs_access_crawler_for_queries],
             self.inventory_database,
+            self.parent_run_id,
+            self.workspace_id,
+            self.config.ucx_catalog,
+        )
+
+    @cached_property
+    def workflow_problem_progress(self) -> ProgressEncoder[JobProblem]:
+        return ProgressEncoder(
+            self.sql_backend,
+            self.workflow_problem_ownership,
+            JobProblem,
             self.parent_run_id,
             self.workspace_id,
             self.config.ucx_catalog,

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -182,6 +182,12 @@ class MigrationProgress(Workflow):
         Also stores direct filesystem accesses for display in the migration dashboard."""
         ctx.workflow_linter.snapshot(force_refresh=True)
 
+    @job_task(depends_on=[assess_workflows], job_cluster="user_isolation")
+    def update_workflows_history_log(self, ctx: RuntimeContext) -> None:
+        """Update the history log with the latest workflow snapshot."""
+        workflow_problems_snapshot = ctx.workflow_linter.snapshot(force_refresh=False)
+        ctx.dashboards_progress.append_inventory_snapshot(workflow_problems_snapshot)
+
     @job_task(
         depends_on=[
             verify_prerequisites,

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -180,8 +180,7 @@ class MigrationProgress(Workflow):
     def assess_workflows(self, ctx: RuntimeContext):
         """Scans all jobs for migration issues in notebooks.
         Also stores direct filesystem accesses for display in the migration dashboard."""
-        # TODO: Ensure these are captured in the history log.
-        ctx.workflow_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+        ctx.workflow_linter.snapshot(force_refresh=True)
 
     @job_task(
         depends_on=[

--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -183,10 +183,10 @@ class MigrationProgress(Workflow):
         ctx.workflow_linter.snapshot(force_refresh=True)
 
     @job_task(depends_on=[assess_workflows], job_cluster="user_isolation")
-    def update_workflows_history_log(self, ctx: RuntimeContext) -> None:
-        """Update the history log with the latest workflow snapshot."""
+    def update_workflow_problems_history_log(self, ctx: RuntimeContext) -> None:
+        """Update the history log with the latest workflow problems snapshot."""
         workflow_problems_snapshot = ctx.workflow_linter.snapshot(force_refresh=False)
-        ctx.dashboards_progress.append_inventory_snapshot(workflow_problems_snapshot)
+        ctx.workflow_problem_progress.append_inventory_snapshot(workflow_problems_snapshot)
 
     @job_task(
         depends_on=[

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -4,7 +4,6 @@ import logging
 
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from pathlib import Path
 
 from databricks.labs.blueprint.parallel import Threads
 from databricks.labs.lsql.backends import SqlBackend
@@ -111,8 +110,6 @@ class WorkflowLinter(CrawlerBase):
             logger.warning(f"Found job problems:\n{problem_messages}")
         return problems, dfsas, tables
 
-    _UNKNOWN = Path('<UNKNOWN>')
-
     def _lint_job(self, job: jobs.Job) -> tuple[list[JobProblem], list[DirectFsAccess], list[UsedTable]]:
         problems: list[JobProblem] = []
         dfsas: list[DirectFsAccess] = []
@@ -127,12 +124,11 @@ class WorkflowLinter(CrawlerBase):
             if not advices:
                 advices = self._lint_task(graph, session_state)
             for advice in advices:
-                absolute_path = "UNKNOWN" if advice.has_missing_path() else advice.path.absolute().as_posix()
                 job_problem = JobProblem(
                     job_id=job.job_id,
                     job_name=job.settings.name,
                     task_key=task.task_key,
-                    path=absolute_path,
+                    path=advice.path.as_posix(),
                     code=advice.advice.code,
                     message=advice.advice.message,
                     start_line=advice.advice.start_line,

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -47,7 +47,7 @@ class WorkflowLinter(CrawlerBase):
     - Direct file system access (DirectFsAccess)
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         ws: WorkspaceClient,
         sql_backend: SqlBackend,

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -92,10 +92,11 @@ class WorkflowLinter(CrawlerBase):
         if errors:
             error_messages = "\n".join([str(error) for error in errors])
             logger.warning(f"Errors occurred during linting:\n{error_messages}")
-        problems, dfsas, tables = zip(*results)
-        self._directfs_crawler.dump_all(dfsas)
-        self._used_tables_crawler.dump_all(tables)
-        yield from problems
+        if results:
+            problems, dfsas, tables = zip(*results)
+            self._directfs_crawler.dump_all(dfsas)
+            self._used_tables_crawler.dump_all(tables)
+            yield from problems
 
     def lint_job(self, job_id: int) -> tuple[list[JobProblem], list[DirectFsAccess], list[UsedTable]]:
         try:

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -85,6 +85,8 @@ class WorkflowLinter(CrawlerBase):
         - Direct file system access (DirectFsAccess)
         """
         tasks = [functools.partial(self.lint_job, job.job_id) for job in self._jobs_crawler.snapshot()]
+        if not tasks:
+            return
         logger.info(f"Running {len(tasks)} linting tasks in parallel...")
         results, errors = Threads.gather("linting workflows", tasks)
         if errors:

--- a/src/databricks/labs/ucx/source_code/linters/jobs.py
+++ b/src/databricks/labs/ucx/source_code/linters/jobs.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 
 
 class WorkflowLinter:
+    """Lint workflows for UC compatibility and references to data assets.
+
+    Data assets linted:
+    - Table and view references (UsedTables)
+    - Direct file system access (DirectFsAccess)
+    """
+
     def __init__(
         self,
         ws: WorkspaceClient,

--- a/src/databricks/labs/ucx/source_code/linters/queries.py
+++ b/src/databricks/labs/ucx/source_code/linters/queries.py
@@ -40,6 +40,10 @@ class _ReportingContext:
 
 
 class QueryLinter:
+    """Lint queries
+
+    TODO: Let QueryLinter inherit from `BaseCrawler`
+    """
 
     def __init__(
         self,

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -79,8 +79,6 @@ def test_lakeview_query_dfsa_ownership(runtime_ctx) -> None:
 def test_path_dfsa_ownership(
     runtime_ctx,
     make_directory,
-    inventory_schema,
-    sql_backend,
 ) -> None:
     """Verify the ownership of a direct-fs record for a notebook/source path associated with a job."""
 
@@ -92,6 +90,8 @@ def test_path_dfsa_ownership(
     # Produce a DFSA record for the job.
     linter = WorkflowLinter(
         runtime_ctx.workspace_client,
+        runtime_ctx.sql_backend,
+        runtime_ctx.inventory_database,
         runtime_ctx.jobs_crawler,
         runtime_ctx.dependency_resolver,
         runtime_ctx.path_lookup,
@@ -99,7 +99,7 @@ def test_path_dfsa_ownership(
         runtime_ctx.directfs_access_crawler_for_paths,
         runtime_ctx.used_tables_crawler_for_paths,
     )
-    linter.refresh_report(sql_backend, inventory_schema)
+    linter.snapshot()
 
     # Find a record for our job.
     records = runtime_ctx.directfs_access_crawler_for_paths.snapshot()

--- a/tests/integration/source_code/test_jobs.py
+++ b/tests/integration/source_code/test_jobs.py
@@ -36,7 +36,7 @@ def test_linter_from_context(simple_ctx, make_job) -> None:
     # Ensure we have at least 1 job that fails: "Deprecated file system path in call to: /mnt/things/e/f/g"
     job = make_job(content="spark.read.table('a_table').write.csv('/mnt/things/e/f/g')\n")
     simple_ctx.config.include_job_ids = [job.job_id]
-    simple_ctx.workflow_linter.refresh_report(simple_ctx.sql_backend, simple_ctx.inventory_database)
+    simple_ctx.workflow_linter.refresh_report()
 
     # Verify that the 'problems' table has content.
     cursor = simple_ctx.sql_backend.fetch(

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -109,7 +109,11 @@ def test_migration_progress_assess_dashboards_calls_query_linter_refresh_report(
 
 def test_migration_progress_assess_workflows_calls_workflow_linter_snapshot(run_workflow) -> None:
     mock_linter = create_autospec(WorkflowLinter)
+    mock_history_log = create_autospec(ProgressEncoder)
     run_workflow(MigrationProgress.assess_workflows, workflow_linter=mock_linter)
+    run_workflow(
+        MigrationProgress.update_workflow_problems_history_log, workflow_progress=mock_history_log, parent_run_id=1234
+    )
     mock_linter.snapshot.assert_called_once()
 
 

--- a/tests/unit/progress/test_workflows.py
+++ b/tests/unit/progress/test_workflows.py
@@ -3,6 +3,7 @@ from typing import get_type_hints
 from unittest.mock import create_autospec
 
 import pytest
+
 from databricks.labs.ucx.hive_metastore import TablesCrawler
 from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigrationStatusRefresher
 from databricks.labs.ucx.progress.history import ProgressEncoder
@@ -12,6 +13,8 @@ from databricks.sdk.service.jobs import BaseRun, RunResultState, RunState, Pause
 
 from databricks.labs.ucx.progress.workflows import MigrationProgress
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
+from databricks.labs.ucx.source_code.linters.jobs import WorkflowLinter
+from databricks.labs.ucx.source_code.linters.queries import QueryLinter
 
 
 @pytest.mark.parametrize(
@@ -98,19 +101,16 @@ def test_migration_progress_runtime_tables_refresh_update_history_log(run_workfl
     mock_history_log.append_inventory_snapshot.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "task, linter",
-    (
-        (MigrationProgress.assess_dashboards, RuntimeContext.query_linter),
-        (MigrationProgress.assess_workflows, RuntimeContext.workflow_linter),
-    ),
-)
-def test_linter_runtime_refresh(run_workflow, task, linter) -> None:
-    linter_class = get_type_hints(linter.func)["return"]
-    mock_linter = create_autospec(linter_class)
-    linter_name = linter.attrname
-    run_workflow(task, **{linter_name: mock_linter})
+def test_migration_progress_assess_dashboards_calls_query_linter_refresh_report(run_workflow) -> None:
+    mock_linter = create_autospec(QueryLinter)
+    run_workflow(MigrationProgress.assess_dashboards, query_linter=mock_linter)
     mock_linter.refresh_report.assert_called_once()
+
+
+def test_migration_progress_assess_workflows_calls_workflow_linter_snapshot(run_workflow) -> None:
+    mock_linter = create_autospec(WorkflowLinter)
+    run_workflow(MigrationProgress.assess_workflows, workflow_linter=mock_linter)
+    mock_linter.snapshot.assert_called_once()
 
 
 def test_migration_progress_with_valid_prerequisites(run_workflow) -> None:

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -233,11 +233,14 @@ def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_l
     expected_message = "Found job problems:\nUNKNOWN:-1 [library-install-failed] 'pip --disable-pip-version-check install unknown-library"
 
     ws = create_autospec(WorkspaceClient)
+    sql_backend = MockBackend()
     jobs_crawler = create_autospec(JobsCrawler)
     directfs_crawler = create_autospec(DirectFsAccessCrawler)
     used_tables_crawler = create_autospec(UsedTablesCrawler)
     linter = WorkflowLinter(
         ws,
+        sql_backend,
+        "test",
         jobs_crawler,
         dependency_resolver,
         mock_path_lookup,
@@ -567,6 +570,8 @@ def test_workflow_linter_refresh_report(dependency_resolver, mock_path_lookup, m
     used_tables_crawler = UsedTablesCrawler.for_paths(sql_backend, "test")
     linter = WorkflowLinter(
         ws,
+        sql_backend,
+        "test",
         jobs_crawler,
         dependency_resolver,
         mock_path_lookup,
@@ -574,7 +579,7 @@ def test_workflow_linter_refresh_report(dependency_resolver, mock_path_lookup, m
         directfs_crawler,
         used_tables_crawler,
     )
-    linter.refresh_report(sql_backend, 'test')
+    linter.snapshot()
 
     jobs_crawler.snapshot.assert_called_once()
     sql_backend.has_rows_written_for('test.workflow_problems')

--- a/tests/unit/source_code/test_jobs.py
+++ b/tests/unit/source_code/test_jobs.py
@@ -230,7 +230,7 @@ def test_workflow_task_container_builds_dependency_graph_spark_python_task(
 
 
 def test_workflow_linter_lint_job_logs_problems(dependency_resolver, mock_path_lookup, empty_index, caplog) -> None:
-    expected_message = "Found job problems:\nUNKNOWN:-1 [library-install-failed] 'pip --disable-pip-version-check install unknown-library"
+    expected_message = "Found job problems:\n<MISSING_SOURCE_PATH>:-1 [library-install-failed] 'pip --disable-pip-version-check install unknown-library"
 
     ws = create_autospec(WorkspaceClient)
     sql_backend = MockBackend()


### PR DESCRIPTION
## Changes
Persist workflow problems in UCX multiworkspace catalog:
- Persist `JobProblem` ownership in UCX multiworkspace catalog
- Refactor `WorkflowLinter` to be a crawler for similar API for persisting snapshot in mutlworkspace catalog
- Introduce `JobProblemOwnership` to identify owners for job problems

### Linked issues

Resolves #3237

### Functionality

- [ ] modified existing workflow: `migration-progress`

### Tests

- [ ] added unit tests
- [ ] added integration tests
