### PR TITLE
Adds retries and uses listing to fetch groups

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1466,7 +1466,7 @@ def pytest_ignore_collect(path):
         logger.debug(f"pytest_ignore_collect: error: {err}")
         return False
 
-@retried(on=[KeyError], timeout=timedelta(minutes=2))
+@retried(on=[AssertionError], timeout=timedelta(seconds=30))
 def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
     """
     # Group deletion is eventually consistent. Although the group manager tries to wait for convergence, parts of the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1466,7 +1466,7 @@ def pytest_ignore_collect(path):
         logger.debug(f"pytest_ignore_collect: error: {err}")
         return False
 
-@retried(on=[AssertionError], timeout=timedelta(seconds=30))
+@retried(on=[AssertionError], timeout=timedelta(minutes=1))
 def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
     """
     # Group deletion is eventually consistent. Although the group manager tries to wait for convergence, parts of the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1466,6 +1466,7 @@ def pytest_ignore_collect(path):
         logger.debug(f"pytest_ignore_collect: error: {err}")
         return False
 
+
 @retried(on=[AssertionError], timeout=timedelta(minutes=1))
 def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
     """

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -4,7 +4,6 @@ import logging
 import subprocess
 import sys
 from datetime import timedelta
-from typing import NoReturn
 
 import pytest
 

--- a/tests/integration/workspace_access/test_groups.py
+++ b/tests/integration/workspace_access/test_groups.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 from datetime import timedelta
-from typing import NoReturn
 
 import pytest
 from databricks.sdk.errors import NotFound, ResourceConflict
@@ -127,6 +126,7 @@ def test_reflect_account_groups_on_workspace(ws, make_ucx_group, sql_backend, in
 
     check_group_renamed(ws, ws_group)
     # At this time previous ws level groups aren't deleted
+
 
 @retried(on=[NotFound], timeout=timedelta(minutes=2))
 def test_delete_ws_groups_should_delete_renamed_and_reflected_groups_only(


### PR DESCRIPTION
## Changes
The original function being used to fetch groups is taking a long time to be eventually consistent. Using the same retry logic and fetching the entire groups list is a much faster approach.

### Linked issues
Resolves #4368

### Tests
- [x] modified integration tests
