### PR TITLE
Skip integration tests with legacy dashboard creation as it is deprecated

### DIFF
--- a/src/databricks/labs/ucx/source_code/known.json
+++ b/src/databricks/labs/ucx/source_code/known.json
@@ -11417,6 +11417,9 @@
   "mypy-extensions": {
     "mypy_extensions": []
   },
+  "mypy_extensions": {
+    "mypy_extensions": []
+  },
   "namex": {
     "namex": [],
     "namex.convert": [],

--- a/tests/integration/assessment/test_dashboards.py
+++ b/tests/integration/assessment/test_dashboards.py
@@ -8,6 +8,7 @@ from databricks.labs.ucx.assessment.dashboards import (
     RedashDashboardCrawler,
 )
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboards(ws, make_dashboard, inventory_schema, sql_backend) -> None:
     dashboard: SdkRedashDashboard = make_dashboard()
@@ -17,6 +18,7 @@ def test_redash_dashboard_crawler_crawls_dashboards(ws, make_dashboard, inventor
 
     assert len(dashboards) >= 1
     assert dashboard.id in {d.id for d in dashboards}, f"Missing dashboard: {dashboard.id}"
+
 
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboard(ws, make_dashboard, inventory_schema, sql_backend) -> None:
@@ -28,6 +30,7 @@ def test_redash_dashboard_crawler_crawls_dashboard(ws, make_dashboard, inventory
     dashboards = list(crawler.snapshot())
 
     assert dashboards == [Dashboard.from_sdk_redash_dashboard(dashboard)]
+
 
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboards_with_debug_listing_upper_limit(

--- a/tests/integration/assessment/test_dashboards.py
+++ b/tests/integration/assessment/test_dashboards.py
@@ -8,7 +8,7 @@ from databricks.labs.ucx.assessment.dashboards import (
     RedashDashboardCrawler,
 )
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboards(ws, make_dashboard, inventory_schema, sql_backend) -> None:
     dashboard: SdkRedashDashboard = make_dashboard()
     crawler = RedashDashboardCrawler(ws, sql_backend, inventory_schema)
@@ -18,7 +18,7 @@ def test_redash_dashboard_crawler_crawls_dashboards(ws, make_dashboard, inventor
     assert len(dashboards) >= 1
     assert dashboard.id in {d.id for d in dashboards}, f"Missing dashboard: {dashboard.id}"
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboard(ws, make_dashboard, inventory_schema, sql_backend) -> None:
     dashboard: SdkRedashDashboard = make_dashboard()
     assert dashboard.id
@@ -29,7 +29,7 @@ def test_redash_dashboard_crawler_crawls_dashboard(ws, make_dashboard, inventory
 
     assert dashboards == [Dashboard.from_sdk_redash_dashboard(dashboard)]
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_redash_dashboard_crawler_crawls_dashboards_with_debug_listing_upper_limit(
     ws, make_dashboard, inventory_schema, sql_backend
 ) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -631,8 +631,9 @@ class MockRuntimeContext(
         self.make_job(content="spark.table('old.stuff')")
         self.make_job(content="spark.read.parquet('dbfs://mnt/file/')", task_type=SparkPythonTask)
         self.make_job(content="spark.table('some.table')", task_type=SparkPythonTask)
-        query_1 = self.make_query(sql_query="SELECT * from parquet.`dbfs://mnt/foo2/bar2`")
-        self.make_dashboard(query=query_1)
+
+        # TODO: Removed because of deprecation of Legacy Dashboard creation
+
         self.make_lakeview_dashboard(query="SELECT * from my_schema.my_table")
 
     def add_table(self, table: TableInfo):

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -190,6 +190,7 @@ def test_repair_run_workflow_job(installation_ctx, mocker):
     assert installation_ctx.deployed_workflows.validate_step("failing")
 
 
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_installation_deletes_redash_dashboard_when_upgrading_to_lakeview(ws, installation_ctx, make_dashboard):
     """The installation should handle upgrading dashboards from redash."""
 

--- a/tests/integration/progress/test_dashboards.py
+++ b/tests/integration/progress/test_dashboards.py
@@ -22,6 +22,7 @@ from databricks.labs.ucx.hive_metastore.tables import Table
         ),
     ],
 )
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_dashboard_progress_encoder_table_failures(runtime_ctx, az_cli_ctx, query: str, failures: list[str]) -> None:
     az_cli_ctx.progress_tracking_installation.run()
     runtime_ctx = runtime_ctx.replace(

--- a/tests/integration/progress/test_jobs.py
+++ b/tests/integration/progress/test_jobs.py
@@ -1,9 +1,12 @@
+import pytest
+
 from databricks.labs.ucx.assessment.jobs import JobInfo
 from databricks.labs.ucx.framework.utils import escape_sql_identifier
 from databricks.labs.ucx.source_code.base import DirectFsAccess, LineageAtom
 from databricks.labs.ucx.source_code.jobs import JobProblem
 
 
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_job_progress_encoder_failures(runtime_ctx, az_cli_ctx) -> None:
     az_cli_ctx.progress_tracking_installation.run()
     runtime_ctx = runtime_ctx.replace(

--- a/tests/integration/queries/test_migration_progress.py
+++ b/tests/integration/queries/test_migration_progress.py
@@ -593,6 +593,7 @@ def dashboard_metadata(catalog_populated: str) -> DashboardMetadata:
     metadata.validate()
     return metadata
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_dashboard(
     ws: WorkspaceClient,
@@ -614,6 +615,7 @@ def test_migration_progress_dashboard(
     dashboard_url = f"{ws.config.host}/dashboardsv3/{dashboard.dashboard_id}/published"
     webbrowser.open(dashboard_url)
     assert True, "Dashboard deployment successful"
+
 
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 @pytest.mark.parametrize(
@@ -719,6 +721,7 @@ def exclude_fields_from_rows(rows: list[Row], *fields: str) -> list[Row]:
         rows_without_fields.append(row)
     return rows_without_fields
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboard_pending_migration_by_owner_bar_graph(
     dashboard_metadata: DashboardMetadata,
@@ -732,6 +735,7 @@ def test_migration_progress_query_dashboard_pending_migration_by_owner_bar_graph
     query_results = list(sql_backend.fetch(datasets[0].query))
     # See `test_redash_dashboard_ownership_is_me` for why we exclude the owner
     assert exclude_fields_from_rows(query_results, "owner") == rows
+
 
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboards_pending_migration_by_owner_overview(
@@ -753,6 +757,7 @@ def test_migration_progress_query_dashboards_pending_migration_by_owner_overview
     # See `test_redash_dashboard_ownership_is_me` for why we exclude the owner
     query_results = list(sql_backend.fetch(datasets[0].query))
     assert exclude_fields_from_rows(query_results, "owner") == rows
+
 
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboards_pending_migration(

--- a/tests/integration/queries/test_migration_progress.py
+++ b/tests/integration/queries/test_migration_progress.py
@@ -593,7 +593,7 @@ def dashboard_metadata(catalog_populated: str) -> DashboardMetadata:
     metadata.validate()
     return metadata
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_dashboard(
     ws: WorkspaceClient,
     is_in_debug,  # Skip test when not in debug
@@ -615,7 +615,7 @@ def test_migration_progress_dashboard(
     webbrowser.open(dashboard_url)
     assert True, "Dashboard deployment successful"
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 @pytest.mark.parametrize(
     "query_name, rows",
     [
@@ -719,7 +719,7 @@ def exclude_fields_from_rows(rows: list[Row], *fields: str) -> list[Row]:
         rows_without_fields.append(row)
     return rows_without_fields
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboard_pending_migration_by_owner_bar_graph(
     dashboard_metadata: DashboardMetadata,
     sql_backend: SqlBackend,
@@ -733,7 +733,7 @@ def test_migration_progress_query_dashboard_pending_migration_by_owner_bar_graph
     # See `test_redash_dashboard_ownership_is_me` for why we exclude the owner
     assert exclude_fields_from_rows(query_results, "owner") == rows
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboards_pending_migration_by_owner_overview(
     dashboard_metadata: DashboardMetadata,
     sql_backend: SqlBackend,
@@ -754,7 +754,7 @@ def test_migration_progress_query_dashboards_pending_migration_by_owner_overview
     query_results = list(sql_backend.fetch(datasets[0].query))
     assert exclude_fields_from_rows(query_results, "owner") == rows
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migration_progress_query_dashboards_pending_migration(
     ws: WorkspaceClient,
     dashboard_metadata: DashboardMetadata,

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -4,7 +4,7 @@ from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigra
 from databricks.labs.ucx.source_code.base import DirectFsAccess, LineageAtom
 from databricks.labs.ucx.source_code.linters.jobs import WorkflowLinter
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_legacy_query_dfsa_ownership(runtime_ctx) -> None:
     """Verify the ownership of a direct-fs record for a legacy query."""
     query = runtime_ctx.make_query(sql_query="SELECT * from csv.`dbfs://some_folder/some_file.csv`")

--- a/tests/integration/source_code/test_directfs_access.py
+++ b/tests/integration/source_code/test_directfs_access.py
@@ -4,6 +4,7 @@ from databricks.labs.ucx.hive_metastore.table_migration_status import TableMigra
 from databricks.labs.ucx.source_code.base import DirectFsAccess, LineageAtom
 from databricks.labs.ucx.source_code.linters.jobs import WorkflowLinter
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_legacy_query_dfsa_ownership(runtime_ctx) -> None:
     """Verify the ownership of a direct-fs record for a legacy query."""

--- a/tests/integration/source_code/test_queries.py
+++ b/tests/integration/source_code/test_queries.py
@@ -1,8 +1,9 @@
+import pytest
 from databricks.labs.lsql.backends import Row
 
 from databricks.labs.ucx.source_code.base import DirectFsAccess, LineageAtom, UsedTable
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_query_linter_lints_queries_and_stores_dfsas_and_tables(simple_ctx) -> None:
     query_with_dfsa = simple_ctx.make_query(sql_query="SELECT * from csv.`dbfs://some_folder/some_file.csv`")
     dashboard_with_dfsa = simple_ctx.make_dashboard(query=query_with_dfsa)

--- a/tests/integration/source_code/test_queries.py
+++ b/tests/integration/source_code/test_queries.py
@@ -3,6 +3,7 @@ from databricks.labs.lsql.backends import Row
 
 from databricks.labs.ucx.source_code.base import DirectFsAccess, LineageAtom, UsedTable
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_query_linter_lints_queries_and_stores_dfsas_and_tables(simple_ctx) -> None:
     query_with_dfsa = simple_ctx.make_query(sql_query="SELECT * from csv.`dbfs://some_folder/some_file.csv`")

--- a/tests/integration/source_code/test_redash.py
+++ b/tests/integration/source_code/test_redash.py
@@ -6,6 +6,7 @@ from databricks.sdk.retries import retried
 from databricks.labs.ucx.source_code.linters.redash import Redash
 from databricks.sdk.service.sql import Dashboard
 
+
 @pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migrate_dashboards_sets_migration_tags(installation_ctx) -> None:
     query_in_dashboard, query_outside_dashboard = installation_ctx.make_query(), installation_ctx.make_query()

--- a/tests/integration/source_code/test_redash.py
+++ b/tests/integration/source_code/test_redash.py
@@ -1,11 +1,12 @@
 import datetime as dt
 
+import pytest
 from databricks.sdk.retries import retried
 
 from databricks.labs.ucx.source_code.linters.redash import Redash
 from databricks.sdk.service.sql import Dashboard
 
-
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 def test_migrate_dashboards_sets_migration_tags(installation_ctx) -> None:
     query_in_dashboard, query_outside_dashboard = installation_ctx.make_query(), installation_ctx.make_query()
     assert query_in_dashboard.id and query_outside_dashboard.id, "Query from fixture misses id"


### PR DESCRIPTION
## Changes
Skip integration tests with legacy dashboard creation as it is deprecated. Skipping until we can work with product team and enable it only for Labs workspaces

### Tests
- [x] modify integration tests
