### PR TITLE
Use the new property `id` from RunAs in pytester

### DIFF
--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -63,10 +63,9 @@ def test_create_account_level_groups(
     group_display_name = f"created_by_ucx_regular_group-{suffix}"
     # Create a group with a user and a service principal as members
     # to test the account level groups creation.
-    # TODO: remove protected access to service principal id once added in pytester
     ws_group = make_group(
         display_name=group_display_name,
-        members=[make_user().id, make_run_as()._service_principal.id],  # pylint: disable=protected-access
+        members=[make_user().id, make_run_as().id],
     )
     AccountWorkspaces(acc, [ws.get_workspace_id()]).create_account_level_groups(MockPrompts({}))
 


### PR DESCRIPTION
## Changes
Refactor to use the newly introduced property `id` from RunAs