### PR TITLE
Workaround for acceptance with dependabot PR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 
 
-dependencies = ["databricks-sdk>=0.44.0,<0.45.0",
+dependencies = ["databricks-sdk>=0.44.0,<0.54.0",
                 "databricks-labs-lsql>=0.16.0,<0.17.0",
                 "databricks-labs-blueprint>=0.10.0,<0.11.0",
                 "PyYAML>=6.0.0,<6.1.0",

--- a/src/databricks/labs/ucx/account/metastores.py
+++ b/src/databricks/labs/ucx/account/metastores.py
@@ -79,7 +79,8 @@ class AccountMetastores:
             etag = default_namespace.get().etag
         except NotFound as err:
             # if not found, the etag is returned in the header
-            etag = err.details[0].metadata.get("etag")
+            if err.details[0].metadata:
+                etag = err.details[0].metadata.get("etag")
         default_namespace.update(
             allow_missing=True,
             field_mask="namespace.value",


### PR DESCRIPTION
## Changes
Dependabot PRs are not running acceptance tests seemingly due to a permissions issue. This workaround runs the acceptance tests

#4026 


