### PR TITLE
Warns instead of an error while finding an acc group in workspace

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -569,7 +569,9 @@ class GroupManager(CrawlerBase[MigratedGroup]):
                 logger.info(f"Skipping {migrated_group.name_in_account}: already in workspace")
                 continue
             if migrated_group.name_in_account in workspace_groups_in_workspace:
-                logger.error(f"Skipping {migrated_group.name_in_account}: group already exists in workspace")
+                ## After introduction of creating nested groups,
+                # we will come across groups that are already in the workspace
+                logger.warning(f"Skipping {migrated_group.name_in_account}: group already exists in workspace")
                 continue
             if migrated_group.name_in_account not in account_groups_in_account:
                 logger.warning(f"Skipping {migrated_group.name_in_account}: not in account")


### PR DESCRIPTION
## Changes
After the introduction of creation of nested account groups from workspace local groups, the `reflect_account_groups_on_workspace` shoots out an error which instead should be a warning.

### Functionality

- [x] change error level

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] existing tests
