### PR TITLE
Update the minimum version of `databricks-labs-pytester` to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "pylint~=3.3.1",
     "pylint-pytest==2.0.0a0",
     "databricks-labs-pylint~=0.5",
-    "databricks-labs-pytester>=0.3.0",
+    "databricks-labs-pytester>=0.7.2",
     "pytest~=8.3.3",
     "pytest-cov~=4.1.0",
     "pytest-mock~=3.14.0",


### PR DESCRIPTION
The [just released](https://github.com/databrickslabs/pytester/releases/tag/v0.7.2) version of `pytester` includes a fix for a breaking change that was introduced by Databricks SDK 0.51: older versions of pytester will fail to import if the new Databricks SDK is present.

This PR updates the test dependency to the version that was just released:

 - This is mainly informational in terms of the breaking change: it doesn't affect user installs, and fresh development environments will probably pick up the newer version anyway.
 - The existing specified version is probably wrong: since 0.3.0 we've introduced things in pytester that `ucx` requires, but the dependency was not updated to reflect this.
