### PR TITLE
Fixes fmt and unit test failures from new blueprint release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 
 dependencies = ["databricks-sdk>=0.44.0,<0.54.0",
                 "databricks-labs-lsql>=0.16.0,<0.17.0",
-                "databricks-labs-blueprint>=0.10.0,<0.11.0",
+                "databricks-labs-blueprint>=0.10.0,<0.12.0",
                 "PyYAML>=6.0.0,<6.1.0",
                 "sqlglot>=26.7.0,<26.8.0",
                 "astroid>=3.3.0,<3.4.0"]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import create_autospec
 
 import yaml
-from databricks.labs.blueprint.installation import MockInstallation
+from databricks.labs.blueprint.installation import MockInstallation, RootJsonValue
 from databricks.labs.lsql.backends import MockBackend
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
@@ -24,7 +24,7 @@ from databricks.labs.ucx.source_code.graph import SourceContainer
 logging.getLogger("tests").setLevel("DEBUG")
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG = {
+DEFAULT_CONFIG: dict[str, RootJsonValue] = {
     "config.yml": {
         'version': 2,
         'inventory_database': 'ucx',


### PR DESCRIPTION
## Changes
Breaking changes in the blueprint release needs adding type hints to MockInstallation and fix a failing unit tests. This PR will also allow the acceptance tests to run that fail for dependabot.

### Tests
- [x] manually tested
