### PR TITLE
Handle PermisssionDenied exception so that a new dashboard is created.

### DIFF
--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -619,34 +619,47 @@ class WorkspaceInstallation(InstallationMixin):
             str | None :
                 The dashboard id. If None, the dashboard will be recreated.
         """
-        if "-" in dashboard_id:
-            logger.info(f"Upgrading dashboard to Lakeview: {display_name} ({dashboard_id})")
-            try:
-                self._ws.dashboards.delete(dashboard_id=dashboard_id)
-            except BadRequest:
-                logger.warning(f"Cannot delete dashboard: {display_name} ({dashboard_id})")
-            return None  # Recreate the dashboard if upgrading from Redash
+        if self._is_redash_dashboard(dashboard_id):
+            self._upgrade_redash_dashboard(dashboard_id, display_name)
         try:
             dashboard = self._ws.lakeview.get(dashboard_id)
-            if dashboard.lifecycle_state is None:
-                raise NotFound(f"Dashboard life cycle state: {display_name} ({dashboard_id})")
-            if dashboard.lifecycle_state == LifecycleState.TRASHED:
-                logger.info(f"Recreating trashed dashboard: {display_name} ({dashboard_id})")
+            if self._is_trashed_dashboard(dashboard, display_name, dashboard_id):
                 return None  # Recreate the dashboard if it is trashed (manually)
         except (NotFound, InvalidParameterValue):
-            logger.info(f"Recovering invalid dashboard: {display_name} ({dashboard_id})")
-            try:
-                dashboard_path = f"{parent_path}/{display_name}.lvdash.json"
-                self._ws.workspace.delete(dashboard_path)  # Cannot recreate dashboard if file still exists
-                logger.debug(f"Deleted dangling dashboard {display_name} ({dashboard_id}): {dashboard_path}")
-            except NotFound:
-                pass
-            return None  # Recreate the dashboard if it's reference is corrupted (manually)
+            self._recover_invalid_dashboard(dashboard_id, display_name, parent_path)
+            return None
         except PermissionDenied:
-                logger.warning(f"Cannot access dashboard {display_name} ({dashboard_id}), permission denied")
-                pass
-                return None  # Create a new dashboard if permission is denied.
+            logger.warning(f"Cannot access dashboard {display_name} ({dashboard_id}), permission denied")
+            return None  # Create a new dashboard if permission is denied.
         return dashboard_id  # Update the existing dashboard
+
+    def _is_redash_dashboard(self, dashboard_id: str) -> bool:
+        """Check if the dashboard is a Redash dashboard"""
+        return "-" in dashboard_id
+
+    def _upgrade_redash_dashboard(self, dashboard_id: str, display_name: str) -> None:
+        logger.info(f"Upgrading dashboard to Lakeview: {display_name} ({dashboard_id})")
+        try:
+            self._ws.dashboards.delete(dashboard_id=dashboard_id)
+        except BadRequest:
+            logger.warning(f"Cannot delete dashboard: {display_name} ({dashboard_id})")
+
+    def _is_trashed_dashboard(self, dashboard, display_name: str, dashboard_id: str) -> bool:
+        if dashboard.lifecycle_state is None:
+            raise NotFound(f"Dashboard life cycle state: {display_name} ({dashboard_id})")
+        if dashboard.lifecycle_state == LifecycleState.TRASHED:
+            logger.info(f"Recreating trashed dashboard: {display_name} ({dashboard_id})")
+            return True
+        return False
+
+    def _recover_invalid_dashboard(self, dashboard_id: str, display_name: str, parent_path: str) -> None:
+        logger.info(f"Recovering invalid dashboard: {display_name} ({dashboard_id})")
+        try:
+            dashboard_path = f"{parent_path}/{display_name}.lvdash.json"
+            self._ws.workspace.delete(dashboard_path)  # Cannot recreate dashboard if file still exists
+            logger.debug(f"Deleted dangling dashboard {display_name} ({dashboard_id}): {dashboard_path}")
+        except NotFound:
+            pass
 
     # InternalError and DeadlineExceeded are retried because of Lakeview internal issues
     # These issues have been reported to and are resolved by the Lakeview team

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -642,6 +642,10 @@ class WorkspaceInstallation(InstallationMixin):
             except NotFound:
                 pass
             return None  # Recreate the dashboard if it's reference is corrupted (manually)
+        except PermissionDenied:
+                logger.warning(f"Cannot access dashboard {display_name} ({dashboard_id}), permission denied")
+                pass
+                return None  # Create a new dashboard if permission is denied.
         return dashboard_id  # Update the existing dashboard
 
     # InternalError and DeadlineExceeded are retried because of Lakeview internal issues


### PR DESCRIPTION
## Changes
Integration test for invalid dashboard is failining on PermissionDenied which we currently do not handle. Add a handler for PermissionDenied so that the older one is ignored and a new dashboard is creted.

### Linked issues
Resolves #4208 

### Functionality

- [x] handle older dangling dashboard 

### Tests

- [x] existing test
