### PR TITLE
Add a dataframe call matcher for linting tables

### DIFF
--- a/src/databricks/labs/ucx/workspace_access/groups.py
+++ b/src/databricks/labs/ucx/workspace_access/groups.py
@@ -929,7 +929,7 @@ class AccountGroupLookup:
             return None
         if len(groups) == 1:
             return groups[0].display_name
-        group_names = [group.display_name for group in groups]
+        group_names = [group.display_name for group in groups if group.display_name is not None]
         return prompt.choice("Select the group to be used as the owner group", group_names, max_attempts=3)
 
     def user_in_group(self, group_name: str, user: User) -> bool:


### PR DESCRIPTION
## Changes
Current linting does not collect dataframe calls like df.write.(table). Adding a method to fix this issue.

Small fix for recent blueprint change for prompts