### PR TITLE
Fix 403 on databricks labs install lsql by passing GITHUB_TOKEN

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,6 +89,7 @@ jobs:
         env:  # this is a temporary hack
           DATABRICKS_HOST: any
           DATABRICKS_TOKEN: any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Reformat SQL queries
         run: databricks labs lsql fmt --normalize-case false --exclude tests/unit/source_code/samples/


### PR DESCRIPTION
## Summary

- `databricks labs install lsql` was returning a 403 in CI because the GitHub token was not being passed to the environment during the install step.
- Adds `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `env` block of the relevant CI job in `push.yml`.

## Test plan

- [x] Confirm the `lsql fmt` step in CI no longer fails with a 403 on `databricks labs install lsql`
