### PR TITLE
Partial revert "Let dashboard name adhere to naming convention"

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -662,16 +662,7 @@ class WorkspaceInstallation(InstallationMixin):
                 catalog_to_replace="ucx_catalog",
             )
         )
-        metadata.display_name = f"{self._name('UCX ')} {folder.parent.stem.title()} ({folder.stem.title()})"
-        # TODO: Remove temporary fix for the dashboard name:
-        # resource names should only contain alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), or underscores (_)
-        metadata.display_name = (
-            metadata.display_name.replace(" ", "_")
-            .replace("[", "-")
-            .replace("]", "-")
-            .replace("(", "")
-            .replace(")", "")
-        )
+        metadata.display_name = self._name(f"{folder.parent.stem.title()} ({folder.stem.title()})")
         reference = f"{folder.parent.stem}_{folder.stem}".lower()
         dashboard_id = self._install_state.dashboards.get(reference)
         if dashboard_id is not None:

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -662,7 +662,7 @@ class WorkspaceInstallation(InstallationMixin):
                 catalog_to_replace="ucx_catalog",
             )
         )
-        metadata.display_name = self._name(f"{folder.parent.stem.title()} ({folder.stem.title()})")
+        metadata.display_name = self._name(f"{folder.parent.stem.title()}_{folder.stem.title()}")
         reference = f"{folder.parent.stem}_{folder.stem}".lower()
         dashboard_id = self._install_state.dashboards.get(reference)
         if dashboard_id is not None:

--- a/src/databricks/labs/ucx/installer/mixins.py
+++ b/src/databricks/labs/ucx/installer/mixins.py
@@ -19,7 +19,7 @@ class InstallationMixin:
 
     def _name(self, name: str) -> str:
         prefix = os.path.basename(self._installation.install_folder()).removeprefix('.')
-        return f"[{prefix.upper()}] {name}"
+        return f"{prefix.upper()}_{name}"
 
     @property
     def _my_username(self):

--- a/tests/unit/install/test_install.py
+++ b/tests/unit/install/test_install.py
@@ -153,7 +153,7 @@ def test_install_cluster_override_jobs(ws, mock_installation) -> None:
 
     workflows_installation.create_jobs()
 
-    tasks = created_job_tasks(ws, '[MOCK] assessment')
+    tasks = created_job_tasks(ws, 'MOCK_assessment')
     assert tasks['assess_jobs'].existing_cluster_id == 'one'
     assert tasks['crawl_grants'].existing_cluster_id == 'two'
     wheels.upload_to_wsfs.assert_called_once()
@@ -175,7 +175,7 @@ def test_writeable_dbfs(ws, tmp_path, mock_installation) -> None:
 
     workflows_installation.create_jobs()
 
-    job = created_job(ws, '[MOCK] assessment')
+    job = created_job(ws, 'MOCK_assessment')
     job_clusters = {_.job_cluster_key: _ for _ in job['job_clusters']}
     assert 'main' in job_clusters
     assert 'tacl' in job_clusters


### PR DESCRIPTION
## Changes

Reverts back to dashboard names with special characters like spaces and brackets

### Linked issues

Requires #3799
Partially reverts #3789
Reverts 048bc8f9df27452f3e74b284bfabf3325354c0cd

### Functionality

- [x] modified migration progress dashboard

### Tests

- [x] manually tested

