### PR TITLE
Fix wheel and sdist build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,20 @@ requires = [
 ]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-sources = ["src"]
-include = ["src"]
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "/.build-constraints.txt",
+    "/README.*",
+    "/LICEN[CS]E",
+    "/NOTICE",
+    "/pyproject.toml",
+    "/src/",
+    "/tests/",
+    "/uv.lock",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/databricks"]
 
 [tool.uv]
 required-version = "~= 0.11.0"


### PR DESCRIPTION
## Changes

This PR updates the project configuration so that the source distribution properly contains the files needed to build the wheel.

### Linked issues

For more context refer to databrickslabs/lakebridge#2419.

### Functionality

- update project packaging

### Tests

- manually tested: `make build` and examined the produced source and wheel distributions
