### PR TITLE
Upgrade hatch: 1.9.4 → 1.16.5

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  HATCH_VERBOSE: "2"
+  HATCH_VERSION: "1.16.5"
+
 jobs:
   integration:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
@@ -38,7 +42,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==1.9.4 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install "hatch==${HATCH_VERSION}"
 
       - name: Fetch relevant branches
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,10 @@ permissions:
 concurrency:
   group: single-acceptance-job-per-repo
 
+env:
+  HATCH_VERBOSE: "2"
+  HATCH_VERSION: "1.16.5"
+
 jobs:
   integration:
     environment: account-admin
@@ -32,7 +36,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==1.9.4 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install "hatch==${HATCH_VERSION}"
 
       - name: Run nightly tests
         uses: databrickslabs/sandbox/acceptance@acceptance/v0.4.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,8 @@ on:
       - main
 
 env:
-  HATCH_VERSION: 1.9.4
+  HATCH_VERBOSE: "2"
+  HATCH_VERSION: "1.16.5"
 
 jobs:
   ci:
@@ -38,7 +39,7 @@ jobs:
           python-version: ${{ matrix.pyVersion }}
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install "hatch==${HATCH_VERSION}"
 
       - name: Run unit tests
         run: hatch run test
@@ -64,7 +65,7 @@ jobs:
           python-version: 3.10.x
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install "hatch==${HATCH_VERSION}"
 
       - name: Reformat code
         run: make fmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  HATCH_VERBOSE: "2"
+  HATCH_VERSION: "1.16.5"
+
 jobs:
   publish:
     runs-on:
@@ -27,7 +31,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          pip install hatch==1.9.4 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+          pip install "hatch==${HATCH_VERSION}"
           hatch build
 
       - name: Draft release

--- a/.github/workflows/solacc.yml
+++ b/.github/workflows/solacc.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 7 * * *'
 
+env:
+  HATCH_VERBOSE: "2"
+  HATCH_VERSION: "1.16.5"
+
 jobs:
   solacc:
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==1.9.4 'click<8.3.0' # https://github.com/pallets/click/issues/3065
+        run: pip install "hatch==${HATCH_VERSION}"
 
       - name: Verify linters on solution accelerators
         run: make solacc


### PR DESCRIPTION
## Changes

This PR upgrades Hatch from 1.9.4 → 1.16.5.

Versions of Hatch prior to this release were broken by a change made to `pip`.
