### PR TITLE
Fix three flaky integration tests

### DIFF
--- a/.build-constraints.txt
+++ b/.build-constraints.txt
@@ -1,13 +1,13 @@
 hatchling==1.29.0 \
     --hash=sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0 \
     --hash=sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6
-packaging==26.0 \
-    --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
-    --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
+packaging==26.1 \
+    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
+    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
     # via hatchling
-pathspec==1.0.4 \
-    --hash=sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645 \
-    --hash=sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
+pathspec==1.1.0 \
+    --hash=sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42 \
+    --hash=sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080
     # via hatchling
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -58,3 +58,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          UCX_PYTEST_DIAG_DIR: ${{ runner.temp }}
+
+      - name: Dump pytest diagnostics
+        if: always()
+        run: |
+          diag="${RUNNER_TEMP}/ucx_pytest_diag.log"
+          if [[ -s "$diag" ]]; then
+            echo "::group::pytest diagnostics ($diag)"
+            cat "$diag"
+            echo "::endgroup::"
+          else
+            echo "No diagnostics captured at $diag (file missing or empty)."
+          fi

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -59,6 +59,10 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           UCX_PYTEST_DIAG_DIR: ${{ runner.temp }}
+          # Pin coverage.py to the project's [tool.coverage.run] config (branch = true,
+          # parallel = true) regardless of which CWD the acceptance wrapper invokes pytest
+          # from, so every session writes the same data shape and combine() succeeds.
+          COVERAGE_RCFILE: ${{ github.workspace }}/pyproject.toml
 
       - name: Dump pytest diagnostics
         if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -58,20 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          UCX_PYTEST_DIAG_DIR: ${{ runner.temp }}
           # Pin coverage.py to the project's [tool.coverage.run] config (branch = true,
           # parallel = true) regardless of which CWD the acceptance wrapper invokes pytest
           # from, so every session writes the same data shape and combine() succeeds.
           COVERAGE_RCFILE: ${{ github.workspace }}/pyproject.toml
-
-      - name: Dump pytest diagnostics
-        if: always()
-        run: |
-          diag="${RUNNER_TEMP}/ucx_pytest_diag.log"
-          if [[ -s "$diag" ]]; then
-            echo "::group::pytest diagnostics ($diag)"
-            cat "$diag"
-            echo "::endgroup::"
-          else
-            echo "No diagnostics captured at $diag (file missing or empty)."
-          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ pytest = [
 ]
 test = [
     { include-group = "pytest" },
-    "pip",
+    "pip~=26.0",
     "python-lsp-server>=1.9.0",
 ]
 

--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -74,7 +74,7 @@ def test_create_account_level_groups(
 
 
 def test_create_account_level_groups_nested_groups(
-    make_group, make_user, acc, ws, make_random, clean_account_level_groups, watchdog_purge_suffix, runtime_ctx, caplog
+    make_group, make_user, acc, ws, make_random, clean_account_level_groups, watchdog_purge_suffix, runtime_ctx
 ):
     suffix = f"{make_random(4).lower()}-{watchdog_purge_suffix}"
     # Test groups:
@@ -109,6 +109,7 @@ def test_create_account_level_groups_nested_groups(
         assert group
         assert len(group.members) == len(ws_group.members)
 
-    runtime_ctx.group_manager.validate_group_membership()
-
-    assert 'There are no groups with different membership between account and workspace.' in caplog.text
+    mismatches = runtime_ctx.group_manager.validate_group_membership()
+    created_names = {g.display_name for g in ws_groups}
+    mismatched_created = {m["wf_group_name"] for m in mismatches} & created_names
+    assert not mismatched_created, f"Created groups have mismatched membership: {mismatched_created}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1484,30 +1484,51 @@ def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
 # Diagnostic hooks: when the acceptance wrapper reports `exit status 3` with no failed
 # tests, pytest is hitting an internal error after the visible test stream ends. The
 # wrapper only surfaces structured ✅/❌/⏭️ markers, so unhandled exceptions and signal
-# crashes vanish. Print them with grep-able prefixes (and dump faulthandler tracebacks)
-# so they show up in the raw GH Actions log.
+# crashes vanish from the GH Actions log. Write tracebacks and faulthandler output to a
+# file that a subsequent workflow step (`if: always()`) can dump verbatim.
+import atexit  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
 import faulthandler  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
 import sys  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
+import tempfile  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
 import traceback  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
 
 
-faulthandler.enable()
+_DIAG_DIR = os.environ.get("UCX_PYTEST_DIAG_DIR") or os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
+_DIAG_PATH = os.path.join(_DIAG_DIR, "ucx_pytest_diag.log")
+_DIAG_FILE = open(_DIAG_PATH, "a", buffering=1, encoding="utf-8")  # pylint: disable=consider-using-with
+atexit.register(_DIAG_FILE.close)
+
+
+# faulthandler must own a writable file with a real fileno; reuse the same one so signal
+# crashes land alongside the rest of the diagnostic output.
+faulthandler.enable(file=_DIAG_FILE)
+
+
+def _diag(*parts: str) -> None:
+    line = " ".join(parts)
+    print(line, file=sys.stderr, flush=True)
+    _DIAG_FILE.write(line + "\n")
+    _DIAG_FILE.flush()
 
 
 def pytest_internalerror(excrepr, excinfo):
-    print("UCX_INTERNALERROR_BEGIN", file=sys.stderr, flush=True)
-    print(str(excrepr), file=sys.stderr, flush=True)
+    _diag("UCX_INTERNALERROR_BEGIN")
+    _diag(str(excrepr))
     if excinfo is not None:
+        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=_DIAG_FILE)
+        _DIAG_FILE.flush()
         traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
-    print("UCX_INTERNALERROR_END", file=sys.stderr, flush=True)
+    _diag("UCX_INTERNALERROR_END")
     return False  # let pytest's default handler run too
 
 
 def pytest_keyboard_interrupt(excinfo):
-    print("UCX_KEYBOARD_INTERRUPT", file=sys.stderr, flush=True)
+    _diag("UCX_KEYBOARD_INTERRUPT")
     if excinfo is not None:
+        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=_DIAG_FILE)
+        _DIAG_FILE.flush()
         traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
 
 
 def pytest_sessionfinish(session, exitstatus):  # pylint: disable=unused-argument
-    print(f"UCX_SESSION_FINISH exitstatus={exitstatus}", file=sys.stderr, flush=True)
+    _diag(f"UCX_SESSION_FINISH exitstatus={exitstatus}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,16 +1,10 @@
-import atexit
 import collections
-import faulthandler
 import functools
-import glob
 import json
 import logging
 import os
 import shutil
 import subprocess
-import sys
-import tempfile
-import traceback
 from collections.abc import Callable, Generator
 from dataclasses import replace
 from datetime import timedelta
@@ -1485,71 +1479,3 @@ def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
         logger.info(f"Group {group_name} was not deleted. Retrying...")
         raise AssertionError(f"Group is not deleted: {group_name}")
     raise NotFound(f"Group not found: {group_name}")
-
-
-# Diagnostic hooks: when the acceptance wrapper reports `exit status 3` with no failed
-# tests, pytest is hitting an internal error after the visible test stream ends. The
-# wrapper only surfaces structured ✅/❌/⏭️ markers, so unhandled exceptions and signal
-# crashes vanish from the GH Actions log. Write tracebacks and faulthandler output to a
-# file that a subsequent workflow step (`if: always()`) can dump verbatim.
-def _diag_path() -> str:
-    diag_dir = os.environ.get("UCX_PYTEST_DIAG_DIR") or os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
-    return os.path.join(diag_dir, "ucx_pytest_diag.log")
-
-
-# Persistent file descriptor opened via os.open so faulthandler has a real fileno that
-# outlives the registering function. Closed via atexit.
-_DIAG_FD = os.open(_diag_path(), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-atexit.register(os.close, _DIAG_FD)
-faulthandler.enable(file=_DIAG_FD)
-
-
-def _diag(*parts: str) -> None:
-    line = " ".join(parts) + "\n"
-    print(line, end="", file=sys.stderr, flush=True)
-    os.write(_DIAG_FD, line.encode("utf-8"))
-
-
-def _diag_traceback(excinfo) -> None:
-    if excinfo is None:
-        return
-    formatted = "".join(traceback.format_exception(excinfo.type, excinfo.value, excinfo.tb))
-    print(formatted, end="", file=sys.stderr, flush=True)
-    os.write(_DIAG_FD, formatted.encode("utf-8"))
-
-
-def _diag_coverage_state() -> None:
-    """Snapshot coverage-related state when an internal error fires.
-
-    The wrapper invokes pytest multiple times; coverage's per-session combine() only
-    fails on the last one, so this snapshot of remaining `.coverage*` parts plus the
-    active config path narrows down which session wrote incompatible data.
-    """
-    rcfile = os.environ.get("COVERAGE_RCFILE", "<unset>")
-    _diag(f"UCX_COVERAGE_RCFILE={rcfile}")
-    coverage_files = sorted(glob.glob(".coverage*")) + sorted(glob.glob(os.path.join(os.getcwd(), ".coverage*")))
-    _diag(f"UCX_COVERAGE_FILES count={len(coverage_files)}")
-    for path in coverage_files:
-        try:
-            size = os.path.getsize(path)
-        except OSError:
-            size = -1
-        _diag(f"UCX_COVERAGE_FILE size={size} path={path}")
-
-
-def pytest_internalerror(excrepr, excinfo):
-    _diag("UCX_INTERNALERROR_BEGIN")
-    _diag_coverage_state()
-    _diag(str(excrepr))
-    _diag_traceback(excinfo)
-    _diag("UCX_INTERNALERROR_END")
-    return False  # let pytest's default handler run too
-
-
-def pytest_keyboard_interrupt(excinfo):
-    _diag("UCX_KEYBOARD_INTERRUPT")
-    _diag_traceback(excinfo)
-
-
-def pytest_sessionfinish(exitstatus):
-    _diag(f"UCX_SESSION_FINISH exitstatus={exitstatus}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1479,3 +1479,35 @@ def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
         logger.info(f"Group {group_name} was not deleted. Retrying...")
         raise AssertionError(f"Group is not deleted: {group_name}")
     raise NotFound(f"Group not found: {group_name}")
+
+
+# Diagnostic hooks: when the acceptance wrapper reports `exit status 3` with no failed
+# tests, pytest is hitting an internal error after the visible test stream ends. The
+# wrapper only surfaces structured ✅/❌/⏭️ markers, so unhandled exceptions and signal
+# crashes vanish. Print them with grep-able prefixes (and dump faulthandler tracebacks)
+# so they show up in the raw GH Actions log.
+import faulthandler  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
+import sys  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
+import traceback  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
+
+
+faulthandler.enable()
+
+
+def pytest_internalerror(excrepr, excinfo):
+    print("UCX_INTERNALERROR_BEGIN", file=sys.stderr, flush=True)
+    print(str(excrepr), file=sys.stderr, flush=True)
+    if excinfo is not None:
+        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
+    print("UCX_INTERNALERROR_END", file=sys.stderr, flush=True)
+    return False  # let pytest's default handler run too
+
+
+def pytest_keyboard_interrupt(excinfo):
+    print("UCX_KEYBOARD_INTERRUPT", file=sys.stderr, flush=True)
+    if excinfo is not None:
+        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
+
+
+def pytest_sessionfinish(session, exitstatus):  # pylint: disable=unused-argument
+    print(f"UCX_SESSION_FINISH exitstatus={exitstatus}", file=sys.stderr, flush=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@ import atexit
 import collections
 import faulthandler
 import functools
+import glob
 import json
 import logging
 import os
@@ -1517,8 +1518,28 @@ def _diag_traceback(excinfo) -> None:
     os.write(_DIAG_FD, formatted.encode("utf-8"))
 
 
+def _diag_coverage_state() -> None:
+    """Snapshot coverage-related state when an internal error fires.
+
+    The wrapper invokes pytest multiple times; coverage's per-session combine() only
+    fails on the last one, so this snapshot of remaining `.coverage*` parts plus the
+    active config path narrows down which session wrote incompatible data.
+    """
+    rcfile = os.environ.get("COVERAGE_RCFILE", "<unset>")
+    _diag(f"UCX_COVERAGE_RCFILE={rcfile}")
+    coverage_files = sorted(glob.glob(".coverage*")) + sorted(glob.glob(os.path.join(os.getcwd(), ".coverage*")))
+    _diag(f"UCX_COVERAGE_FILES count={len(coverage_files)}")
+    for path in coverage_files:
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = -1
+        _diag(f"UCX_COVERAGE_FILE size={size} path={path}")
+
+
 def pytest_internalerror(excrepr, excinfo):
     _diag("UCX_INTERNALERROR_BEGIN")
+    _diag_coverage_state()
     _diag(str(excrepr))
     _diag_traceback(excinfo)
     _diag("UCX_INTERNALERROR_END")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,15 @@
-import json
-import functools
+import atexit
 import collections
-import os
+import faulthandler
+import functools
+import json
 import logging
+import os
 import shutil
 import subprocess
+import sys
+import tempfile
+import traceback
 from collections.abc import Callable, Generator
 from dataclasses import replace
 from datetime import timedelta
@@ -1486,49 +1491,44 @@ def get_group(group_manager: GroupManager, group_name: str) -> NoReturn:
 # wrapper only surfaces structured ✅/❌/⏭️ markers, so unhandled exceptions and signal
 # crashes vanish from the GH Actions log. Write tracebacks and faulthandler output to a
 # file that a subsequent workflow step (`if: always()`) can dump verbatim.
-import atexit  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
-import faulthandler  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
-import sys  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
-import tempfile  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
-import traceback  # noqa: E402  pylint: disable=wrong-import-position,wrong-import-order
+def _diag_path() -> str:
+    diag_dir = os.environ.get("UCX_PYTEST_DIAG_DIR") or os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
+    return os.path.join(diag_dir, "ucx_pytest_diag.log")
 
 
-_DIAG_DIR = os.environ.get("UCX_PYTEST_DIAG_DIR") or os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
-_DIAG_PATH = os.path.join(_DIAG_DIR, "ucx_pytest_diag.log")
-_DIAG_FILE = open(_DIAG_PATH, "a", buffering=1, encoding="utf-8")  # pylint: disable=consider-using-with
-atexit.register(_DIAG_FILE.close)
-
-
-# faulthandler must own a writable file with a real fileno; reuse the same one so signal
-# crashes land alongside the rest of the diagnostic output.
-faulthandler.enable(file=_DIAG_FILE)
+# Persistent file descriptor opened via os.open so faulthandler has a real fileno that
+# outlives the registering function. Closed via atexit.
+_DIAG_FD = os.open(_diag_path(), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+atexit.register(os.close, _DIAG_FD)
+faulthandler.enable(file=_DIAG_FD)
 
 
 def _diag(*parts: str) -> None:
-    line = " ".join(parts)
-    print(line, file=sys.stderr, flush=True)
-    _DIAG_FILE.write(line + "\n")
-    _DIAG_FILE.flush()
+    line = " ".join(parts) + "\n"
+    print(line, end="", file=sys.stderr, flush=True)
+    os.write(_DIAG_FD, line.encode("utf-8"))
+
+
+def _diag_traceback(excinfo) -> None:
+    if excinfo is None:
+        return
+    formatted = "".join(traceback.format_exception(excinfo.type, excinfo.value, excinfo.tb))
+    print(formatted, end="", file=sys.stderr, flush=True)
+    os.write(_DIAG_FD, formatted.encode("utf-8"))
 
 
 def pytest_internalerror(excrepr, excinfo):
     _diag("UCX_INTERNALERROR_BEGIN")
     _diag(str(excrepr))
-    if excinfo is not None:
-        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=_DIAG_FILE)
-        _DIAG_FILE.flush()
-        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
+    _diag_traceback(excinfo)
     _diag("UCX_INTERNALERROR_END")
     return False  # let pytest's default handler run too
 
 
 def pytest_keyboard_interrupt(excinfo):
     _diag("UCX_KEYBOARD_INTERRUPT")
-    if excinfo is not None:
-        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=_DIAG_FILE)
-        _DIAG_FILE.flush()
-        traceback.print_exception(excinfo.type, excinfo.value, excinfo.tb, file=sys.stderr)
+    _diag_traceback(excinfo)
 
 
-def pytest_sessionfinish(session, exitstatus):  # pylint: disable=unused-argument
+def pytest_sessionfinish(exitstatus):
     _diag(f"UCX_SESSION_FINISH exitstatus={exitstatus}")

--- a/tests/integration/install/test_installation.py
+++ b/tests/integration/install/test_installation.py
@@ -214,6 +214,7 @@ def test_installation_when_dashboard_is_trashed(ws, installation_ctx):
     assert True, "Installation succeeded when dashboard was trashed"
 
 
+@pytest.mark.skip(reason="Legacy dashboard creation is no longer supported by Databricks.")
 @pytest.mark.parametrize("dashboard_id", ["01ef4d7b294112968fa07ffae17dd55f", "invalid-dashboard-id", ""])
 def test_installation_when_dashboard_id_is_invalid(ws, installation_ctx, dashboard_id):
     """A dashboard reference might be invalid (after manual changes), the upgrade should handle this."""

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -3,6 +3,7 @@ These tests uses part of unit testing framework to mock the path lookup, and the
 because it uses the context and the time it takes to run the test.
 """
 
+import configparser
 import logging
 import os
 import re
@@ -16,15 +17,22 @@ from tests.unit.conftest import MockPathLookup
 
 
 def _resolved_index_url() -> str:
-    """Return the pip index URL configured for the current environment.
+    """Return a pip-usable index URL for the current environment.
 
-    Local dev points at the Databricks pypi proxy; CI configures JFrog via PIP_INDEX_URL/UV_INDEX_URL.
+    The notebook fixture invokes a real `pip install --index-url <url>`. CI's jfrog-auth action
+    writes a pip.conf at ``$PIP_CONFIG_FILE`` whose ``[global] index-url`` carries the
+    JFrog token; ``UV_INDEX_URL`` exists too but lacks credentials (uv stores auth in its keyring),
+    so passing it to pip would 401. Prefer ``PIP_CONFIG_FILE`` so pip can authenticate; fall back
+    to ``PIP_INDEX_URL`` and finally to the dev proxy used in local development.
     """
-    return (
-        os.environ.get("PIP_INDEX_URL")
-        or os.environ.get("UV_INDEX_URL")
-        or "https://pypi-proxy.dev.databricks.com/simple/"
-    )
+    pip_config_file = os.environ.get("PIP_CONFIG_FILE")
+    if pip_config_file and Path(pip_config_file).is_file():
+        parser = configparser.ConfigParser()
+        parser.read(pip_config_file)
+        url = parser.get("global", "index-url", fallback=None)
+        if url:
+            return url
+    return os.environ.get("PIP_INDEX_URL") or "https://pypi-proxy.dev.databricks.com/simple/"
 
 
 def _write_pytest_with_index_url_notebook(directory: Path) -> str:

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -19,18 +19,13 @@ from tests.unit.conftest import MockPathLookup
 def _resolved_index_url() -> str:
     """Return whichever pip mirror is configured locally, or public PyPI as a fallback.
 
-    ``pip config get`` only inspects the ``user``/``global``/``site`` scopes; it does not
-    read ``PIP_CONFIG_FILE`` (which loads as the ``env`` scope). CI's jfrog-auth action
-    configures pip via ``PIP_CONFIG_FILE``, so ``get`` returns no key there and we'd fall
-    back to public PyPI, which is unreachable from CI. ``pip config list`` *does* surface
-    every scope as ``key='value'`` lines, so parse that instead.
+    Note: this only checks the configuration files, it ignores the PIP_INDEX_URL environment variable.
     """
-    cmd = [sys.executable, "-m", "pip", "config", "list"]
+    cmd = [sys.executable, "-m", "pip", "config", "get", "global.index-url"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=10)
     if result.returncode == 0:
-        for line in result.stdout.splitlines():
-            if line.startswith("global.index-url="):
-                return line.split("=", 1)[1].strip().strip("'\"")
+        if index_url := result.stdout.strip():
+            return index_url
     return "https://pypi.python.org/simple"
 
 

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -4,13 +4,48 @@ because it uses the context and the time it takes to run the test.
 """
 
 import logging
+import os
 import re
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from databricks.labs.ucx.source_code.base import CurrentSessionState
 from tests.unit.conftest import MockPathLookup
+
+
+def _resolved_index_url() -> str:
+    """Return the pip index URL configured for the current environment.
+
+    Local dev points at the Databricks pypi proxy; CI configures JFrog via PIP_INDEX_URL/UV_INDEX_URL.
+    """
+    return (
+        os.environ.get("PIP_INDEX_URL")
+        or os.environ.get("UV_INDEX_URL")
+        or "https://pypi-proxy.dev.databricks.com/simple/"
+    )
+
+
+def _write_pytest_with_index_url_notebook(directory: Path) -> str:
+    notebook_name = "pip_install_pytest_with_index_url"
+    notebook = directory / f"{notebook_name}.py"
+    notebook.write_text(
+        textwrap.dedent(
+            f"""\
+            # Databricks notebook source
+
+            # COMMAND ----------
+
+            # MAGIC %pip install pytest --index-url {_resolved_index_url()}
+
+            # COMMAND ----------
+
+            import pytest
+            """
+        )
+    )
+    return notebook_name
 
 
 @pytest.mark.parametrize(
@@ -31,11 +66,10 @@ def test_build_notebook_dependency_graphs_installs_wheel_with_pip_cell_in_notebo
     assert maybe.graph.all_relative_names() == {f"{notebook}.py", "thingy/__init__.py"}
 
 
-def test_build_notebook_dependency_graphs_installs_pytest_from_index_url(simple_ctx):
-    ctx = simple_ctx.replace(path_lookup=MockPathLookup())
-    maybe = ctx.dependency_resolver.build_notebook_dependency_graph(
-        Path("pip_install_pytest_with_index_url"), CurrentSessionState()
-    )
+def test_build_notebook_dependency_graphs_installs_pytest_from_index_url(simple_ctx, tmp_path):
+    notebook_name = _write_pytest_with_index_url_notebook(tmp_path)
+    ctx = simple_ctx.replace(path_lookup=MockPathLookup(cwd=tmp_path))
+    maybe = ctx.dependency_resolver.build_notebook_dependency_graph(Path(notebook_name), CurrentSessionState())
     assert not maybe.problems
 
 
@@ -79,11 +113,18 @@ def test_build_notebook_dependency_graphs_when_installing_pytest_twice(caplog, s
     (
         "pip_install_demo_wheel",
         "pip_install_multiple_packages",
-        "pip_install_pytest_with_index_url",
     ),
 )
 def test_build_notebook_dependency_graphs_when_installing_notebooks_twice(caplog, simple_ctx, notebook) -> None:
     ctx = simple_ctx.replace(path_lookup=MockPathLookup())
     for _ in range(2):
         maybe = ctx.dependency_resolver.build_notebook_dependency_graph(Path(notebook), CurrentSessionState())
+        assert not maybe.problems
+
+
+def test_build_notebook_dependency_graphs_when_installing_pytest_from_index_url_twice(simple_ctx, tmp_path) -> None:
+    notebook_name = _write_pytest_with_index_url_notebook(tmp_path)
+    ctx = simple_ctx.replace(path_lookup=MockPathLookup(cwd=tmp_path))
+    for _ in range(2):
+        maybe = ctx.dependency_resolver.build_notebook_dependency_graph(Path(notebook_name), CurrentSessionState())
         assert not maybe.problems

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -17,10 +17,21 @@ from tests.unit.conftest import MockPathLookup
 
 
 def _resolved_index_url() -> str:
-    """Return whichever pip mirror is configured locally, or public PyPI as a fallback."""
-    cmd = [sys.executable, "-m", "pip", "config", "get", "global.index-url"]
+    """Return whichever pip mirror is configured locally, or public PyPI as a fallback.
+
+    ``pip config get`` only inspects the ``user``/``global``/``site`` scopes; it does not
+    read ``PIP_CONFIG_FILE`` (which loads as the ``env`` scope). CI's jfrog-auth action
+    configures pip via ``PIP_CONFIG_FILE``, so ``get`` returns no key there and we'd fall
+    back to public PyPI, which is unreachable from CI. ``pip config list`` *does* surface
+    every scope as ``key='value'`` lines, so parse that instead.
+    """
+    cmd = [sys.executable, "-m", "pip", "config", "list"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=10)
-    return result.stdout.strip() if result.returncode == 0 else "https://pypi.python.org/simple"
+    if result.returncode == 0:
+        for line in result.stdout.splitlines():
+            if line.startswith("global.index-url="):
+                return line.split("=", 1)[1].strip().strip("'\"")
+    return "https://pypi.python.org/simple"
 
 
 def _write_pytest_with_index_url_notebook(directory: Path) -> str:

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -21,11 +21,13 @@ def _resolved_index_url() -> str:
 
     Note: this only checks the configuration files, it ignores the PIP_INDEX_URL environment variable.
     """
-    cmd = [sys.executable, "-m", "pip", "config", "get", "global.index-url"]
+    # Cannot use 'config get': that will not consult the file if PIP_CONFIG_FILE is set.
+    cmd = [sys.executable, "-m", "pip", "config", "list"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=10)
     if result.returncode == 0:
-        if index_url := result.stdout.strip():
-            return index_url
+        for line in result.stdout.splitlines():
+            if line.startswith("global.index-url="):
+                return line.split("=", 1)[1].strip().strip("'\"")
     return "https://pypi.python.org/simple"
 
 

--- a/tests/integration/source_code/test_libraries.py
+++ b/tests/integration/source_code/test_libraries.py
@@ -3,10 +3,10 @@ These tests uses part of unit testing framework to mock the path lookup, and the
 because it uses the context and the time it takes to run the test.
 """
 
-import configparser
 import logging
-import os
 import re
+import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -17,22 +17,10 @@ from tests.unit.conftest import MockPathLookup
 
 
 def _resolved_index_url() -> str:
-    """Return a pip-usable index URL for the current environment.
-
-    The notebook fixture invokes a real `pip install --index-url <url>`. CI's jfrog-auth action
-    writes a pip.conf at ``$PIP_CONFIG_FILE`` whose ``[global] index-url`` carries the
-    JFrog token; ``UV_INDEX_URL`` exists too but lacks credentials (uv stores auth in its keyring),
-    so passing it to pip would 401. Prefer ``PIP_CONFIG_FILE`` so pip can authenticate; fall back
-    to ``PIP_INDEX_URL`` and finally to the dev proxy used in local development.
-    """
-    pip_config_file = os.environ.get("PIP_CONFIG_FILE")
-    if pip_config_file and Path(pip_config_file).is_file():
-        parser = configparser.ConfigParser()
-        parser.read(pip_config_file)
-        url = parser.get("global", "index-url", fallback=None)
-        if url:
-            return url
-    return os.environ.get("PIP_INDEX_URL") or "https://pypi-proxy.dev.databricks.com/simple/"
+    """Return whichever pip mirror is configured locally, or public PyPI as a fallback."""
+    cmd = [sys.executable, "-m", "pip", "config", "get", "global.index-url"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=10)
+    return result.stdout.strip() if result.returncode == 0 else "https://pypi.python.org/simple"
 
 
 def _write_pytest_with_index_url_notebook(directory: Path) -> str:

--- a/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
+++ b/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
@@ -1,9 +1,0 @@
-# Databricks notebook source
-
-# COMMAND ----------
-
-# MAGIC %pip install pytest --index-url https://pypi-proxy.dev.databricks.com/simple/
-
-# COMMAND ----------
-
-import pytest

--- a/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
+++ b/tests/unit/source_code/samples/pip_install_pytest_with_index_url.py
@@ -2,7 +2,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install pytest --index-url https://pypi.python.org/simple
+# MAGIC %pip install pytest --index-url https://pypi-proxy.dev.databricks.com/simple/
 
 # COMMAND ----------
 

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ dev = [
     { name = "databricks-labs-pylint", specifier = "~=0.5" },
     { name = "databricks-labs-pytester", specifier = ">=0.7.2" },
     { name = "mypy", specifier = "~=1.9.0" },
-    { name = "pip" },
+    { name = "pip", specifier = "~=26.0" },
     { name = "pylint", specifier = "~=3.3.1" },
     { name = "pylint-pytest", specifier = "==2.0.0a0" },
     { name = "pytest", specifier = "~=8.3.3" },
@@ -564,7 +564,7 @@ pytest = [
 test = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.4.4" },
     { name = "databricks-labs-pytester", specifier = ">=0.7.2" },
-    { name = "pip" },
+    { name = "pip", specifier = "~=26.0" },
     { name = "pytest", specifier = "~=8.3.3" },
     { name = "pytest-cov", specifier = "~=4.1.0" },
     { name = "pytest-mock", specifier = "~=3.14.0" },


### PR DESCRIPTION
## Summary

Three previously-failing integration tests, plus a CI fix for a coverage-config issue that was masking the runner's exit status.

### Test fixes

- **`test_build_notebook_dependency_graphs_installs_pytest_from_index_url`** (and its installed-twice sibling) — generate the notebook fixture at test time using whichever pip mirror is configured locally. The helper shells out to `python -m pip config list` (not `pip config get`, because `get` only inspects `user`/`global`/`site` scopes and ignores the `env` scope that `PIP_CONFIG_FILE` loads as) and parses the `global.index-url='...'` line. Falls back to public PyPI when no mirror is configured. The same test now exercises the JFrog mirror in CI and the dev proxy locally without any environment knowledge baked into the test code. Depends on #4804 keeping the JFrog URL credential-free.
- **`test_installation_when_dashboard_id_is_invalid`** — skipped; it exercises a deprecated dashboard API, matching the existing skip on line 185 of the same file.
- **`test_create_account_level_groups_nested_groups`** — scoped the final assertion to the 4 groups the test actually creates, instead of asserting a global "no mismatches anywhere" log line that gets polluted by stale UCX groups left in the shared workspace by earlier runs.

### CI: pin `COVERAGE_RCFILE`

The integration job was failing with `failed: trigger: run: unknown: exit status 3` even when zero tests failed. Root cause: the `databrickslabs/sandbox/acceptance` wrapper invokes pytest in multiple per-directory sessions, and coverage.py walks up from CWD looking for config. At least one CWD wasn't surfacing the project's `pyproject.toml`, so coverage fell back to defaults (`branch=false`) and wrote line data while sibling sessions wrote arc data. The final session's `cov.combine()` then raised `Can't combine arc data with line data`. Setting `COVERAGE_RCFILE: ${{ github.workspace }}/pyproject.toml` forces every session to read the same `[tool.coverage.run]` config regardless of CWD.

## Test plan

- [x] `make fmt` (black, ruff, mypy, pylint 10.00/10)
- [x] `make test` (2011 passed, coverage 89.83%)
- [x] `labs test-one` for each of the three originally-failing integration tests
- [x] CI integration job green (76 ✅ / 0 ❌ / 11 ⏭️, all 11 pytest sessions exit 0)