### PR TITLE
Convert UCX job ids to `int` before passing to `JobsCrawler`

### DIFF
--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -283,7 +283,7 @@ class GlobalContext(abc.ABC):
             self.sql_backend,
             self.inventory_database,
             include_job_ids=self.config.include_job_ids,
-            exclude_job_ids=list(self.install_state.jobs.values()),
+            exclude_job_ids=[int(job_id) for job_id in self.install_state.jobs.values()],
         )
 
     @cached_property


### PR DESCRIPTION
## Changes
Convert UCX job ids to integers before passing to `JobsCrawler`

### Linked issues

Resolves #3722

### Test

- [x] Manually tests

