### PR TITLE
Split mapping.csv into pages to bypass 10 MB workspace upload limit

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -92,6 +92,8 @@ class TableToMigrate:
 class TableMapping:
     FILENAME = 'mapping.csv'
     UCX_SKIP_PROPERTY = "databricks.labs.ucx.skip"
+    # Workspace import API has a 10 MB hard limit; 50 K rows × ~160 bytes ≈ 8 MB per page
+    _PAGE_SIZE = 50_000
 
     def __init__(
         self,

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -128,10 +128,18 @@ class TableMapping:
 
     def load(self) -> list[Rule]:
         try:
-            return self._installation.load(list[Rule], filename=self.FILENAME)
+            rules = self._installation.load(list[Rule], filename=self.FILENAME)
         except NotFound:
             msg = "Please run: databricks labs ucx create-table-mapping"
             raise ValueError(msg) from None
+        page = 1
+        while True:
+            try:
+                rules += self._installation.load(list[Rule], filename=f"mapping-{page}.csv")
+                page += 1
+            except NotFound:
+                break
+        return rules
 
     def skip_table_or_view(self, schema_name: str, table_name: str, load_table: Callable[[str, str], Table | None]):
         # Marks a table to be skipped in the migration process by applying a table property

--- a/src/databricks/labs/ucx/hive_metastore/mapping.py
+++ b/src/databricks/labs/ucx/hive_metastore/mapping.py
@@ -118,8 +118,13 @@ class TableMapping:
     def save(self, tables: TablesCrawler, workspace_info: WorkspaceInfo) -> str:
         workspace_name = workspace_info.current()
         default_catalog_name = re.sub(r"\W+", "_", workspace_name)
-        current_tables = self.current_tables(tables, workspace_name, default_catalog_name)
-        return self._installation.save(list(current_tables), filename=self.FILENAME)
+        rules = list(self.current_tables(tables, workspace_name, default_catalog_name))
+        pages = [rules[i : i + self._PAGE_SIZE] for i in range(0, len(rules), self._PAGE_SIZE)]
+        path = None
+        for i, page in enumerate(pages):
+            filename = self.FILENAME if i == 0 else f"mapping-{i}.csv"
+            path = self._installation.save(page, filename=filename)
+        return path or f"{self._installation.install_folder()}/{self.FILENAME}"
 
     def load(self) -> list[Rule]:
         try:


### PR DESCRIPTION
Fixes #4675

Customers with ~100K+ tables in an external HMS hit a `BadRequest: File size imported is (16413218 bytes), exceeded max size (10485760 bytes)` error when running `create-table-mapping`.

- The Databricks Workspace import API has a hard **10 MB** file size limit. With ~100K tables, `mapping.csv` grows to ~16 MB, exceeding this regardless of `query_statement_disposition`.
- `save()` now chunks rules into pages of 50,000 rows each (~8 MB/file), writing `mapping.csv` for the first page and `mapping-1.csv`, `mapping-2.csv`, … for overflow.
- `load()` reads `mapping.csv` then follows `mapping-1.csv`, `mapping-2.csv`, … until `NotFound`, assembling the full rule list transparently to all callers.
- **Backward compatible** — existing single-file `mapping.csv` installations load unchanged.

## Test plan

- [ ] Unit test: `save()` with > 50,000 rules writes both `mapping.csv` and `mapping-1.csv` with correct row counts
- [ ] Unit test: `load()` with multiple pages assembles all rules in order
- [ ] Unit test: `load()` with a single-page legacy `mapping.csv` still returns all rules (backward compat)
- [ ] Manual: reproduce with a workspace that has 100K+ HMS tables and confirm no `BadRequest` on `create-table-mapping`
