### PR TITLE
Pause migration progress workflow schedule

### DIFF
--- a/src/databricks/labs/ucx/progress/workflows.py
+++ b/src/databricks/labs/ucx/progress/workflows.py
@@ -29,7 +29,7 @@ class MigrationProgress(Workflow):
     def schedule(self) -> CronSchedule:
         """Schedule the migration progress workflow to run by default daily at 5:00 a.m. (UTC)."""
         return CronSchedule(
-            quartz_cron_expression="0 0 5 * * ?", timezone_id="Etc/UTC", pause_status=PauseStatus.UNPAUSED
+            quartz_cron_expression="0 0 5 * * ?", timezone_id="Etc/UTC", pause_status=PauseStatus.PAUSED
         )
 
     @job_task(job_cluster="user_isolation")


### PR DESCRIPTION
As the workflow is experimental and fails if no UCX catalog was created by the customer, we are pausing this workflow.
We suggest that the user unpause it after running the [`create-ucx-catalog`](https://databrickslabs.github.io/ucx/docs/reference/commands/#create-ucx-catalog) command.
