### PR TITLE
Unit test fix: `test_cluster_remap_error` (didn't fix it properly in #4030)

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -919,9 +919,9 @@ def test_cluster_remap(ws, caplog) -> None:
 def test_cluster_remap_error(ws, caplog) -> None:
     prompts = MockPrompts({"Please provide the cluster id's as comma separated value from the above list.*": "1"})
     ws.clusters.list.return_value = []
-    cluster_remap(ws, prompts)
     with caplog.at_level(logging.INFO, logger="databricks.labs.ucx"):
-        assert "No cluster information present in the workspace" in caplog.messages
+        cluster_remap(ws, prompts)
+    assert "No cluster information present in the workspace" in caplog.messages
 
 
 def test_revert_cluster_remap(caplog):


### PR DESCRIPTION
## Changes

One of the unit tests (`test_cluster_remap_error`) updated in #4030 wasn't done properly, and still wasn't capturing the logs in the right way. This PR fixes that.

### Linked issues

Follows #4030.

### Tests

- [x] manually tested (against `blueprint@cli-missing-debug-logging`)
- [x] updated unit test
