### PR TITLE
Improve STS Export to Assessment to Excel

### DIFF
--- a/src/databricks/labs/ucx/cli.py
+++ b/src/databricks/labs/ucx/cli.py
@@ -918,7 +918,8 @@ def export_assessment(w: WorkspaceClient, prompts: Prompts):
     """Export the UCX assessment queries to a zip file."""
     ctx = WorkspaceContext(w)
     exporter = ctx.assessment_exporter
-    exporter.export_results(prompts)
+    results_path = exporter.cli_export_results(prompts)
+    logger.info(f"Results exported to {results_path}")
 
 
 @ucx.command

--- a/src/databricks/labs/ucx/contexts/application.py
+++ b/src/databricks/labs/ucx/contexts/application.py
@@ -362,7 +362,7 @@ class GlobalContext(abc.ABC):
 
     @cached_property
     def assessment_exporter(self):
-        return AssessmentExporter(self.sql_backend, self.config)
+        return AssessmentExporter(self.workspace_client, self.sql_backend, self.config)
 
     @cached_property
     def acl_migrator(self):

--- a/src/databricks/labs/ucx/installer/workflows.py
+++ b/src/databricks/labs/ucx/installer/workflows.py
@@ -143,111 +143,35 @@ EXPORT_TO_EXCEL_NOTEBOOK = """# Databricks notebook source
 
 # COMMAND ----------
 
-# DBTITLE 1,Installing Packages
 # MAGIC %pip install {remote_wheel} -qqq
 # MAGIC %pip install xlsxwriter -qqq
 # MAGIC dbutils.library.restartPython()
 
 # COMMAND ----------
 
-# DBTITLE 1,Libraries Import and Setting UCX
-import os
 import logging
-import threading
-import shutil
 from pathlib import Path
-from threading import Lock
-from functools import partial
 
-import pandas as pd
 import xlsxwriter
+import pandas as pd
 
 from databricks.sdk.config import with_user_agent_extra
+
 from databricks.labs.blueprint.logger import install_logger
-from databricks.labs.blueprint.parallel import Threads
-from databricks.labs.lsql.dashboards import Dashboards
-from databricks.labs.lsql.lakeview.model import Dataset
 from databricks.labs.ucx.contexts.workflow_task import RuntimeContext
 
-# ctx
 install_logger()
 with_user_agent_extra("cmd", "export-assessment")
+logging.getLogger("databricks").setLevel("INFO")
+
 named_parameters = dict(config="/Workspace{config_file}")
 ctx = RuntimeContext(named_parameters)
-lock = Lock()
 
 # COMMAND ----------
 
-# DBTITLE 1,Assessment Export
-FILE_NAME = "ucx_assessment_main.xlsx"
-UCX_PATH = Path(f"/Workspace{{ctx.installation.install_folder()}}")
-DOWNLOAD_PATH = Path("/dbfs/FileStore/excel-export/")
-
-
-def _cleanup() -> None:
-    '''Move the temporary results file to the download path and clean up the temp directory.'''
-    shutil.move(
-        UCX_PATH / "tmp" / FILE_NAME,
-        DOWNLOAD_PATH / FILE_NAME,
-    )
-    shutil.rmtree(UCX_PATH / "tmp/")
-
-
-def _prepare_directories() -> None:
-    '''Ensure that the necessary directories exist.'''
-    os.makedirs(UCX_PATH / "tmp/", exist_ok=True)
-    os.makedirs(DOWNLOAD_PATH, exist_ok=True)
-
-def _process_id_columns(df):
-    id_columns = [col for col in df.columns if 'id' in col.lower()]
-
-    if id_columns:
-        for col in id_columns:
-            df[col] = "'" + df[col].astype(str)
-    return df
-
-def _to_excel(dataset: Dataset, writer: ...) -> None:
-    '''Execute a SQL query and write the result to an Excel sheet.'''
-    worksheet_name = dataset.display_name[:31]
-    df = spark.sql(dataset.query).toPandas()
-    df = _process_id_columns(df)
-    with lock:
-        df.to_excel(writer, sheet_name=worksheet_name, index=False)
-
-
-def _render_export() -> None:
-    '''Render an HTML link for downloading the results.'''
-    html_content = '''
-    <style>@font-face{{font-family:'DM Sans';src:url(https://cdn.bfldr.com/9AYANS2F/at/p9qfs3vgsvnp5c7txz583vgs/dm-sans-regular.ttf?auto=webp&format=ttf) format('truetype');font-weight:400;font-style:normal}}body{{font-family:'DM Sans',Arial,sans-serif}}.export-container{{text-align:center;margin-top:20px}}.export-container h2{{color:#1B3139;font-size:24px;margin-bottom:20px}}.export-container a{{display:inline-block;padding:12px 25px;background-color:#1B3139;color:#fff;text-decoration:none;border-radius:4px;font-size:18px;font-weight:500;transition:background-color 0.3s ease,transform:translateY(-2px) ease}}.export-container a:hover{{background-color:#FF3621;transform:translateY(-2px)}}</style>
-    <div class="export-container"><h2>Export Results</h2><a href='{workspace_host}/files/excel-export/ucx_assessment_main.xlsx?o={workspace_id}' target='_blank' download>Download Results</a></div>
-
-    '''
-    displayHTML(html_content)
-
-
-def export_results() -> None:
-    '''Main method to export results to an Excel file.'''
-    _prepare_directories()
-
-    assessment_dashboard = next(UCX_PATH.glob("dashboards/*Assessment (Main)*"))
-    dashboard_datasets = Dashboards(ctx.workspace_client).get_dashboard(assessment_dashboard).datasets
-
-    try:
-        target = UCX_PATH / "tmp/ucx_assessment_main.xlsx"
-        with pd.ExcelWriter(target, engine="xlsxwriter") as writer:
-            tasks = []
-            for dataset in dashboard_datasets:
-                tasks.append(partial(_to_excel, dataset, writer))
-                Threads.strict("exporting", tasks)
-        _cleanup()
-        _render_export()
-    except Exception as e:
-        print(f"Error exporting results ", e)
-
-# COMMAND ----------
-
-# DBTITLE 1,Data Export
-export_results()
+displayHTML(
+    ctx.assessment_exporter.web_export_results(pd)
+)
 """
 
 

--- a/tests/unit/assessment/test_export.py
+++ b/tests/unit/assessment/test_export.py
@@ -1,3 +1,6 @@
+from unittest.mock import create_autospec, patch
+
+
 from databricks.labs.ucx.config import WorkspaceConfig
 from databricks.labs.ucx.assessment.export import AssessmentExporter
 from databricks.labs.lsql.backends import MockBackend
@@ -5,8 +8,8 @@ from databricks.labs.blueprint.tui import MockPrompts
 from databricks.labs.lsql.core import Row
 
 
-def test_export(tmp_path):
-    """Test the export_results method of the AssessmentExporter class."""
+def test_cli_export(ws, tmp_path):
+    """Test the cli export_results method of the AssessmentExporter class."""
     query = {
         "SELECT\n  one\nFROM ucx.external_locations": [
             Row(location="s3://bucket1/folder1", table_count=1),
@@ -33,9 +36,53 @@ def test_export(tmp_path):
     )
 
     # Execute export process
-    export = AssessmentExporter(mock_backend, config)
-    exported = export.export_results(mock_prompts)
+    export = AssessmentExporter(ws, mock_backend, config)
+    exported = export.cli_export_results(mock_prompts)
 
     # Assertion based on the query_choice
     expected_file_name = f"export_{query_choice['assessment_name']}_results.zip"  # Adjusted filename
     assert exported == export_path / expected_file_name
+
+
+def test_web_export(ws, tmp_path):
+    """Test the web export_results method of the AssessmentExporter class."""
+    config = WorkspaceConfig(inventory_database="ucx")
+    mock_backend = MockBackend()
+
+    export = AssessmentExporter(ws, mock_backend, config)
+    expected_html = """
+            <div class="export-container">
+                <h2>Export Results</h2>
+                <button onclick="downloadExcel()">Download Results</button>
+            </div>
+            """
+
+    class ExcelWriterSpec:
+        def __init__(self, path, engine=None, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def close(self):
+            pass
+
+        def save(self):
+            pass
+
+    class PandasSpec:
+        ExcelWriter = ExcelWriterSpec
+
+    mock_writer = create_autospec(PandasSpec)
+
+    with patch.object(export, '_render_export') as mock_render_export:
+        mock_render_export.return_value = expected_html
+
+        result = export.web_export_results(mock_writer)
+        assert "downloadExcel()" in result
+        assert "Download Results" in result
+
+    mock_writer.ExcelWriter.assert_called_once()


### PR DESCRIPTION
## Changes

This notebook is heavily used by the STS Team and this change alleviates the need of sending a custom notebook for the export.

Refactored assessment UI export functionality EXPORT_ASSESSMENT_TO_EXCEL to improve compatibility and remove compute constraints.

### Linked issues
Not reported, but the Notebook failed as the lsql library returned empty queries. 

### Functionality
- [x] Refactored `EXPORT_ASSESSMENT_TO_EXCEL` code into `AssessmentExporter` class
- [x] Enabled assessment execution from RuntimeContext
- [x] Removed DBFS dependency for export file generation
- [x] Eliminated lsql library dependency that was causing notebook execution failures


### Technical Details

**Before:** The export functionality was tightly coupled to personal compute environments due to DBFS dependencies and lsql library requirements, limiting where the notebook could be executed.

**After:** 
- Export logic is now encapsulated in the `AssessmentExporter` class
- Removed DBFS dependency, allowing the notebook to run on any compute type including serverless
- Eliminated lsql library dependency that was preventing successful execution
- Assessment can now be executed directly from Runtime context

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [x] verified on local environment (screenshot attached)
<img width="1730" height="859" alt="export_to_excel_notebook" src="https://github.com/user-attachments/assets/b31a79a1-6700-4fdf-b499-dc70cf1d260e" />
