### PR TITLE
Add offending view name to error logs in view_migrate

### DIFF
--- a/src/databricks/labs/ucx/hive_metastore/view_migrate.py
+++ b/src/databricks/labs/ucx/hive_metastore/view_migrate.py
@@ -28,9 +28,9 @@ class ViewToMigrate(TableToMigrate):
         try:
             statements = sqlglot.parse(self.src.view_text, read='databricks')
         except ParseError as e:
-            raise ValueError(f"Could not analyze view SQL: {self.src.view_text}") from e
+            raise ValueError(f"Could not analyze view SQL: {self.src.view_text} for view {self.src.key}") from e
         if len(statements) != 1 or statements[0] is None:
-            raise ValueError(f"Could not analyze view SQL: {self.src.view_text}")
+            raise ValueError(f"Could not analyze view SQL: {self.src.view_text} for view {self.src.key}")
         statement = statements[0]
         aliases = self._read_aliases(statement)
         for old_table in statement.find_all(expressions.Table):
@@ -40,7 +40,7 @@ class ViewToMigrate(TableToMigrate):
                 continue
             src_db = old_table.db if old_table.db else self.src.database
             if not src_db:
-                logger.error(f"Could not determine schema for table {old_table.name}")
+                logger.error(f"Could not determine schema for table {old_table.name} in view {self.src.key}")
                 continue
             yield TableView("hive_metastore", src_db, old_table.name)
 

--- a/tests/unit/hive_metastore/test_view_migrate.py
+++ b/tests/unit/hive_metastore/test_view_migrate.py
@@ -188,6 +188,8 @@ def test_sequence_view_with_invalid_query_raises_value_error(tables) -> None:
     with pytest.raises(ValueError) as error:
         sequencer.sequence_batches()
     assert "Could not analyze view SQL:" in str(error)
+    # The offending view name must be included in the error to aid troubleshooting (issue #4438)
+    assert tables[0].src.key in str(error)
 
 
 @pytest.mark.parametrize("tables", [("db1.v9",)], indirect=True)


### PR DESCRIPTION
Resolves #4438

## Problem

When `migrate-tables` fails to analyze a view's SQL in `view_migrate.py`,
the error and log messages include the view's DDL but not the view's name.
With many views processed in parallel, this makes it hard to identify which
view caused the failure.

## Change

Adds the offending view's key (`self.src.key`) to the three failure sites in
`ViewToMigrate._view_dependencies`:

- The `ValueError` raised on a sqlglot `ParseError`
- The `ValueError` raised when parsing yields no usable statement
- The `logger.error` emitted when a referenced table's schema can't be determined

## Tests

Extended `test_sequence_view_with_invalid_query_raises_value_error` to assert
the offending view's key appears in the raised error message.

## Note on scope

This PR is scoped to the logging improvement requested
("at a minimum add logging"), which also provides the diagnostics needed
to confirm the offending view and DDL when investigating that underlying
parsing behavior.