### PR TITLE
Fix skip command to use three-part table name for HMS ALTER

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -133,7 +133,7 @@ class TableMapping:
             if table is None:
                 raise NotFound("[TABLE_OR_VIEW_NOT_FOUND]")
             self._sql_backend.execute(
-                f"ALTER {table.kind} {escape_sql_identifier(schema_name)}.{escape_sql_identifier(table_name)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
+                f"ALTER {table.kind} {escape_sql_identifier(table.full_name)} SET TBLPROPERTIES('{self.UCX_SKIP_PROPERTY}' = true)"
             )
         except NotFound as err:
             if "[TABLE_OR_VIEW_NOT_FOUND]" in str(err) or "[DELTA_TABLE_NOT_FOUND]" in str(err):

--- a/tests/unit/hive_metastore/test_mapping.py
+++ b/tests/unit/hive_metastore/test_mapping.py
@@ -208,15 +208,15 @@ def test_skip_happy_path(caplog):
     mapping.skip_table_or_view(schema_name="schema", table_name="table", load_table=lambda _schema, _table: table)
     ws.tables.get.assert_not_called()
     sbe.execute.assert_called_with(
-        f"ALTER TABLE `schema`.`table` SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)"
+        f"ALTER TABLE `catalog`.`schema`.`table` SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)"
     )
     view = Table(
-        catalog="catalog", database="schema", name="table", object_type="table", table_format="csv", view_text="stuff"
+        catalog="catalog", database="schema", name="view", object_type="table", table_format="csv", view_text="stuff"
     )
     mapping.skip_table_or_view(schema_name="schema", table_name="view", load_table=lambda _schema, _table: view)
     ws.tables.get.assert_not_called()
     sbe.execute.assert_called_with(
-        f"ALTER VIEW `schema`.`view` SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)"
+        f"ALTER VIEW `catalog`.`schema`.`view` SET TBLPROPERTIES('{mapping.UCX_SKIP_PROPERTY}' = true)"
     )
     assert len(caplog.records) == 0
     mapping.skip_schema(schema="schema")


### PR DESCRIPTION
## Problem
`databricks labs ucx skip --schema ... --table ...` emitted `ALTER TABLE \`schema\`.\`table\`` without the `hive_metastore` catalog qualifier. On Unity Catalog-enabled SQL warehouses whose default catalog is not `hive_metastore`, this fails with `[TABLE_OR_VIEW_NOT_FOUND]` even when the row exists in UCX inventory (`hive_metastore.<inventory>.tables`).

`unskip_table_or_view` already used `table.full_name` (three-part name); `skip_table_or_view` was inconsistent.

## Change
- Use `escape_sql_identifier(table.full_name)` in `skip_table_or_view` when applying the skip TBLPROPERTY, matching `unskip_table_or_view`.

## Tests
- Updated `test_skip_happy_path` expected SQL and corrected the view fixture `name=`view`` so it matches the skipped object.

```
python -m pytest tests/unit/hive_metastore/test_mapping.py::test_skip_happy_path -q
```

Made with [Cursor](https://cursor.com)