### PR TITLE
Add hyperlinks to tables and order the rows by type, name

### DIFF
--- a/src/databricks/labs/ucx/queries/assessment/main/10_1_all_tables.sql
+++ b/src/databricks/labs/ucx/queries/assessment/main/10_1_all_tables.sql
@@ -1,4 +1,20 @@
-/* --title 'Table Types' --filter name --width 6 */
+/*
+--title 'Table Types'
+--filter name
+--width 6
+--overrides '{"spec":{
+    "encodings":{
+      "columns": [
+        {"fieldName": "name", "booleanValues": ["false", "true"], "linkUrlTemplate": "/explore/data/hive_metastore/{{ @ }}", "linkTextTemplate": "{{ @ }}", "linkTitleTemplate": "{{ @ }}", "linkOpenInNewTab": true, "type": "string", "displayAs": "link", "title": "name"},
+        {"fieldName": "type", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "type"},
+        {"fieldName": "format", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "format"},
+        {"fieldName": "storage", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "storage"},
+        {"fieldName": "is_delta", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "is_delta"},
+        {"fieldName": "location", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "location"},
+        {"fieldName": "table_size", "booleanValues": ["false", "true"], "type": "string", "displayAs": "string", "title": "table_size"}
+      ]}
+  }}'
+*/
 SELECT
   CONCAT(tables.`database`, '.', tables.name) AS name,
   object_type AS type,
@@ -42,3 +58,4 @@ SELECT
 FROM inventory.tables AS tables
 LEFT OUTER JOIN inventory.table_size AS table_size
   ON tables.catalog = table_size.catalog AND tables.database = table_size.database AND tables.name = table_size.name
+ORDER by type, name


### PR DESCRIPTION
## Changes
For the table types widget
1. Table names are clickable
2. Rows are orders by type and then name

### Linked issues
Resolves #3259

### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/8c4d0d23-edef-4e80-9c32-8e585eb3d076" />
