### PR TITLE
Update for Databricks SDK 0.56+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 
 
-dependencies = ["databricks-sdk>=0.56.0,<0.57.0",
+dependencies = ["databricks-sdk>=0.56.0,<0.58.0",
                 "databricks-labs-lsql>=0.16.0,<0.17.0",
                 "databricks-labs-blueprint>=0.11.0,<0.12.0",
                 "PyYAML>=6.0.0,<6.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 
 
-dependencies = ["databricks-sdk>=0.44.0,<0.54.0",
+dependencies = ["databricks-sdk>=0.56.0,<0.57.0",
                 "databricks-labs-lsql>=0.16.0,<0.17.0",
                 "databricks-labs-blueprint>=0.11.0,<0.12.0",
                 "PyYAML>=6.0.0,<6.1.0",

--- a/src/databricks/labs/ucx/hive_metastore/federation.py
+++ b/src/databricks/labs/ucx/hive_metastore/federation.py
@@ -299,11 +299,11 @@ class HiveMetastoreFederation(SecretsMixin):
         grants = self._location_grants(location_name)
         if Privilege.CREATE_FOREIGN_SECURABLE not in grants[current_user]:
             change = PermissionsChange(principal=current_user, add=[Privilege.CREATE_FOREIGN_SECURABLE])
-            self._ws.grants.update(SecurableType.EXTERNAL_LOCATION, location_name, changes=[change])
+            self._ws.grants.update(SecurableType.EXTERNAL_LOCATION.value, location_name, changes=[change])
 
     def _location_grants(self, location_name: str) -> dict[str, set[Privilege]]:
         grants: dict[str, set[Privilege]] = collections.defaultdict(set)
-        result = self._ws.grants.get(SecurableType.EXTERNAL_LOCATION, location_name)
+        result = self._ws.grants.get(SecurableType.EXTERNAL_LOCATION.value, location_name)
         if not result.privilege_assignments:
             return grants
         for assignment in result.privilege_assignments:

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -737,7 +737,7 @@ class PrincipalACL:
                 self._update_location_permissions(location_name, principals)
         logger.info("Applied all the permission on external location")
 
-    def _update_location_permissions(self, location_name: str, principals: list[str]):
+    def _update_location_permissions(self, location_name: str, principals: list[str]) -> None:
         permissions = [Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES]
         changes = [PermissionsChange(add=permissions, principal=principal) for principal in principals]
         self._ws.grants.update(

--- a/src/databricks/labs/ucx/hive_metastore/grants.py
+++ b/src/databricks/labs/ucx/hive_metastore/grants.py
@@ -741,7 +741,7 @@ class PrincipalACL:
         permissions = [Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES]
         changes = [PermissionsChange(add=permissions, principal=principal) for principal in principals]
         self._ws.grants.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             location_name,
             changes=changes,
         )

--- a/src/databricks/labs/ucx/hive_metastore/table_move.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_move.py
@@ -192,7 +192,7 @@ class TableMove:
                 logger.error(f"Failed to alias table {from_table_name}: {err!s}", exc_info=True)
             return False
 
-    def _reapply_grants(self, from_table_name, to_table_name, *, target_view: bool = False):
+    def _reapply_grants(self, from_table_name: str, to_table_name: str, *, target_view: bool = False) -> None:
         try:
             grants = self._ws.grants.get(SecurableType.TABLE, from_table_name)
         except NotFound:

--- a/src/databricks/labs/ucx/hive_metastore/table_move.py
+++ b/src/databricks/labs/ucx/hive_metastore/table_move.py
@@ -194,7 +194,7 @@ class TableMove:
 
     def _reapply_grants(self, from_table_name: str, to_table_name: str, *, target_view: bool = False) -> None:
         try:
-            grants = self._ws.grants.get(SecurableType.TABLE, from_table_name)
+            grants = self._ws.grants.get(SecurableType.TABLE.value, from_table_name)
         except NotFound:
             logger.warning(f"removed on the backend {from_table_name}")
             return
@@ -215,7 +215,7 @@ class TableMove:
             if privileges:
                 grants_changes.append(PermissionsChange(list(privileges), permission.principal))
 
-        self._ws.grants.update(SecurableType.TABLE, to_table_name, changes=grants_changes)
+        self._ws.grants.update(SecurableType.TABLE.value, to_table_name, changes=grants_changes)
 
     def _recreate_table(self, from_table_name, to_table_name, *, is_managed: bool, del_table: bool):
         drop_table = f"DROP TABLE {escape_sql_identifier(from_table_name)}"

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -150,7 +150,7 @@ def test_create_external_location_validate_acl(
     try:
         external_location_migration.run()
         permissions = ws.grants.get(
-            SecurableType.EXTERNAL_LOCATION, external_location_name, principal=cluster_user.user_name
+            SecurableType.EXTERNAL_LOCATION.value, external_location_name, principal=cluster_user.user_name
         )
         expected_aws_permission = PrivilegeAssignment(
             principal=cluster_user.user_name,
@@ -165,7 +165,7 @@ def test_create_external_location_validate_acl(
         ]
         ws.external_locations.delete(external_location_name)
         ws.grants.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             env_or_skip("TEST_A_LOCATION"),
             changes=[PermissionsChange(remove=remove_aws_permissions, principal=cluster_user.user_name)],
         )

--- a/tests/integration/aws/test_access.py
+++ b/tests/integration/aws/test_access.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from databricks.labs.blueprint.tui import MockPrompts
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.catalog import AwsIamRoleRequest
 from databricks.sdk.service.compute import DataSecurityMode, AwsAttributes
 from databricks.sdk.service.iam import PermissionLevel
@@ -104,13 +105,13 @@ def test_create_uber_instance_profile(ws, env_or_skip, make_random, make_cluster
 
 def test_create_external_location_validate_acl(
     make_cluster_permissions,
-    ws,
+    ws: WorkspaceClient,
     make_user,
     make_cluster,
     aws_cli_ctx,
     env_or_skip,
     inventory_schema,
-):
+) -> None:
     aws_cli_ctx.workspace_installation.run()
     aws_cli_ctx.with_dummy_resource_permission()
     aws_cli_ctx.sql_backend.save_table(
@@ -155,7 +156,7 @@ def test_create_external_location_validate_acl(
             principal=cluster_user.user_name,
             privileges=[Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES],
         )
-        assert expected_aws_permission in permissions.privilege_assignments
+        assert permissions.privilege_assignments and expected_aws_permission in permissions.privilege_assignments
     finally:
         remove_aws_permissions = [
             Privilege.CREATE_EXTERNAL_TABLE,

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import pytest
 from databricks.labs.blueprint.installation import MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import NotFound
 from databricks.sdk.service.iam import PermissionLevel
 from databricks.sdk.service.compute import DataSecurityMode
@@ -217,7 +218,9 @@ def test_overlapping_location(caplog, ws, sql_backend, inventory_schema, az_cli_
         save_delete_location(ws, "uctest_ziyuanqintest_overlap")
 
 
-def test_run_validate_acl(make_cluster_permissions, ws, make_user, make_cluster, az_cli_ctx, env_or_skip):
+def test_run_validate_acl(
+    make_cluster_permissions, ws: WorkspaceClient, make_user, make_cluster, az_cli_ctx, env_or_skip
+) -> None:
     az_cli_ctx.with_dummy_resource_permission()
     az_cli_ctx.save_locations()
     cluster = make_cluster(single_node=True, spark_conf=_SPARK_CONF, data_security_mode=DataSecurityMode.NONE)
@@ -238,7 +241,7 @@ def test_run_validate_acl(make_cluster_permissions, ws, make_user, make_cluster,
             principal=user.user_name,
             privileges=[Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES],
         )
-        assert expected_azure_permission in permissions.privilege_assignments
+        assert permissions.privilege_assignments and expected_azure_permission in permissions.privilege_assignments
     finally:
         remove_azure_permissions = [
             Privilege.CREATE_EXTERNAL_TABLE,

--- a/tests/integration/azure/test_locations.py
+++ b/tests/integration/azure/test_locations.py
@@ -235,7 +235,7 @@ def test_run_validate_acl(
     try:
         location_migration.run()
         permissions = ws.grants.get(
-            SecurableType.EXTERNAL_LOCATION, env_or_skip("TEST_A_LOCATION"), principal=user.user_name
+            SecurableType.EXTERNAL_LOCATION.value, env_or_skip("TEST_A_LOCATION"), principal=user.user_name
         )
         expected_azure_permission = PrivilegeAssignment(
             principal=user.user_name,
@@ -249,7 +249,7 @@ def test_run_validate_acl(
             Privilege.READ_FILES,
         ]
         ws.grants.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             env_or_skip("TEST_A_LOCATION"),
             changes=[PermissionsChange(remove=remove_azure_permissions, principal=user.user_name)],
         )

--- a/tests/integration/hive_metastore/test_catalog_schema.py
+++ b/tests/integration/hive_metastore/test_catalog_schema.py
@@ -6,9 +6,8 @@ from databricks.labs.blueprint.tui import MockPrompts
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
-from databricks.sdk.service.catalog import PermissionsList
 from databricks.sdk.service.compute import DataSecurityMode, AwsAttributes
-from databricks.sdk.service.catalog import Privilege, SecurableType, PrivilegeAssignment
+from databricks.sdk.service.catalog import GetPermissionsResponse, Privilege, SecurableType, PrivilegeAssignment
 from databricks.sdk.service.iam import PermissionLevel
 
 from databricks.labs.ucx.hive_metastore.grants import Grant
@@ -94,8 +93,8 @@ def test_create_catalog_schema_with_principal_acl_azure(
     mock_prompts = MockPrompts({"Please provide storage location url for catalog: *": ""})
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
-    schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
+    schema_grants = ws.grants.get(SecurableType.SCHEMA.value, schema_name)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG.value, catalog_name)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments
@@ -128,8 +127,8 @@ def test_create_catalog_schema_with_principal_acl_aws(
     mock_prompts = MockPrompts({"Please provide storage location url for catalog: *": ""})
     catalog_schema.create_all_catalogs_schemas(mock_prompts)
 
-    schema_grants = ws.grants.get(SecurableType.SCHEMA, schema_name)
-    catalog_grants = ws.grants.get(SecurableType.CATALOG, catalog_name)
+    schema_grants = ws.grants.get(SecurableType.SCHEMA.value, schema_name)
+    catalog_grants = ws.grants.get(SecurableType.CATALOG.value, catalog_name)
     schema_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_SCHEMA])
     catalog_grant = PrivilegeAssignment(user.user_name, [Privilege.USE_CATALOG])
     assert schema_grant in schema_grants.privilege_assignments
@@ -167,8 +166,8 @@ def test_create_catalog_schema_with_legacy_hive_metastore_privileges(
     runtime_ctx.catalog_schema.create_all_catalogs_schemas(mock_prompts, properties=properties)
 
     @retried(on=[NotFound], timeout=timedelta(seconds=20))
-    def get_schema_permissions_list(full_name: str) -> PermissionsList:
-        return ws.grants.get(SecurableType.SCHEMA, full_name)
+    def get_schema_permissions_list(full_name: str) -> GetPermissionsResponse:
+        return ws.grants.get(SecurableType.SCHEMA.value, full_name)
 
     assert (
         ws.schemas.get(f"{dst_catalog_name}.{dst_schema_name}").owner

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -2,12 +2,13 @@ import logging
 from datetime import timedelta
 
 import pytest
-from databricks.sdk import AccountClient
+from databricks.sdk import AccountClient, WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
 from databricks.sdk.service.compute import DataSecurityMode, AwsAttributes
 from databricks.sdk.service.catalog import Privilege, SecurableType, TableInfo, TableType
 from databricks.sdk.service.iam import PermissionLevel
+
 from databricks.labs.ucx.__about__ import __version__
 
 from databricks.labs.ucx.config import WorkspaceConfig
@@ -650,7 +651,9 @@ def test_mapping_reverts_table(ws, sql_backend, runtime_ctx, make_catalog):
 
 
 # @retried(on=[NotFound], timeout=timedelta(minutes=3))
-def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_catalog, make_user, env_or_skip):
+def test_migrate_managed_tables_with_acl(
+    ws: WorkspaceClient, sql_backend, runtime_ctx, make_catalog, make_user, env_or_skip
+) -> None:
     src_schema = runtime_ctx.make_schema(catalog_name="hive_metastore")
     src_managed_table = runtime_ctx.make_table(catalog_name=src_schema.catalog_name, schema_name=src_schema.name)
     user = make_user()
@@ -687,6 +690,7 @@ def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_cata
     assert len(target_tables) == 1
 
     target_table_properties = ws.tables.get(f"{dst_schema.full_name}.{src_managed_table.name}").properties
+    assert target_table_properties
     assert target_table_properties["upgraded_from"] == src_managed_table.full_name
     assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
 
@@ -721,8 +725,8 @@ def test_migrate_managed_tables_with_acl(ws, sql_backend, runtime_ctx, make_cata
 
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_migrate_external_tables_with_principal_acl_azure(
-    ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, make_ucx_group
-):
+    ws: WorkspaceClient, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, make_ucx_group
+) -> None:
     if not ws.config.is_azure:
         pytest.skip("only works in azure test env")
     ctx, table_full_name, _, _ = prepared_principal_acl
@@ -742,6 +746,7 @@ def test_migrate_external_tables_with_principal_acl_azure(
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
         if _.principal == user_with_cluster_access.user_name and _.privileges == [Privilege.ALL_PRIVILEGES]:
@@ -764,8 +769,8 @@ def test_migrate_external_tables_with_principal_acl_azure(
 
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_migrate_external_tables_with_principal_acl_aws(
-    ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, env_or_skip
-):
+    ws: WorkspaceClient, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster, env_or_skip
+) -> None:
     ctx, table_full_name, _, _ = prepared_principal_acl
     ctx.with_dummy_resource_permission()
     cluster = make_cluster(
@@ -783,6 +788,7 @@ def test_migrate_external_tables_with_principal_acl_aws(
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
         if _.principal == user.user_name and _.privileges == [Privilege.ALL_PRIVILEGES]:
@@ -793,8 +799,12 @@ def test_migrate_external_tables_with_principal_acl_aws(
 
 @retried(on=[NotFound], timeout=timedelta(minutes=3))
 def test_migrate_external_tables_with_principal_acl_aws_warehouse(
-    ws, make_user, prepared_principal_acl, make_warehouse_permissions, make_warehouse, env_or_skip
-):
+    ws: WorkspaceClient,
+    make_user,
+    prepared_principal_acl,
+    make_warehouse_permissions,
+    make_warehouse,
+) -> None:
     if not ws.config.is_aws:
         pytest.skip("temporary: only works in aws test env")
     ctx, table_full_name, _, _ = prepared_principal_acl
@@ -810,6 +820,7 @@ def test_migrate_external_tables_with_principal_acl_aws_warehouse(
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
         if _.principal == user.user_name and _.privileges == [Privilege.ALL_PRIVILEGES]:
@@ -879,8 +890,8 @@ def test_migrate_table_in_mount(
 
 
 def test_migrate_external_tables_with_spn_azure(
-    ws, make_user, prepared_principal_acl, make_cluster_permissions, make_cluster
-):
+    ws: WorkspaceClient, prepared_principal_acl, make_cluster_permissions, make_cluster
+) -> None:
     if not ws.config.is_azure:
         pytest.skip("temporary: only works in azure test env")
     ctx, table_full_name, _, _ = prepared_principal_acl
@@ -898,6 +909,7 @@ def test_migrate_external_tables_with_spn_azure(
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
     target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
         if _.principal == spn_with_mount_access and _.privileges == [Privilege.ALL_PRIVILEGES]:

--- a/tests/integration/hive_metastore/test_migrate.py
+++ b/tests/integration/hive_metastore/test_migrate.py
@@ -694,7 +694,7 @@ def test_migrate_managed_tables_with_acl(
     assert target_table_properties["upgraded_from"] == src_managed_table.full_name
     assert target_table_properties[Table.UPGRADED_FROM_WS_PARAM] == str(ws.get_workspace_id())
 
-    target_table_grants = ws.grants.get(SecurableType.TABLE, f"{dst_schema.full_name}.{src_managed_table.name}")
+    target_table_grants = ws.grants.get(SecurableType.TABLE.value, f"{dst_schema.full_name}.{src_managed_table.name}")
     target_principals = [pa for pa in target_table_grants.privilege_assignments or [] if pa.principal == user.user_name]
     assert len(target_principals) == 1, f"Missing grant for user {user.user_name}"
     assert target_principals[0].privileges == [Privilege.MODIFY, Privilege.SELECT]
@@ -745,7 +745,7 @@ def test_migrate_external_tables_with_principal_acl_azure(
     )
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
-    target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    target_table_grants = ws.grants.get(SecurableType.TABLE.value, table_full_name)
     assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
@@ -787,7 +787,7 @@ def test_migrate_external_tables_with_principal_acl_aws(
     )
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
-    target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    target_table_grants = ws.grants.get(SecurableType.TABLE.value, table_full_name)
     assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
@@ -819,7 +819,7 @@ def test_migrate_external_tables_with_principal_acl_aws_warehouse(
     )
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
-    target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    target_table_grants = ws.grants.get(SecurableType.TABLE.value, table_full_name)
     assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:
@@ -908,7 +908,7 @@ def test_migrate_external_tables_with_spn_azure(
     )
     table_migrate.migrate_tables(what=What.EXTERNAL_SYNC)
 
-    target_table_grants = ws.grants.get(SecurableType.TABLE, table_full_name)
+    target_table_grants = ws.grants.get(SecurableType.TABLE.value, table_full_name)
     assert target_table_grants.privilege_assignments is not None
     match = False
     for _ in target_table_grants.privilege_assignments:

--- a/tests/integration/hive_metastore/test_table_move.py
+++ b/tests/integration/hive_metastore/test_table_move.py
@@ -2,6 +2,8 @@ import logging
 from datetime import timedelta
 
 import pytest
+
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound, BadRequest
 from databricks.sdk.retries import retried
 from databricks.sdk.service.catalog import Privilege, PrivilegeAssignment, SecurableType
@@ -26,7 +28,7 @@ def test_move_tables_no_from_schema(ws, sql_backend, make_random, make_catalog, 
 
 
 def test_move_tables(
-    ws,
+    ws: WorkspaceClient,
     sql_backend,
     make_catalog,
     make_schema,
@@ -148,7 +150,7 @@ def test_move_views(ws, sql_backend, make_catalog, make_schema, make_table, make
 
 
 def test_alias_tables(
-    ws,
+    ws: WorkspaceClient,
     sql_backend,
     make_catalog,
     make_schema,

--- a/tests/integration/hive_metastore/test_table_move.py
+++ b/tests/integration/hive_metastore/test_table_move.py
@@ -62,16 +62,16 @@ def test_move_tables(
 
     to_tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema.name)
     table_1_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_1.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_1.name}"
     )
     table_2_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_2.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_2.name}"
     )
     table_3_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_3.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_3.name}"
     )
     view_1_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_view_1.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_view_1.name}"
     )
     for table in to_tables:
         assert table.name in [from_table_1.name, from_table_2.name, from_table_3.name, from_view_1.name]
@@ -184,16 +184,16 @@ def test_alias_tables(
 
     to_tables = ws.tables.list(catalog_name=to_catalog.name, schema_name=to_schema.name)
     table_1_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_1.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_1.name}"
     )
     table_2_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_2.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_2.name}"
     )
     table_3_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_3.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_table_3.name}"
     )
     view_1_grant = ws.grants.get(
-        securable_type=SecurableType.TABLE, full_name=f"{to_catalog.name}.{to_schema.name}.{from_view_1.name}"
+        securable_type=SecurableType.TABLE.value, full_name=f"{to_catalog.name}.{to_schema.name}.{from_view_1.name}"
     )
     for table in to_tables:
         assert table.name in [from_table_1.name, from_table_2.name, from_table_3.name, from_view_1.name]

--- a/tests/unit/hive_metastore/test_federation.py
+++ b/tests/unit/hive_metastore/test_federation.py
@@ -11,7 +11,7 @@ from databricks.sdk.service.catalog import (
     ConnectionType,
     CatalogInfo,
     ExternalLocationInfo,
-    PermissionsList,
+    GetPermissionsResponse,
     PrivilegeAssignment,
     SecurableType,
     PermissionsChange,
@@ -48,7 +48,7 @@ def test_create_federated_catalog_int(mock_installation) -> None:
         ExternalLocationInfo(url='s3://b/c/d', name='b'),
         ExternalLocationInfo(url='s3://e/f/g', name='e'),
     ]
-    workspace_client.grants.get.return_value = PermissionsList(
+    workspace_client.grants.get.return_value = GetPermissionsResponse(
         privilege_assignments=[PrivilegeAssignment(privileges=[Privilege.MANAGE], principal='any')]
     )
 
@@ -73,15 +73,15 @@ def test_create_federated_catalog_int(mock_installation) -> None:
         options={"authorized_paths": 's3://b/c/d,s3://e/f/g'},
     )
     calls = [
-        call.get(SecurableType.EXTERNAL_LOCATION, 'b'),
+        call.get(SecurableType.EXTERNAL_LOCATION.value, 'b'),
         call.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             'b',
             changes=[PermissionsChange(principal='serge', add=[Privilege.CREATE_FOREIGN_SECURABLE])],
         ),
-        call.get(SecurableType.EXTERNAL_LOCATION, 'e'),
+        call.get(SecurableType.EXTERNAL_LOCATION.value, 'e'),
         call.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             'e',
             changes=[PermissionsChange(principal='serge', add=[Privilege.CREATE_FOREIGN_SECURABLE])],
         ),
@@ -158,7 +158,7 @@ def test_create_federated_catalog_ext(mock_installation, config, expected) -> No
     workspace_client.external_locations.list.return_value = [
         ExternalLocationInfo(url='s3://b/c/d', name='b'),
     ]
-    workspace_client.grants.get.return_value = PermissionsList(
+    workspace_client.grants.get.return_value = GetPermissionsResponse(
         privilege_assignments=[PrivilegeAssignment(privileges=[Privilege.MANAGE], principal='any')]
     )
     mock_installation.load = lambda _: WorkspaceConfig(
@@ -189,9 +189,9 @@ def test_create_federated_catalog_ext(mock_installation, config, expected) -> No
         options={"authorized_paths": 's3://b/c/d'},
     )
     calls = [
-        call.get(SecurableType.EXTERNAL_LOCATION, 'b'),
+        call.get(SecurableType.EXTERNAL_LOCATION.value, 'b'),
         call.update(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             'b',
             changes=[PermissionsChange(principal='serge', add=[Privilege.CREATE_FOREIGN_SECURABLE])],
         ),
@@ -217,7 +217,7 @@ def test_already_existing_connection(mock_installation) -> None:
         ExternalLocationInfo(url='s3://b/c/d', name='b'),
         ExternalLocationInfo(url='s3://e/f/g', name='e'),
     ]
-    workspace_client.grants.get.return_value = PermissionsList(
+    workspace_client.grants.get.return_value = GetPermissionsResponse(
         privilege_assignments=[PrivilegeAssignment(privileges=[Privilege.MANAGE], principal='any')]
     )
 

--- a/tests/unit/hive_metastore/test_federation.py
+++ b/tests/unit/hive_metastore/test_federation.py
@@ -31,7 +31,7 @@ from databricks.labs.ucx.hive_metastore.federation import (
 from databricks.labs.ucx.hive_metastore.locations import ExternalLocation
 
 
-def test_create_federated_catalog_int(mock_installation):
+def test_create_federated_catalog_int(mock_installation) -> None:
     workspace_client = create_autospec(WorkspaceClient)
     external_locations = create_autospec(ExternalLocations)
     workspace_info = create_autospec(WorkspaceInfo)
@@ -141,7 +141,7 @@ def test_create_federated_catalog_int(mock_installation):
         ),
     ],
 )
-def test_create_federated_catalog_ext(mock_installation, config, expected):
+def test_create_federated_catalog_ext(mock_installation, config, expected) -> None:
     workspace_client = create_autospec(WorkspaceClient)
     external_locations = create_autospec(ExternalLocations)
     workspace_info = create_autospec(WorkspaceInfo)
@@ -199,7 +199,7 @@ def test_create_federated_catalog_ext(mock_installation, config, expected):
     assert calls == workspace_client.grants.method_calls
 
 
-def test_already_existing_connection(mock_installation):
+def test_already_existing_connection(mock_installation) -> None:
     workspace_client = create_autospec(WorkspaceClient)
     external_locations = create_autospec(ExternalLocations)
     workspace_info = create_autospec(WorkspaceInfo)
@@ -211,7 +211,7 @@ def test_already_existing_connection(mock_installation):
         ExternalLocation('s3://h/i/j', 1),
     ]
     workspace_client.current_user.me.return_value = User(user_name='serge')
-    workspace_client.connections.create.side_effect = AlreadyExists(...)
+    workspace_client.connections.create.side_effect = AlreadyExists()
     workspace_client.connections.list.return_value = [ConnectionInfo(name='a'), ConnectionInfo(name='b')]
     workspace_client.external_locations.list.return_value = [
         ExternalLocationInfo(url='s3://b/c/d', name='b'),

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -600,7 +600,7 @@ def test_apply_location_acl_single_spn_azure(ws, installation) -> None:
     permissions = [Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES]
     calls = [
         call(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             'loc1',
             changes=[
                 PermissionsChange(add=permissions, principal='group1'),
@@ -608,7 +608,7 @@ def test_apply_location_acl_single_spn_azure(ws, installation) -> None:
             ],
         ),
         call(
-            SecurableType.EXTERNAL_LOCATION,
+            SecurableType.EXTERNAL_LOCATION.value,
             'loc2',
             changes=[
                 PermissionsChange(add=permissions, principal='group2'),
@@ -637,7 +637,15 @@ def test_apply_location_acl_single_spn_aws(ws, installation):
     location_acl.apply_location_acl()
     permissions = [Privilege.CREATE_EXTERNAL_TABLE, Privilege.CREATE_EXTERNAL_VOLUME, Privilege.READ_FILES]
     calls = [
-        call(SecurableType.EXTERNAL_LOCATION, 'loc1', changes=[PermissionsChange(add=permissions, principal='spn1')]),
-        call(SecurableType.EXTERNAL_LOCATION, 'loc1', changes=[PermissionsChange(add=permissions, principal='group2')]),
+        call(
+            SecurableType.EXTERNAL_LOCATION.value,
+            'loc1',
+            changes=[PermissionsChange(add=permissions, principal='spn1')],
+        ),
+        call(
+            SecurableType.EXTERNAL_LOCATION.value,
+            'loc1',
+            changes=[PermissionsChange(add=permissions, principal='group2')],
+        ),
     ]
     ws.grants.update.assert_has_calls(calls, any_order=True)

--- a/tests/unit/hive_metastore/test_principal_grants.py
+++ b/tests/unit/hive_metastore/test_principal_grants.py
@@ -1,4 +1,4 @@
-from unittest.mock import create_autospec, call
+from unittest.mock import Mock, create_autospec, call
 
 import pytest
 from databricks.labs.blueprint.installation import MockInstallation
@@ -35,7 +35,7 @@ from databricks.labs.ucx.hive_metastore.tables import Table
 
 
 @pytest.fixture
-def ws():
+def ws() -> Mock:
     w = create_autospec(WorkspaceClient)
     w.external_locations.list.return_value = [
         ExternalLocationInfo(url="abfss://container1@storage1.dfs.core.windows.net/folder1", name='loc1'),
@@ -97,7 +97,7 @@ def ws():
     return w
 
 
-def azure_acl(w, install, cluster_spn: list, warehouse_spn: list):
+def azure_acl(w: WorkspaceClient, install, cluster_spn: list, warehouse_spn: list) -> AzureACL:
     config = install.load(WorkspaceConfig)
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
     spn_crawler = create_autospec(AzureServicePrincipalCrawler)
@@ -106,13 +106,13 @@ def azure_acl(w, install, cluster_spn: list, warehouse_spn: list):
     return AzureACL(w, sql_backend, spn_crawler, install)
 
 
-def aws_acl(w, install):
+def aws_acl(w: WorkspaceClient, install) -> AwsACL:
     config = install.load(WorkspaceConfig)
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
     return AwsACL(w, sql_backend, install)
 
 
-def principal_acl(w, install, cluster_spn: list, warehouse_spn: list):
+def principal_acl(w: WorkspaceClient, install, cluster_spn: list, warehouse_spn: list) -> PrincipalACL:
     config = install.load(WorkspaceConfig)
     sql_backend = StatementExecutionBackend(w, config.warehouse_id)
     table_crawler = create_autospec(TablesCrawler)
@@ -586,7 +586,7 @@ def test_apply_location_acl_no_location_name(ws, installation):
     ws.grants.update.assert_not_called()
 
 
-def test_apply_location_acl_single_spn_azure(ws, installation):
+def test_apply_location_acl_single_spn_azure(ws, installation) -> None:
     ws.config.is_azure = True
     ws.config.is_aws = False
     cluster_spn = ServicePrincipalClusterMapping(

--- a/tests/unit/hive_metastore/test_table_move.py
+++ b/tests/unit/hive_metastore/test_table_move.py
@@ -231,7 +231,7 @@ def test_move_tables_get_grants_fails_because_table_removed(caplog):
 
 
 @pytest.mark.parametrize("del_table", [True, False])
-def test_move_all_tables(del_table: bool):
+def test_move_all_tables(del_table: bool) -> None:
     client = create_autospec(WorkspaceClient)
 
     client.tables.list.return_value = [
@@ -353,7 +353,7 @@ def test_move_all_tables(del_table: bool):
     assert sorted(expected_queries) == sorted(backend.queries)
 
 
-def test_alias_all_tables():
+def test_alias_all_tables() -> None:
     client = create_autospec(WorkspaceClient)
 
     client.tables.list.return_value = [
@@ -441,7 +441,7 @@ def test_alias_all_tables():
     ] == sorted(backend.queries)
 
 
-def test_move_one_table_without_dropping_source():
+def test_move_one_table_without_dropping_source() -> None:
     client = create_autospec(WorkspaceClient)
 
     client.tables.list.return_value = [
@@ -483,7 +483,7 @@ def test_move_one_table_without_dropping_source():
     ] == sorted(backend.queries)
 
 
-def test_move_apply_grants():
+def test_move_apply_grants() -> None:
     client = create_autospec(WorkspaceClient)
 
     client.tables.list.return_value = [
@@ -523,7 +523,7 @@ def test_move_apply_grants():
     )
 
 
-def test_alias_apply_grants():
+def test_alias_apply_grants() -> None:
     client = create_autospec(WorkspaceClient)
 
     client.tables.list.return_value = [


### PR DESCRIPTION
## Changes

This PR updates the project to work with Databricks SDK 0.56+ which included breaking changes.

Incidental changes included adding type-hints to ensure that all the updated functions are linted; some were not, which prevented some of the breaking changes from being found during linting.

### Linked issues

Supersedes #4144.

This PR is also required for the upstream blueprint, whose CI/CD always tests UCX with the latest available SDK (even if UCX specifies an earlier one):

 - databrickslabs/blueprint#243
 - databrickslabs/blueprint#244

### Tests

- existing unit tests
- existing integration tests
