### PR TITLE
Update integration test to use `make_random()` properly

### DIFF
--- a/tests/integration/hive_metastore/test_external_locations.py
+++ b/tests/integration/hive_metastore/test_external_locations.py
@@ -101,6 +101,6 @@ def test_save_external_location_mapping_missing_location(ws, sql_backend, invent
     tables_crawler = TablesCrawler(sql_backend, inventory_schema)
     mounts_crawler = MountsCrawler(sql_backend, ws, inventory_schema)
     location_crawler = ExternalLocations(ws, sql_backend, inventory_schema, tables_crawler, mounts_crawler)
-    installation = Installation(ws, make_random)
+    installation = Installation(ws, make_random())
     path = location_crawler.save_as_terraform_definitions_on_workspace(installation)
     assert ws.workspace.get_status(path)


### PR DESCRIPTION
## Changes

This PR updates a test that was using the `make_random` fixture incorrectly: instead of calling the function and using the result, it was passing the function itself.

### Tests

- updated integration test
