### PR TITLE
Pin dependencies to minor releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,15 @@ classifiers = [
 ]
 
 dependencies = ["databricks-sdk>=0.40,<0.42",
-                "databricks-labs-lsql>=0.14.0,<0.15",
-                "databricks-labs-blueprint>=0.9.1,<0.11",
-                "PyYAML>=6.0.0,<7.0.0",
-                "sqlglot>=25.5.0,<26.7",
-                "astroid>=3.3.1"]
+                "databricks-labs-lsql>=0.15.0,<0.16.0",
+                "databricks-labs-blueprint>=0.10.0,<0.11.0",
+                "PyYAML>=6.0.0,<6.1.0",
+                "sqlglot>=26.7.0,<26.8.0",
+                "astroid>=3.3.0,<3.4.0"]
 
 [project.optional-dependencies]
 pylsp = [
-    "python-lsp-server>=1.9.0"
+    "python-lsp-server>=1.12.0,<1.13.0"
 ]
 
 [project.entry-points.databricks]


### PR DESCRIPTION
## Changes
Pin dependencies to minor releases to test dependency changes before users are affected by them.

The reasoning for choosing between pinned vs loose requirements is:
1. For applications (like UCX), pin the dependency minor versions to minimize instability due to changes in dependencies while still receiving dependency bug/patch fixes. We automatically test dependency changes in Dependabot's PRs.
2. For libraries (like pytest, lsql and blueprint), prefer loose requirements so that the libraries and projects that use your library have the freedom to chose their preferred version, especially important to increase the likelihood for finding a library version that fits the constrains of all dependencies and sub-dependencies (dependencies of dependencies of dependencies ...).

We prefer the greater than or equal to & lower than syntax over the tilde as it is more clear what the version range is

The sdk version pinning is covered by #3686
Supersedes #3766 