### PR TITLE
Split `assess_workflows` task into its new Workflow

### DIFF
--- a/src/databricks/labs/ucx/assessment/workflows.py
+++ b/src/databricks/labs/ucx/assessment/workflows.py
@@ -231,6 +231,21 @@ class Assessment(Workflow):  # pylint: disable=too-many-public-methods
         ctx.workflow_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
 
 
+class AssessWorkflow(Workflow):
+    def __init__(self):
+        super().__init__('assess_workflows', [JobParameterDefinition(name="force_refresh", default=False)])
+
+    @job_task
+    def assess_workflows(self, ctx: RuntimeContext):
+        """Scans all jobs for migration issues in notebooks jobs.
+
+        Also, stores direct filesystem accesses for display in the migration dashboard.
+        """
+        if ctx.config.skip_assess_workflows:
+            logger.info("Skipping assess_workflows as skip_assess_workflows is enabled.")
+            return
+        ctx.workflow_linter.refresh_report(ctx.sql_backend, ctx.inventory_database)
+
 class Failing(Workflow):
     def __init__(self):
         super().__init__('failing')


### PR DESCRIPTION
## Changes
Separates the `assess_workflows` task from the main Assessment workflow and introduces it as its own standalone UCX job. Previously, assess_workflows was bundled within the Assessment workflow, often making the overall run significantly longer. By splitting it out, users gain more control over when and how workflow assessment is executed.

### Linked issues
Resolves #4393 

### Functionality

- [x] added a new workflow, split a task from existing workflow
- [x] modified existing workflow: `assessment`. removed the `assess_workflows` task

### Tests
- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
