### PR TITLE
Partial revert "Let dashboard name adhere to naming convention"

### DIFF
--- a/src/databricks/labs/ucx/queries/progress/main/02_0_owner.filter.yml
+++ b/src/databricks/labs/ucx/queries/progress/main/02_0_owner.filter.yml
@@ -1,0 +1,4 @@
+title: Filter for owner(s)
+column: owner
+type: MULTI_SELECT
+width: 6


### PR DESCRIPTION
## Changes

Puts back the owner filter in the migration progress dashboard

### Linked issues

Partially reverts #3789
Reverts c24e6eafb8f7f3b89fb0edf49d14d3e6a48e3aa7
Requires lsql release after merging https://github.com/databrickslabs/lsql/pull/357

### Functionality

- [x] modified migration progress dashboard

### Tests

- [x] manually tested
