### PR TITLE
Adds option to skip `assess_workflows` via install-time choice & config

### DIFF
--- a/docs/ucx/docs/reference/workflows/index.mdx
+++ b/docs/ucx/docs/reference/workflows/index.mdx
@@ -89,6 +89,7 @@ the [assessment report](/docs/reference/assessment).
 19. `assess_workflows`(experimnetal): This task retrieves the jobs to analyze their notebooks and files for
     [migration problems](/docs/reference/linter_codes). This will run for workflows that ran within the last 30 days.
     To analyze all workflows run the ["migration-progress-experimental"] workflow](/docs/reference/workflows#migration-progress-experimental).
+    The assess_workflows task can be skipped during installation by responding to the prompt, or by setting the 'skip_assess_workflows' flag in config.yml. This allows you to control whether workflow analysis is performed as part of the assessment workflow.
 
 After UCX assessment workflow finished, see the assessment dashboard for findings and recommendations.
 See [this guide](/docs/reference/assessment) for more details.

--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -225,6 +225,9 @@ class Assessment(Workflow):  # pylint: disable=too-many-public-methods
 
         Also, stores direct filesystem accesses for display in the migration dashboard.
         """
+        if ctx.config.skip_assess_workflows:
+            logger.info("Skipping assess_workflows as skip_assess_workflows is enabled.")
+            return
         ctx.workflow_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
 
 

--- a/src/databricks/labs/ucx/config.py
+++ b/src/databricks/labs/ucx/config.py
@@ -93,6 +93,9 @@ class WorkspaceConfig:  # pylint: disable=too-many-instance-attributes
     # Skip TACL migration during table migration
     skip_tacl_migration: bool = False
 
+    # Skip assess_workflows task during assessment
+    skip_assess_workflows: bool = False
+
     # Select SQL query statement disposition
     query_statement_disposition: Disposition = Disposition.INLINE
 

--- a/src/databricks/labs/ucx/install.py
+++ b/src/databricks/labs/ucx/install.py
@@ -245,6 +245,7 @@ class WorkspaceInstaller(WorkspaceContext):
         include_databases = self._select_databases()
 
         skip_tacl_migration = self.prompts.confirm("Do you want to skip TACL migration when migrating tables?")
+        skip_assess_workflows = self.prompts.confirm("Do you want to skip workflow assessment?")
 
         # Checking if the user wants to define a default owner group.
         default_owner_group = None
@@ -269,6 +270,7 @@ class WorkspaceInstaller(WorkspaceContext):
             include_group_names=configure_groups.include_group_names,
             renamed_group_prefix=configure_groups.renamed_group_prefix,
             skip_tacl_migration=skip_tacl_migration,
+            skip_assess_workflows=skip_assess_workflows,
             log_level=log_level,
             num_threads=num_threads,
             include_databases=include_databases,


### PR DESCRIPTION
## Changes
Adds an installation prompt and a configurable flag in config.yml for users to skip `assess_workflows`.

### Linked issues
Resolves #4374 

### Functionality
- [x] modified existing workflow: `assessment`

### Tests
- [x] manually tested

<img width="996" height="316" alt="image" src="https://github.com/user-attachments/assets/b22105a9-c1ae-475f-9466-cc79add58a1c" />

