### PR TITLE
Fix service principal not re-created while creating account groups

### DIFF
--- a/src/databricks/labs/ucx/account/workspaces.py
+++ b/src/databricks/labs/ucx/account/workspaces.py
@@ -127,7 +127,7 @@ class AccountWorkspaces:
         members_to_add = []
         assert valid_group.members is not None, "group members undefined"
         for member in valid_group.members:
-            if member.ref and member.ref.startswith("Users"):
+            if member.ref and (member.ref.startswith("Users") or member.ref.startswith("ServicePrincipals")):
                 members_to_add.append(member)
             elif member.ref and member.ref.startswith("Groups"):
                 assert member.display is not None, "group name undefined"
@@ -135,7 +135,7 @@ class AccountWorkspaces:
                 if members_to_append:
                     members_to_add.append(members_to_append)
             else:
-                logger.warning(f"Member {member.ref} is not a user or group, skipping")
+                logger.warning(f"Member {member.ref} is not a user, service principal or a group, skipping")
 
         acc_group = self._try_create_account_groups(group_name, context.preexisting_account_groups)
         if acc_group:

--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -55,8 +55,11 @@ def test_create_account_level_groups(
     group_display_name = f"created_by_ucx_regular_group-{suffix}"
     # Create a group with a user and a service principal as members
     # to test the account level groups creation.
-    #TODO: remove protected access to service principal id once added in pytester
-    make_group(display_name=group_display_name, members=[make_user().id, make_run_as()._service_principal.id]) # pylint: disable=W0212
+    # TODO: remove protected access to service principal id once added in pytester
+    make_group(
+        display_name=group_display_name,
+        members=[make_user().id, make_run_as()._service_principal.id],  # pylint: disable=protected-access
+    )
     AccountWorkspaces(acc, [ws.get_workspace_id()]).create_account_level_groups(MockPrompts({}))
 
     @retried(on=[KeyError], timeout=timedelta(minutes=2))

--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -53,7 +53,10 @@ def test_create_account_level_groups(
     make_ucx_group(f"test_ucx_migrate_invalid-{suffix}", f"test_ucx_migrate_invalid-{suffix}")
 
     group_display_name = f"created_by_ucx_regular_group-{suffix}"
-    make_group(display_name=group_display_name, members=[make_user().id, make_run_as()._service_principal.id])
+    # Create a group with a user and a service principal as members
+    # to test the account level groups creation.
+    #TODO: remove protected access to service principal id once added in pytester
+    make_group(display_name=group_display_name, members=[make_user().id, make_run_as()._service_principal.id]) # pylint: disable=W0212
     AccountWorkspaces(acc, [ws.get_workspace_id()]).create_account_level_groups(MockPrompts({}))
 
     @retried(on=[KeyError], timeout=timedelta(minutes=2))

--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -42,6 +42,7 @@ def test_create_account_level_groups(
     make_ucx_group,
     make_group,
     make_user,
+    make_run_as,
     acc,
     ws,
     make_random,
@@ -52,7 +53,7 @@ def test_create_account_level_groups(
     make_ucx_group(f"test_ucx_migrate_invalid-{suffix}", f"test_ucx_migrate_invalid-{suffix}")
 
     group_display_name = f"created_by_ucx_regular_group-{suffix}"
-    make_group(display_name=group_display_name, members=[make_user().id])
+    make_group(display_name=group_display_name, members=[make_user().id, make_run_as()._service_principal.id])
     AccountWorkspaces(acc, [ws.get_workspace_id()]).create_account_level_groups(MockPrompts({}))
 
     @retried(on=[KeyError], timeout=timedelta(minutes=2))
@@ -64,6 +65,7 @@ def test_create_account_level_groups(
 
     group = get_group(group_display_name)
     assert group
+    assert len(group.members) == 2  # 2 members: user and service principal
 
 
 def test_create_account_level_groups_nested_groups(


### PR DESCRIPTION
## Changes
Service Principals were not being created during account group creation. This PR fixes the bug and adds a test

### Linked issues
Resolves #4359 

### Tests
- [x] modified integration tests