### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We welcome your feedback! Please submit an [an issue](https://github.com/databri
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=databrickslabs/ucx&type=Date)](https://star-history.com/#databrickslabs/ucx)
+[![Star History Chart](https://star-history.dera.page/svg?repos=databrickslabs/ucx&type=Date)](https://star-history.dera.page/#databrickslabs/ucx&type=Date)
 
 
 # Project Support


### PR DESCRIPTION
The Star History chart in the README is currently broken due to the GitHub stargazer API restrictions. This change moves the chart to star-history.dera.page, which uses an alternative data source that requires no API token, restoring the chart for the project.