### PR TITLE
Let dashboard name adhere to naming convention

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -663,6 +663,15 @@ class WorkspaceInstallation(InstallationMixin):
             )
         )
         metadata.display_name = f"{self._name('UCX ')} {folder.parent.stem.title()} ({folder.stem.title()})"
+        # TODO: Remove temporary fix for the dashboard name:
+        # resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)
+        metadata.display_name = (
+            metadata.display_name.replace(" ", "_")
+            .replace("[", "-")
+            .replace("]", "-")
+            .replace("(", "")
+            .replace(")", "")
+        )
         reference = f"{folder.parent.stem}_{folder.stem}".lower()
         dashboard_id = self._install_state.dashboards.get(reference)
         if dashboard_id is not None:

--- a/src/databricks/labs/ucx/queries/progress/main/02_0_owner.filter.yml
+++ b/src/databricks/labs/ucx/queries/progress/main/02_0_owner.filter.yml
@@ -1,4 +1,0 @@
-title: Filter for owner(s)
-column: owner
-type: MULTI_SELECT
-width: 6


### PR DESCRIPTION
## Changes

Dashboard names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)

Fix for failing tests in https://github.com/databrickslabs/ucx/actions/runs/13559322493

### Linked issues

Resolves #3761
Resolves #3762 
Resolves #3763 
Resolves #3764 
Resolves #3769 
Resolves #3770 
Resolves #3771
Resolves #3772 
Resolves #3773 
Resolves #3774 
Resolves #3775
Resolves #3776 
Resolves #3777 
Resolves #3778
Resolves #3779
Resolves #3780
Resolves #3781 
Resolves #3782 
Resolves #3783 
Resolves #3784
Resolves #3785 
Resolves #3786 
Resolves #3787 
Resolves #3788 

### Functionality

- [x] modified existing command: `databricks labs install ucx`

### Tests

- [x] manually tested
