### PR TITLE
Lint notebooks to warn on dbutils.credential.assumerole as this is not UC supported

### DIFF
--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -128,6 +128,9 @@ class NotebookRunCall(NodeBase):
             has_unresolved = True
         return has_unresolved, paths
 
+class DbutilsCall(NodeBase):
+    def __init__(self, node: Call):
+        super().__init__(node)
 
 class DbutilsPyLinter(PythonLinter):
 

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -140,9 +140,20 @@ class DbutilsPyLinter(PythonLinter):
         self._session_state = session_state
 
     def lint_tree(self, tree: Tree) -> Iterable[Advice]:
-        nodes = self.list_dbutils_notebook_run_calls(tree)
-        for node in nodes:
+        notebook_call_nodes = self.list_dbutils_notebook_run_calls(tree)
+        for node in notebook_call_nodes:
             yield from self._raise_advice_if_unresolved(node.node, self._session_state)
+
+        credentials_assumerole_call_nodes = self.list_dbutils_credentials_assumerole_calls(tree)
+
+        for node in credentials_assumerole_call_nodes:
+            assert isinstance(node, Call)
+            # call = DbutilsCall(cast(Call, node))
+            yield Advisory.from_node(
+                code='dbutils-credentials-assume-role',
+                message="dbutils.credentials.assumeRole is not supported",
+                node=node)
+
 
     @classmethod
     def _raise_advice_if_unresolved(cls, node: NodeNG, session_state: CurrentSessionState) -> Iterable[Advice]:

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -163,6 +163,11 @@ class DbutilsPyLinter(PythonLinter):
         calls = tree.locate(Call, [("run", Attribute), ("notebook", Attribute), ("dbutils", Name)])
         return [NotebookRunCall(call) for call in calls]
 
+    @staticmethod
+    def list_dbutils_credentials_assumerole_calls(tree: Tree) -> list[DbutilsCall]:
+        calls = tree.locate(Call, [("assumeRole", Attribute), ("credentials", Attribute), ("dbutils", Name)])
+        return [DbutilsCall(call) for call in calls]
+
 
 class SysPathChange(NodeBase, abc.ABC):
 

--- a/src/databricks/labs/ucx/source_code/linters/imports.py
+++ b/src/databricks/labs/ucx/source_code/linters/imports.py
@@ -128,9 +128,11 @@ class NotebookRunCall(NodeBase):
             has_unresolved = True
         return has_unresolved, paths
 
+
 class DbutilsCall(NodeBase):
     def __init__(self, node: Call):
         super().__init__(node)
+
 
 class DbutilsPyLinter(PythonLinter):
 

--- a/src/databricks/labs/ucx/source_code/linters/python.py
+++ b/src/databricks/labs/ucx/source_code/linters/python.py
@@ -106,6 +106,7 @@ class PythonCodeAnalyzer:
         tree = maybe_tree.tree
         syspath_changes = SysPathChange.extract_from_tree(self._context.session_state, tree)
         run_calls = DbutilsPyLinter.list_dbutils_notebook_run_calls(tree)
+        credential_calls = DbutilsPyLinter.list_dbutils_credentials_assumerole_calls(tree)
         import_sources: list[ImportSource]
         import_problems: list[DependencyProblem]
         import_sources, import_problems = ImportSource.extract_from_tree(tree, DependencyProblem.from_node)
@@ -113,7 +114,7 @@ class PythonCodeAnalyzer:
         magic_lines, command_problems = MagicLine.extract_from_tree(tree, DependencyProblem.from_node)
         problems.extend(command_problems)
         # need to evaluate things in intertwined sequence so concat and sort them
-        nodes: list[NodeBase] = cast(list[NodeBase], syspath_changes + run_calls + import_sources + magic_lines)
+        nodes: list[NodeBase] = cast(list[NodeBase], syspath_changes + run_calls + import_sources + magic_lines + credential_calls)
         nodes = sorted(nodes, key=lambda node: (node.node.lineno, node.node.col_offset))
         return tree, nodes, problems
 

--- a/src/databricks/labs/ucx/source_code/linters/python.py
+++ b/src/databricks/labs/ucx/source_code/linters/python.py
@@ -114,7 +114,9 @@ class PythonCodeAnalyzer:
         magic_lines, command_problems = MagicLine.extract_from_tree(tree, DependencyProblem.from_node)
         problems.extend(command_problems)
         # need to evaluate things in intertwined sequence so concat and sort them
-        nodes: list[NodeBase] = cast(list[NodeBase], syspath_changes + run_calls + import_sources + magic_lines + credential_calls)
+        nodes: list[NodeBase] = cast(
+            list[NodeBase], syspath_changes + run_calls + import_sources + magic_lines + credential_calls
+        )
         nodes = sorted(nodes, key=lambda node: (node.node.lineno, node.node.col_offset))
         return tree, nodes, problems
 

--- a/src/databricks/labs/ucx/source_code/linters/python.py
+++ b/src/databricks/labs/ucx/source_code/linters/python.py
@@ -24,7 +24,8 @@ from databricks.labs.ucx.source_code.linters.imports import (
     DbutilsPyLinter,
     ImportSource,
     NotebookRunCall,
-    UnresolvedPath, DbutilsCall,
+    UnresolvedPath,
+    DbutilsCall,
 )
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
 from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree, NodeBase
@@ -132,7 +133,9 @@ class PythonCodeAnalyzer:
         elif isinstance(base_node, DbutilsCall):
             problem = DependencyProblem.from_node(
                 'dbutils-credentials-assume-role',
-                "dbutils.credentials.assumeRole is not supported", base_node.node,)
+                "dbutils.credentials.assumeRole is not supported",
+                base_node.node,
+            )
             yield problem
         else:
             problem = DependencyProblem.from_node(

--- a/src/databricks/labs/ucx/source_code/linters/python.py
+++ b/src/databricks/labs/ucx/source_code/linters/python.py
@@ -24,7 +24,7 @@ from databricks.labs.ucx.source_code.linters.imports import (
     DbutilsPyLinter,
     ImportSource,
     NotebookRunCall,
-    UnresolvedPath,
+    UnresolvedPath, DbutilsCall,
 )
 from databricks.labs.ucx.source_code.notebooks.magic import MagicLine
 from databricks.labs.ucx.source_code.python.python_ast import MaybeTree, Tree, NodeBase
@@ -129,6 +129,11 @@ class PythonCodeAnalyzer:
             yield from self._register_import(base_node)
         elif isinstance(base_node, MagicLine):
             yield from base_node.build_dependency_graph(self._context.parent)
+        elif isinstance(base_node, DbutilsCall):
+            problem = DependencyProblem.from_node(
+                'dbutils-credentials-assume-role',
+                "dbutils.credentials.assumeRole is not supported", base_node.node,)
+            yield problem
         else:
             problem = DependencyProblem.from_node(
                 "unsupported-node-type",

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -61,4 +61,4 @@ def test_dbutils_credentials_assumerole_is_not_supported(simple_ctx):
         dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()
     )
     problems = notebook.build_dependency_graph(parent)
-    assert not problems
+    assert problems

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -48,3 +48,17 @@ def test_relative_grand_parent_path_is_supported(
     container = dependency.load(simple_ctx.path_lookup)
     problems = container.build_dependency_graph(root)
     assert not problems
+
+def test_dbutils_credentials_assumerole_is_not_supported(simple_ctx):
+    source = """# Databricks notebook source
+# COMMAND ----------
+
+# dbutils.credentials.assumeRole("arn:aws:iam::123456789012:roles/my-role")
+"""
+    notebook = Notebook.parse(Path(""), source=source, default_language=Language.PYTHON)
+    dependency = Dependency(FileLoader(), Path(""))
+    parent = DependencyGraph(
+        dependency, None, simple_ctx.dependency_resolver, simple_ctx.path_lookup, CurrentSessionState()
+    )
+    problems = notebook.build_dependency_graph(parent)
+    assert not problems

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -49,6 +49,7 @@ def test_relative_grand_parent_path_is_supported(
     problems = container.build_dependency_graph(root)
     assert not problems
 
+
 def test_dbutils_credentials_assumerole_is_not_supported(simple_ctx):
     source = """# Databricks notebook source
 # COMMAND ----------

--- a/tests/integration/source_code/test_cells.py
+++ b/tests/integration/source_code/test_cells.py
@@ -52,8 +52,7 @@ def test_relative_grand_parent_path_is_supported(
 def test_dbutils_credentials_assumerole_is_not_supported(simple_ctx):
     source = """# Databricks notebook source
 # COMMAND ----------
-
-# dbutils.credentials.assumeRole("arn:aws:iam::123456789012:roles/my-role")
+    dbutils.credentials.assumeRole("arn:aws:iam::123456789012:roles/my-role")
 """
     notebook = Notebook.parse(Path(""), source=source, default_language=Language.PYTHON)
     dependency = Dependency(FileLoader(), Path(""))


### PR DESCRIPTION
## Changes
Linting should be able to identify notebooks which contain [dbutils.credentials.assumeRole](https://docs.databricks.com/en/dev-tools/databricks-utils.html#dbutils-credentials-assumerole) function and put this in assessment result so that the customer knows that this is a code change needed to migrate to UC.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #3527 

### Functionality

- [x] added linting for a function

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] verified on staging environment (screenshot attached)
