### PR TITLE
Scope linted dashboards on mock runtime context

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -631,7 +631,7 @@ class MockRuntimeContext(
         self.make_job(content="spark.table('old.stuff')")
         self.make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
         self.make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
-        query_1 = self.make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
+        query_1 = self.make_query(sql_query="SELECT * from parquet.`dbfs://mnt/foo2/bar2`")
         self.make_dashboard(query=query_1)
         self.make_lakeview_dashboard(query="SELECT * from my_schema.my_table")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -632,9 +632,9 @@ class MockRuntimeContext(
         self.make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
         self.make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
         query_1 = self.make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
-        self._make_dashboard(query=query_1)
+        self.make_dashboard(query=query_1)
         query_2 = self.make_query(sql_query='SELECT * from my_schema.my_table')
-        self._make_dashboard(query=query_2)
+        self.make_dashboard(query=query_2)
 
     def add_table(self, table: TableInfo):
         self._tables.append(table)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -633,8 +633,7 @@ class MockRuntimeContext(
         self.make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
         query_1 = self.make_query(sql_query='SELECT * from parquet.`dbfs://mnt/foo2/bar2`')
         self.make_dashboard(query=query_1)
-        query_2 = self.make_query(sql_query='SELECT * from my_schema.my_table')
-        self.make_dashboard(query=query_2)
+        self.make_lakeview_dashboard(query="SELECT * from my_schema.my_table")
 
     def add_table(self, table: TableInfo):
         self._tables.append(table)


### PR DESCRIPTION
## Changes
Scope linted dashboards on mock runtime context. We should use `make_dashboard` instead of the dashboard fixture directly `_make_dashboard`. Also changed one dashboard to a `LakeviewDashboard` so that we lint that too
