### PR TITLE
Extends assert retries for table and schema grants

### DIFF
--- a/tests/integration/workspace_access/test_tacl.py
+++ b/tests/integration/workspace_access/test_tacl.py
@@ -18,7 +18,7 @@ from . import apply_tasks
 logger = logging.getLogger(__name__)
 
 
-@retried(on=[AssertionError], timeout=dt.timedelta(seconds=10))
+@retried(on=[AssertionError], timeout=dt.timedelta(seconds=30))
 def assert_grants_with_retry(
     grants_crawler: GrantsCrawler,
     object_type: str,


### PR DESCRIPTION
## Changes
In line with adding retries to failing integration tests (because fetching grants is taking a tad bit longer) extend the previously designed function for UDFs to Tables and Schemas in the tests

### Linked issues
Resolves #4367

### Tests
- [x] modified integration tests
